### PR TITLE
Translate code comments from Spanish to English in PHP files

### DIFF
--- a/src/Command/net/exelearning/Command/DatabaseTestCommand.php
+++ b/src/Command/net/exelearning/Command/DatabaseTestCommand.php
@@ -60,7 +60,7 @@ class DatabaseTestCommand extends Command
         ]);
 
         try {
-            // Verificar si la conexión está establecida
+            // Check if the connection is established
             if ($this->connection->isConnected() || $this->connection->getNativeConnection()) {
                 $output->writeln('<info>Database connection successful!</info>');
 

--- a/src/Command/net/exelearning/Command/ElpConvertCommand.php
+++ b/src/Command/net/exelearning/Command/ElpConvertCommand.php
@@ -201,9 +201,9 @@ class ElpConvertCommand extends Command
         // Export the processed file
         $exportResult = $this->odeExportService->export(
             $user,                  // UserInterface
-            $user,                  // dbUser (el mismo en este caso)
+            $user,                  // dbUser (the same in this case)
             $checkResult['odeSessionId'],
-            false,                  // baseUrl (false porque no es un preview)
+            false,                  // baseUrl (false because it is not a preview)
             Constants::EXPORT_TYPE_ELP,
             false,                  // preview
             false                   // isIntegration

--- a/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
@@ -149,7 +149,7 @@ class PlatformIntegrationApiController extends DefaultApiController
 
                     $responseData['responseMessage'] = $platformJsonResponse['description'];
                     $responseData['returnUrl'] = $integrationParams['returnurl'];
-                // TO DO Eliminado por no ser necesario por el JWT
+                // TO DO Removed as it is not necessary due to the JWT
                 // $this->odeService->setOdePlatformId($saveOdeResult['elpFileName'], $platformJsonResponse['ode_id']);
                 } else {
                     $responseData['responseMessage'] = $odeExportResult['responseMessage'];
@@ -178,7 +178,7 @@ class PlatformIntegrationApiController extends DefaultApiController
         $odeId = $request->get('ode_id');
 
         $jwtToken = $request->get('jwt_token');
-        // TO DO: parar la aplicación si el JWT no es válido porque este es el punto de entrada de la integración
+        // TO DO: stop the application if the JWT is not valid because this is the entry point of the integration
 
         // Debug redirect
         $this->logger->debug('ode_id to receive from platform:', ['ode_id:' => $odeId, 'file:' => $this, 'line' => __LINE__]);

--- a/src/Controller/net/exelearning/Controller/ErrorController.php
+++ b/src/Controller/net/exelearning/Controller/ErrorController.php
@@ -12,11 +12,11 @@ class ErrorController extends AbstractController
 {
     public function show(Request $request, FlattenException $exception, ?DebugLoggerInterface $logger = null): Response
     {
-        // Obtén información del error
+        // Get error information
         $statusCode = $exception->getStatusCode();
         $message = $exception->getMessage();
 
-        // Renderiza tu plantilla personalizada
+        // Render your custom template
         return $this->render('security/error.html.twig', [
             'status_code' => $statusCode,
             'status_text' => Response::$statusTexts[$statusCode] ?? '',

--- a/src/Entity/net/exelearning/Dto/IdeviceDto.php
+++ b/src/Entity/net/exelearning/Dto/IdeviceDto.php
@@ -733,7 +733,7 @@ class IdeviceDto extends BaseDto
                     $this->addEditionJs($filename);
                 }
             }
-        } else { // Search all files in dir and subdirs
+        } else { // Search all files in dir and subdirectories
             if (file_exists($iDeviceEditionDirPath)) {
                 $jsEditionFileList = FileUtil::listFilesByName(
                     $iDeviceEditionDirPath,
@@ -763,7 +763,7 @@ class IdeviceDto extends BaseDto
                     $this->addEditionCss($filename);
                 }
             }
-        } else { // Search all files in dir and subdirs
+        } else { // Search all files in dir and subdirectories
             if (file_exists($iDeviceEditionDirPath)) {
                 $cssEditionFileList = FileUtil::listFilesByName(
                     $iDeviceEditionDirPath,
@@ -793,7 +793,7 @@ class IdeviceDto extends BaseDto
                     $this->addExportJs($filename);
                 }
             }
-        } else { // Search all files in dir and subdirs
+        } else { // Search all files in dir and subdirectories
             if (file_exists($iDeviceExportDirPath)) {
                 $jsExportFileList = FileUtil::listFilesByName(
                     $iDeviceExportDirPath,
@@ -823,7 +823,7 @@ class IdeviceDto extends BaseDto
                     $this->addExportCss($filename);
                 }
             }
-        } else { // Search all files in dir and subdirs
+        } else { // Search all files in dir and subdirectories
             if (file_exists($iDeviceExportDirPath)) {
                 $cssExportFileList = FileUtil::listFilesByName(
                     $iDeviceExportDirPath,

--- a/src/Entity/net/exelearning/Entity/BaseEntity.php
+++ b/src/Entity/net/exelearning/Entity/BaseEntity.php
@@ -32,7 +32,7 @@ class BaseEntity
     }
 
     /**
-     * Replica un objeto, poniendo a nulo el atributo id en la copia.
+     * Replicates an object, setting the id attribute to null in the copy.
      */
     public function __clone(): void
     {
@@ -73,6 +73,9 @@ class BaseEntity
         $this->updatedAt = new \DateTime();
     }
 
+    /**
+     * Performs a logical delete by setting the isActive flag to false.
+     */
     public function borradoLogico(): void
     {
         $this->isActive = false;

--- a/src/Helper/net/exelearning/Helper/FileHelper.php
+++ b/src/Helper/net/exelearning/Helper/FileHelper.php
@@ -569,7 +569,7 @@ class FileHelper
     }
 
     /**
-     * Añade un sufijo numérico al nombre del fichero si ya existe en el directorio.
+     * Adds a numeric suffix to the filename if it already exists in the directory.
      */
     public function addFilenameSuffix(string $filename, string $path): string
     {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -13,31 +13,31 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
-    // Sobrescribir el directorio de caché usando la variable de entorno CACHE_DIR
+    // Override the cache directory using the CACHE_DIR environment variable
     public function getCacheDir(): string
     {
-        // Verificar si la variable CACHE_DIR existe y no está vacía
+        // Check if the CACHE_DIR variable exists and is not empty
         $cacheDir = !empty($_ENV['CACHE_DIR']) ? $_ENV['CACHE_DIR'] : parent::getCacheDir();
 
-        // Verificar si el directorio existe, si no, crearlo
+        // Check if the directory exists, if not, create it
         $filesystem = new Filesystem();
         if (!$filesystem->exists($cacheDir)) {
-            $filesystem->mkdir($cacheDir, 0755); // Crear el directorio con permisos adecuados
+            $filesystem->mkdir($cacheDir, 0755); // Create the directory with appropriate permissions
         }
 
         return $cacheDir;
     }
 
-    // Sobrescribir el directorio de logs usando la variable de entorno LOG_DIR
+    // Override the log directory using the LOG_DIR environment variable
     public function getLogDir(): string
     {
-        // Verificar si la variable LOG_DIR existe y no está vacía
+        // Check if the LOG_DIR variable exists and is not empty
         $logDir = !empty($_ENV['LOG_DIR']) ? $_ENV['LOG_DIR'] : parent::getLogDir();
 
-        // Verificar si el directorio existe, si no, crearlo
+        // Check if the directory exists, if not, create it
         $filesystem = new Filesystem();
         if (!$filesystem->exists($logDir)) {
-            $filesystem->mkdir($logDir, 0755); // Crear el directorio con permisos adecuados
+            $filesystem->mkdir($logDir, 0755); // Create the directory with appropriate permissions
         }
 
         return $logDir;
@@ -47,7 +47,7 @@ class Kernel extends BaseKernel
     {
         parent::initializeContainer();
 
-        // Asegurarse de que el contenedor esté disponible para SettingsUtil
+        // Make sure the container is available for SettingsUtil
         SettingsUtil::setContainer($this->getContainer());
     }
 }

--- a/src/Service/net/exelearning/Service/Api/OdeExportService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeExportService.php
@@ -133,7 +133,7 @@ class OdeExportService implements OdeExportServiceInterface
         // Get ode pages
         $odeNavStructureSyncRepo = $this->entityManager->getRepository(OdeNavStructureSync::class);
         $odeNavStructureSyncs = $odeNavStructureSyncRepo->findByOdeSessionId($odeSessionId);
-        // TODO NO NECESARIO porque siempre va a tener una página ******************
+        // TODO NOT NECESSARY because it will always have a page ******************
         if (empty($odeNavStructureSyncs)) {
             $error = $this->translator->trans('Please create at least one page before exporting.');
             $responseData['responseMessage'] = $error;
@@ -148,7 +148,7 @@ class OdeExportService implements OdeExportServiceInterface
         $odeProperties = $this->odeService->getOdePropertiesFromDatabase($odeSessionId, $user);
 
         // Get user preferences
-        // TODO siguiente instrucción se ejecuta al inicio del método
+        // TODO next instruction is executed at the beginning of the method
         $dbUserPreferences = $this->userHelper->getUserPreferencesFromDatabase($user);
         $userPreferencesDtos = [];
         foreach ($dbUserPreferences as $userPreference) {
@@ -568,7 +568,7 @@ class OdeExportService implements OdeExportServiceInterface
         // COPY FILES
         // ///////////////////////////////////////////////////
 
-        // TODO VER QUé HACE PORQUE NO COPIA NADA en export ELP ****************
+        // TODO SEE WHAT IT DOES BECAUSE IT DOESN'T COPY ANYTHING in ELP export ****************
         // Copy project schema files
         $this->copySchemaFilesToExportDir($exportDirPath, $exportType);
 
@@ -579,16 +579,16 @@ class OdeExportService implements OdeExportServiceInterface
             $newExportDirName = Constants::EXPORT_DIR_CONTENT_BY_EXPORT[$exportType];
             $newExportDirPath = self::createDirInExportDir($exportDirPath, $newExportDirName);
         }
-        // TODO VER QUé HACE PORQUE NO COPIA NADA en export ELP ****************
+        // TODO SEE WHAT IT DOES BECAUSE IT DOESN'T COPY ANYTHING in ELP export ****************
         // Copy project common files
         $this->copyCommonFilesToExportDir($newExportDirPath, $exportType);
 
-        // vamos a crear un método que analice recursivamente odeNavStructureSyncs y que copie los archivos de las librerías que se deben de incluir en el proyecto
-        // debe de buscar en cada idevice si tiene una algún efecto incluido. El método retornará todos un array con todos los efectos que encuentre.
+        // we are going to create a method that recursively analyzes odeNavStructureSyncs and copies the library files that should be included in the project
+        // it should search in each idevice if it has any effect included. The method will return an array with all the effects it finds.
         list($librariesToCopy, $librariesFileToCopy) = ExportXmlUtil::getPathForLibrariesInIdevices($odeNavStructureSyncs, $odeProperties);
 
-        // copia todos los libs, jquery, bootstrap
-        // Copy project base files to export --> Aquí vamos a copiar los obligatorios
+        // copy all libs, jquery, bootstrap
+        // Copy project base files to export --> Here we are going to copy the mandatory ones
         $this->copyBaseFilesToExportDir($newExportDirPath, $exportType, $resourcesPrefix, $isPreview, $librariesToCopy);
 
         // Copy ode files
@@ -605,7 +605,7 @@ class OdeExportService implements OdeExportServiceInterface
             Constants::PERMANENT_SAVE_CONTENT_CSS_DIRNAME.DIRECTORY_SEPARATOR.
             Constants::WORKAREA_STYLE_BASE_CSS_FILENAME;
         $this->replaceUrlsBaseCssFile($baseCssPath, $resourcesPrefix, $isPreview);
-        // array con todos las rutas de las librerías
+        // array with all the library paths
         // Get links to files (previously copied files)
         $libsResourcesPath = $this->getFilesLoadedPath($exportType, $librariesFileToCopy);
 

--- a/src/Service/net/exelearning/Service/Export/ExportHTML5SPService.php
+++ b/src/Service/net/exelearning/Service/Export/ExportHTML5SPService.php
@@ -294,7 +294,7 @@ class ExportHTML5SPService implements ExportServiceInterface
         // Write the file as real HTML5
         $dom->saveHTMLFile($pageFile);
 
-        // Añade el doctype al principio del HTML5: <!DOCTYPE html>
+        // Add the doctype to the beginning of the HTML5: <!DOCTYPE html>
         $pageFileNewText = '<!DOCTYPE html>'.PHP_EOL.file_get_contents($pageFile);
 
         file_put_contents($pageFile, $pageFileNewText);

--- a/src/Service/net/exelearning/Service/Export/ExportHTML5Service.php
+++ b/src/Service/net/exelearning/Service/Export/ExportHTML5Service.php
@@ -167,7 +167,7 @@ class ExportHTML5Service implements ExportServiceInterface
             // Write the file as real HTML5
             $dom->saveHTMLFile($pageFile);
 
-            // Añade el doctype al principio del HTML5: <!DOCTYPE html>
+            // Add the doctype to the beginning of the HTML5: <!DOCTYPE html>
             $pageFileNewText = '<!DOCTYPE html>'.PHP_EOL.file_get_contents($pageFile);
 
             file_put_contents($pageFile, $pageFileNewText);

--- a/src/Service/net/exelearning/Service/Export/ExportIMSService.php
+++ b/src/Service/net/exelearning/Service/Export/ExportIMSService.php
@@ -226,7 +226,7 @@ class ExportIMSService implements ExportServiceInterface
             // Write the file as real HTML5
             $dom->saveHTMLFile($pageFile);
 
-            // Añade el doctype al principio del HTML5: <!DOCTYPE html>
+            // Add the doctype to the beginning of the HTML5: <!DOCTYPE html>
             $pageFileNewText = '<!DOCTYPE html>'.PHP_EOL.file_get_contents($pageFile);
 
             file_put_contents($pageFile, $pageFileNewText);

--- a/src/Service/net/exelearning/Service/Export/ExportSCORM12Service.php
+++ b/src/Service/net/exelearning/Service/Export/ExportSCORM12Service.php
@@ -231,7 +231,7 @@ class ExportSCORM12Service implements ExportServiceInterface
             // Write the file as real HTML5
             $dom->saveHTMLFile($pageFile);
 
-            // Añade el doctype al principio del HTML5: <!DOCTYPE html>
+            // Add the doctype to the beginning of the HTML5: <!DOCTYPE html>
             $pageFileNewText = '<!DOCTYPE html>'.PHP_EOL.file_get_contents($pageFile);
 
             file_put_contents($pageFile, $pageFileNewText);

--- a/src/Service/net/exelearning/Service/Export/ExportSCORM2004Service.php
+++ b/src/Service/net/exelearning/Service/Export/ExportSCORM2004Service.php
@@ -230,7 +230,7 @@ class ExportSCORM2004Service implements ExportServiceInterface
             // Write the file as real HTML5
             $dom->saveHTMLFile($pageFile);
 
-            // Añade el doctype al principio del HTML5: <!DOCTYPE html>
+            // Add the doctype to the beginning of the HTML5: <!DOCTYPE html>
             $pageFileNewText = '<!DOCTYPE html>'.PHP_EOL.file_get_contents($pageFile);
             file_put_contents($pageFile, $pageFileNewText);
 

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -441,7 +441,7 @@ class ExportXmlUtil
 
             if (in_array($exportType, [Constants::EXPORT_TYPE_SCORM12, Constants::EXPORT_TYPE_SCORM2004])) {
                 // The next code is an example of how to add a namespace to the attribute
-                // $adlcp_ns = 'http://www.adlnet.org/xsd/adlcp_rootv1p2'; // Ejemplo de URI de namespace
+                // $adlcp_ns = 'http://www.adlnet.org/xsd/adlcp_rootv1p2'; // Namespace URI example
                 // $resource->addAttribute('scormtype', 'sco', $adlcp_ns);
                 $resource->addAttribute('adlcp:adlcp:scormtype', 'sco');
             }
@@ -548,12 +548,12 @@ class ExportXmlUtil
             }
         }
 
-        // TODO, a parte del anterior hay mas directorios "raros"
+        // TODO, besides the previous one, there are more "weird" directories
 
-        // ¿Dónde podemos crear directorios?
-        // Hay que procesar los HTML de los idevices y mirar los que hagan referencia a custom/ porque son los del file manager
-        // TODO ver quee mas hay que meter como lo del file manger y de libs hay que quitar los que están en los idevices
-        // TODO deberíamos añadir los archivos de math que se cargan solos? en commun resourse?
+        // Where can we create directories?
+        // We need to process the iDevices' HTML and look for references to custom/ because they are from the file manager
+        // TODO see what else needs to be added, like the file manager stuff, and remove the libs that are in the iDevices
+        // TODO should we add the math files that load by themselves? in common resource?
     }
 
     /**
@@ -632,7 +632,7 @@ class ExportXmlUtil
         $dateTime = $date->addChild('dateTime', $formatted);
         $dateTime->addAttribute('uniqueElementName', 'dateTime');
         $description = $date->addChild('description');
-        // TODO cambiar la frase al idioma del ODE
+        // TODO change the phrase to the ODE's language
         $descriptionString = $description->addChild('string', 'Fecha de creación de los metadatos');
         $descriptionString->addAttribute('language', $langValue);
 
@@ -657,7 +657,7 @@ class ExportXmlUtil
 
         $description = $date->addChild('description');
 
-        // TODO cambiar la frase al idioma del ODE
+        // TODO change the phrase to the ODE's language
         $string = $description->addChild('string', 'Fecha de creación de los metadatos');
         $string->addAttribute('language', $langValue);
 
@@ -2485,7 +2485,7 @@ class ExportXmlUtil
         $filesToCopy = [];
         $libsToSearch = [
             // the following library may not be mandatory
-            // [constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'exe_export.js',"clas=xxxx"], //lleva SCORM y parece obligatorio para exportación web
+            // [constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'exe_export.js',"clas=xxxx"], // it has SCORM and seems mandatory for web export
             [$commonPath.'exe_effects', 'class', 'exe-fx', ['/exe_effects/exe_effects.js', '/exe_effects/exe_effects.css']],
             [$commonPath.'exe_games', 'class', 'exe-game', ['/exe_games/exe_games.js', '/exe_games/exe_games.css']],
             [$commonPath.'exe_highlighter', 'class', 'highlighted-code', ['/exe_highlighter/exe_highlighter.js', '/exe_highlighter/exe_highlighter.css']],
@@ -2627,7 +2627,7 @@ class ExportXmlUtil
 
         // TODO issue 315
         // if ('true' == $odeProperties['pp_addSearchBox']->getValue()) {
-        //    Aquí añadimos los ficheros de búsqueda
+        //    Here we add the search files
         // }
 
         return [$librariesToCopy, $filesToCopy];

--- a/src/Util/net/exelearning/Util/FileUtil.php
+++ b/src/Util/net/exelearning/Util/FileUtil.php
@@ -7,7 +7,7 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Mime\MimeTypes;
-use Symfony\Component\Translation\Loader\XliffFileLoader; // Agrega esta línea
+use Symfony\Component\Translation\Loader\XliffFileLoader; // Add this line
 
 /**
  * FileUtil.


### PR DESCRIPTION
This commit translates all Spanish code comments to English within the `.php` files in the `src` directory. This was done to improve the readability and maintainability of the codebase for English-speaking developers.

The changes are limited to comments only; no code has been modified.