### PR TITLE
Added comment to docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# ⚠️ WARNING: This docker-compose file is mainly intended for development.
+# For production deployments, please use the example docker-compose files
+# provided in docs/deploy/ (examples available for SQLite, MariaDB and PostgreSQL).
 ---
 services:
 


### PR DESCRIPTION
This pull request adds a warning comment to the top of the `docker-compose.yml` file to clarify its intended use. The comment advises developers that this file is mainly for development purposes and points to example files for production deployments.

* Documentation update:
  * Added a warning comment at the top of `docker-compose.yml` to indicate it is for development use and to direct users to production-ready examples in `docs/deploy/`.