### PR TITLE
Added a make pull-vendor command to Makefile

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -9,7 +9,7 @@ APP_DEBUG=0
 APP_SECRET=CHANGE_THIS_TO_A_SECRET
 APP_PORT=8080
 APP_ONLINE_MODE=1
-XDEBUG_MODE=off  # You can enable it by changing to "debug"
+XDEBUG_MODE=off  # You can enable it by changing to "debug", "off" to leave it disabled
 XDEBUG_CONFIG="client_host=host.docker.internal"
 
 # Configure the BASE_PATH for subdirectory installation.

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,16 @@ endif
 	@echo "Package created successfully with version $(VERSION)"
 	@echo "Installer files available in the dist/ directory"
 
+# Copy the vendor/ directory from the container to the local host
+# Use this when you want to inspect or debug vendor code locally
+pull-vendor: check-docker check-env upd
+	@echo "⚠️  Copying /app/vendor from the container to ./vendor on your machine..."
+	@echo "💡 Use this only when you want to debug vendor libraries locally."
+	@echo "📁 This will overwrite your local ./vendor directory."
+	@docker compose cp exelearning:/app/vendor ./vendor
+	@echo "✅ Done. Local ./vendor directory updated from container."
+
+
 # Display help with available commands
 help:
 	@echo ""
@@ -376,6 +386,7 @@ help:
 	@echo "  up-local              - Run local Symfony server and prepare the environment (unstable)"
 	@echo "  upd                   - Start Docker containers in background mode (daemon)"
 	@echo "  update                - Update Composer dependencies"
+	@echo "  pull-vendor           - Copy vendor/ from container to local ./vendor (for debugging)"
 	@echo ""
 	@echo "Code quality:"
 	@echo ""

--- a/doc/03-development-environment.md
+++ b/doc/03-development-environment.md
@@ -248,6 +248,13 @@ The Docker container includes Xdebug preconfigured for Visual Studio Code:
 5. Start the debugger in VS Code
 6. Access the application from your browser
 
+It is highly recommended to keep a local copy of the vendor directory to improve the debugging experience.
+You can obtain this copy by running:
+
+```
+make pull-vendor
+```
+
 ## Troubleshooting
 
 ### Permission Issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ services:
       - ./composer.lock:/app/composer.lock
       - mnt-data:/mnt/data:rw # Mount the volume for persistent data
       - ./e2e_screenshots:/tmp/e2e_screenshots
-      # - ./vendor:/app/vendor # WARNING: Uncomment only when you need to debug vendor libraries from the host.
-                               # Do NOT leave this enabled during normal development.
     environment:
       MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET_KEY}
       MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET_KEY}


### PR DESCRIPTION
This pull request introduces changes to enhance debugging capabilities and improve clarity in configuration and documentation. The most notable updates include adjustments to the `.env.dist` file, the addition of a new `pull-vendor` Makefile target for debugging vendor libraries, and cleanup in the `docker-compose.yml` file to prevent accidental misconfigurations.

### Debugging Enhancements:
* **Makefile**: Added a new `pull-vendor` target to copy the `vendor/` directory from the container to the local machine for debugging purposes. This includes detailed warnings and instructions to avoid accidental overwrites of the local `vendor/` directory.  
* **Makefile Help Section**: Updated the help section to include a description of the new `pull-vendor` command.

### Configuration Improvements:
* **`.env.dist`**: Clarified the comment for `XDEBUG_MODE` to explicitly describe that setting it to "off" disables it.

### Cleanup:
* **`docker-compose.yml`**: Removed commented-out code that previously suggested mounting the `vendor/` directory from the host, to prevent accidental misuse during development.