### PR TITLE
Use ephemeral users in ELP commands for better isolation

### DIFF
--- a/tests/Command/ElpConvertCommandTest.php
+++ b/tests/Command/ElpConvertCommandTest.php
@@ -3,13 +3,10 @@
 namespace App\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use App\Command\net\exelearning\Command\ElpConvertCommand;
 use PHPUnit\Framework\Attributes\DataProvider;
-use App\Entity\net\exelearning\Entity\User;
-use App\Repository\net\exelearning\Repository\UserRepository;
 
 class ElpConvertCommandTest extends KernelTestCase
 {
@@ -24,28 +21,7 @@ class ElpConvertCommandTest extends KernelTestCase
 
         $container = static::getContainer();
 
-        // Create user 1 if not exists
-        $userRepository = $container->get(UserRepository::class);
-        $entityManager = $container->get('doctrine.orm.entity_manager');
-
-        if (!$userRepository->find(1)) {
-            $user = new User();
-            $user->setUserId(1);
-            $user->setEmail('tests@example.com');
-            $user->setPassword('random-pass');
-            $user->setIsLopdAccepted(true);
-
-            $metadata = $entityManager->getClassMetadata(User::class);
-            $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
-
-            $entityManager->persist($user);
-            $entityManager->flush();
-        }
-
-        $application = new Application();
         $command = $container->get(ElpConvertCommand::class);
-        $application->add($command);
-
         $this->commandTester = new CommandTester($command);
     }
 
@@ -59,7 +35,6 @@ class ElpConvertCommandTest extends KernelTestCase
         $this->assertFileExists($inputFile, "Input ELP file does not exist: $inputFile");
 
         $this->commandTester->execute([
-            'command' => 'elp:convert',
             'input' => $inputFile,
             'output' => $outputFile,
             '--debug' => true,
@@ -74,11 +49,12 @@ class ElpConvertCommandTest extends KernelTestCase
     public static function elpFileProvider(): array
     {
         return [
-            ['basic-example.elp'],
-            ['old_elp_modelocrea.elp'],
-            ['old_elp_nebrija.elp'],
-            ['old_elp_poder_conexiones.elp'],
-            ['old_manual_exe29_compressed.elp'],
+            ['basic-example.elp'],                  //   85K
+            ['encoding_test.elp'],                  //  477K
+            // ['old_elp_modelocrea.elp'],          //  4,2M
+            // ['old_elp_nebrija.elp'],             //  7,6M
+            // ['old_elp_poder_conexiones.elp'],    //  5,1M
+            // ['old_manual_exe29_compressed.elp'], // 10,0M
         ];
     }
 
@@ -94,7 +70,6 @@ class ElpConvertCommandTest extends KernelTestCase
         $this->assertFileExists($tempInvalidFile);
 
         $this->commandTester->execute([
-            'command' => 'elp:convert',
             'input' => $tempInvalidFile,
             'output' => $tempOutput,
             '--debug' => true,

--- a/tests/Command/ElpExportEncodingTest.php
+++ b/tests/Command/ElpExportEncodingTest.php
@@ -2,7 +2,6 @@
 namespace App\Tests\Functional\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use App\Command\net\exelearning\Command\ElpExportHtml5Command;
@@ -29,9 +28,6 @@ class ElpExportEncodingTest extends KernelTestCase
         $this->fs = new Filesystem();
 
         $command = $c->get(ElpExportHtml5Command::class);
-        $app = new Application();
-        $app->add($command);
-
         $this->tester = new CommandTester($command);
     }
 

--- a/tests/Command/ElpExportHtml5CommandTest.php
+++ b/tests/Command/ElpExportHtml5CommandTest.php
@@ -3,13 +3,10 @@
 namespace App\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use App\Command\net\exelearning\Command\ElpExportHtml5Command;
 use PHPUnit\Framework\Attributes\DataProvider;
-use App\Entity\net\exelearning\Entity\User;
-use App\Repository\net\exelearning\Repository\UserRepository;
 
 class ElpExportHtml5CommandTest extends KernelTestCase
 {
@@ -24,28 +21,7 @@ class ElpExportHtml5CommandTest extends KernelTestCase
         $container = static::getContainer();
         $this->filesystem = new Filesystem();
 
-        // Create user 1 if not exists
-        $userRepository = $container->get(UserRepository::class);
-        $entityManager = $container->get('doctrine.orm.entity_manager');
-
-        if (!$userRepository->find(1)) {
-            $user = new User();
-            $user->setUserId(1);
-            $user->setEmail('tests@example.com');
-            $user->setPassword("random-pass");
-            $user->setIsLopdAccepted(true);
-
-            $metadata = $entityManager->getClassMetadata(User::class);
-            $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
-
-            $entityManager->persist($user);
-            $entityManager->flush();
-        }
-
-        $application = new Application();
         $command = $container->get(ElpExportHtml5Command::class);
-        $application->add($command);
-
         $this->commandTester = new CommandTester($command);
     }
 
@@ -60,7 +36,6 @@ class ElpExportHtml5CommandTest extends KernelTestCase
         $this->assertFileExists($inputFile, "Input ELP file does not exist: $inputFile");
 
         $this->commandTester->execute([
-            'command' => 'elp:export-html5',
             'input' => $inputFile,
             'output' => $outputDir,
             '--debug' => true,
@@ -76,11 +51,12 @@ class ElpExportHtml5CommandTest extends KernelTestCase
     public static function elpFileProvider(): array
     {
         return [
-            ['basic-example.elp'],
-            ['old_elp_modelocrea.elp'],
-            ['old_elp_nebrija.elp'],
-            ['old_elp_poder_conexiones.elp'],
-            ['old_manual_exe29_compressed.elp'],
+            ['basic-example.elp'],                  //   85K
+            ['encoding_test.elp'],                  //  477K
+            // ['old_elp_modelocrea.elp'],          //  4,2M
+            // ['old_elp_nebrija.elp'],             //  7,6M
+            // ['old_elp_poder_conexiones.elp'],    //  5,1M
+            // ['old_manual_exe29_compressed.elp'], // 10,0M
         ];
     }
 
@@ -97,7 +73,6 @@ class ElpExportHtml5CommandTest extends KernelTestCase
         $this->assertFileExists($tempInvalidFile);
 
         $this->commandTester->execute([
-            'command' => 'elp:export-html5',
             'input' => $tempInvalidFile,
             'output' => $outputDir,
             '--debug' => true,

--- a/tests/Command/ElpExportSimpleTest.php
+++ b/tests/Command/ElpExportSimpleTest.php
@@ -4,7 +4,6 @@ namespace App\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use App\Command\net\exelearning\Command\ElpExportHtml5Command;
@@ -22,8 +21,6 @@ class ElpExportSimpleTest extends KernelTestCase
 
         $this->filesystem = new Filesystem();
         $command = $container->get(ElpExportHtml5Command::class);
-        $application = new Application();
-        $application->add($command);
         $this->commandTester = new CommandTester($command);
     }
 


### PR DESCRIPTION
This pull request refactors both the `ElpConvertCommand` and `ElpExportCommand` to improve user handling and session cleanup, and updates their corresponding tests. The main change is the shift from using a static user (user 1) to dynamically creating and removing ephemeral users for each command execution, ensuring better isolation and cleanup. Additionally, export directory copying is optimized, and test setup is simplified.

**Command user management and session cleanup:**

* Both `ElpConvertCommand` and `ElpExportCommand` now create a unique ephemeral `User` entity for each run, replacing the previous approach of using a static/mock user. These users are persisted at the start and removed at the end of the command execution, including on error paths. 
**Export directory handling:**

* In `ElpExportCommand`, the custom recursive `copyDirectory` method is replaced with Symfony's optimized `Filesystem::mirror()` for copying export directories, improving performance and reliability. 

**Dependency injection and constructor changes:**

* Both commands now accept `EntityManagerInterface` via dependency injection to manage user persistence and removal. 

**Test simplification and updates:**

* Test setup for both commands no longer creates or relies on a static test user. The tests now directly use the command services, and unnecessary application registration is removed. 
* The ELP file provider in `ElpConvertCommandTest` is updated to include a new test file and comment out large files for efficiency.

These changes improve the robustness, security, and maintainability of the ELP conversion/export commands and their tests.