### PR TITLE
PHP-generated common_i18n.js (#233)

### DIFF
--- a/src/Service/net/exelearning/Service/Api/OdeExportService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeExportService.php
@@ -952,13 +952,13 @@ class OdeExportService implements OdeExportServiceInterface
      * @return array
      */
     private function copyBaseFilesToExportDir(
-        $exportDirPath, 
-        $exportType, 
-        $resourcesPrefix, 
-        $isPreview, 
+        $exportDirPath,
+        $exportType,
+        $resourcesPrefix,
+        $isPreview,
         $libraries,
         $packageLanguage,
-        $user
+        $user,
     ) {
         $filesToCopy = [];
 
@@ -966,7 +966,7 @@ class OdeExportService implements OdeExportServiceInterface
         // $filesToCopy = array_merge($filesToCopy, Constants::EXPORT_SYMFONY_PUBLIC_FILES_BASE);
         $filesToCopy = [
             Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'exe_export.js',
-            //Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common_i18n.js',
+            // Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common_i18n.js',
             Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common.js',
             Constants::LIBS_DIR.DIRECTORY_SEPARATOR.'jquery',
             Constants::LIBS_DIR.DIRECTORY_SEPARATOR.'bootstrap',

--- a/src/Service/net/exelearning/Service/Api/OdeExportService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeExportService.php
@@ -20,6 +20,7 @@ use App\Service\net\exelearning\Service\Export\ExportHTML5SPService;
 use App\Service\net\exelearning\Service\Export\ExportIMSService;
 use App\Service\net\exelearning\Service\Export\ExportSCORM12Service;
 use App\Service\net\exelearning\Service\Export\ExportSCORM2004Service;
+use App\Util\net\exelearning\Util\CommonI18nUtil;
 use App\Util\net\exelearning\Util\ExportXmlUtil;
 use App\Util\net\exelearning\Util\FilePermissionsUtil;
 use App\Util\net\exelearning\Util\FileUtil;
@@ -596,9 +597,12 @@ class OdeExportService implements OdeExportServiceInterface
         // it should search in each idevice if it has any effect included. The method will return an array with all the effects it finds.
         list($librariesToCopy, $librariesFileToCopy) = ExportXmlUtil::getPathForLibrariesInIdevices($odeNavStructureSyncs, $odeProperties);
 
+        // The package language can be obtained from the $odeProperties array using the pp_lang key.
+        $packageLanguage = isset($odeProperties['pp_lang']) ? $odeProperties['pp_lang']->getValue() : Settings::DEFAULT_LOCALE;
+
         // copy all libs, jquery, bootstrap
         // Copy project base files to export --> Here we are going to copy the mandatory ones
-        $this->copyBaseFilesToExportDir($newExportDirPath, $exportType, $resourcesPrefix, $isPreview, $librariesToCopy);
+        $this->copyBaseFilesToExportDir($newExportDirPath, $exportType, $resourcesPrefix, $isPreview, $librariesToCopy, $packageLanguage, $user);
 
         // Copy ode files
         $idevicesMapping = $odeSaveXML->getOdeComponentsMapping();
@@ -868,28 +872,125 @@ class OdeExportService implements OdeExportServiceInterface
     }
 
     /**
+     * Generate common i18n JavaScript content with main translations and iDevice translations.
+     *
+     * @param string        $packageLanguage
+     * @param array         $translations
+     * @param UserInterface $user
+     *
+     * @return string
+     */
+    private function generateCommonI18nJs(
+        $packageLanguage,
+        $translations,
+        $user,
+    ) {
+        // Build JS object $exe_i18n
+        $entriesCommon = [];
+        $commonTranslations = $translations['common'] ?? [];
+        $jsContent = "// The content of this file will be dynamically generated in the language of the elp.\n";
+        $jsContent .= '$exe_i18n = {';
+        foreach ($commonTranslations as $key => $value) {
+            $entriesCommon[] = $key.': "'.addslashes($value).'"';
+        }
+
+        $jsContent .= implode(', ', $entriesCommon);
+        $jsContent .= '};'."\n";
+
+        // Build JS object $exe_i18n.exeGames
+        $entriesGames = [];
+        $gamesTranslations = $translations['games'] ?? [];
+        $jsContent .= "// This line is only present if the elp contains a hangman game.\n";
+        $jsContent .= '$exe_i18n.exeGames = {';
+        foreach ($gamesTranslations as $key => $value) {
+            $entriesGames[] = $key.': "'.addslashes($value).'"';
+        }
+
+        $jsContent .= implode(', ', $entriesGames);
+        $jsContent .= '};'."\n";
+
+        // Add iDevice translations
+        try {
+            $idevicesInstalled = $this->ideviceHelper->getInstalledIdevices($user);
+            foreach ($idevicesInstalled as $idevice) {
+                $ideviceName = $idevice->getName();
+                $ideviceDir = $idevice->getDirName();
+
+                $ideviceTranslationPath = $this->ideviceHelper->getIdeviceTranslationFilePathName(
+                    $packageLanguage,
+                    $ideviceDir,
+                    $ideviceName
+                );
+
+                if (file_exists($ideviceTranslationPath)) {
+                    $ideviceTranslations = FileUtil::readXlfFile($ideviceTranslationPath, $packageLanguage);
+                    foreach ($ideviceTranslations as $key => $value) {
+                        $translated = $this->translator->trans($value, [], null, $packageLanguage);
+                        $prefixedKey = $ideviceName.'_'.$key;
+                        $jsContent .= '$exe_i18n.exeGames["'.addslashes($prefixedKey).'"] = "'.addslashes($translated)."\";\n";
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Failed to load iDevice translations: '.$e->getMessage());
+        }
+
+        return $jsContent;
+    }
+
+    /**
      * Copy symfony base files to project export libs dir.
      *
-     * @param string $exportDirPath
-     * @param string $exportType
-     * @param string $isPreview
+     * @param string        $exportDirPath
+     * @param string        $exportType
+     * @param string        $resourcesPrefix
+     * @param string        $isPreview
+     * @param array         $libraries
+     * @param string        $packageLanguage
+     * @param UserInterface $user
      *
      * @return array
      */
-    private function copyBaseFilesToExportDir($exportDirPath, $exportType, $resourcesPrefix, $isPreview, $libraries)
-    {
+    private function copyBaseFilesToExportDir(
+        $exportDirPath, 
+        $exportType, 
+        $resourcesPrefix, 
+        $isPreview, 
+        $libraries,
+        $packageLanguage,
+        $user
+    ) {
         $filesToCopy = [];
 
         // Base files
         // $filesToCopy = array_merge($filesToCopy, Constants::EXPORT_SYMFONY_PUBLIC_FILES_BASE);
         $filesToCopy = [
             Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'exe_export.js',
-            Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common_i18n.js',
+            //Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common_i18n.js',
             Constants::JS_APP_NAME.DIRECTORY_SEPARATOR.Constants::COMMON_NAME.DIRECTORY_SEPARATOR.'common.js',
             Constants::LIBS_DIR.DIRECTORY_SEPARATOR.'jquery',
             Constants::LIBS_DIR.DIRECTORY_SEPARATOR.'bootstrap',
         ];
         $filesToCopy = array_merge($filesToCopy, $libraries);
+
+        // Get translations
+        $commonI18n = new CommonI18nUtil($this->translator, $packageLanguage);
+
+        $translations = [
+            'common' => $commonI18n->getCommonStringsi18n(),
+            'games' => $commonI18n->getGamesStringsi18n(),
+        ];
+
+        // Generate common_i18n.js directly in the export folder
+        $commonI18nContent = $this->generateCommonI18nJs($packageLanguage, $translations, $user);
+        $exportLibsDir = $exportDirPath.Constants::EXPORT_DIR_PUBLIC_LIBS.DIRECTORY_SEPARATOR;
+
+        if (!is_dir($exportLibsDir)) {
+            mkdir($exportLibsDir, 0777, true);
+        }
+
+        $commonI18nPath = $exportLibsDir.'common_i18n.js';
+        file_put_contents($commonI18nPath, $commonI18nContent);
 
         // Add symfony path
         $symfonyPublicDirPath = $this->fileHelper->getSymfonyPublicDir();

--- a/src/Util/net/exelearning/Util/Commoni18nUtil.php
+++ b/src/Util/net/exelearning/Util/Commoni18nUtil.php
@@ -61,7 +61,7 @@ class CommonI18nUtil
             'drag_and_drop' => $this->translator->trans('Drag and drop', [], null, $this->lang),
             'reset' => $this->translator->trans('Reset', [], null, $this->lang),
             'mode_toggler' => $this->translator->trans('Light/dark mode', [], null, $this->lang),
-            'teacher_mode' => $this->translator->trans('Teacher mode', [], null, $this->lang)
+            'teacher_mode' => $this->translator->trans('Teacher mode', [], null, $this->lang),
         ];
     }
 
@@ -91,7 +91,7 @@ class CommonI18nUtil
             'confirmReload' => $this->translator->trans('Reload the game?', [], null, $this->lang),
             'clickOnPlay' => $this->translator->trans('Click "Play" to start a new game.', [], null, $this->lang),
             'clickOnOtherWord' => $this->translator->trans('Click "Another word" to continue.', [], null, $this->lang),
-            'az' => $this->translator->trans('abcdefghijklmnñopqrstuvwxyz', [], null, $this->lang)
+            'az' => $this->translator->trans('abcdefghijklmnñopqrstuvwxyz', [], null, $this->lang),
         ];
     }
 }

--- a/src/Util/net/exelearning/Util/Commoni18nUtil.php
+++ b/src/Util/net/exelearning/Util/Commoni18nUtil.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Util\net\exelearning\Util;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * CommonI18nUtil.
+ *
+ * Utility functions for working with strings i18n
+ */
+class CommonI18nUtil
+{
+    private TranslatorInterface $translator;
+    private string $lang;
+
+    public function __construct(TranslatorInterface $translator, string $lang)
+    {
+        $this->translator = $translator;
+        $this->lang = $lang;
+    }
+
+    /**
+     * Generate strings for i18n.
+     */
+    public function getCommonStringsi18n()
+    {
+        return [
+            'previous' => $this->translator->trans('Previous', [], null, $this->lang),
+            'next' => $this->translator->trans('Next', [], null, $this->lang),
+            'show' => $this->translator->trans('Show', [], null, $this->lang),
+            'hide' => $this->translator->trans('Hide', [], null, $this->lang),
+            'showFeedback' => $this->translator->trans('Show feedback', [], null, $this->lang),
+            'hideFeedback' => $this->translator->trans('Hide feedback', [], null, $this->lang),
+            'correct' => $this->translator->trans('Correct', [], null, $this->lang),
+            'incorrect' => $this->translator->trans('Incorrect', [], null, $this->lang),
+            'menu' => $this->translator->trans('Menu', [], null, $this->lang),
+            'download' => $this->translator->trans('Download', [], null, $this->lang),
+            'yourScoreIs' => $this->translator->trans('Your score is', [], null, $this->lang),
+            'dataError' => $this->translator->trans('Error retrieving data', [], null, $this->lang),
+            'epubJSerror' => $this->translator->trans('This might not work in this ePub reader.', [], null, $this->lang),
+            'epubDisabled' => $this->translator->trans('This activity does not work in ePub format.', [], null, $this->lang),
+            'solution' => $this->translator->trans('Solution', [], null, $this->lang),
+            'print' => $this->translator->trans('Print', [], null, $this->lang),
+            'fullSearch' => $this->translator->trans('Search all pages', [], null, $this->lang),
+            'noSearchResults' => $this->translator->trans('No results found for %', [], null, $this->lang),
+            'searchResults' => $this->translator->trans('Search results for %', [], null, $this->lang),
+            'hideResults' => $this->translator->trans('Hide results', [], null, $this->lang),
+            'more' => $this->translator->trans('More', [], null, $this->lang),
+            'newWindow' => $this->translator->trans('New window', [], null, $this->lang),
+            'fullSize' => $this->translator->trans('Full size', [], null, $this->lang),
+            'search' => $this->translator->trans('Search', [], null, $this->lang),
+            'accessibility_tools' => $this->translator->trans('Accessibility tools', [], null, $this->lang),
+            'close_toolbar' => $this->translator->trans('Close', [], null, $this->lang),
+            'default_font' => $this->translator->trans('Default typography', [], null, $this->lang),
+            'increase_text_size' => $this->translator->trans('Increase text size', [], null, $this->lang),
+            'decrease_text_size' => $this->translator->trans('Decrease text size', [], null, $this->lang),
+            'read' => $this->translator->trans('Read', [], null, $this->lang),
+            'stop_reading' => $this->translator->trans('Stop reading', [], null, $this->lang),
+            'translate' => $this->translator->trans('Translate', [], null, $this->lang),
+            'drag_and_drop' => $this->translator->trans('Drag and drop', [], null, $this->lang),
+            'reset' => $this->translator->trans('Reset', [], null, $this->lang),
+            'mode_toggler' => $this->translator->trans('Light/dark mode', [], null, $this->lang),
+            'teacher_mode' => $this->translator->trans('Teacher mode', [], null, $this->lang)
+        ];
+    }
+
+    /**
+     * Generate strings for idevices in i18n.
+     */
+    public function getGamesStringsi18n()
+    {
+        return [
+            'hangManGame' => $this->translator->trans('Hangman Game', [], null, $this->lang),
+            'accept' => $this->translator->trans('Accept', [], null, $this->lang),
+            'yes' => $this->translator->trans('Yes', [], null, $this->lang),
+            'no' => $this->translator->trans('No', [], null, $this->lang),
+            'right' => $this->translator->trans('Correct', [], null, $this->lang),
+            'wrong' => $this->translator->trans('Incorrect', [], null, $this->lang),
+            'rightAnswer' => $this->translator->trans('Correct answer', [], null, $this->lang),
+            'stat' => $this->translator->trans('Stat', [], null, $this->lang),
+            'selectedLetters' => $this->translator->trans('Selected letters', [], null, $this->lang),
+            'word' => $this->translator->trans('Word', [], null, $this->lang),
+            'words' => $this->translator->trans('Words', [], null, $this->lang),
+            'play' => $this->translator->trans('Play', [], null, $this->lang),
+            'playAgain' => $this->translator->trans('Play again', [], null, $this->lang),
+            'results' => $this->translator->trans('Results', [], null, $this->lang),
+            'total' => $this->translator->trans('Total', [], null, $this->lang),
+            'otherWord' => $this->translator->trans('Other word', [], null, $this->lang),
+            'gameOver' => $this->translator->trans('Game Over', [], null, $this->lang),
+            'confirmReload' => $this->translator->trans('Reload the game?', [], null, $this->lang),
+            'clickOnPlay' => $this->translator->trans('Click "Play" to start a new game.', [], null, $this->lang),
+            'clickOnOtherWord' => $this->translator->trans('Click "Another word" to continue.', [], null, $this->lang),
+            'az' => $this->translator->trans('abcdefghijklmnñopqrstuvwxyz', [], null, $this->lang)
+        ];
+    }
+}


### PR DESCRIPTION
This pull request updates the way the commoni18n.js file is added to exports to do so dynamically.

To do this, a new helper class called CommonI18nUtil is created within the utilities folder with the strings prepared for translation extraction and resolved on the fly while exporting packages using the OdeExportService service.

Within OdeExportService, the copyBaseFilesToExportDir method is modified for dynamic generation, and a new method called generateCommonI18nJs is added.