### PR TITLE
Avoid login and pushing to docker registries on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
           path: ${{ env.REPORT_NAME }}
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.repository == 'exelearning/exelearning' && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.repository == 'exelearning/exelearning' && github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -126,7 +126,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.repository == 'exelearning/exelearning' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -139,7 +139,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy (GHCR) only on main branch
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.repository == 'exelearning/exelearning' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ghcr.io/${{ github.repository }}:main
@@ -155,13 +155,14 @@ jobs:
           no-fail: true
 
       - name: Upload SARIF results
+        if: github.repository == 'exelearning/exelearning' && github.event_name != 'pull_request'      
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: hadolint-results.sarif
           category: hadolint-dockerfile
 
       - name: Docker Hub Description
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.repository == 'exelearning/exelearning' && startsWith(github.ref, 'refs/tags/') && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_PASSWORD != ''
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to ensure that certain steps only run for the main repository (`exelearning/exelearning`). This helps prevent unintended actions (like Docker pushes or security scans) from running on forks or other repositories. The most important changes are:

Workflow step restrictions for repository safety:

* Added checks to ensure DockerHub and GHCR login steps only run for the main repository and not on pull requests (`.github/workflows/ci.yml`).
* Restricted the build and push step to only run for the main repository on `main` or tag refs (`.github/workflows/ci.yml`).
* Limited the Trivy image scan to only run for the main repository on the `main` branch and not on pull requests (`.github/workflows/ci.yml`).
* Added a condition to the SARIF results upload step so it only runs for the main repository and not on pull requests (`.github/workflows/ci.yml`).
* Updated the Docker Hub Description step to only run for the main repository when tagging, and only if DockerHub credentials are provided (`.github/workflows/ci.yml`).