### PR TITLE
Disable AppImage generation due to sandboxing issues on Ubuntu 24.04+

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -126,11 +126,12 @@ jobs:
         uses: crazy-max/ghaction-virustotal@v4
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           update_release_body: true
           files: |
-            dist/*.msi
-            dist/*.exe
-            dist/*.dmg
-            dist/*.zip
-            dist/*.deb
-            dist/*.rpm
+            .msi$
+            .exe$
+            .dmg$
+            .deb$
+            .rpm$
+            .zip$

--- a/doc/06-build-generation.md
+++ b/doc/06-build-generation.md
@@ -28,7 +28,6 @@ Each production release generates and publishes the following installers:
 
 * `.deb` (Debian/Ubuntu)
 * `.rpm` (RedHat, Fedora)
-* `.AppImage` (portable executable)
 
 ### **macOS**
 

--- a/package.json
+++ b/package.json
@@ -144,12 +144,6 @@
             ],
             "target": [
                 {
-                    "target": "AppImage",
-                    "arch": [
-                        "x64"
-                    ]
-                },
-                {
                     "target": "deb",
                     "arch": [
                         "x64"


### PR DESCRIPTION
This pull request disables the generation of the `.AppImage` installer and updates the related documentation accordingly.

Due to upstream Electron sandboxing issues affecting recent Ubuntu-based systems (especially Kubuntu 24.04+), running AppImages fails with a fatal error unless users apply unsafe or cumbersome workarounds. See discussion in [electron/electron#42510](https://github.com/electron/electron/issues/42510#issuecomment-2323029273) for context.

We have chosen to **disable AppImage generation temporarily**, considering:

* The `--no-sandbox` workaround is insecure and discouraged for production.
* The majority of Linux users rely on `.deb` or `.rpm` packages.
* This aligns with how other apps (e.g. Chrome) distribute their Linux installers.
* The online version of eXeLearning is already prioritized.

📊 **Package format usage overview** (approximate):

| Format   | Usage estimate         |
| -------- | ---------------------- |
| `.deb`   | 50–60%                 |
| `.rpm`   | 25–30%                 |
| Flatpak  | 5–10% (desktop growth) |
| Snap     | 3–5% (mostly Ubuntu)   |
| AppImage | <1%                    |

We can revisit this in the future if Electron resolves the issue or demand justifies reconsidering AppImage or Snap formats.

Closes #90
Also fixes documentation typo and updates VirusTotal config (fixes #26)