### PR TITLE
feature: Add apiToken to User entity and GenerateApiKeyCommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,14 @@ create-user: check-docker check-env upd
 	read -p "Enter username: " username; \
 	docker compose exec exelearning php bin/console app:create-user $$email $$password $$username --no-fail;
 
+# Generate API key for a user (Usage: make generate-api-key USER_ID=123 [OVERWRITE=1])
+generate-api-key: check-docker check-env upd
+	@if [ -z "$(USER_ID)" ]; then \
+		echo "❌ USER_ID is required. Usage: make generate-api-key USER_ID=123 [OVERWRITE=1]"; \
+		exit 1; \
+	fi
+	docker compose exec exelearning composer --no-cache generate-api-key -- $(USER_ID) $(if $(OVERWRITE),--overwrite,)
+
 # Update Composer dependencies
 update: check-docker check-env upd
 	docker compose exec exelearning composer update --no-cache --with-all-dependencies

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "assets-install": "php bin/console assets:install public",
         "db-schema-update": "php bin/console doctrine:schema:update --complete --force",
         "create-user": "php bin/console app:create-user ${TEST_USER_EMAIL} ${TEST_USER_PASSWORD} ${TEST_USER_USERNAME} --no-fail",
+        "generate-api-key": "php bin/console app:generate-api-key",
         "php-cs-checker": "vendor/bin/php-cs-fixer check src --config=.php-cs-fixer.dist.php --using-cache=no",
         "php-cs-fixer": "vendor/bin/php-cs-fixer fix src --config=.php-cs-fixer.dist.php --using-cache=no",
         "js-lint": "yarn lint",

--- a/src/Command/net/exelearning/Command/GenerateApiKeyCommand.php
+++ b/src/Command/net/exelearning/Command/GenerateApiKeyCommand.php
@@ -47,26 +47,28 @@ class GenerateApiKeyCommand extends Command
 
         $userRepository = $this->entityManager->getRepository(User::class);
         /** @var User|null $user */
-        $user = $userRepository->findOneBy(['userId' => $userId]); # Adjusted to find by userId as per CreateUserCommand example context
+        $user = $userRepository->findOneBy(['userId' => $userId]); // Adjusted to find by userId as per CreateUserCommand example context
 
         if (!$user) {
             // Try finding by email if userId was actually an email
             $user = $userRepository->findOneBy(['email' => $userId]);
             if (!$user) {
-                 // Try finding by database ID if userId was an integer id
+                // Try finding by database ID if userId was an integer id
                 if (ctype_digit($userId)) {
-                    $user = $userRepository->find((int)$userId);
+                    $user = $userRepository->find((int) $userId);
                 }
             }
         }
 
         if (!$user) {
             $io->error(sprintf('User with ID/email "%s" not found.', $userId));
+
             return Command::FAILURE;
         }
 
         if ($user->getApiToken() && !$overwrite) {
             $io->error('User already has an API token. Use --overwrite to replace it.');
+
             return Command::FAILURE;
         }
 

--- a/src/Command/net/exelearning/Command/GenerateApiKeyCommand.php
+++ b/src/Command/net/exelearning/Command/GenerateApiKeyCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Command\net\exelearning\Command;
+
+use App\Entity\net\exelearning\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[AsCommand(
+    name: 'app:generate-api-key',
+    description: 'Generates a random API key for the specified user.',
+    hidden: false
+)]
+class GenerateApiKeyCommand extends Command
+{
+    private EntityManagerInterface $entityManager;
+    private UserPasswordHasherInterface $passwordHasher;
+
+    public function __construct(EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher)
+    {
+        $this->entityManager = $entityManager;
+        $this->passwordHasher = $passwordHasher;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('user_id', InputArgument::REQUIRED, 'The ID of the user to generate the API key for.')
+            ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite the API key if it already exists.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $userId = $input->getArgument('user_id');
+        $overwrite = $input->getOption('overwrite');
+
+        $userRepository = $this->entityManager->getRepository(User::class);
+        /** @var User|null $user */
+        $user = $userRepository->findOneBy(['userId' => $userId]); # Adjusted to find by userId as per CreateUserCommand example context
+
+        if (!$user) {
+            // Try finding by email if userId was actually an email
+            $user = $userRepository->findOneBy(['email' => $userId]);
+            if (!$user) {
+                 // Try finding by database ID if userId was an integer id
+                if (ctype_digit($userId)) {
+                    $user = $userRepository->find((int)$userId);
+                }
+            }
+        }
+
+        if (!$user) {
+            $io->error(sprintf('User with ID/email "%s" not found.', $userId));
+            return Command::FAILURE;
+        }
+
+        if ($user->getApiToken() && !$overwrite) {
+            $io->error('User already has an API token. Use --overwrite to replace it.');
+            return Command::FAILURE;
+        }
+
+        $apiKey = Uuid::v4()->toRfc4122();
+        $hashedApiKey = $this->passwordHasher->hashPassword($user, $apiKey);
+        $user->setApiToken($hashedApiKey);
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('API key generated for user %s (%s).', $user->getUserIdentifier(), $user->getUserId()));
+        $io->writeln('Your API Key (raw UUID - store it securely, it will not be shown again):');
+        $io->writeln("<info>$apiKey</info>");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/net/exelearning/Entity/User.php
+++ b/src/Entity/net/exelearning/Entity/User.php
@@ -14,6 +14,9 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
     #[ORM\Column(type: 'string', length: 180, unique: true, nullable: true)]
     private ?string $externalIdentifier = null; // sub (OIDC) or uid (CAS)
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $apiToken = null;
+
     #[ORM\Column(name: 'email', type: 'string', length: 180, unique: true)]
     private string $email;
 
@@ -37,6 +40,18 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
     public function setExternalIdentifier(string $externalIdentifier): self
     {
         $this->externalIdentifier = $externalIdentifier;
+
+        return $this;
+    }
+
+    public function getApiToken(): ?string
+    {
+        return $this->apiToken;
+    }
+
+    public function setApiToken(?string $apiToken): self
+    {
+        $this->apiToken = $apiToken;
 
         return $this;
     }

--- a/tests/Command/GenerateApiKeyCommandTest.php
+++ b/tests/Command/GenerateApiKeyCommandTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\net\exelearning\Command\GenerateApiKeyCommand;
+use App\Entity\net\exelearning\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+class GenerateApiKeyCommandTest extends TestCase
+{
+    private $entityManager;
+    private $passwordHasher;
+    private $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $this->userRepository = $this->createMock(EntityRepository::class);
+
+        $this->entityManager->method('getRepository')
+            ->with(User::class)
+            ->willReturn($this->userRepository);
+    }
+
+    private function createUserMock(string $userId, ?string $existingApiToken = null, string $email = 'test@example.com'): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserId')->willReturn($userId);
+        $user->method('getUserIdentifier')->willReturn($email);
+        $user->method('getApiToken')->willReturn($existingApiToken);
+        return $user;
+    }
+
+    public function testExecuteGeneratesTokenForUserWithoutToken()
+    {
+        $userId = 'user123';
+        $user = $this->createUserMock($userId);
+
+        $this->userRepository->method('findOneBy')
+            ->with(['userId' => $userId])
+            ->willReturn($user);
+
+        $this->passwordHasher->expects($this->once())
+            ->method('hashPassword')
+            ->with($user, $this->callback(function ($token) {
+                return Uuid::isValid($token);
+            }))
+            ->willReturn('hashed_api_key');
+
+        $user->expects($this->once())
+            ->method('setApiToken')
+            ->with('hashed_api_key');
+
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $command = new GenerateApiKeyCommand($this->entityManager, $this->passwordHasher);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['user_id' => $userId]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('API key generated for user', $output);
+        $this->assertStringContainsString('Your API Key (raw UUID - store it securely, it will not be shown again):', $output);
+        $this->assertMatchesRegularExpression('/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/', $output);
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testExecuteFailsIfTokenExistsAndNoOverwrite()
+    {
+        $userId = 'userWithToken';
+        $user = $this->createUserMock($userId, 'existing_hashed_token');
+
+        $this->userRepository->method('findOneBy')
+            ->with(['userId' => $userId])
+            ->willReturn($user);
+
+        $command = new GenerateApiKeyCommand($this->entityManager, $this->passwordHasher);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['user_id' => $userId]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('User already has an API token. Use --overwrite to replace it.', $output);
+        $this->assertEquals(1, $commandTester->getStatusCode());
+        $this->passwordHasher->expects($this->never())->method('hashPassword');
+        $user->expects($this->never())->method('setApiToken');
+        $this->entityManager->expects($this->never())->method('flush');
+    }
+
+    public function testExecuteGeneratesTokenIfOverwriteIsTrue()
+    {
+        $userId = 'userToOverwrite';
+        $user = $this->createUserMock($userId, 'old_hashed_token');
+
+        $this->userRepository->method('findOneBy')
+            ->with(['userId' => $userId])
+            ->willReturn($user);
+
+        $this->passwordHasher->expects($this->once())
+            ->method('hashPassword')
+            ->willReturn('new_hashed_api_key');
+
+        $user->expects($this->once())
+            ->method('setApiToken')
+            ->with('new_hashed_api_key');
+
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $command = new GenerateApiKeyCommand($this->entityManager, $this->passwordHasher);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'user_id' => $userId,
+            '--overwrite' => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('API key generated for user', $output);
+        $this->assertMatchesRegularExpression('/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/', $output);
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testExecuteShowsErrorIfUserNotFound()
+    {
+        $userId = 'nonexistentuser';
+        $this->userRepository->method('findOneBy')->willReturn(null);
+        $this->userRepository->method('find')->willReturn(null);
+
+
+        $command = new GenerateApiKeyCommand($this->entityManager, $this->passwordHasher);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['user_id' => $userId]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString(sprintf('User with ID/email "%s" not found.', $userId), $output);
+        $this->assertEquals(1, $commandTester->getStatusCode());
+    }
+
+    public function testStoredTokenIsHashed()
+    {
+        // This is implicitly tested by testExecuteGeneratesTokenForUserWithoutToken and testExecuteGeneratesTokenIfOverwriteIsTrue
+        // as they check that passwordHasher->hashPassword is called and its result is passed to setApiToken.
+        // We also check that the displayed token is a raw UUID, not the hashed one.
+        $this->assertTrue(true); // Placeholder assertion
+    }
+
+    public function testRawTokenIsUuid()
+    {
+        // This is tested by the regex in testExecuteGeneratesTokenForUserWithoutToken and testExecuteGeneratesTokenIfOverwriteIsTrue.
+        $this->assertTrue(true); // Placeholder assertion
+    }
+}


### PR DESCRIPTION
This PR introduces support for generating and managing API tokens for users, intended for authentication via Bearer token in the upcoming **v2 REST API**.

#### 🔧 Changes Summary

* **User Entity**

  * Added a new nullable string field: `apiToken`.
  * The token is stored **hashed**, using Symfony's hasher service (same as user passwords).

* **New Symfony Console Command**

  * `app:generate-api-key [--overwrite] <user_id>`
  * Generates a random UUIDv4 token, hashes it, and saves it to the specified user.
  * The raw token is shown **once** in the terminal (for secure copy), and cannot be recovered later.
  * If the user already has a token, the command will **refuse to overwrite** unless `--overwrite` is passed explicitly.
  * Added PHPUnit tests covering:

#### ✅ How to test it

To generate an API key for a user from the Makefile:

```bash
make generate-api-key USER_ID=1
```

To **force overwrite** an existing token:

```bash
make generate-api-key USER_ID=1 OVERWRITE=1
```

The raw token will be shown once in the terminal. Copy it immediately — it will not be displayed again.


#### 📸 Screenshot

*Included below: example of successful token generation output.*
<img width="1044" height="368" alt="Captura de pantalla 2025-07-11 a las 7 54 02" src="https://github.com/user-attachments/assets/0fa27e73-dc44-45f6-9300-d1bbcc0570d1" />

