### PR TITLE
Disable directory listing and enforce not execute uploaded scripts

### DIFF
--- a/idevices.conf
+++ b/idevices.conf
@@ -1,13 +1,66 @@
-# nginx configuration to serve files and idevices
-
+# Nginx configuration to serve static files and idevices securely
 location ^~ /files/ {
     alias /mnt/data/;
-    try_files $uri $uri/ =404;
-    autoindex on;
+    
+    # Disable directory browsing
+    autoindex off;
+    
+    # Only serve existing files, not directories
+    try_files $uri =404;
+    
+    # Prevent PHP and other script execution
+    location ~* \.(php|phtml|php3|php4|php5|php7|php8|phar|phps)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Prevent execution of other script types
+    location ~* \.(pl|py|jsp|asp|sh|cgi)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Block configuration and sensitive files
+    location ~* \.(htaccess|htpasswd|ini|log|sql|conf|config)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Only allow specific file types (optional)
+    location ~* \.(jpg|jpeg|png|gif|ico|svg|webp|css|js|pdf|txt|doc|docx|xls|xlsx|zip|rar)$ {
+        add_header X-Content-Type-Options nosniff;
+    }
 }
 
 location ^~ /files/perm/ {
     alias /app/public/files/perm/;
-    try_files $uri $uri/ =404;
-    autoindex on;
+    
+    # Disable directory browsing
+    autoindex off;
+    
+    # Only serve existing files, not directories
+    try_files $uri =404;
+    
+    # Prevent PHP and other script execution
+    location ~* \.(php|phtml|php3|php4|php5|php7|php8|phar|phps)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Prevent execution of other script types
+    location ~* \.(pl|py|jsp|asp|sh|cgi)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Block configuration and sensitive files
+    location ~* \.(htaccess|htpasswd|ini|log|sql|conf|config)$ {
+        deny all;
+        return 404;
+    }
+    
+    # Only allow specific file types (optional)
+    location ~* \.(jpg|jpeg|png|gif|ico|svg|webp|css|js|pdf|txt|doc|docx|xls|xlsx|zip|rar)$ {
+        add_header X-Content-Type-Options nosniff;
+    }
 }


### PR DESCRIPTION
This pull request improves the security and functionality of the Nginx configuration in the `idevices.conf` file. The changes focus on disabling directory browsing, restricting script execution, blocking access to sensitive files, and enhancing content type handling.

### Security Enhancements:

* Disabled directory browsing by setting `autoindex off` for both `/files/` and `/files/perm/` locations.
* Restricted execution of PHP, Perl, Python, JSP, ASP, shell scripts, and other potentially harmful script types by denying access and returning a 404 error.
* Blocked access to sensitive configuration and log files (e.g., `.htaccess`, `.ini`, `.log`, `.sql`, `.config`) to prevent unauthorized access.

### Functionality Improvements:

* Ensured only existing files are served by using `try_files $uri =404`, preventing directories from being served.
* Added a response header (`X-Content-Type-Options: nosniff`) for specific file types to mitigate MIME type sniffing attacks.