### PR TITLE
Allow continue on error sending files to virus total

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: VirusTotal Scan
         uses: crazy-max/ghaction-virustotal@v4
+        continue-on-error: true
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/workflows/app.yml` file by allowing the VirusTotal Scan step to continue even if it encounters an error.

* [`.github/workflows/app.yml`](diffhunk://#diff-d119feda77103cd5ff3e0dc8d14de750a9de942a0eb277e9b967fd6c33f9b402R127): Added the `continue-on-error: true` property to the VirusTotal Scan job to prevent the workflow from failing due to errors in this step.