### PR TITLE
Add the .xml extension on metadata export

### DIFF
--- a/main.js
+++ b/main.js
@@ -119,7 +119,7 @@ function inferKnownExt(suggestedName) {
   try {
     const ext = (path.extname(suggestedName || '') || '').toLowerCase().replace(/^\./, '');
     if (!ext) return null;
-    if (ext === 'elp' || ext === 'zip' || ext === 'epub') return `.${ext}`;
+    if (ext === 'elp' || ext === 'zip' || ext === 'epub' || ext === 'xml') return `.${ext}`;
     return null;
   } catch (_e) {
     return null;

--- a/public/app/workarea/menus/navbar/items/navbarFile.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.js
@@ -2098,6 +2098,7 @@ export default class NavbarFile {
             let ext = '';
             if (lower.endsWith('epub3')) ext = '.epub';
             else if (lower.endsWith('elp')) ext = '.elp';
+            else if (lower.includes('xml')) ext = '.xml';
             else ext = '.zip';
             if (!hasDot) base += ext;
             return base;


### PR DESCRIPTION
This pull request adds improved handling for files with the `.xml` extension in both the file extension inference logic and the file naming logic. The changes ensure that files related to XML are correctly recognized and named.

**File extension handling improvements:**

* Updated `inferKnownExt` in `main.js` to recognize `.xml` as a known extension, allowing it to be returned alongside `.elp`, `.zip`, and `.epub`.

**File naming logic enhancements:**

* Modified `NavbarFile` in `navbarFile.js` to append `.xml` to filenames that include "xml" in their name, ensuring consistent handling of XML files.