### PR TITLE
Fix: avoid JS error when loading structures with missing properties

### DIFF
--- a/public/app/workarea/project/structure/structureNode.js
+++ b/public/app/workarea/project/structure/structureNode.js
@@ -65,7 +65,9 @@ export default class StructureNode {
         for (let [key, value] of Object.entries(this.properties)) {
             // skip if missing
             if (!properties[key]) {
-                console.warn(`Missing property '${key}' in odeNavStructureSyncProperties`);
+                console.warn(
+                    `Missing property '${key}' in odeNavStructureSyncProperties`,
+                );
                 continue;
             }
             if (onlyHeritable) {

--- a/public/app/workarea/project/structure/structureNode.js
+++ b/public/app/workarea/project/structure/structureNode.js
@@ -63,6 +63,11 @@ export default class StructureNode {
      */
     setProperties(properties, onlyHeritable) {
         for (let [key, value] of Object.entries(this.properties)) {
+            // skip if missing
+            if (!properties[key]) {
+                console.warn(`Missing property '${key}' in odeNavStructureSyncProperties`);
+                continue;
+            }
             if (onlyHeritable) {
                 if (properties[key].heritable)
                     value.value = properties[key].value;


### PR DESCRIPTION
When opening the file `tests/Fixtures/basic-example.elp`, a JavaScript error occurred:

```javascript
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'value')
    at StructureNode.setProperties (structureNode.js:70)
```

This happened because the function `setProperties` assumed that all properties defined in the configuration would also exist in the loaded data. If a property was missing from the loaded JSON, accessing `.value` caused an exception.

**Solution:**
The method now checks that the property exists before accessing its value, preventing the error and allowing files with missing properties to load correctly.

**How to test:**

1. Open the file `tests/Fixtures/basic-example.elp`.
2. Before this fix, a JavaScript error would appear in the console.
3. With this fix applied, the file loads without errors.