### PR TITLE
59-epub-navigation-menu-errors

### DIFF
--- a/src/Service/net/exelearning/Service/Export/ExportEPUB3Service.php
+++ b/src/Service/net/exelearning/Service/Export/ExportEPUB3Service.php
@@ -142,7 +142,7 @@ class ExportEPUB3Service implements ExportServiceInterface
             $odeNavStructureSyncs,
             $pagesFileData,
             $odeProperties,
-            $elpFileName,
+            $exportDirPath,
             $resourcesPrefix,
             $this->exportType
         );

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -822,8 +822,11 @@ class ExportXmlUtil
             if ('.' !== $file && '..' !== $file) {
                 $filePath = $exportDirPath.'/'.$file;
                 if (is_file($filePath) && !preg_match('/index\.html$/', $file)) {
-                    $fileElement = $manifest->addChild('file');
-                    $fileElement->addAttribute('href', $file);
+                    $item = $manifest->addChild('item', ' ');
+                    $item->addAttribute('id', $file);
+                    $item->addAttribute('href', $file);
+                    $item->addAttribute('media-type', mime_content_type($filePath));
+                    $item->addAttribute('fallback', 'fallback');
                 }
             }
         }

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -2664,37 +2664,7 @@ class ExportXmlUtil
                     $item = $manifest->addChild('item', ' ');
                     $item->addAttribute('id', $dir.'/'.$relativePath);
                     $item->addAttribute('href', $dir.'/'.$relativePath);
-                    // Determine media-type based on file extension
-                    $ext = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));
-                    $mediaTypes = [
-                        'jpg' => 'image/jpeg',
-                        'jpeg' => 'image/jpeg',
-                        'png' => 'image/png',
-                        'gif' => 'image/gif',
-                        'svg' => 'image/svg+xml',
-                        'svgz' => 'image/svg+xml',
-                        'webp' => 'image/webp',
-                        'css' => 'text/css',
-                        'js' => 'application/javascript',
-                        'html' => 'application/xhtml+xml',
-                        'xhtml' => 'application/xhtml+xml',
-                        'xml' => 'application/xml',
-                        'mp3' => 'audio/mpeg',
-                        'mp4' => 'video/mp4',
-                        'ogg' => 'audio/ogg',
-                        'ogv' => 'video/ogg',
-                        'json' => 'application/json',
-                        'woff' => 'font/woff',
-                        'woff2' => 'font/woff2',
-                        'ttf' => 'font/ttf',
-                        'otf' => 'font/otf',
-                        'eot' => 'application/vnd.ms-fontobject',
-                        'pdf' => 'application/pdf',
-                        'zip' => 'application/zip',
-                        'txt' => 'text/plain',
-                    ];
-                    $mediaType = isset($mediaTypes[$ext]) ? $mediaTypes[$ext] : 'application/octet-stream';
-                    $item->addAttribute('media-type', $mediaType);
+                    $item->addAttribute('media-type', mime_content_type($file->getPathname()));
                     $item->addAttribute('fallback', 'fallback');
                 }
             }

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -740,21 +740,33 @@ class ExportXmlUtil
         $metadata->addAttribute('xmlns:xmlns:dc', 'http://purl.org/dc/elements/1.1/');
 
         // metadata -> language
-        $lang = isset($odeProperties['pp_lang']) ?
-            $odeProperties['pp_lang']->getValue() : Settings::DEFAULT_LOCALE;
+        $lang = isset($odeProperties['pp_lang']) ? $odeProperties['pp_lang']->getValue() : Settings::DEFAULT_LOCALE;
         $languageDC = $metadata->addChild('dc:dc:language', $lang);
 
         // metadata -> identifier
-        $id = isset($odeProperties['lom_general_identifier_entry'])
-            ? $odeProperties['lom_general_identifier_entry']->getValue() : 'ODE-'.$odeId;
+        $id = isset($odeProperties['lom_general_identifier_entry']) ? $odeProperties['lom_general_identifier_entry']->getValue() : 'ODE-'.$odeId;
         $identifierDC = $metadata->addChild('dc:dc:identifier', $id);
         $identifierDC->addAttribute('id', 'pub-id');
 
         // metadata -> title
-        $title = isset($odeProperties['pp_title']) ?
-            $odeProperties['pp_title']->getValue() : 'eXe-p-'.$odeId;
+        $title = isset($odeProperties['pp_title']) ? $odeProperties['pp_title']->getValue() : 'eXe-p-'.$odeId;
         $titleDC = $metadata->addChild('dc:dc:title', $title);
+        $titleDC->addAttribute('xml:lang', $lang);
 
+        // metadata -> description
+        $descriptionValue = isset($odeProperties['pp_description']) ? $odeProperties['pp_description']->getValue() : '';
+        $descriptionDC = $metadata->addChild('dc:dc:description', $descriptionValue);
+        $descriptionDC->addAttribute('xml:lang', $lang);
+
+        // metadata -> license
+        $licenseValue = isset($odeProperties['license']) ? $odeProperties['license']->getValue() : '';
+        $licenseDC = $metadata->addChild('dc:dc:license', $licenseValue);
+        $licenseDC->addAttribute('xml:lang', $lang);
+
+        // metadata -> creator
+        $authorValue = isset($odeProperties['pp_author']) ? $odeProperties['pp_author']->getValue() : '';
+        $creatorDC = $metadata->addChild('dc:dc:creator', $authorValue);
+        
         // metadata -> meta
         $date = new \DateTime('now');
         $meta = $metadata->addChild('meta', $date->format('Y-m-d\TH:i:s\Z'));
@@ -2564,6 +2576,28 @@ class ExportXmlUtil
      * @param string           $dir           the directory to add files from
      */
     public static function addCommonExportedFilesToImsManifest($resource, $exportDirPath, $dir)
+    {
+        $resourcesDir = $exportDirPath.$dir;
+        if (is_dir($resourcesDir)) {
+            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($resourcesDir));
+            foreach ($iterator as $file) {
+                if ($file->isFile()) {
+                    $relativePath = str_replace($resourcesDir.'/', '', $file->getPathname());
+                    $fileElement = $resource->addChild('file');
+                    $fileElement->addAttribute('href', $dir.'/'.$relativePath);
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds exported files to the OPF manifest.
+     *
+     * @param SimpleXMLElement $resource      the XML resource to add files to
+     * @param string           $exportDirPath the path to the export directory
+     * @param string           $dir           the directory to add files from
+     */
+    public static function addCommonExportedFilesToOpfManifest($resource, $exportDirPath, $dir)
     {
         $resourcesDir = $exportDirPath.$dir;
         if (is_dir($resourcesDir)) {


### PR DESCRIPTION
Improve the EPUB3 export by fixing the navigation menu, adding metadata properties, including all used files in the package, and ensuring invisible pages do not appear in the navigation. Additionally, add mimetype files to the root EPUB directory and refactor the code for better clarity and maintainability.