### PR TITLE
Add unit tests for utility classes

### DIFF
--- a/tests/Unit/Util/net/exelearning/Util/DateUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/DateUtilTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\DateUtil;
+use PHPUnit\Framework\TestCase;
+
+class DateUtilTest extends TestCase
+{
+    public function test_getSecondsDateInterval()
+    {
+        $seconds = 10;
+        $interval = DateUtil::getSecondsDateInterval($seconds);
+        $this->assertInstanceOf(\DateInterval::class, $interval);
+        $this->assertEquals($seconds, $interval->s);
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/DropboxUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/DropboxUtilTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\DropboxUtil;
+use PHPUnit\Framework\TestCase;
+
+class DropboxUtilTest extends TestCase
+{
+    public function test_Constants()
+    {
+        $this->assertEquals('https://api.dropboxapi.com/2/files/list_folder', DropboxUtil::DROPBOX_API_FOLDER_LIST);
+        $this->assertEquals('https://content.dropboxapi.com/2/files/upload', DropboxUtil::DROPBOX_API_UPLOAD);
+        $this->assertEquals('https://api.dropboxapi.com/oauth2/token', DropboxUtil::DROPBOX_API_OAUTH2_TOKEN_URI);
+        $this->assertEquals('https://www.dropbox.com/oauth2/authorize', DropboxUtil::DROPBOX_API_OAUTH2_URL);
+        $this->assertEquals('https://api.dropboxapi.com/2/files/get_metadata', DropboxUtil::DROPBOX_API_GET_METADATA);
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/ExportXmlUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/ExportXmlUtilTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\ExportXmlUtil;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ExportXmlUtilTest extends TestCase
+{
+    public function test_decrypt()
+    {
+        $originalString = 'hello world';
+        $encryptedString = ExportXmlUtil::decrypt($originalString);
+        $decryptedString = ExportXmlUtil::decrypt($encryptedString);
+        $this->assertEquals($originalString, $decryptedString);
+    }
+
+    public function test_createMadeWithExeLink()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')
+            ->willReturnMap([
+                ['Made with eXeLearning', [], null, null, 'Made with eXeLearning'],
+                ['(new window)', [], null, null, '(new window)'],
+            ]);
+
+        $xml = ExportXmlUtil::createMadeWithExeLink($translator);
+
+        $this->assertInstanceOf(\SimpleXMLElement::class, $xml);
+        $this->assertEquals('made-with-exe-link', $xml->getName());
+        $p = $xml->p;
+        $this->assertEquals('made-with-eXe', (string)$p['id']);
+        $a = $p->a;
+        $this->assertEquals('https://exelearning.net/', (string)$a['href']);
+        $this->assertEquals('_blank', (string)$a['target']);
+        $this->assertEquals('noopener', (string)$a['rel']);
+        $this->assertStringContainsString('Made with eXeLearning', (string)$a->span[0]);
+        $this->assertStringContainsString('(new window)', (string)$a->span[0]->span[0]);
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/FilePermissionsUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/FilePermissionsUtilTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\FilePermissionsUtil;
+use PHPUnit\Framework\TestCase;
+
+class FilePermissionsUtilTest extends TestCase
+{
+    private $testDir;
+    private $testFile;
+
+    protected function setUp(): void
+    {
+        $this->testDir = sys_get_temp_dir() . '/test_dir';
+        if (!is_dir($this->testDir)) {
+            mkdir($this->testDir, 0777, true);
+        }
+        $this->testFile = $this->testDir . '/test_file.txt';
+        file_put_contents($this->testFile, 'test');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+        if (is_dir($this->testDir)) {
+            rmdir($this->testDir);
+        }
+    }
+
+    public function test_isWritable()
+    {
+        $this->assertTrue(FilePermissionsUtil::isWritable($this->testDir));
+        $this->assertTrue(FilePermissionsUtil::isWritable($this->testFile));
+    }
+
+    public function test_isReadable()
+    {
+        $this->assertTrue(FilePermissionsUtil::isReadable($this->testFile));
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/FileUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/FileUtilTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\FileUtil;
+use PHPUnit\Framework\TestCase;
+
+class FileUtilTest extends TestCase
+{
+    private $testDir;
+
+    protected function setUp(): void
+    {
+        $this->testDir = sys_get_temp_dir() . '/file_util_test';
+        if (!is_dir($this->testDir)) {
+            mkdir($this->testDir, 0777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->testDir)) {
+            FileUtil::removeDir($this->testDir);
+        }
+    }
+
+    public function test_formatFilesize()
+    {
+        $this->assertEquals('1 KB', FileUtil::formatFilesize(1024));
+        $this->assertEquals('1 MB', FileUtil::formatFilesize(1024 * 1024));
+        $this->assertEquals('1.5 KB', FileUtil::formatFilesize(1536));
+    }
+
+    public function test_getDateDirStructureFromIdentifier()
+    {
+        $identifier = '20201018103234EWHDKF';
+        $expected = '2020' . DIRECTORY_SEPARATOR . '10' . DIRECTORY_SEPARATOR . '18' . DIRECTORY_SEPARATOR;
+        $this->assertEquals($expected, FileUtil::getDateDirStructureFromIdentifier($identifier));
+    }
+
+    public function test_listSubdirsAndFiles()
+    {
+        $subDir1 = $this->testDir . '/subdir1';
+        $subDir2 = $this->testDir . '/subdir2';
+        mkdir($subDir1);
+        mkdir($subDir2);
+
+        $file1 = $this->testDir . '/file1.txt';
+        $file2 = $this->testDir . '/file2.txt';
+        file_put_contents($file1, 'test1');
+        file_put_contents($file2, 'test2');
+
+        $expectedSubdirs = ['subdir1', 'subdir2'];
+        $actualSubdirs = FileUtil::listSubdirs($this->testDir);
+        sort($expectedSubdirs);
+        sort($actualSubdirs);
+        $this->assertEquals($expectedSubdirs, $actualSubdirs);
+
+        $expectedFiles = ['file1.txt', 'file2.txt'];
+        $actualFiles = FileUtil::listFilesByParentFolder($this->testDir);
+        sort($expectedFiles);
+        sort($actualFiles);
+        $this->assertEquals($expectedFiles, $actualFiles);
+    }
+
+    public function test_createAndRemoveDir()
+    {
+        $newDir = $this->testDir . '/newdir';
+        $this->assertTrue(FileUtil::createDir($newDir));
+        $this->assertTrue(is_dir($newDir));
+        $this->assertTrue(FileUtil::removeDir($newDir));
+        $this->assertFalse(is_dir($newDir));
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/GoogleUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/GoogleUtilTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\GoogleUtil;
+use PHPUnit\Framework\TestCase;
+
+class GoogleUtilTest extends TestCase
+{
+    public function test_Constants()
+    {
+        $this->assertEquals('https://accounts.google.com/o/oauth2/auth', GoogleUtil::GOOGLE_OAUTH_URL);
+        $this->assertEquals('https://www.googleapis.com/auth/drive', GoogleUtil::GOOGLE_DRIVE_OAUTH_SCOPE);
+        $this->assertEquals('https://www.googleapis.com/drive/v3/files/', GoogleUtil::GOOGLE_DRIVE_FOLDER_LIST);
+        $this->assertEquals('https://www.googleapis.com/upload/drive/v3/files', GoogleUtil::GOOGLE_DRIVE_FILE_UPLOAD_URI);
+        $this->assertEquals('https://www.googleapis.com/drive/v3/files/', GoogleUtil::GOOGLE_DRIVE_FILE_META_URI);
+        $this->assertEquals('https://oauth2.googleapis.com/token', GoogleUtil::GOOGLE_OAUTH2_TOKEN_URI);
+        $this->assertEquals('https://drive.google.com/open', GoogleUtil::GOOGLE_DRIVE_FILE_OPEN_URL);
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/IntegrationUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/IntegrationUtilTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\IntegrationUtil;
+use App\Settings;
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class IntegrationUtilTest extends TestCase
+{
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $_ENV['PROVIDER_URLS'] = 'https://moodle.com,https://other.com';
+        $_ENV['PROVIDER_TOKENS'] = 'moodle_token,other_token';
+        $_ENV['PROVIDER_IDS'] = 'moodle,other';
+        $_ENV['APP_SECRET'] = 'test_secret';
+    }
+
+    public function test_generateAndDecodeJwt()
+    {
+        $integrationUtil = new IntegrationUtil($this->logger);
+        $payload = ['user' => 'testuser'];
+        $providerId = 'moodle';
+
+        $jwt = $integrationUtil->generateProviderJWT($payload, $providerId);
+        $this->assertIsString($jwt);
+
+        $decoded = $integrationUtil->decodeJWT($jwt, $providerId);
+        $this->assertIsArray($decoded);
+        $this->assertEquals('testuser', $decoded['user']);
+        $this->assertEquals($providerId, $decoded['provider_id']);
+    }
+
+    public function test_validateProviderConfiguration()
+    {
+        $integrationUtil = new IntegrationUtil($this->logger);
+        $this->assertEmpty($integrationUtil->validateProviderConfiguration());
+
+        $_ENV['PROVIDER_TOKENS'] = 'moodle_token';
+        $integrationUtil = new IntegrationUtil($this->logger);
+        $this->assertNotEmpty($integrationUtil->validateProviderConfiguration());
+    }
+
+    public function test_getPlatformIntegrationParams()
+    {
+        $integrationUtil = new IntegrationUtil($this->logger);
+        $payload = [
+            'returnurl' => 'https://moodle.com/mod/exescorm/view.php?id=1',
+            'pkgtype' => 'scorm',
+            'user' => 'testuser',
+            'provider_id' => 'moodle',
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ];
+
+        $jwt = JWT::encode($payload, $_ENV['APP_SECRET'], Settings::JWT_SECRET_HASH);
+
+        $params = $integrationUtil->getPlatformIntegrationParams($jwt, 'set');
+        $this->assertIsArray($params);
+        $this->assertEquals('https://moodle.com/mod/exescorm/set_ode.php', $params['platformIntegrationUrl']);
+        $this->assertEquals('scorm12', $params['exportType']);
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/OdeXmlUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/OdeXmlUtilTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\OdeXmlUtil;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class OdeXmlUtilTest extends TestCase
+{
+    public function test_prepareText()
+    {
+        $class = new ReflectionClass(OdeXmlUtil::class);
+        $method = $class->getMethod('prepareText');
+        $method->setAccessible(true);
+
+        $text = '<p>This is a test</p>';
+        $expected = '&lt;p&gt;This is a test&lt;/p&gt;';
+        $this->assertEquals($expected, $method->invoke(null, $text));
+
+        $text = 'This has "quotes" & ampersands';
+        $expected = 'This has &quot;quotes&quot; &amp; ampersands';
+        $this->assertEquals($expected, $method->invoke(null, $text));
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/UrlUtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/UrlUtilTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\UrlUtil;
+use App\Constants;
+use PHPUnit\Framework\TestCase;
+
+class UrlUtilTest extends TestCase
+{
+    public function test_getTemporaryContentStorageUrl()
+    {
+        $expectedUrl = Constants::FILES_DIR_NAME . Constants::SLASH . Constants::TEMPORARY_CONTENT_STORAGE_DIRECTORY;
+        $this->assertEquals($expectedUrl, UrlUtil::getTemporaryContentStorageUrl());
+    }
+}

--- a/tests/Unit/Util/net/exelearning/Util/UtilTest.php
+++ b/tests/Unit/Util/net/exelearning/Util/UtilTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Unit\Util\net\exelearning\Util;
+
+use App\Util\net\exelearning\Util\Util;
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+    public function test_generateId()
+    {
+        $id = Util::generateId();
+        $this->assertIsString($id);
+        $this->assertEquals(20, strlen($id));
+        $this->assertMatchesRegularExpression('/^\d{14}[A-Z]{6}$/', $id);
+    }
+
+    public function test_generateIdCheckUnique()
+    {
+        $existingIds = ['20201018103234EWHDKF'];
+        $newId = Util::generateIdCheckUnique($existingIds);
+        $this->assertIsString($newId);
+        $this->assertNotContains($newId, $existingIds);
+    }
+
+    public function test_generateRandomStr()
+    {
+        $randomStr = Util::generateRandomStr(10);
+        $this->assertIsString($randomStr);
+        $this->assertEquals(10, strlen($randomStr));
+        $this->assertMatchesRegularExpression('/^[A-Z]{10}$/', $randomStr);
+    }
+
+    public function test_checkPhpZipExtension()
+    {
+        if (extension_loaded('zip')) {
+            $this->assertTrue(Util::checkPhpZipExtension());
+        } else {
+            $this->markTestSkipped('zip extension not loaded.');
+        }
+    }
+
+    public function test_checkPhpGdExtension()
+    {
+        if (extension_loaded('gd')) {
+            $this->assertTrue(Util::checkPhpGdExtension());
+        } else {
+            $this->markTestSkipped('gd extension not loaded.');
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a suite of unit tests for various utility classes within the `App\Util\net\exelearning\Util` namespace.

The following utility classes are now covered by basic unit tests:
- DateUtil
- DropboxUtil
- ExportXmlUtil
- FilePermissionsUtil
- FileUtil
- GoogleUtil
- IntegrationUtil
- OdeXmlUtil
- UrlUtil
- Util

For complex classes that interact with external APIs or the filesystem, the tests focus on pure functions and constants to provide a baseline of test coverage without extensive mocking.