### PR TITLE
Fix mount of `public/bundles` to resolve permission errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - ./composer.lock:/app/composer.lock
       - mnt-data:/mnt/data:rw # Mount the volume for persistent data
       - ./e2e_screenshots:/tmp/e2e_screenshots
+    tmpfs:
+      - /app/public/bundles:rw,size=64m,mode=1777 # public/bundles mounted as tmpfs to avoid permission errors
     environment:
       MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET_KEY}
       MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET_KEY}


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to address recurring permission errors when Symfony installs bundle assets into the `public/bundles` directory:

```
✘   ApiPlatformBundle   Failed to create "public/bundles/apiplatform": mkdir(): Permission denied
```

**Changes introduced:**

* Added a `tmpfs` mount for `/app/public/bundles` in the `exelearning` service.
* Configured it with read-write access, a 64 MB size limit, and `1777` permissions.
* Ensures that the Symfony `assets:install` command can create and manage assets without failing due to permission issues.

**Result:**
The application now installs assets successfully on macOS, Windows, and Linux development environments, avoiding manual directory creation or permission adjustments.