### PR TITLE
feature: Add agnostic provider support with configuration validation and JWT handling throug .env

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -133,6 +133,29 @@ OPENEQUELLA_CLIENT_ID=example.com
 OPENEQUELLA_CLIENT_SECRET=example.com
 ###< openEQUELLA ###
 
+###> Multiple Platform Providers Configuration ###
+# Support for multiple educational platform providers (e.g., Moodle, Moodle Workplace, Others etc.)
+# Each provider needs a URL, token, and unique identifier
+# Use comma-separated values with positional mapping (same order for all three variables)
+
+# Provider URLs - base URLs for each platform
+# Example: PROVIDER_URLS=https://moodle_lms.com,https://moodle_workplace.example.com,https://custom_lms.example.com
+PROVIDER_URLS=
+
+# Provider tokens - authentication tokens/secrets for each platform
+# Example: PROVIDER_TOKENS=moodle_lms_token,workplace_token,custom_lms_token
+PROVIDER_TOKENS=
+
+# Provider IDs - unique identifiers for each platform
+# Example: PROVIDER_IDS=moodlelms,workplace,custommoodle
+PROVIDER_IDS=
+
+# Default provider fallback settings
+DEFAULT_PROVIDER_URL=
+DEFAULT_PROVIDER_TOKEN=
+DEFAULT_PROVIDER_ID=
+###< Multiple Platform Providers Configuration ###
+
 ###> symfony/mercure-bundle ###
 # See https://symfony.com/doc/current/mercure.html#configuration
 #

--- a/config/providers.example.env
+++ b/config/providers.example.env
@@ -1,0 +1,30 @@
+# Example configuration for multiple platform providers
+# This file shows how to configure eXeLearning for multiple educational platforms
+
+# Multiple Platform Providers Configuration
+# Each provider needs a URL, token, and unique identifier in the same positional order
+
+# Example 1: Moodle + Workplace
+PROVIDER_URLS=https://moodle_lms.com,https://moodle_workplace.example.com,https://custom_lms.example.com
+PROVIDER_TOKENS=moodle_lms_token,workplace_token,custom_lms_token
+PROVIDER_IDS=moodlelms,workplace,custommoodle
+
+# Example 2: Single Moodle instance
+# PROVIDER_URLS=https://moodle.example.com
+# PROVIDER_TOKENS=your_moodle_secret_token
+# PROVIDER_IDS=moodle_main
+
+# Default provider fallback (optional)
+# These values will be used if no specific provider is found
+DEFAULT_PROVIDER_URL=https://default.lms.com
+DEFAULT_PROVIDER_TOKEN=default_secret_token
+DEFAULT_PROVIDER_ID=default_lms
+
+# JWT Configuration
+# The main application secret
+APP_SECRET=CHANGE_THIS_TO_A_SECRET
+
+# Important Notes:
+# 1. All three arrays (URLs, TOKENS, IDS) must have the same number of elements
+# 2. The order must match: first URL goes with first TOKEN and first ID
+# 3. Provider IDs must be unique

--- a/src/Command/ValidateProvidersCommand.php
+++ b/src/Command/ValidateProvidersCommand.php
@@ -60,7 +60,7 @@ class ValidateProvidersCommand extends Command
                 $rows[] = [
                     $provider['id'],
                     $provider['url'] ?: 'Not configured',
-                    $provider['url_reachable'] ? '✓' : '✗'
+                    $provider['url_reachable'] ? '✓' : '✗',
                 ];
             }
 
@@ -73,7 +73,7 @@ class ValidateProvidersCommand extends Command
         } else {
             $io->error('Provider configuration has issues:');
             foreach ($validation['errors'] as $error) {
-                $io->writeln('  • ' . $error);
+                $io->writeln('  • '.$error);
             }
         }
 
@@ -85,7 +85,7 @@ class ValidateProvidersCommand extends Command
                     'warning' => 'yellow',
                     'security' => 'red',
                     'info' => 'blue',
-                    default => 'white'
+                    default => 'white',
                 };
 
                 $io->writeln(sprintf(

--- a/src/Command/ValidateProvidersCommand.php
+++ b/src/Command/ValidateProvidersCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\ProviderConfigurationService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Console command to validate provider configuration.
+ *
+ * This command allows administrators to validate their multi-provider
+ * configuration from the command line.
+ *
+ * @author eXeLearning
+ */
+#[AsCommand(
+    name: 'app:validate-providers',
+    description: 'Validate the configuration of platform providers'
+)]
+class ValidateProvidersCommand extends Command
+{
+    private ProviderConfigurationService $providerConfigService;
+
+    public function __construct(ProviderConfigurationService $providerConfigService)
+    {
+        parent::__construct();
+        $this->providerConfigService = $providerConfigService;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('eXeLearning Provider Configuration Validation');
+
+        // Get validation results
+        $validation = $this->providerConfigService->validateConfiguration();
+        $statistics = $this->providerConfigService->getProviderStatistics();
+        $recommendations = $this->providerConfigService->getConfigurationRecommendations();
+
+        // Display statistics
+        $io->section('Configuration Overview');
+        $io->definitionList(
+            ['Total Providers' => $statistics['total_providers']],
+            ['Configuration Valid' => $statistics['configuration_valid'] ? 'Yes' : 'No'],
+            ['Provider IDs' => implode(', ', $statistics['provider_ids']) ?: 'None']
+        );
+
+        // Display provider details
+        if (!empty($validation['providers'])) {
+            $io->section('Provider Details');
+            $headers = ['Provider ID', 'URL', 'Reachable'];
+            $rows = [];
+
+            foreach ($validation['providers'] as $provider) {
+                $rows[] = [
+                    $provider['id'],
+                    $provider['url'] ?: 'Not configured',
+                    $provider['url_reachable'] ? '✓' : '✗'
+                ];
+            }
+
+            $io->table($headers, $rows);
+        }
+
+        // Display validation results
+        if ($validation['valid']) {
+            $io->success('Provider configuration is valid!');
+        } else {
+            $io->error('Provider configuration has issues:');
+            foreach ($validation['errors'] as $error) {
+                $io->writeln('  • ' . $error);
+            }
+        }
+
+        // Display recommendations
+        if (!empty($recommendations)) {
+            $io->section('Recommendations');
+            foreach ($recommendations as $recommendation) {
+                $style = match ($recommendation['type']) {
+                    'warning' => 'yellow',
+                    'security' => 'red',
+                    'info' => 'blue',
+                    default => 'white'
+                };
+
+                $io->writeln(sprintf(
+                    '<fg=%s>[%s]</> %s',
+                    $style,
+                    strtoupper($recommendation['type']),
+                    $recommendation['message']
+                ));
+            }
+        }
+
+        // Return appropriate exit code
+        return $validation['valid'] ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/src/Controller/Api/ProviderController.php
+++ b/src/Controller/Api/ProviderController.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Service\ProviderConfigurationService;
+use App\Util\net\exelearning\Util\IntegrationUtil;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * API controller for provider management and validation.
+ *
+ * Provides endpoints for validating and managing platform provider configurations.
+ *
+ * @author eXeLearning
+ */
+#[Route('/api/providers', name: 'api_providers_')]
+class ProviderController extends AbstractController
+{
+    private ProviderConfigurationService $providerConfigService;
+    private IntegrationUtil $integrationUtil;
+
+    public function __construct(
+        ProviderConfigurationService $providerConfigService,
+        IntegrationUtil $integrationUtil
+    ) {
+        $this->providerConfigService = $providerConfigService;
+        $this->integrationUtil = $integrationUtil;
+    }
+
+    /**
+     * Validate provider configuration.
+     */
+    #[Route('/validate', name: 'validate', methods: ['GET'])]
+    public function validateConfiguration(): JsonResponse
+    {
+        $validation = $this->providerConfigService->validateConfiguration();
+        $statistics = $this->providerConfigService->getProviderStatistics();
+        $recommendations = $this->providerConfigService->getConfigurationRecommendations();
+
+        return $this->json([
+            'validation' => $validation,
+            'statistics' => $statistics,
+            'recommendations' => $recommendations
+        ]);
+    }
+
+    /**
+     * Get provider statistics.
+     */
+    #[Route('/statistics', name: 'statistics', methods: ['GET'])]
+    public function getStatistics(): JsonResponse
+    {
+        $statistics = $this->providerConfigService->getProviderStatistics();
+
+        return $this->json($statistics);
+    }
+
+    /**
+     * Generate JWT for a specific provider.
+     */
+    #[Route('/jwt/generate', name: 'generate_jwt', methods: ['POST'])]
+    public function generateJWT(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data['provider_id']) || !isset($data['payload'])) {
+            return $this->json([
+                'error' => 'Missing required fields: provider_id and payload'
+            ], 400);
+        }
+
+        $providerId = $data['provider_id'];
+        $payload = $data['payload'];
+
+        // Validate provider exists
+        if (!$this->providerConfigService->isProviderConfigured($providerId)) {
+            return $this->json([
+                'error' => "Provider not configured: {$providerId}"
+            ], 404);
+        }
+
+        $jwt = $this->integrationUtil->generateProviderJWT($payload, $providerId);
+
+        if (!$jwt) {
+            return $this->json([
+                'error' => 'Failed to generate JWT token'
+            ], 500);
+        }
+
+        return $this->json([
+            'jwt' => $jwt,
+            'provider_id' => $providerId,
+            'expires_in' => 3600 // 1 hour
+        ]);
+    }
+
+    /**
+     * Decode JWT and validate provider.
+     */
+    #[Route('/jwt/decode', name: 'decode_jwt', methods: ['POST'])]
+    public function decodeJWT(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data['jwt'])) {
+            return $this->json([
+                'error' => 'Missing required field: jwt'
+            ], 400);
+        }
+
+        $jwt = $data['jwt'];
+        $providerId = $data['provider_id'] ?? null;
+
+        $decoded = $this->integrationUtil->decodeJWT($jwt, $providerId);
+
+        if (!$decoded) {
+            return $this->json([
+                'error' => 'Invalid or expired JWT token'
+            ], 400);
+        }
+
+        return $this->json([
+            'payload' => $decoded,
+            'valid' => true
+        ]);
+    }
+
+    /**
+     * Process platform integration parameters.
+     */
+    #[Route('/integration/params', name: 'integration_params', methods: ['POST'])]
+    public function getIntegrationParams(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data['jwt']) || !isset($data['operation'])) {
+            return $this->json([
+                'error' => 'Missing required fields: jwt and operation'
+            ], 400);
+        }
+
+        $jwt = $data['jwt'];
+        $operation = $data['operation'];
+
+        $params = $this->integrationUtil->getPlatformIntegrationParams($jwt, $operation);
+
+        if (!$params) {
+            return $this->json([
+                'error' => 'Failed to process integration parameters'
+            ], 400);
+        }
+
+        return $this->json([
+            'params' => $params,
+            'operation' => $operation
+        ]);
+    }
+
+    /**
+     * List all configured providers.
+     */
+    #[Route('/list', name: 'list', methods: ['GET'])]
+    public function listProviders(): JsonResponse
+    {
+        $providerIds = $this->integrationUtil->getProviderIds();
+        $providers = [];
+
+        foreach ($providerIds as $providerId) {
+            $providers[] = [
+                'id' => $providerId,
+                'url' => $this->integrationUtil->getProviderUrl($providerId),
+                'configured' => $this->providerConfigService->isProviderConfigured($providerId)
+            ];
+        }
+
+        return $this->json([
+            'providers' => $providers,
+            'count' => count($providers)
+        ]);
+    }
+}

--- a/src/Controller/Api/ProviderController.php
+++ b/src/Controller/Api/ProviderController.php
@@ -24,7 +24,7 @@ class ProviderController extends AbstractController
 
     public function __construct(
         ProviderConfigurationService $providerConfigService,
-        IntegrationUtil $integrationUtil
+        IntegrationUtil $integrationUtil,
     ) {
         $this->providerConfigService = $providerConfigService;
         $this->integrationUtil = $integrationUtil;
@@ -43,7 +43,7 @@ class ProviderController extends AbstractController
         return $this->json([
             'validation' => $validation,
             'statistics' => $statistics,
-            'recommendations' => $recommendations
+            'recommendations' => $recommendations,
         ]);
     }
 
@@ -68,7 +68,7 @@ class ProviderController extends AbstractController
 
         if (!isset($data['provider_id']) || !isset($data['payload'])) {
             return $this->json([
-                'error' => 'Missing required fields: provider_id and payload'
+                'error' => 'Missing required fields: provider_id and payload',
             ], 400);
         }
 
@@ -78,7 +78,7 @@ class ProviderController extends AbstractController
         // Validate provider exists
         if (!$this->providerConfigService->isProviderConfigured($providerId)) {
             return $this->json([
-                'error' => "Provider not configured: {$providerId}"
+                'error' => "Provider not configured: {$providerId}",
             ], 404);
         }
 
@@ -86,14 +86,14 @@ class ProviderController extends AbstractController
 
         if (!$jwt) {
             return $this->json([
-                'error' => 'Failed to generate JWT token'
+                'error' => 'Failed to generate JWT token',
             ], 500);
         }
 
         return $this->json([
             'jwt' => $jwt,
             'provider_id' => $providerId,
-            'expires_in' => 3600 // 1 hour
+            'expires_in' => 3600, // 1 hour
         ]);
     }
 
@@ -107,7 +107,7 @@ class ProviderController extends AbstractController
 
         if (!isset($data['jwt'])) {
             return $this->json([
-                'error' => 'Missing required field: jwt'
+                'error' => 'Missing required field: jwt',
             ], 400);
         }
 
@@ -118,13 +118,13 @@ class ProviderController extends AbstractController
 
         if (!$decoded) {
             return $this->json([
-                'error' => 'Invalid or expired JWT token'
+                'error' => 'Invalid or expired JWT token',
             ], 400);
         }
 
         return $this->json([
             'payload' => $decoded,
-            'valid' => true
+            'valid' => true,
         ]);
     }
 
@@ -138,7 +138,7 @@ class ProviderController extends AbstractController
 
         if (!isset($data['jwt']) || !isset($data['operation'])) {
             return $this->json([
-                'error' => 'Missing required fields: jwt and operation'
+                'error' => 'Missing required fields: jwt and operation',
             ], 400);
         }
 
@@ -149,13 +149,13 @@ class ProviderController extends AbstractController
 
         if (!$params) {
             return $this->json([
-                'error' => 'Failed to process integration parameters'
+                'error' => 'Failed to process integration parameters',
             ], 400);
         }
 
         return $this->json([
             'params' => $params,
-            'operation' => $operation
+            'operation' => $operation,
         ]);
     }
 
@@ -172,13 +172,13 @@ class ProviderController extends AbstractController
             $providers[] = [
                 'id' => $providerId,
                 'url' => $this->integrationUtil->getProviderUrl($providerId),
-                'configured' => $this->providerConfigService->isProviderConfigured($providerId)
+                'configured' => $this->providerConfigService->isProviderConfigured($providerId),
             ];
         }
 
         return $this->json([
             'providers' => $providers,
-            'count' => count($providers)
+            'count' => count($providers),
         ]);
     }
 }

--- a/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
@@ -88,7 +88,7 @@ class PlatformIntegrationApiController extends DefaultApiController
         // collect parameters
         $odeSessionId = $request->get('odeSessionId');
         $jwtToken = $request->get('jwt_token');
-        $integrationParams = $this->integrationUtil->getParamsMoodleIntegration($jwtToken, 'set');
+        $integrationParams = $this->integrationUtil->getPlatformIntegrationParams($jwtToken, 'set');
 
         // if $odeSessionId is set load data from database
         if (!empty($odeSessionId)) {

--- a/src/Service/ProviderConfigurationService.php
+++ b/src/Service/ProviderConfigurationService.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Service;
+
+use App\Util\net\exelearning\Util\IntegrationUtil;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for managing and validating platform provider configurations.
+ *
+ * This service provides an interface for validating provider configurations
+ * and ensuring that the multi-provider setup is correctly configured.
+ *
+ * @author eXeLearning
+ */
+class ProviderConfigurationService
+{
+    private IntegrationUtil $integrationUtil;
+    private LoggerInterface $logger;
+
+    public function __construct(IntegrationUtil $integrationUtil, LoggerInterface $logger)
+    {
+        $this->integrationUtil = $integrationUtil;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Validate the current provider configuration.
+     *
+     * @return array Array of validation results with 'valid' boolean and 'errors' array
+     */
+    public function validateConfiguration(): array
+    {
+        $errors = $this->integrationUtil->validateProviderConfiguration();
+        $providerIds = $this->integrationUtil->getProviderIds();
+
+        $result = [
+            'valid' => empty($errors),
+            'errors' => $errors,
+            'provider_count' => count($providerIds),
+            'providers' => []
+        ];
+
+        // Check each provider individually
+        foreach ($providerIds as $providerId) {
+            $providerUrl = $this->integrationUtil->getProviderUrl($providerId);
+            $providerCheck = [
+                'id' => $providerId,
+                'url' => $providerUrl,
+                'url_reachable' => $this->checkUrlReachability($providerUrl)
+            ];
+
+            $result['providers'][] = $providerCheck;
+
+            if (!$providerCheck['url_reachable']) {
+                $result['errors'][] = "Provider URL not reachable: {$providerUrl}";
+                $result['valid'] = false;
+            }
+        }
+
+        // Log validation results
+        if ($result['valid']) {
+            $this->logger->info('Provider configuration validation passed', [
+                'provider_count' => $result['provider_count']
+            ]);
+        } else {
+            $this->logger->warning('Provider configuration validation failed', [
+                'errors' => $result['errors']
+            ]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get provider statistics.
+     *
+     * @return array Provider statistics
+     */
+    public function getProviderStatistics(): array
+    {
+        $providerIds = $this->integrationUtil->getProviderIds();
+
+        return [
+            'total_providers' => count($providerIds),
+            'provider_ids' => $providerIds,
+            'configuration_valid' => empty($this->integrationUtil->validateProviderConfiguration())
+        ];
+    }
+
+    /**
+     * Check if a provider exists and is configured.
+     *
+     * @param string $providerId Provider ID to check
+     *
+     * @return bool True if provider exists and is configured
+     */
+    public function isProviderConfigured(string $providerId): bool
+    {
+        $providerIds = $this->integrationUtil->getProviderIds();
+        return in_array($providerId, $providerIds, true);
+    }
+
+    /**
+     * Get configuration recommendations.
+     *
+     * @return array Array of recommendations for improving configuration
+     */
+    public function getConfigurationRecommendations(): array
+    {
+        $recommendations = [];
+        $providerIds = $this->integrationUtil->getProviderIds();
+
+        if (empty($providerIds)) {
+            $recommendations[] = [
+                'type' => 'warning',
+                'message' => 'No providers configured. Add PROVIDER_URLS, PROVIDER_TOKENS, ' .
+                            'and PROVIDER_IDS to environment.'
+            ];
+        } elseif (count($providerIds) === 1) {
+            $recommendations[] = [
+                'type' => 'info',
+                'message' => 'Single provider configured. Consider adding backup providers for redundancy.'
+            ];
+        }
+
+        // Check for HTTPS usage
+        foreach ($providerIds as $providerId) {
+            $url = $this->integrationUtil->getProviderUrl($providerId);
+            if ($url && !str_starts_with($url, 'https://')) {
+                $recommendations[] = [
+                    'type' => 'security',
+                    'message' => "Provider {$providerId} uses HTTP instead of HTTPS. Consider upgrading for security."
+                ];
+            }
+        }
+
+        return $recommendations;
+    }
+
+    /**
+     * Basic URL reachability check.
+     *
+     * @param string|null $url URL to check
+     *
+     * @return bool True if URL appears to be reachable
+     */
+    private function checkUrlReachability(?string $url): bool
+    {
+        if (!$url) {
+            return false;
+        }
+
+        // Basic URL format validation
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        // In a production environment, you might want to do actual HTTP checks
+        // For now, we just validate the URL format
+        return true;
+    }
+}

--- a/src/Service/ProviderConfigurationService.php
+++ b/src/Service/ProviderConfigurationService.php
@@ -38,7 +38,7 @@ class ProviderConfigurationService
             'valid' => empty($errors),
             'errors' => $errors,
             'provider_count' => count($providerIds),
-            'providers' => []
+            'providers' => [],
         ];
 
         // Check each provider individually
@@ -47,7 +47,7 @@ class ProviderConfigurationService
             $providerCheck = [
                 'id' => $providerId,
                 'url' => $providerUrl,
-                'url_reachable' => $this->checkUrlReachability($providerUrl)
+                'url_reachable' => $this->checkUrlReachability($providerUrl),
             ];
 
             $result['providers'][] = $providerCheck;
@@ -61,11 +61,11 @@ class ProviderConfigurationService
         // Log validation results
         if ($result['valid']) {
             $this->logger->info('Provider configuration validation passed', [
-                'provider_count' => $result['provider_count']
+                'provider_count' => $result['provider_count'],
             ]);
         } else {
             $this->logger->warning('Provider configuration validation failed', [
-                'errors' => $result['errors']
+                'errors' => $result['errors'],
             ]);
         }
 
@@ -84,7 +84,7 @@ class ProviderConfigurationService
         return [
             'total_providers' => count($providerIds),
             'provider_ids' => $providerIds,
-            'configuration_valid' => empty($this->integrationUtil->validateProviderConfiguration())
+            'configuration_valid' => empty($this->integrationUtil->validateProviderConfiguration()),
         ];
     }
 
@@ -98,6 +98,7 @@ class ProviderConfigurationService
     public function isProviderConfigured(string $providerId): bool
     {
         $providerIds = $this->integrationUtil->getProviderIds();
+
         return in_array($providerId, $providerIds, true);
     }
 
@@ -114,13 +115,13 @@ class ProviderConfigurationService
         if (empty($providerIds)) {
             $recommendations[] = [
                 'type' => 'warning',
-                'message' => 'No providers configured. Add PROVIDER_URLS, PROVIDER_TOKENS, ' .
-                            'and PROVIDER_IDS to environment.'
+                'message' => 'No providers configured. Add PROVIDER_URLS, PROVIDER_TOKENS, '.
+                            'and PROVIDER_IDS to environment.',
             ];
-        } elseif (count($providerIds) === 1) {
+        } elseif (1 === count($providerIds)) {
             $recommendations[] = [
                 'type' => 'info',
-                'message' => 'Single provider configured. Consider adding backup providers for redundancy.'
+                'message' => 'Single provider configured. Consider adding backup providers for redundancy.',
             ];
         }
 
@@ -130,7 +131,7 @@ class ProviderConfigurationService
             if ($url && !str_starts_with($url, 'https://')) {
                 $recommendations[] = [
                     'type' => 'security',
-                    'message' => "Provider {$providerId} uses HTTP instead of HTTPS. Consider upgrading for security."
+                    'message' => "Provider {$providerId} uses HTTP instead of HTTPS. Consider upgrading for security.",
                 ];
             }
         }

--- a/src/Util/net/exelearning/Util/IntegrationUtil.php
+++ b/src/Util/net/exelearning/Util/IntegrationUtil.php
@@ -8,86 +8,328 @@ use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Generic platform integration utility for eXeLearning.
+ *
+ * This utility handles integration with multiple educational platforms (LMS)
+ * in a platform-agnostic way, supporting multiple providers through environment configuration.
+ *
+ * @author eXeLearning
+ */
 class IntegrationUtil
 {
-    private $logger;
+    private LoggerInterface $logger;
+    private array $providerUrls;
+    private array $providerTokens;
+    private array $providerIds;
 
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
+        $this->initializeProviders();
     }
 
     /**
-     * Decode a JSON Web Token.
-     *
-     * @param string $jwtToken
-     *
-     * @return array|null decoded
+     * Initialize provider configurations from environment variables.
      */
-    public function decodeJWT($jwtToken)
+    private function initializeProviders(): void
+    {
+        $this->providerUrls = $this->parseEnvArray($_ENV['PROVIDER_URLS'] ?? '');
+        $this->providerTokens = $this->parseEnvArray($_ENV['PROVIDER_TOKENS'] ?? '');
+        $this->providerIds = $this->parseEnvArray($_ENV['PROVIDER_IDS'] ?? '');
+
+        // Log configuration status
+        $providerCount = count($this->providerIds);
+        $this->logger->info("Initialized {$providerCount} platform providers");
+    }
+
+    /**
+     * Parse comma-separated environment variable values.
+     */
+    private function parseEnvArray(string $envValue): array
+    {
+        if (empty($envValue)) {
+            return [];
+        }
+
+        return array_map('trim', explode(',', $envValue));
+    }
+
+    /**
+     * Decode a JSON Web Token using the appropriate provider token.
+     *
+     * @param string $jwtToken The JWT token to decode
+     * @param string|null $providerId Optional provider ID for token validation
+     *
+     * @return array|null Decoded payload or null on failure
+     */
+    public function decodeJWT(string $jwtToken, ?string $providerId = null): ?array
     {
         try {
-            $decoded = (array) JWT::decode($jwtToken, new Key($_ENV['APP_SECRET'], Settings::JWT_SECRET_HASH));
+            // If provider ID is specified, use its token; otherwise use default APP_SECRET
+            $secret = $this->getProviderToken($providerId) ?? $_ENV['APP_SECRET'];
+
+            $decoded = (array) JWT::decode($jwtToken, new Key($secret, Settings::JWT_SECRET_HASH));
 
             return $decoded;
         } catch (\Throwable $e) {
-            $this->logger->error('Exception: '.$e->getMessage());
-
-            // Opcional: lanzar una excepción personalizada
-            // throw new \RuntimeException('Error decoding JWT', 0, $e);
+            $this->logger->error('JWT decode error: ' . $e->getMessage(), [
+                'provider_id' => $providerId,
+                'error' => $e->getMessage()
+            ]);
 
             return null;
         }
     }
 
     /**
-     * Decode JSON Web Token and export parameters for Moodle.
+     * Generate a JWT token for a specific provider.
      *
-     * @param string $jwtToken
+     * @param array $payload The payload to encode
+     * @param string $providerId The provider ID to use for token generation
      *
-     * @return array|null decoded
+     * @return string|null The generated JWT token or null on failure
      */
-    public function getParamsMoodleIntegration($jwtToken, $setOp)
+    public function generateProviderJWT(array $payload, string $providerId): ?string
     {
-        if ('set' === $setOp) {
-            $op = 's';
-        } else {
-            $op = 'g';
-        }
+        try {
+            $token = $this->getProviderToken($providerId);
+            if (!$token) {
+                $this->logger->error("Provider token not found for ID: {$providerId}");
+                return null;
+            }
 
+            // Add standard JWT claims
+            $payload = array_merge($payload, [
+                'iat' => time(),
+                'exp' => time() + 3600, // 1 hour expiration
+                'provider_id' => $providerId
+            ]);
+
+            return JWT::encode($payload, $token, Settings::JWT_SECRET_HASH);
+        } catch (\Throwable $e) {
+            $this->logger->error('JWT generation error: ' . $e->getMessage(), [
+                'provider_id' => $providerId,
+                'error' => $e->getMessage()
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Process platform integration parameters in a generic way.
+     *
+     * @param string $jwtToken The JWT token containing integration parameters
+     * @param string $operation The operation type ('set' or 'get')
+     *
+     * @return array|null Integration parameters or null on failure
+     */
+    public function getPlatformIntegrationParams(string $jwtToken, string $operation): ?array
+    {
         $exportParams = $this->decodeJWT($jwtToken);
-        if (null != $exportParams) {
-            // Check if 'localhost' is in the return URL and replace it if necessary
-            $returnUrl = $exportParams['returnurl'] ?? '';
-            if ('' !== $returnUrl && str_contains($returnUrl, 'localhost')) {
-                $clientIP = $this->getClientIP();
-                $returnUrl = str_replace('localhost', $clientIP, $returnUrl);
-            }
-
-            // Generate platformIntegrationUrl based on package type
-            switch ($exportParams['pkgtype']) {
-                case 'scorm':
-                    if (str_contains($returnUrl, '/mod/exescorm')) {
-                        $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/mod/exescorm', true).'/mod/exescorm/'.$op.'et_ode.php';
-                    } elseif (str_contains($returnUrl, '/course/section')) {
-                        $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/course/section', true).'/mod/exescorm/'.$op.'et_ode.php';
-                    }
-                    // $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/mod/exescorm', true).'/mod/exescorm/'.$op.'et_ode.php';
-                    $exportParams['exportType'] = Constants::EXPORT_TYPE_SCORM12;
-                    break;
-                case 'webzip':
-                    if (str_contains($returnUrl, '/mod/exeweb')) {
-                        $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/mod/exeweb', true).'/mod/exeweb/'.$op.'et_ode.php';
-                    } elseif (str_contains($returnUrl, '/course/section')) {
-                        $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/course/section', true).'/mod/exeweb/'.$op.'et_ode.php';
-                    }
-                    // $exportParams['platformIntegrationUrl'] = strstr($returnUrl, '/mod/exeweb', true).'/mod/exeweb/'.$op.'et_ode.php';
-                    $exportParams['exportType'] = Constants::EXPORT_TYPE_HTML5;
-                    break;
-            }
+        if (!$exportParams) {
+            return null;
         }
+
+        // Extract provider information from payload (support both new and legacy formats)
+        $providerId = $this->extractProviderId($exportParams);
+
+        // Validate provider if specified (only for new format with provider_id)
+        if ($providerId && !empty($this->providerIds) && !$this->isValidProvider($providerId)) {
+            $this->logger->warning("Invalid provider ID in JWT: {$providerId}");
+            return null;
+        }
+
+        // Replace localhost with actual client IP if needed
+        $returnUrl = $exportParams['returnurl'] ?? '';
+        if (!empty($returnUrl) && str_contains($returnUrl, 'localhost')) {
+            $clientIP = $this->getClientIP();
+            $returnUrl = str_replace('localhost', $clientIP, $returnUrl);
+            $exportParams['returnurl'] = $returnUrl;
+        }
+
+        // Validate return URL against allowed providers (only if providers are configured)
+        if (!empty($this->providerUrls) && !$this->isAllowedUrl($returnUrl)) {
+            $this->logger->warning("Return URL not in allowed providers: {$returnUrl}");
+            return null;
+        }
+
+        // Generate platform integration URL and export type based on package type
+        $this->enrichWithPlatformData($exportParams, $operation, $returnUrl);
 
         return $exportParams;
+    }
+
+    /**
+     * Legacy method name for backwards compatibility.
+     *
+     * @deprecated Use getPlatformIntegrationParams() instead
+     */
+    public function getParamsMoodleIntegration(string $jwtToken, string $setOp): ?array
+    {
+        return $this->getPlatformIntegrationParams($jwtToken, $setOp);
+    }
+
+    /**
+     * Enrich export parameters with platform-specific integration data.
+     */
+    private function enrichWithPlatformData(array &$exportParams, string $operation, string $returnUrl): void
+    {
+        $op = ('set' === $operation) ? 's' : 'g';
+        $pkgType = $exportParams['pkgtype'] ?? '';
+
+        switch ($pkgType) {
+            case 'scorm':
+                $exportParams['platformIntegrationUrl'] = $this->buildIntegrationUrl(
+                    $returnUrl,
+                    ['/mod/exescorm', '/course/section'],
+                    '/mod/exescorm/' . $op . 'et_ode.php'
+                );
+                $exportParams['exportType'] = Constants::EXPORT_TYPE_SCORM12;
+                break;
+
+            case 'webzip':
+                $exportParams['platformIntegrationUrl'] = $this->buildIntegrationUrl(
+                    $returnUrl,
+                    ['/mod/exeweb', '/course/section'],
+                    '/mod/exeweb/' . $op . 'et_ode.php'
+                );
+                $exportParams['exportType'] = Constants::EXPORT_TYPE_HTML5;
+                break;
+
+            default:
+                // For unknown package types, don't add platform-specific URLs
+                $this->logger->info("Unknown package type: {$pkgType}");
+                break;
+        }
+    }
+
+    /**
+     * Build integration URL based on return URL patterns.
+     */
+    private function buildIntegrationUrl(string $returnUrl, array $patterns, string $endpoint): ?string
+    {
+        foreach ($patterns as $pattern) {
+            if (str_contains($returnUrl, $pattern)) {
+                $baseUrl = strstr($returnUrl, $pattern, true);
+                return $baseUrl . $endpoint;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if a provider ID is valid.
+     */
+    private function isValidProvider(string $providerId): bool
+    {
+        return in_array($providerId, $this->providerIds, true);
+    }
+
+    /**
+     * Check if a URL is allowed by any configured provider.
+     */
+    private function isAllowedUrl(string $url): bool
+    {
+        if (empty($url) || empty($this->providerUrls)) {
+            return true; // Allow if no restrictions configured
+        }
+
+        foreach ($this->providerUrls as $allowedUrl) {
+            if (str_starts_with($url, $allowedUrl)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get provider token by ID.
+     */
+    private function getProviderToken(?string $providerId): ?string
+    {
+        if (!$providerId) {
+            return null;
+        }
+
+        $index = array_search($providerId, $this->providerIds, true);
+        if ($index === false) {
+            return null;
+        }
+
+        return $this->providerTokens[$index] ?? null;
+    }
+
+    /**
+     * Get provider URL by ID.
+     */
+    public function getProviderUrl(string $providerId): ?string
+    {
+        $index = array_search($providerId, $this->providerIds, true);
+        if ($index === false) {
+            return null;
+        }
+
+        return $this->providerUrls[$index] ?? null;
+    }
+
+    /**
+     * Get all configured provider IDs.
+     */
+    public function getProviderIds(): array
+    {
+        return $this->providerIds;
+    }
+
+    /**
+     * Validate provider configuration consistency.
+     */
+    public function validateProviderConfiguration(): array
+    {
+        $errors = [];
+
+        $urlCount = count($this->providerUrls);
+        $tokenCount = count($this->providerTokens);
+        $idCount = count($this->providerIds);
+
+        if ($urlCount !== $tokenCount || $urlCount !== $idCount) {
+            $errors[] = "Provider configuration mismatch: URLs({$urlCount}), Tokens({$tokenCount}), IDs({$idCount})";
+        }
+
+        // Check for duplicate IDs
+        if (count($this->providerIds) !== count(array_unique($this->providerIds))) {
+            $errors[] = "Duplicate provider IDs found";
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Extract provider ID from JWT payload, supporting both legacy and new formats.
+     *
+     * @param array $payload JWT payload
+     *
+     * @return string|null Provider ID or null if not found
+     */
+    private function extractProviderId(array $payload): ?string
+    {
+        // New format: direct provider_id field
+        if (isset($payload['provider_id'])) {
+            return $payload['provider_id'];
+        }
+
+        // Legacy format: provider object with name
+        if (isset($payload['provider']['name'])) {
+            // Convert provider name to a normalized ID
+            $providerName = strtolower($payload['provider']['name']);
+            return $providerName . '_legacy';
+        }
+
+        // No provider information found
+        return null;
     }
 
     /**
@@ -95,7 +337,7 @@ class IntegrationUtil
      *
      * @return string IP address of the client
      */
-    private function getClientIP()
+    private function getClientIP(): string
     {
         if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
             // Use X-Forwarded-For if available (for proxy setups)

--- a/src/Util/net/exelearning/Util/IntegrationUtil.php
+++ b/src/Util/net/exelearning/Util/IntegrationUtil.php
@@ -58,7 +58,7 @@ class IntegrationUtil
     /**
      * Decode a JSON Web Token using the appropriate provider token.
      *
-     * @param string $jwtToken The JWT token to decode
+     * @param string      $jwtToken   The JWT token to decode
      * @param string|null $providerId Optional provider ID for token validation
      *
      * @return array|null Decoded payload or null on failure
@@ -73,9 +73,9 @@ class IntegrationUtil
 
             return $decoded;
         } catch (\Throwable $e) {
-            $this->logger->error('JWT decode error: ' . $e->getMessage(), [
+            $this->logger->error('JWT decode error: '.$e->getMessage(), [
                 'provider_id' => $providerId,
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ]);
 
             return null;
@@ -85,7 +85,7 @@ class IntegrationUtil
     /**
      * Generate a JWT token for a specific provider.
      *
-     * @param array $payload The payload to encode
+     * @param array  $payload    The payload to encode
      * @param string $providerId The provider ID to use for token generation
      *
      * @return string|null The generated JWT token or null on failure
@@ -96,6 +96,7 @@ class IntegrationUtil
             $token = $this->getProviderToken($providerId);
             if (!$token) {
                 $this->logger->error("Provider token not found for ID: {$providerId}");
+
                 return null;
             }
 
@@ -103,14 +104,14 @@ class IntegrationUtil
             $payload = array_merge($payload, [
                 'iat' => time(),
                 'exp' => time() + 3600, // 1 hour expiration
-                'provider_id' => $providerId
+                'provider_id' => $providerId,
             ]);
 
             return JWT::encode($payload, $token, Settings::JWT_SECRET_HASH);
         } catch (\Throwable $e) {
-            $this->logger->error('JWT generation error: ' . $e->getMessage(), [
+            $this->logger->error('JWT generation error: '.$e->getMessage(), [
                 'provider_id' => $providerId,
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ]);
 
             return null;
@@ -120,7 +121,7 @@ class IntegrationUtil
     /**
      * Process platform integration parameters in a generic way.
      *
-     * @param string $jwtToken The JWT token containing integration parameters
+     * @param string $jwtToken  The JWT token containing integration parameters
      * @param string $operation The operation type ('set' or 'get')
      *
      * @return array|null Integration parameters or null on failure
@@ -138,6 +139,7 @@ class IntegrationUtil
         // Validate provider if specified (only for new format with provider_id)
         if ($providerId && !empty($this->providerIds) && !$this->isValidProvider($providerId)) {
             $this->logger->warning("Invalid provider ID in JWT: {$providerId}");
+
             return null;
         }
 
@@ -152,6 +154,7 @@ class IntegrationUtil
         // Validate return URL against allowed providers (only if providers are configured)
         if (!empty($this->providerUrls) && !$this->isAllowedUrl($returnUrl)) {
             $this->logger->warning("Return URL not in allowed providers: {$returnUrl}");
+
             return null;
         }
 
@@ -184,7 +187,7 @@ class IntegrationUtil
                 $exportParams['platformIntegrationUrl'] = $this->buildIntegrationUrl(
                     $returnUrl,
                     ['/mod/exescorm', '/course/section'],
-                    '/mod/exescorm/' . $op . 'et_ode.php'
+                    '/mod/exescorm/'.$op.'et_ode.php'
                 );
                 $exportParams['exportType'] = Constants::EXPORT_TYPE_SCORM12;
                 break;
@@ -193,7 +196,7 @@ class IntegrationUtil
                 $exportParams['platformIntegrationUrl'] = $this->buildIntegrationUrl(
                     $returnUrl,
                     ['/mod/exeweb', '/course/section'],
-                    '/mod/exeweb/' . $op . 'et_ode.php'
+                    '/mod/exeweb/'.$op.'et_ode.php'
                 );
                 $exportParams['exportType'] = Constants::EXPORT_TYPE_HTML5;
                 break;
@@ -213,7 +216,8 @@ class IntegrationUtil
         foreach ($patterns as $pattern) {
             if (str_contains($returnUrl, $pattern)) {
                 $baseUrl = strstr($returnUrl, $pattern, true);
-                return $baseUrl . $endpoint;
+
+                return $baseUrl.$endpoint;
             }
         }
 
@@ -256,7 +260,7 @@ class IntegrationUtil
         }
 
         $index = array_search($providerId, $this->providerIds, true);
-        if ($index === false) {
+        if (false === $index) {
             return null;
         }
 
@@ -269,7 +273,7 @@ class IntegrationUtil
     public function getProviderUrl(string $providerId): ?string
     {
         $index = array_search($providerId, $this->providerIds, true);
-        if ($index === false) {
+        if (false === $index) {
             return null;
         }
 
@@ -301,7 +305,7 @@ class IntegrationUtil
 
         // Check for duplicate IDs
         if (count($this->providerIds) !== count(array_unique($this->providerIds))) {
-            $errors[] = "Duplicate provider IDs found";
+            $errors[] = 'Duplicate provider IDs found';
         }
 
         return $errors;
@@ -325,7 +329,8 @@ class IntegrationUtil
         if (isset($payload['provider']['name'])) {
             // Convert provider name to a normalized ID
             $providerName = strtolower($payload['provider']['name']);
-            return $providerName . '_legacy';
+
+            return $providerName.'_legacy';
         }
 
         // No provider information found

--- a/tests/Integration/IntegrationUtilMultiProviderTest.php
+++ b/tests/Integration/IntegrationUtilMultiProviderTest.php
@@ -144,7 +144,7 @@ final class IntegrationUtilMultiProviderTest extends TestCase
 
         self::assertNotNull($params);
         self::assertSame(Constants::EXPORT_TYPE_SCORM12, $params['exportType']);
-        self::assertStringContains('set_ode.php', $params['platformIntegrationUrl']);
+        self::assertStringContainsString('set_ode.php', $params['platformIntegrationUrl']);
     }
 
     public function testGetPlatformIntegrationParamsWithInvalidProvider(): void
@@ -180,6 +180,10 @@ final class IntegrationUtilMultiProviderTest extends TestCase
 
     public function testBackwardsCompatibilityMethod(): void
     {
+        $payload = [
+            'pkgtype' => 'webzip',
+            'returnurl' => 'https://moodle.example.com/mod/exeweb/view.php?id=7'
+        ];
 
         $jwt = self::createJwt($payload);
         $params = $this->util->getParamsMoodleIntegration($jwt, 'get');
@@ -238,7 +242,7 @@ final class IntegrationUtilMultiProviderTest extends TestCase
 
         if ($expectedPath) {
             self::assertNotNull($params);
-            self::assertStringContains($expectedPath, $params['platformIntegrationUrl']);
+            self::assertStringContainsString($expectedPath, $params['platformIntegrationUrl']);
         } else {
             self::assertArrayNotHasKey('platformIntegrationUrl', $params ?? []);
         }

--- a/tests/Integration/IntegrationUtilMultiProviderTest.php
+++ b/tests/Integration/IntegrationUtilMultiProviderTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Constants;
+use App\Settings;
+use App\Util\net\exelearning\Util\IntegrationUtil;
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Extended tests for the refactored IntegrationUtil with multiple provider support.
+ */
+final class IntegrationUtilMultiProviderTest extends TestCase
+{
+    private const SECRET = 'test_secret';
+    private const PROVIDER_SECRET = 'provider_secret';
+
+    private IntegrationUtil $util;
+
+    protected function setUp(): void
+    {
+        // Set up multiple provider environment for testing
+        $_ENV['APP_SECRET'] = self::SECRET;
+        $_ENV['PROVIDER_URLS'] = 'https://moodle.example.com';
+        $_ENV['PROVIDER_TOKENS'] = self::PROVIDER_SECRET;
+        $_ENV['PROVIDER_IDS'] = 'moodle_main';
+
+        $this->util = new IntegrationUtil(new NullLogger());
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up environment variables
+        unset($_ENV['PROVIDER_URLS'], $_ENV['PROVIDER_TOKENS'], $_ENV['PROVIDER_IDS']);
+    }
+
+    private static function createJwt(array $payload, string $secret = self::SECRET): string
+    {
+        return JWT::encode(
+            $payload + ['iat' => time(), 'exp' => time() + 3600],
+            $secret,
+            Settings::JWT_SECRET_HASH
+        );
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Provider Management Tests                                          */
+    /* ------------------------------------------------------------------ */
+
+    public function testGetProviderIds(): void
+    {
+        $ids = $this->util->getProviderIds();
+        self::assertSame(['moodle_main'], $ids);
+    }
+
+    public function testGetProviderUrl(): void
+    {
+        self::assertSame('https://moodle.example.com', $this->util->getProviderUrl('moodle_main'));
+        self::assertNull($this->util->getProviderUrl('nonexistent'));
+    }
+
+    public function testValidateProviderConfiguration(): void
+    {
+        $errors = $this->util->validateProviderConfiguration();
+        self::assertEmpty($errors, 'Configuration should be valid');
+    }
+
+    public function testValidateProviderConfigurationWithMismatch(): void
+    {
+        // Set mismatched configuration
+        $_ENV['PROVIDER_URLS'] = 'https://example.com';
+        $_ENV['PROVIDER_TOKENS'] = 'token1,token2';
+        $_ENV['PROVIDER_IDS'] = 'id1';
+
+        $util = new IntegrationUtil(new NullLogger());
+        $errors = $util->validateProviderConfiguration();
+
+        self::assertNotEmpty($errors);
+        self::assertStringContainsString('configuration mismatch', $errors[0]);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* JWT Generation Tests                                               */
+    /* ------------------------------------------------------------------ */
+
+    public function testGenerateProviderJWT(): void
+    {
+        $payload = ['test' => 'data'];
+        $jwt = $this->util->generateProviderJWT($payload, 'moodle_main');
+
+        self::assertNotNull($jwt);
+        self::assertIsString($jwt);
+
+        // Verify the token can be decoded with the correct secret
+        $decoded = JWT::decode($jwt, new \Firebase\JWT\Key(self::PROVIDER_SECRET, Settings::JWT_SECRET_HASH));
+        $decodedArray = (array) $decoded;
+
+        self::assertSame('data', $decodedArray['test']);
+        self::assertSame('moodle_main', $decodedArray['provider_id']);
+    }
+
+    public function testGenerateProviderJWTWithInvalidProvider(): void
+    {
+        $jwt = $this->util->generateProviderJWT(['test' => 'data'], 'invalid_provider');
+        self::assertNull($jwt);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* JWT Decoding with Provider Tests                                   */
+    /* ------------------------------------------------------------------ */
+
+    public function testDecodeJWTWithProviderToken(): void
+    {
+        $payload = ['test' => 'value'];
+        $jwt = self::createJwt($payload, self::PROVIDER_SECRET);
+
+        // Should fail with default secret but succeed with provider token
+        self::assertNull($this->util->decodeJWT($jwt));
+
+        $decoded = $this->util->decodeJWT($jwt, 'moodle_main');
+        self::assertNotNull($decoded);
+        self::assertSame('value', $decoded['test']);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Platform Integration Tests                                         */
+    /* ------------------------------------------------------------------ */
+
+    public function testGetPlatformIntegrationParamsWithProvider(): void
+    {
+        $payload = [
+            'pkgtype' => 'scorm',
+            'returnurl' => 'https://moodle.example.com/mod/exescorm/view.php?id=99',
+            'provider_id' => 'moodle_main'
+        ];
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getPlatformIntegrationParams($jwt, 'set');
+
+        self::assertNotNull($params);
+        self::assertSame(Constants::EXPORT_TYPE_SCORM12, $params['exportType']);
+        self::assertStringContains('set_ode.php', $params['platformIntegrationUrl']);
+    }
+
+    public function testGetPlatformIntegrationParamsWithInvalidProvider(): void
+    {
+        $payload = [
+            'pkgtype' => 'scorm',
+            'returnurl' => 'https://moodle.example.com/mod/exescorm/view.php?id=99',
+            'provider_id' => 'invalid_provider'
+        ];
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getPlatformIntegrationParams($jwt, 'set');
+
+        self::assertNull($params);
+    }
+
+    public function testGetPlatformIntegrationParamsWithDisallowedUrl(): void
+    {
+        $payload = [
+            'pkgtype' => 'scorm',
+            'returnurl' => 'https://forbidden.example.com/mod/exescorm/view.php?id=99'
+        ];
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getPlatformIntegrationParams($jwt, 'set');
+
+        self::assertNull($params);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Backwards Compatibility Tests                                      */
+    /* ------------------------------------------------------------------ */
+
+    public function testBackwardsCompatibilityMethod(): void
+    {
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getParamsMoodleIntegration($jwt, 'get');
+
+        self::assertNotNull($params);
+        self::assertSame(Constants::EXPORT_TYPE_HTML5, $params['exportType']);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Provider URL Validation Tests                                      */
+    /* ------------------------------------------------------------------ */
+
+    #[DataProvider('allowedUrlCases')]
+    public function testUrlValidation(string $url, bool $shouldBeAllowed): void
+    {
+        $payload = [
+            'pkgtype' => 'scorm',
+            'returnurl' => $url
+        ];
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getPlatformIntegrationParams($jwt, 'set');
+
+        if ($shouldBeAllowed) {
+            self::assertNotNull($params, "URL {$url} should be allowed");
+        } else {
+            self::assertNull($params, "URL {$url} should not be allowed");
+        }
+    }
+
+    public static function allowedUrlCases(): iterable
+    {
+        yield ['https://moodle.example.com/course/view.php', true];
+        yield ['https://forbidden.site.com/course/view.php', false];
+        yield ['http://malicious.com/mod/exescorm/view.php', false];
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Integration URL Building Tests                                     */
+    /* ------------------------------------------------------------------ */
+
+    #[DataProvider('integrationUrlCases')]
+    public function testIntegrationUrlBuilding(
+        string $returnUrl,
+        string $pkgType,
+        string $operation,
+        string $expectedPath
+    ): void {
+        $payload = [
+            'pkgtype' => $pkgType,
+            'returnurl' => $returnUrl
+        ];
+
+        $jwt = self::createJwt($payload);
+        $params = $this->util->getPlatformIntegrationParams($jwt, $operation);
+
+        if ($expectedPath) {
+            self::assertNotNull($params);
+            self::assertStringContains($expectedPath, $params['platformIntegrationUrl']);
+        } else {
+            self::assertArrayNotHasKey('platformIntegrationUrl', $params ?? []);
+        }
+    }
+
+    public static function integrationUrlCases(): iterable
+    {
+        yield ['https://moodle.example.com/mod/exescorm/view.php?id=1', 'scorm', 'set', '/mod/exescorm/set_ode.php'];
+        yield ['https://moodle.example.com/mod/exescorm/view.php?id=1', 'scorm', 'get', '/mod/exescorm/get_ode.php'];
+        yield ['https://moodle.example.com/course/section.php?id=3', 'scorm', 'set', '/mod/exescorm/set_ode.php'];
+        yield ['https://moodle.example.com/some/unknown/path.php', 'unknown_type', 'set', ''];
+    }
+}


### PR DESCRIPTION
Need to add new configuration to .env

# Example 1: Moodle + Workplace 
PROVIDER_URLS=https://moodle_lms.com,https://moodle_workplace.example.com,https://custom_lms.example.com
PROVIDER_TOKENS=moodle_lms_token,workplace_token,custom_lms_token
PROVIDER_IDS=moodlelms,workplace,custommoodle

Check `providers.env.example`