### PR TITLE
Fixed the checked file with APP_VERSION, upgrade outdated libs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,8 @@
     },
     "extra": {
         "symfony": {
-            "docker": false
+            "docker": false,
+            "allow-contrib": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7996aa73c7d58e54eb1b311d9d7e0fb0",
+    "content-hash": "6c2e2a554c33efb46cb2e983f1fa6b8d",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -783,16 +783,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.9.3",
+            "version": "3.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "cd12028853c418b454602e3fda89e519e9af947b"
+                "reference": "1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/cd12028853c418b454602e3fda89e519e9af947b",
-                "reference": "cd12028853c418b454602e3fda89e519e9af947b",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c",
+                "reference": "1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c",
                 "shasum": ""
             },
             "require": {
@@ -866,7 +866,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.9.3"
+                "source": "https://github.com/doctrine/migrations/tree/3.9.4"
             },
             "funding": [
                 {
@@ -882,7 +882,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T22:04:47+00:00"
+            "time": "2025-08-19T06:41:07+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -4625,7 +4625,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4684,7 +4684,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4696,6 +4696,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4704,16 +4708,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
                 "shasum": ""
             },
             "require": {
@@ -4762,7 +4766,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4774,24 +4778,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-06-27T09:58:17+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "763d2a91fea5681509ca01acbc1c5e450d127811"
+                "reference": "bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/763d2a91fea5681509ca01acbc1c5e450d127811",
-                "reference": "763d2a91fea5681509ca01acbc1c5e450d127811",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c",
+                "reference": "bfc8fa13dbaf21d69114b0efcd72ab700fb04d0c",
                 "shasum": ""
             },
             "require": {
@@ -4846,7 +4854,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4858,15 +4866,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T18:38:29+00:00"
+            "time": "2025-06-20T22:24:30+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -4929,7 +4941,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4941,6 +4953,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4949,7 +4965,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5010,7 +5026,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5022,6 +5038,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -5030,7 +5050,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -5091,7 +5111,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5103,6 +5123,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -5111,7 +5135,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -5171,7 +5195,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5183,6 +5207,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -5191,16 +5219,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "2fb86d65e2d424369ad2905e83b236a8805ba491"
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/2fb86d65e2d424369ad2905e83b236a8805ba491",
-                "reference": "2fb86d65e2d424369ad2905e83b236a8805ba491",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
                 "shasum": ""
             },
             "require": {
@@ -5247,7 +5275,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5259,24 +5287,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-07-08T02:45:35+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "000df7860439609837bbe28670b0be15783b7fbf"
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/000df7860439609837bbe28670b0be15783b7fbf",
-                "reference": "000df7860439609837bbe28670b0be15783b7fbf",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
                 "shasum": ""
             },
             "require": {
@@ -5323,7 +5355,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5335,15 +5367,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-20T12:04:08+00:00"
+            "time": "2025-06-24T13:30:11+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -5402,7 +5438,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -5411,6 +5447,10 @@
                 },
                 {
                     "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
                     "type": "github"
                 },
                 {
@@ -9295,23 +9335,23 @@
         },
         {
             "name": "react/promise",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
                 "phpunit/phpunit": "^9.6 || ^7.5"
             },
             "type": "library",
@@ -9356,7 +9396,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -9364,7 +9404,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-24T10:39:05+00:00"
+            "time": "2025-08-19T18:57:03+00:00"
         },
         {
             "name": "react/socket",
@@ -11041,7 +11081,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -11097,7 +11137,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -11106,6 +11146,10 @@
                 },
                 {
                     "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
                     "type": "github"
                 },
                 {
@@ -11257,13 +11301,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4",
         "ext-ctype": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
 >
   <php>
     <ini name="memory_limit" value="512M"/>
+    <ini name="max_execution_time" value="600"/>
     <ini name="display_errors" value="1"/>
     <ini name="error_reporting" value="E_ALL"/>
     <server name="APP_ENV" value="test" force="true"/>

--- a/public/files/perm/idevices/base/example/edition/example.js
+++ b/public/files/perm/idevices/base/example/edition/example.js
@@ -83,7 +83,7 @@ var $exeDevice = {
     this.color = this.ideviceBody.querySelector(`#${this.colorId}`).value;
     this.switch = this.ideviceBody.querySelector(`#${this.switchId}`).checked;
     this.radio = this.ideviceBody.querySelector(`input[name="${this.radioId}"]:checked`).id;
-    // Check if the values ​​are valid
+    // Check if the values are valid
     if (this.checkFormValues()) {
       return this.getDataJson();
     } else {
@@ -109,14 +109,14 @@ var $exeDevice = {
     html += `</div>`;
     // [eXeLearning] - Set html to eXe idevice body
     this.ideviceBody.innerHTML = html;
-    // Load the previous values ​​of the idevice data from eXe
+    // Load the previous values of the idevice data from eXe
     this.loadPreviousValues();
     // Set behaviour to elements of form
     this.setBehaviour();
   },
 
   /**
-   * Check if the form values ​​are correct
+   * Check if the form values are correct
    *
    * @returns {Boolean}
    */
@@ -356,7 +356,6 @@ var $exeDevice = {
   },
 
   /**
-   * Switch
    * Function to create HTML switch
    *
    * @param {String} id

--- a/public/files/perm/themes/base/base/content.css
+++ b/public/files/perm/themes/base/base/content.css
@@ -1,4 +1,4 @@
-/* Default style (to review) */
+/* eXeLearning v3.0.0-beta default style (to review) */
 
 body.exe-export {
     padding: 1em 0;

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -56,7 +56,6 @@ class Constants
 
     // Files
     public const FILE_CHECKED_FILENAME = 'checked';
-    public const FILE_CHECKED_VERSION = 'v01.00.10';
 
     // Themes
     public const THEME_DEFAULT = 'base';

--- a/src/Service/net/exelearning/Service/FilesDir/FilesDirService.php
+++ b/src/Service/net/exelearning/Service/FilesDir/FilesDirService.php
@@ -21,7 +21,7 @@ class FilesDirService implements FilesDirServiceInterface
     ) {
         $this->fileHelper = $fileHelper;
         $this->filesDir = $this->fileHelper->getFilesDir();
-        $this->checkFile = $this->filesDir.Constants::FILE_CHECKED_FILENAME.Constants::FILE_CHECKED_VERSION;
+        $this->checkFile = $this->filesDir.Constants::FILE_CHECKED_FILENAME.'-'.Constants::APP_VERSION;
         $this->translator = $translator;
     }
 
@@ -107,6 +107,7 @@ class FilesDirService implements FilesDirServiceInterface
 
         try {
             FileUtil::removeDir($this->fileHelper->getIdevicesBaseDir());
+            FileUtil::removeDir($this->fileHelper->getThemesBaseDir());
             $copied = FileUtil::copyDir(
                 $this->fileHelper->getSymfonyFilesDir(),
                 $this->fileHelper->getFilesDir()

--- a/tests/Unit/Service/FilesDirServiceTest.php
+++ b/tests/Unit/Service/FilesDirServiceTest.php
@@ -1,0 +1,307 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\net\exelearning\Service\FilesDir;
+
+use App\Constants;
+use App\Helper\net\exelearning\Helper\FileHelper;
+use App\Service\net\exelearning\Service\FilesDir\FilesDirService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[CoversClass(FilesDirService::class)]
+final class FilesDirServiceTest extends TestCase
+{
+    /** @var TranslatorInterface&MockObject */
+    private TranslatorInterface $translator;
+
+    private Filesystem $filesystem;
+
+    /** Absolute path to a unique temp project dir for each test run */
+    private string $projectDir;
+
+    private string $filesDir;
+    private string $symfonyPublicDir;
+    private string $symfonyFilesDir;
+
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        // Create a unique temp dir per run to avoid collisions.
+        $unique = 'fds_' . bin2hex(random_bytes(6));
+
+        $this->filesystem = new Filesystem();
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->projectDir = rtrim(sys_get_temp_dir(), '/')."/{$unique}/project/";
+        $this->filesDir = $this->projectDir.'files/';
+        $this->symfonyPublicDir = $this->projectDir.'public/';
+        $this->symfonyFilesDir = $this->symfonyPublicDir.'files/';
+
+        // Ensure a clean slate.
+        $this->filesystem->remove($this->projectDir);
+        $this->filesystem->mkdir($this->filesDir);
+        $this->filesystem->mkdir($this->symfonyFilesDir);
+
+        // Translator stub that applies a basic vsprintf substitution for "%s".
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator
+            ->method('trans')
+            ->willReturnCallback(
+                /**
+                 * Simple "%s" replacement preserving the original message id.
+                 */
+                function (string $id, array $parameters = []): string {
+                    return $parameters ? vsprintf($id, array_values($parameters)) : $id;
+                }
+            );
+    }
+
+    protected function tearDown(): void
+    {
+        // Always clean up and restore perms if needed.
+        if (is_dir($this->filesDir)) {
+            @chmod($this->filesDir, 0777);
+        }
+        $this->filesystem->remove($this->projectDir);
+    }
+
+    /**
+     * It should refresh structure when the version marker is old,
+     * preserving user files, copying new base files, and removing old base files.
+     */
+    public function test_checkFilesDirWithOldVersion(): void
+    {
+        $fileHelper = $this->buildFileHelper();
+
+        // Old version marker.
+        $oldVersionFile = $this->filesDir . Constants::FILE_CHECKED_FILENAME . '-v0.0.0-old';
+        $this->filesystem->touch($oldVersionFile);
+
+        // User file that must persist.
+        $userThemesDir = $this->filesDir . 'perm/themes/users/';
+        $userFilePath = $userThemesDir . 'someuser/somefile.txt';
+        $this->filesystem->mkdir(\dirname($userFilePath));
+        $this->filesystem->touch($userFilePath);
+
+        // New base file in source (public/files).
+        $symfonyBaseThemesDir = $this->symfonyFilesDir . 'perm/themes/base/';
+        $newBaseThemePath = $symfonyBaseThemesDir . 'new-theme.css';
+        $this->filesystem->mkdir(\dirname($newBaseThemePath));
+        $this->filesystem->touch($newBaseThemePath);
+
+        // Old base file in destination (must be removed).
+        $userBaseThemesDir = $this->filesDir . 'perm/themes/base/';
+        $oldBaseThemePath = $userBaseThemesDir . 'old-theme.css';
+        $this->filesystem->mkdir(\dirname($oldBaseThemePath));
+        $this->filesystem->touch($oldBaseThemePath);
+
+        $service = new FilesDirService($fileHelper, $this->translator);
+        $result = $service->checkFilesDir();
+
+        self::assertTrue($result['checked']);
+        self::assertFileDoesNotExist($oldVersionFile, 'Old version file should be removed.');
+        $newVersionFile = $this->filesDir . Constants::FILE_CHECKED_FILENAME . '-' . Constants::APP_VERSION;
+        self::assertFileExists($newVersionFile, 'New version file should be created.');
+        self::assertFileExists($userFilePath, 'User file should not be deleted.');
+        self::assertFileExists($userBaseThemesDir . 'new-theme.css', 'New base theme file should be copied.');
+        self::assertFileDoesNotExist($oldBaseThemePath, 'Old base theme file should be removed.');
+        self::assertSame('FILES_DIR directory structure generated', $result['info']);
+    }
+
+    /**
+     * First run: no version marker -> it should copy structure,
+     * create version marker, and remove any stray files in base folders.
+     */
+    public function test_firstRunCopiesStructureAndCreatesMarker(): void
+    {
+        $fileHelper = $this->buildFileHelper();
+
+        // Source files in symfony public/files
+        $srcBase = $this->symfonyFilesDir . 'perm/themes/base/';
+        $srcIdevices = $this->symfonyFilesDir . 'perm/idevices/base/';
+        $this->filesystem->mkdir($srcBase);
+        $this->filesystem->mkdir($srcIdevices);
+        $this->filesystem->touch($srcBase.'theme.css');
+        $this->filesystem->touch($srcIdevices.'widget.js');
+
+        // Stray file in destination that should be removed during refresh.
+        $dstStray = $this->filesDir . 'perm/themes/base/obsolete.css';
+        $this->filesystem->mkdir(\dirname($dstStray));
+        $this->filesystem->touch($dstStray);
+
+        // User dir content that must persist.
+        $userFile = $this->filesDir.'perm/themes/users/alice/custom.txt';
+        $this->filesystem->mkdir(\dirname($userFile));
+        $this->filesystem->touch($userFile);
+
+        $service = new FilesDirService($fileHelper, $this->translator);
+        $result = $service->checkFilesDir();
+
+        self::assertTrue($result['checked']);
+        $marker = $this->filesDir . Constants::FILE_CHECKED_FILENAME . '-' . Constants::APP_VERSION;
+        self::assertFileExists($marker, 'Should create version marker.');
+        self::assertFileExists($this->filesDir.'perm/themes/base/theme.css', 'Base theme file should be copied.');
+        self::assertFileExists($this->filesDir.'perm/idevices/base/widget.js', 'Idevices file should be copied.');
+        self::assertFileDoesNotExist($dstStray, 'Stray file should be removed.');
+        self::assertFileExists($userFile, 'User content should persist.');
+    }
+
+    /**
+     * Same version: if marker already exists, nothing should be copied/removed.
+     * We detect "no work" by ensuring a new file present only in source is not copied
+     * and a stale file present only in destination remains.
+     */
+    public function test_sameVersionDoesNoWork(): void
+    {
+        $fileHelper = $this->buildFileHelper();
+
+        // Precreate current marker -> isChecked() === true
+        $marker = $this->filesDir . Constants::FILE_CHECKED_FILENAME . '-' . Constants::APP_VERSION;
+        $this->filesystem->touch($marker);
+
+        // Put a file only in source that SHOULD NOT be copied (since same version).
+        $srcOnly = $this->symfonyFilesDir.'perm/themes/base/should-not-copy.css';
+        $this->filesystem->mkdir(\dirname($srcOnly));
+        $this->filesystem->touch($srcOnly);
+
+        // Put a stale file only in destination that SHOULD remain untouched.
+        $dstStale = $this->filesDir.'perm/themes/base/old-stays.css';
+        $this->filesystem->mkdir(\dirname($dstStale));
+        $this->filesystem->touch($dstStale);
+
+        $service = new FilesDirService($fileHelper, $this->translator);
+        $result = $service->checkFilesDir();
+
+        self::assertTrue($result['checked']);
+        self::assertFileExists($marker, 'Version marker should remain.');
+        self::assertFileDoesNotExist(
+            $this->filesDir.'perm/themes/base/should-not-copy.css',
+            'No copy should happen on same version.'
+        );
+        self::assertFileExists($dstStale, 'No cleanup should happen on same version.');
+    }
+
+    /**
+     * Non-writable FILES_DIR: should return checked=false with the proper message.
+     */
+    public function test_nonWritableFilesDirReturnsError(): void
+    {
+        $fileHelper = $this->buildFileHelper();
+
+        // Make filesDir non-writable
+        @chmod($this->filesDir, 0555);
+
+        $service = new FilesDirService($fileHelper, $this->translator);
+        $result = $service->checkFilesDir();
+
+        // Restore perms for tearDown cleanup.
+        @chmod($this->filesDir, 0777);
+
+        self::assertFalse($result['checked']);
+        self::assertSame('The FILES_DIR directory does not have write permissions', $result['info']);
+    }
+
+	/**
+	 * Missing FILES_DIR but writable parent: service should create it,
+	 * copy structure from symfony/public/files, and write the version marker.
+	 */
+	public function test_missingFilesDirIsCreatedFromSource(): void
+	{
+	    $fileHelper = $this->buildFileHelper();
+
+	    // Prepare source files in symfony public/files
+	    $srcBase = $this->symfonyFilesDir . 'perm/themes/base/';
+	    $this->filesystem->mkdir($srcBase);
+	    $this->filesystem->touch($srcBase . 'theme.css');
+
+	    // Remove destination (FILES_DIR) to simulate "missing"
+	    $this->filesystem->remove($this->filesDir);
+
+	    $service = new FilesDirService($fileHelper, $this->translator);
+	    $result = $service->checkFilesDir();
+
+	    // Should succeed by creating the structure
+	    self::assertTrue($result['checked']);
+	    $marker = $this->filesDir . Constants::FILE_CHECKED_FILENAME . '-' . Constants::APP_VERSION;
+	    self::assertFileExists($marker, 'Version marker should be created.');
+	    self::assertFileExists($this->filesDir . 'perm/themes/base/theme.css', 'Base file should be copied.');
+	    self::assertSame('FILES_DIR directory structure generated', $result['info']);
+	}
+
+	/**
+	 * Missing FILES_DIR with a non-writable parent: should return checked=false
+	 * and the "does not exists" message (per current service logic).
+	 */
+	public function test_missingFilesDirWithNonWritableParentReturnsErrorOrSkip(): void
+	{
+	    $fileHelper = $this->buildFileHelper();
+
+	    // Ensure destination is missing
+	    $this->filesystem->remove($this->filesDir);
+
+	    // Make parent (project dir) non-writable
+	    @chmod($this->projectDir, 0555);
+
+	    // If the environment still reports writable, skip to keep the suite stable.
+	    if (is_writable($this->projectDir)) {
+	        $this->markTestSkipped('Cannot simulate non-writable parent in this environment.');
+	    }
+
+	    $service = new FilesDirService($fileHelper, $this->translator);
+	    $result = $service->checkFilesDir();
+
+	    // Restore permissions for cleanup
+	    @chmod($this->projectDir, 0777);
+
+	    self::assertFalse($result['checked']);
+	    self::assertSame('The FILES_DIR directory does not exists', $result['info']);
+	}
+
+
+    /**
+     * Copy structure fails (e.g. missing symfony/public/files): should return checked=false
+     * and include the three guidance messages in 'info'.
+     */
+    public function test_copyStructureFailureReturnsHelpfulInfo(): void
+    {
+        $fileHelper = $this->buildFileHelper();
+
+        // Remove the source directory so copyDir fails or returns false
+        $this->filesystem->remove($this->symfonyFilesDir);
+
+        $service = new FilesDirService($fileHelper, $this->translator);
+        $result = $service->checkFilesDir();
+
+        self::assertFalse($result['checked']);
+        self::assertIsArray($result['info']);
+        self::assertCount(3, $result['info'], 'Should return three guidance messages.');
+        self::assertStringContainsString('Failed to generate FILES_DIR structure', $result['info'][0]);
+        self::assertStringContainsString('permissions', $result['info'][1]);
+        self::assertStringContainsString('symfony/public/files/', $result['info'][2]);
+    }
+
+    /**
+     * Helper to build FileHelper with our temp paths via a container stub.
+     */
+    private function buildFileHelper(): FileHelper
+    {
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('getParameter')
+            ->willReturnMap([
+                ['kernel.project_dir', rtrim($this->projectDir, '/')],
+                ['filesdir', rtrim($this->filesDir, '/')],
+            ]);
+
+        return new FileHelper($container, $this->logger);
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to the handling and testing of the files directory structure in the application. The main changes include updating the version marker logic for the files directory, enhancing the directory structure copying process, and adding comprehensive unit tests for the `FilesDirService`. Additionally, some configuration and compatibility adjustments have been made.

**Files directory versioning and structure management:**

* Updated the version marker file logic in `FilesDirService` to use `Constants::APP_VERSION` instead of a hardcoded version, ensuring the marker accurately reflects the current application version.
* Removed the now-unused `FILE_CHECKED_VERSION` constant from `Constants.php`, centralizing version management.
* Improved the directory structure copying process by ensuring both the idevices and themes base directories are removed before copying, preventing stale files from persisting.

**Testing and quality assurance:**

* Added a comprehensive unit test suite for `FilesDirService`, covering scenarios such as old or missing version markers, missing or non-writable directories, and copy failures. This ensures robust behavior and guards against regressions.

**Configuration and compatibility:**

* Allowed Symfony Flex contrib recipes by setting `"allow-contrib": true` in `composer.json`, enabling the use of community-contributed Symfony bundles.
* Increased the PHPUnit maximum execution time to 600 seconds in `phpunit.xml.dist` to prevent test timeouts during slow operations.…crease test time