### PR TITLE
142 style management errors

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -21,6 +21,12 @@ XDEBUG_CONFIG="client_host=host.docker.internal"
 #   BASE_PATH=/web/exelearning
 BASE_PATH=
 
+# Allow users to import/install styles
+ONLINE_THEMES_INSTALL=0
+
+# Allow users to import/install iDevices
+ONLINE_IDEVICES_INSTALL=0
+
 # Test user data
 TEST_USER_EMAIL=user@exelearning.net
 TEST_USER_USERNAME=user

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -58,6 +58,12 @@ parameters:
     app.logs.dir:  '%env(default:logs_default_dir:LOG_DIR)%'
     app.cache.dir: '%env(default:cache_default_dir:CACHE_DIR)%'
 
+    # Allow users to import/install styles
+    app.online_themes_install: '%env(bool:ONLINE_THEMES_INSTALL)%'
+
+    # Allow users to import/install iDevices
+    app.online_idevices_install: '%env(bool:ONLINE_IDEVICES_INSTALL)%'
+
 services:
     Symfony\Component\DependencyInjection\ContainerInterface: '@service_container'
     # default configuration for services in *this* file

--- a/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
@@ -1184,7 +1184,7 @@ export default class modalOpenUserOdeFiles extends Modal {
      * @param {*} response
      */
     loadOdeTheme(response) {
-        if (response.theme && response.themeDir) {
+        if (response.theme && response.themeDir && response.authorized) {
             if (
                 Object.keys(eXeLearning.app.themes.list.installed).includes(
                     response.theme

--- a/public/app/workarea/themes/theme.js
+++ b/public/app/workarea/themes/theme.js
@@ -181,7 +181,9 @@ export default class Theme {
                 .path;
         let pathSplit = path.split('/files/');
         let pathParam = pathSplit.length == 2 ? pathSplit[1] : path;
+        pathParam='/'+pathParam;
         let pathServiceResourceContentCss = `${pathServiceResources}?resource=${pathParam}`;
+        
         return pathServiceResourceContentCss;
     }
 

--- a/public/app/workarea/themes/theme.js
+++ b/public/app/workarea/themes/theme.js
@@ -181,9 +181,9 @@ export default class Theme {
                 .path;
         let pathSplit = path.split('/files/');
         let pathParam = pathSplit.length == 2 ? pathSplit[1] : path;
-        pathParam='/'+pathParam;
+        pathParam = '/' + pathParam;
         let pathServiceResourceContentCss = `${pathServiceResources}?resource=${pathParam}`;
-        
+
         return pathServiceResourceContentCss;
     }
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -70,6 +70,7 @@ class Constants
     public const THEME_LOGO_IMG = 'logo';
     public const THEME_TYPE_BASE = 'base';
     public const THEME_TYPE_USER = 'user';
+    public const THEME_INSTALLABLE = 'downloadable';
 
     // iDevices
     public const IDEVICE_CONFIG_FILENAME = 'config.xml';

--- a/src/Controller/net/exelearning/Controller/Api/CurrentOdeUsersApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/CurrentOdeUsersApiController.php
@@ -53,6 +53,8 @@ class CurrentOdeUsersApiController extends DefaultApiController
 
         $currentOdeUsersRepository = $this->entityManager->getRepository(CurrentOdeUsers::class);
 
+        $this->userHelper->saveUserTheme($user, Constants::THEME_DEFAULT);
+
         // Check if user has already an open session
         $currentOdeUserForUser = $currentOdeUsersRepository->getCurrentSessionForUser($databaseUser->getUserIdentifier());
 

--- a/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
@@ -763,6 +763,9 @@ class OdeApiController extends DefaultApiController
         $elpFilePath = $request->get('odeFilePath');
         $forceCloseOdeUserPreviousSession = $request->get('forceCloseOdeUserPreviousSession');
 
+        $installThemesAllowed = $this->getParameter('app.online_themes_install');
+        $isOnline = $this->getParameter('app.online_mode');
+
         if (
             $request->request->has('forceCloseOdeUserPreviousSession')
             && (('true' == $forceCloseOdeUserPreviousSession) || ('1' == $forceCloseOdeUserPreviousSession))
@@ -794,9 +797,8 @@ class OdeApiController extends DefaultApiController
 
                 if ('OK' !== $zipResult['responseMessage']) {
                     $responseData['responseMessage'] = $zipResult['responseMessage'];
-                    $jsonData = $this->getJsonSerialized($responseData);
 
-                    return new JsonResponse($jsonData, $this->status, [], true);
+                    return $this->json($responseData, $this->status);
                 }
 
                 $elpFileName = $zipResult['elpName'];
@@ -815,16 +817,13 @@ class OdeApiController extends DefaultApiController
                 $result['responseMessage'] = $this->translator->trans('The file content is wrong');
                 $responseData['responseMessage'] = $result['responseMessage'];
 
-                $jsonData = $this->getJsonSerialized($responseData);
-
-                return new JsonResponse($jsonData, $this->status, [], true);
+                return $this->json($responseData, $this->status);
             }
 
             if ('OK' !== $odeValues['responseMessage']) {
                 $responseData['responseMessage'] = $odeValues['responseMessage'];
-                $jsonData = $this->getJsonSerialized($responseData);
 
-                return new JsonResponse($jsonData, $this->status, [], true);
+                return $this->json($responseData, $this->status);
             }
 
             // Create the structure in database and update current user
@@ -840,9 +839,7 @@ class OdeApiController extends DefaultApiController
             $result['responseMessage'] = 'error: '.$e->getMessage();
             $responseData['responseMessage'] = $result['responseMessage'];
 
-            $jsonData = $this->getJsonSerialized($responseData);
-
-            return new JsonResponse($jsonData, $this->status, [], true);
+            return $this->json($responseData, $this->status);
         }
 
         if (!empty($odeValues['responseMessage'])) {
@@ -869,10 +866,17 @@ class OdeApiController extends DefaultApiController
         if (!empty($odeValues['themeDir'])) {
             $responseData['themeDir'] = $odeValues['themeDir'];
         }
+        if (!empty($odeValues['themeInstallable'])) {
+            $responseData['authorized'] = $odeValues['themeInstallable'];
+        } else {
+            $responseData['authorized'] = false;
+        }
 
-        $jsonData = $this->getJsonSerialized($responseData);
+        if ($isOnline && !$installThemesAllowed) {
+            $responseData['authorized'] = false;
+        }
 
-        return new JsonResponse($jsonData, $this->status, [], true);
+        return $this->json($responseData, $this->status);
     }
 
     #[Route('/ode/local/xml/properties/open', methods: ['POST'], name: 'api_odes_ode_local_xml_properties_open')]

--- a/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
@@ -740,6 +740,9 @@ class OdeApiController extends DefaultApiController
         }
         if (!empty($odeValues['theme'])) {
             $responseData['theme'] = $odeValues['theme'];
+            $this->userHelper->saveUserTheme($user, $odeValues['theme']);
+        } else {
+            // $this->userHelper->saveUserTheme($user,Constants::THEME_DEFAULT);
         }
         if (!empty($odeValues['themeDir'])) {
             $responseData['themeDir'] = $odeValues['themeDir'];
@@ -859,6 +862,9 @@ class OdeApiController extends DefaultApiController
         }
         if (!empty($odeValues['theme'])) {
             $responseData['theme'] = $odeValues['theme'];
+            $this->userHelper->saveUserTheme($user, $odeValues['theme']);
+        } else {
+            // $this->userHelper->saveUserTheme($user,Constants::THEME_DEFAULT);
         }
         if (!empty($odeValues['themeDir'])) {
             $responseData['themeDir'] = $odeValues['themeDir'];
@@ -873,7 +879,6 @@ class OdeApiController extends DefaultApiController
     public function openLocalXmlPropertiesAction(Request $request)
     {
         $responseData = [];
-
         // Collect parameters
         $xmlFileName = $request->get('odeFileName');
         $xmlFilePath = $request->get('odeFilePath');
@@ -1252,7 +1257,6 @@ class OdeApiController extends DefaultApiController
     public function uploadLargeOdeFilesAction(Request $request)
     {
         $responseData = [];
-
         $user = $this->getUser();
 
         // Set locale (TODO: error translator returns to default locale)

--- a/src/Controller/net/exelearning/Controller/Api/OdeExportApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeExportApiController.php
@@ -122,7 +122,7 @@ class OdeExportApiController extends DefaultApiController
 
         $user = $this->getUser();
         $databaseUser = $this->userHelper->getDatabaseUser($user);
-
+        // $tempID= $this->fileHelper->getTempID(4);
         // Generate export file
         $odeExportResult = $this->odeExportService->export(
             $user,
@@ -131,7 +131,8 @@ class OdeExportApiController extends DefaultApiController
             $baseUrl,
             $exportType,
             true,
-            false
+            false,
+            bin2hex(random_bytes(6 / 2)).DIRECTORY_SEPARATOR
         );
 
         $jsonData = $this->getJsonSerialized($odeExportResult);

--- a/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
@@ -9,7 +9,6 @@ use App\Helper\net\exelearning\Helper\FileHelper;
 use App\Helper\net\exelearning\Helper\ThemeHelper;
 use App\Helper\net\exelearning\Helper\UserHelper;
 use App\Util\net\exelearning\Util\FileUtil;
-use App\Util\net\exelearning\Util\SettingsUtil;
 use App\Util\net\exelearning\Util\Util;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -77,74 +76,88 @@ class ThemeApiController extends DefaultApiController
     }
 
     #[Route('/upload', methods: ['POST'], name: 'api_themes_upload')]
-    public function uploadThemeAction(Request $request)
+    public function uploadThemeAction(Request $request): JsonResponse
     {
-        $ert = 1;
-        if (!SettingsUtil::installationTypeIsOffline() && 1 == $ert) {
-            try {
-                Util::checkPhpZipExtension();
-            } catch (PhpZipExtensionException $e) {
-                $this->logger->error('The zip file cannot be unzipped', ['file:' => $this, 'line' => __LINE__]);
-                $responseData['error'] = 'The zip file cannot be unzipped';
-                $jsonData = $this->getJsonSerialized($responseData);
+        $UNAUTHORIZED = 'Unauthorized';
+        $ERROR_INVALID_DATA = 'Invalid data';
+        $ERROR_ZIP_EXTENSION = 'The zip file cannot be unzipped';
+        $INSTALL_FAILED = 'Could not install the theme';
 
-                return new JsonResponse($jsonData, $this->status, [], true);
-            }
+        $installThemesAllowed = $this->getParameter('app.online_themes_install');
+        $isOnline = $this->getParameter('app.online_mode');
 
-            $user = $this->getUser();
-
-            // Upload zip file parameters
-            $base64String = $request->get('file');
-            $filename = $request->get('filename');
-
-            // Validate received data
-            if ((empty($base64String)) || (empty($filename))) {
-                $this->logger->error('invalid data', ['file:' => $this, 'line' => __LINE__]);
-                $responseData = ['error' => 'Invalid data'];
-                $jsonData = $this->getJsonSerialized($responseData);
-
-                return new JsonResponse($jsonData, $this->status, [], true);
-            }
-
-            // Upload and install theme
-            $newTheme = $this->themeHelper->uploadThemeZip($filename, $base64String, $user);
-
-            // Check installed theme
-            if ($newTheme && $newTheme['error']) {
-                $responseData = ['error' => $newTheme['error']];
-                $jsonData = $this->getJsonSerialized($responseData);
-
-                return new JsonResponse($jsonData, $this->status, [], true);
-            } elseif (!isset($newTheme['theme'])) {
-                $responseData = ['error' => 'Could not install the theme'];
-                $jsonData = $this->getJsonSerialized($responseData);
-
-                return new JsonResponse($jsonData, $this->status, [], true);
-            }
-
-            // Response
-            $responseData = [];
-            $responseData['theme'] = $newTheme['theme'];
-            $responseData['themes'] = $this->getInstalledThemesAction($request, false);
-            $responseData['responseMessage'] = 'OK';
-        } else {
+        if ($isOnline && !$installThemesAllowed) {
             $responseData['responseMessage'] = 'Unauthorized';
-        }
-        $jsonData = $this->getJsonSerialized($responseData);
 
-        return new JsonResponse($jsonData, $this->status, [], true);
+            return $this->json($responseData, $this->status);
+        }
+        try {
+            Util::checkPhpZipExtension();
+        } catch (PhpZipExtensionException $e) {
+            $this->logger->error($ERROR_ZIP_EXTENSION, ['file:' => $this, 'line' => __LINE__]);
+            $responseData['error'] = $ERROR_ZIP_EXTENSION;
+
+            return $this->json($responseData, $this->status);
+        }
+
+        $user = $this->getUser();
+
+        // Upload zip file parameters
+        $base64String = $request->get('file');
+        $filename = $request->get('filename');
+
+        // Validate received data
+        if ((empty($base64String)) || (empty($filename))) {
+            $this->logger->error('invalid data', ['file:' => $this, 'line' => __LINE__]);
+            $responseData = ['error' => $ERROR_INVALID_DATA];
+
+            return $this->json($responseData, $this->status);
+        }
+
+        // Upload and install theme
+        $newTheme = $this->themeHelper->uploadThemeZip($filename, $base64String, $user);
+
+        // Check installed theme
+        if ($newTheme && $newTheme['error']) {
+            $responseData = ['error' => $newTheme['error']];
+
+            return $this->json($responseData, $this->status);
+        } elseif (!isset($newTheme['theme'])) {
+            $responseData = ['error' => $INSTALL_FAILED];
+
+            return $this->json($responseData, $this->status);
+        }
+
+        // Response
+        $responseData = [];
+        $responseData['theme'] = $newTheme['theme'];
+        $responseData['themes'] = $this->getInstalledThemesAction($request, false);
+        $responseData['responseMessage'] = 'OK';
+
+        return $this->json($responseData, $this->status);
     }
 
     #[Route('/import/odetheme', methods: ['POST'], name: 'api_ode_theme_import')]
     public function importOdeThemeAction(Request $request)
     {
         $responseData = [];
+        $isOnline = false;
+
+        $installThemesAllowed = $this->getParameter('app.online_themes_install');
+        $isOnline = $this->getParameter('app.online_mode');
+
+        if ($isOnline && !$installThemesAllowed) {
+            $responseData['responseMessage'] = 'Unauthorized';
+
+            return new JsonResponse($this->getJsonSerialized($responseData), $this->status, [], true);
+        }
 
         try {
             Util::checkPhpZipExtension();
         } catch (PhpZipExtensionException $e) {
             $this->logger->error('The zip file cannot be unzipped', ['file:' => $this, 'line' => __LINE__]);
             $responseData['error'] = 'The zip file cannot be unzipped';
+
             $jsonData = $this->getJsonSerialized($responseData);
 
             return new JsonResponse($jsonData, $this->status, [], true);
@@ -161,13 +174,38 @@ class ThemeApiController extends DefaultApiController
         $odeSessionThemeDir = $odeSessionDir.DIRECTORY_SEPARATOR.Constants::EXPORT_DIR_THEME;
 
         $themesDirPath = $this->fileHelper->getThemesUsersDir().$dbUser->getUserId().DIRECTORY_SEPARATOR;
+        $themeConfigFile = $odeSessionThemeDir.DIRECTORY_SEPARATOR.'config.xml';
+        if (!is_file($themeConfigFile)) {
+            $responseData['responseMessage'] = 'Theme configuration not found';
+
+            $jsonData = $this->getJsonSerialized($responseData);
+
+            return new JsonResponse($jsonData, $this->status, [], true);
+        }
+
+        $isInstallable = $this->fileHelper->xmlKeyValue($themeConfigFile, Constants::THEME_INSTALLABLE);
+
+        if (!$isInstallable) {
+            $responseData['responseMessage'] = 'Unauthorized';
+
+            return new JsonResponse($this->getJsonSerialized($responseData), $this->status, [], true);
+        }
+
         $outputThemePath = $themesDirPath.$themeDirname;
+        try {
+            FileUtil::copyDir($odeSessionThemeDir, $outputThemePath);
 
-        FileUtil::copyDir($odeSessionThemeDir, $outputThemePath);
-
-        // Response
-        $responseData['themes'] = $this->getInstalledThemesAction($request, false);
-        $responseData['responseMessage'] = 'OK';
+            // Response
+            $responseData['themes'] = $this->getInstalledThemesAction($request, false);
+            $responseData['responseMessage'] = 'OK';
+        } catch (\Exception $e) {
+            $this->logger->error('Theme installation failed', [
+                'exception' => $e->getMessage(),
+                'theme' => $themeDirname,
+                'user' => $dbUser->getUserId(),
+            ]);
+            $responseData['responseMessage'] = 'Could not install the theme';
+        }
 
         $jsonData = $this->getJsonSerialized($responseData);
 

--- a/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
@@ -9,6 +9,7 @@ use App\Helper\net\exelearning\Helper\FileHelper;
 use App\Helper\net\exelearning\Helper\ThemeHelper;
 use App\Helper\net\exelearning\Helper\UserHelper;
 use App\Util\net\exelearning\Util\FileUtil;
+use App\Util\net\exelearning\Util\SettingsUtil;
 use App\Util\net\exelearning\Util\Util;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -78,53 +79,57 @@ class ThemeApiController extends DefaultApiController
     #[Route('/upload', methods: ['POST'], name: 'api_themes_upload')]
     public function uploadThemeAction(Request $request)
     {
-        try {
-            Util::checkPhpZipExtension();
-        } catch (PhpZipExtensionException $e) {
-            $this->logger->error('The zip file cannot be unzipped', ['file:' => $this, 'line' => __LINE__]);
-            $responseData['error'] = 'The zip file cannot be unzipped';
-            $jsonData = $this->getJsonSerialized($responseData);
+        $ert = 1;
+        if (!SettingsUtil::installationTypeIsOffline() && 1 == $ert) {
+            try {
+                Util::checkPhpZipExtension();
+            } catch (PhpZipExtensionException $e) {
+                $this->logger->error('The zip file cannot be unzipped', ['file:' => $this, 'line' => __LINE__]);
+                $responseData['error'] = 'The zip file cannot be unzipped';
+                $jsonData = $this->getJsonSerialized($responseData);
 
-            return new JsonResponse($jsonData, $this->status, [], true);
+                return new JsonResponse($jsonData, $this->status, [], true);
+            }
+
+            $user = $this->getUser();
+
+            // Upload zip file parameters
+            $base64String = $request->get('file');
+            $filename = $request->get('filename');
+
+            // Validate received data
+            if ((empty($base64String)) || (empty($filename))) {
+                $this->logger->error('invalid data', ['file:' => $this, 'line' => __LINE__]);
+                $responseData = ['error' => 'Invalid data'];
+                $jsonData = $this->getJsonSerialized($responseData);
+
+                return new JsonResponse($jsonData, $this->status, [], true);
+            }
+
+            // Upload and install theme
+            $newTheme = $this->themeHelper->uploadThemeZip($filename, $base64String, $user);
+
+            // Check installed theme
+            if ($newTheme && $newTheme['error']) {
+                $responseData = ['error' => $newTheme['error']];
+                $jsonData = $this->getJsonSerialized($responseData);
+
+                return new JsonResponse($jsonData, $this->status, [], true);
+            } elseif (!isset($newTheme['theme'])) {
+                $responseData = ['error' => 'Could not install the theme'];
+                $jsonData = $this->getJsonSerialized($responseData);
+
+                return new JsonResponse($jsonData, $this->status, [], true);
+            }
+
+            // Response
+            $responseData = [];
+            $responseData['theme'] = $newTheme['theme'];
+            $responseData['themes'] = $this->getInstalledThemesAction($request, false);
+            $responseData['responseMessage'] = 'OK';
+        } else {
+            $responseData['responseMessage'] = 'Unauthorized';
         }
-
-        $user = $this->getUser();
-
-        // Upload zip file parameters
-        $base64String = $request->get('file');
-        $filename = $request->get('filename');
-
-        // Validate received data
-        if ((empty($base64String)) || (empty($filename))) {
-            $this->logger->error('invalid data', ['file:' => $this, 'line' => __LINE__]);
-            $responseData = ['error' => 'Invalid data'];
-            $jsonData = $this->getJsonSerialized($responseData);
-
-            return new JsonResponse($jsonData, $this->status, [], true);
-        }
-
-        // Upload and install theme
-        $newTheme = $this->themeHelper->uploadThemeZip($filename, $base64String, $user);
-
-        // Check installed theme
-        if ($newTheme && $newTheme['error']) {
-            $responseData = ['error' => $newTheme['error']];
-            $jsonData = $this->getJsonSerialized($responseData);
-
-            return new JsonResponse($jsonData, $this->status, [], true);
-        } elseif (!isset($newTheme['theme'])) {
-            $responseData = ['error' => 'Could not install the theme'];
-            $jsonData = $this->getJsonSerialized($responseData);
-
-            return new JsonResponse($jsonData, $this->status, [], true);
-        }
-
-        // Response
-        $responseData = [];
-        $responseData['theme'] = $newTheme['theme'];
-        $responseData['themes'] = $this->getInstalledThemesAction($request, false);
-        $responseData['responseMessage'] = 'OK';
-
         $jsonData = $this->getJsonSerialized($responseData);
 
         return new JsonResponse($jsonData, $this->status, [], true);

--- a/src/Helper/net/exelearning/Helper/FileHelper.php
+++ b/src/Helper/net/exelearning/Helper/FileHelper.php
@@ -587,4 +587,21 @@ class FileHelper
 
         return $newFilename;
     }
+
+    /**
+     * Extract value from key in xml file.
+     */
+    public function xmlKeyValue(string $filename, string $key): string
+    {
+        $value = '0';
+
+        if (is_file($filename)) {
+            $xml = simplexml_load_file($filename);
+            if (isset($xml->$key)) {
+                $value = (string) $xml->$key;
+            }
+        }
+
+        return $value;
+    }
 }

--- a/src/Helper/net/exelearning/Helper/FileHelper.php
+++ b/src/Helper/net/exelearning/Helper/FileHelper.php
@@ -505,12 +505,13 @@ class FileHelper
     /**
      * Returns absolute path to odeSessionUserTmpExport. If dir doesn't exists it tries to create it.
      *
-     * @param string $odeSessionId
-     * @param User   $user
+     * @param string   $odeSessionId
+     * @param User     $user
+     * @param tempPath $tempPath
      *
      * @return string|bool
      */
-    public function getOdeSessionUserTmpExportDir($odeSessionId, $user)
+    public function getOdeSessionUserTmpExportDir($odeSessionId, $user, $tempPath = '')
     {
         // validade $odeSessionId
         if (strlen($odeSessionId) < 8) {
@@ -519,7 +520,7 @@ class FileHelper
 
         $odeSessionUserTmpDir = $this->getOdeSessionUserTmpDir($odeSessionId, $user);
 
-        $odeSessionUserTmpExportDir = $odeSessionUserTmpDir.Constants::EXPORT_TMP_DIR.DIRECTORY_SEPARATOR;
+        $odeSessionUserTmpExportDir = $odeSessionUserTmpDir.Constants::EXPORT_TMP_DIR.DIRECTORY_SEPARATOR.$tempPath;
 
         // if dir already exists
         if (file_exists($odeSessionUserTmpExportDir)) {

--- a/src/Helper/net/exelearning/Helper/ThemeHelper.php
+++ b/src/Helper/net/exelearning/Helper/ThemeHelper.php
@@ -7,6 +7,7 @@ use App\Entity\net\exelearning\Dto\ThemeDto;
 use App\Entity\net\exelearning\Entity\User;
 use App\Util\net\exelearning\Util\FilePermissionsUtil;
 use App\Util\net\exelearning\Util\FileUtil;
+use App\Util\net\exelearning\Util\SettingsUtil;
 use App\Util\net\exelearning\Util\XmlUtil;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -440,52 +441,57 @@ class ThemeHelper
     public function unzipTheme($outputFileZip, $tmpThemeDirPath, $themesDir, $user)
     {
         $response = [];
+        if (SettingsUtil::installationTypeIsOffline()) {
+            // Load actual themes
+            $preInstallationThemesBase = $this->getThemesConfigBase();
+            $preInstallationThemesUser = $this->getThemesConfigUser($user);
 
-        // Load actual themes
-        $preInstallationThemesBase = $this->getThemesConfigBase();
-        $preInstallationThemesUser = $this->getThemesConfigUser($user);
+            // Unzip theme into tmp dir
+            FileUtil::extractZipTo($outputFileZip, $tmpThemeDirPath);
 
-        // Unzip theme into tmp dir
-        FileUtil::extractZipTo($outputFileZip, $tmpThemeDirPath);
+            // Load theme
+            $theme = $this->getThemeFromThemeDir($this->tmpThemeFileName, Constants::THEME_TYPE_USER, $user);
 
-        // Load theme
-        $theme = $this->getThemeFromThemeDir($this->tmpThemeFileName, Constants::THEME_TYPE_USER, $user);
-
-        if (!$theme) {
-            $response['error'] = $this->translator->trans('Could not load style');
+            if (!$theme) {
+                $response['error'] = $this->translator->trans('Could not load style');
+            } else {
+                if ($theme->isDownloadable()) {
+                    // Theme dir
+                    $response['themeDirName'] = $theme->getName();
+                    // Check if name is valid
+                    if ($theme->getName() == $this->tmpThemeFileName) {
+                        $response['error'] = $this->translator->trans('Invalid style name');
+                    }
+                    // Check if theme already exists in base themes
+                    foreach ($preInstallationThemesBase as $t) {
+                        if ($t->getName() == $theme->getName()) {
+                            $response['error'] = $this->translator->trans(
+                                'The style [%s] already exists',
+                                ['%s' => $theme->getName()]
+                            );
+                        }
+                    }
+                    // Check if theme already exists in user themes
+                    foreach ($preInstallationThemesUser as $t) {
+                        if ($t->getName() == $theme->getName()) {
+                            $response['error'] = $this->translator->trans(
+                                'The style [%s] already exists',
+                                ['%s' => $theme->getName()]
+                            );
+                        }
+                    }
+                } else {
+                    $response['error'] = $this->translator->trans('The style is not installable');
+                }
+            }
+            // Extract zip into theme name dir
+            if (!isset($response['error'])) {
+                $themeDirPath = $themesDir.DIRECTORY_SEPARATOR.$theme->getName();
+                FileUtil::extractZipTo($outputFileZip, $themeDirPath);
+            }
         } else {
-            // Theme dir
-            $response['themeDirName'] = $theme->getName();
-            // Check if name is valid
-            if ($theme->getName() == $this->tmpThemeFileName) {
-                $response['error'] = $this->translator->trans('Invalid style name');
-            }
-            // Check if theme already exists in base themes
-            foreach ($preInstallationThemesBase as $t) {
-                if ($t->getName() == $theme->getName()) {
-                    $response['error'] = $this->translator->trans(
-                        'The style [%s] already exists',
-                        ['%s' => $theme->getName()]
-                    );
-                }
-            }
-            // Check if theme already exists in user themes
-            foreach ($preInstallationThemesUser as $t) {
-                if ($t->getName() == $theme->getName()) {
-                    $response['error'] = $this->translator->trans(
-                        'The style [%s] already exists',
-                        ['%s' => $theme->getName()]
-                    );
-                }
-            }
+            $response['error'] = $this->translator->trans('Unauthorized');
         }
-
-        // Extract zip into theme name dir
-        if (!isset($response['error'])) {
-            $themeDirPath = $themesDir.DIRECTORY_SEPARATOR.$theme->getName();
-            FileUtil::extractZipTo($outputFileZip, $themeDirPath);
-        }
-
         // Delete tmp theme dir
         try {
             $this->fileHelper->deleteDir($tmpThemeDirPath);
@@ -525,5 +531,14 @@ class ThemeHelper
         $user = $userRepo->findOneBy($userFilters);
 
         return $user;
+    }
+
+    public function checkInstallable($themeConfigFilePathName)
+    {
+        $themeConfigFileContent = FileUtil::getFileContent($themeConfigFilePathName);
+        $themeConfigArray = XmlUtil::loadXmlStringToArray($themeConfigFileContent);
+        //  if ($themeConfigArray['downloadable']===1) {}
+
+        return $themeConfigArray['downloadable'];
     }
 }

--- a/src/Helper/net/exelearning/Helper/ThemeHelper.php
+++ b/src/Helper/net/exelearning/Helper/ThemeHelper.php
@@ -58,6 +58,7 @@ class ThemeHelper
             default:
                 $path = false;
         }
+        $path = DIRECTORY_SEPARATOR.$path;
 
         return $path;
     }
@@ -138,7 +139,7 @@ class ThemeHelper
     {
         $dbUser = $this->getDatabaseUser($user);
 
-        return $dbUser->getUserId();
+        return Constants::SLASH.Constants::FILES_DIR_NAME.$dbUser->getUserId();
     }
 
     /**

--- a/src/Helper/net/exelearning/Helper/ThemeHelper.php
+++ b/src/Helper/net/exelearning/Helper/ThemeHelper.php
@@ -7,7 +7,6 @@ use App\Entity\net\exelearning\Dto\ThemeDto;
 use App\Entity\net\exelearning\Entity\User;
 use App\Util\net\exelearning\Util\FilePermissionsUtil;
 use App\Util\net\exelearning\Util\FileUtil;
-use App\Util\net\exelearning\Util\SettingsUtil;
 use App\Util\net\exelearning\Util\XmlUtil;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -435,76 +434,104 @@ class ThemeHelper
      * @param string        $tmpThemeDirPath
      * @param string        $themesDir
      * @param UserInterface $user
-     *
-     * @return array
      */
-    public function unzipTheme($outputFileZip, $tmpThemeDirPath, $themesDir, $user)
+    public function unzipTheme($outputFileZip, $tmpThemeDirPath, $themesDir, $user): array
     {
         $response = [];
-        if (SettingsUtil::installationTypeIsOffline()) {
-            // Load actual themes
-            $preInstallationThemesBase = $this->getThemesConfigBase();
-            $preInstallationThemesUser = $this->getThemesConfigUser($user);
 
-            // Unzip theme into tmp dir
+        $preInstallationThemesBase = $this->getThemesConfigBase();
+        $preInstallationThemesUser = $this->getThemesConfigUser($user);
+
+        try {
             FileUtil::extractZipTo($outputFileZip, $tmpThemeDirPath);
-
-            // Load theme
-            $theme = $this->getThemeFromThemeDir($this->tmpThemeFileName, Constants::THEME_TYPE_USER, $user);
-
-            if (!$theme) {
-                $response['error'] = $this->translator->trans('Could not load style');
-            } else {
-                if ($theme->isDownloadable()) {
-                    // Theme dir
-                    $response['themeDirName'] = $theme->getName();
-                    // Check if name is valid
-                    if ($theme->getName() == $this->tmpThemeFileName) {
-                        $response['error'] = $this->translator->trans('Invalid style name');
-                    }
-                    // Check if theme already exists in base themes
-                    foreach ($preInstallationThemesBase as $t) {
-                        if ($t->getName() == $theme->getName()) {
-                            $response['error'] = $this->translator->trans(
-                                'The style [%s] already exists',
-                                ['%s' => $theme->getName()]
-                            );
-                        }
-                    }
-                    // Check if theme already exists in user themes
-                    foreach ($preInstallationThemesUser as $t) {
-                        if ($t->getName() == $theme->getName()) {
-                            $response['error'] = $this->translator->trans(
-                                'The style [%s] already exists',
-                                ['%s' => $theme->getName()]
-                            );
-                        }
-                    }
-                } else {
-                    $response['error'] = $this->translator->trans('The style is not installable');
-                }
-            }
-            // Extract zip into theme name dir
-            if (!isset($response['error'])) {
-                $themeDirPath = $themesDir.DIRECTORY_SEPARATOR.$theme->getName();
-                FileUtil::extractZipTo($outputFileZip, $themeDirPath);
-            }
-        } else {
-            $response['error'] = $this->translator->trans('Unauthorized');
-        }
-        // Delete tmp theme dir
-        try {
-            $this->fileHelper->deleteDir($tmpThemeDirPath);
         } catch (\Exception $e) {
+            $response['error'] = $this->translator->trans('Could not extract theme');
+            $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
+
+            return $response;
         }
 
-        // Delete zip
-        try {
-            unlink($outputFileZip);
-        } catch (\Exception $e) {
+        $theme = $this->getThemeFromThemeDir($this->tmpThemeFileName, Constants::THEME_TYPE_USER, $user);
+
+        if (!$theme) {
+            $response['error'] = $this->translator->trans('Could not load style');
+            $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
+
+            return $response;
         }
+
+        if (!$theme->isDownloadable()) {
+            $response['error'] = $this->translator->trans('The style is not installable');
+            $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
+
+            return $response;
+        }
+
+        if ($theme->getName() === $this->tmpThemeFileName || empty($theme->getName())) {
+            $response['error'] = $this->translator->trans('Invalid style name');
+            $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
+
+            return $response;
+        }
+
+        if ($this->themeExists($theme->getName(), $preInstallationThemesBase, $preInstallationThemesUser)) {
+            $response['error'] = $this->translator->trans(
+                'The style [%s] already exists',
+                ['%s' => $theme->getName()]
+            );
+            $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
+
+            return $response;
+        }
+
+        $themeDirPath = $themesDir.DIRECTORY_SEPARATOR.$theme->getName();
+
+        try {
+            FileUtil::extractZipTo($outputFileZip, $themeDirPath);
+            $response['themeDirName'] = $theme->getName();
+        } catch (\Exception $e) {
+            $response['error'] = $this->translator->trans('Could not install theme');
+        }
+
+        $this->cleanupResources($outputFileZip, $tmpThemeDirPath);
 
         return $response;
+    }
+
+    private function themeExists(string $themeName, array $baseThemes, array $userThemes): bool
+    {
+        foreach ($baseThemes as $theme) {
+            if ($theme->getName() === $themeName) {
+                return true;
+            }
+        }
+
+        foreach ($userThemes as $theme) {
+            if ($theme->getName() === $themeName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function cleanupResources(string $zipPath, string $tmpDirPath): void
+    {
+        try {
+            if (file_exists($zipPath)) {
+                unlink($zipPath);
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not delete zip file', ['path' => $zipPath]);
+        }
+
+        try {
+            if (is_dir($tmpDirPath)) {
+                $this->fileHelper->deleteDir($tmpDirPath);
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not delete temp directory', ['path' => $tmpDirPath]);
+        }
     }
 
     /**
@@ -531,14 +558,5 @@ class ThemeHelper
         $user = $userRepo->findOneBy($userFilters);
 
         return $user;
-    }
-
-    public function checkInstallable($themeConfigFilePathName)
-    {
-        $themeConfigFileContent = FileUtil::getFileContent($themeConfigFilePathName);
-        $themeConfigArray = XmlUtil::loadXmlStringToArray($themeConfigFileContent);
-        //  if ($themeConfigArray['downloadable']===1) {}
-
-        return $themeConfigArray['downloadable'];
     }
 }

--- a/src/Helper/net/exelearning/Helper/UserHelper.php
+++ b/src/Helper/net/exelearning/Helper/UserHelper.php
@@ -392,6 +392,13 @@ class UserHelper
         $this->entityManager->flush();
     }
 
+    /**
+     * Save user preference theme in database.
+     *
+     * @param $userLogged $theme
+     *
+     * @return void
+     */
     public function saveUserTheme($userLogged, $theme)
     {
         $databaseUserPreferences = $this->getUserPreferencesFromDatabase($userLogged);

--- a/src/Helper/net/exelearning/Helper/UserHelper.php
+++ b/src/Helper/net/exelearning/Helper/UserHelper.php
@@ -391,4 +391,12 @@ class UserHelper
 
         $this->entityManager->flush();
     }
+
+    public function saveUserTheme($userLogged, $theme)
+    {
+        $databaseUserPreferences = $this->getUserPreferencesFromDatabase($userLogged);
+        $userPreferences = $databaseUserPreferences['theme'];
+        $userPreferences->setValue($theme);
+        $this->entityManager->flush();
+    }
 }

--- a/src/Service/net/exelearning/Service/Api/OdeExportService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeExportService.php
@@ -111,6 +111,7 @@ class OdeExportService implements OdeExportServiceInterface
         $exportType,
         $preview = false,
         $isIntegration = false,
+        $tempPath = '',
     ) {
         $response = [];
 
@@ -260,7 +261,8 @@ class OdeExportService implements OdeExportServiceInterface
                 $baseUrl,
                 $exportType,
                 $preview,
-                $isIntegration
+                $isIntegration,
+                $tempPath
             );
         } catch (\Exception $e) {
             $exportStructure = ['responseMessage' => $this->translator->trans('Export generation error')];
@@ -274,15 +276,18 @@ class OdeExportService implements OdeExportServiceInterface
             return $response;
         }
 
+        // Export dir path
+        // $exportDirPath = $this->fileHelper->getOdeSessionUserTmpExportDir($odeSessionId, $dbUser);
+        $exportDirPath = $this->fileHelper->getOdeSessionUserTmpExportDir($odeSessionId, $dbUser, $tempPath);
+        $exportDirPath = $exportDirPath.$tempPath;
+
         // Get url to export dir
         $urlExportDir = UrlUtil::getOdeSessionExportUrl($odeSessionId, $dbUser);
+        $urlExportDir = $urlExportDir.$tempPath;
 
         // Index filename
         $indexFileName = self::generateIndexFileName();
         $response['urlPreviewIndex'] = $urlExportDir.$indexFileName;
-
-        // Export dir path
-        $exportDirPath = $this->fileHelper->getOdeSessionUserTmpExportDir($odeSessionId, $dbUser);
 
         // In case it is not a preview we need compress the export files to generate the zip
         if (!$preview) {
@@ -499,6 +504,7 @@ class OdeExportService implements OdeExportServiceInterface
         $exportType,
         $isPreview,
         $isIntegration,
+        $tempPath = '',
     ) {
         // To do (see #198)
         $isPreview = false;
@@ -512,8 +518,8 @@ class OdeExportService implements OdeExportServiceInterface
         $addElpToExport = false;
 
         // Server export dir path
-        $exportDirPath = $this->fileHelper->getOdeSessionUserTmpExportDir($odeSessionId, $dbUser);
-
+        $exportParentDirPath = $this->fileHelper->getOdeSessionUserTmpExportDir($odeSessionId, $dbUser);
+        $exportDirPath = $exportParentDirPath.'/'.$tempPath.'/';
         // Check dist dir
         if (!($exportDirPath && FilePermissionsUtil::isWritable($exportDirPath))) {
             $response['responseMessage'] = $this->translator->trans('Export folder could not be created');
@@ -521,12 +527,13 @@ class OdeExportService implements OdeExportServiceInterface
             return $response;
         }
 
-        // Export url prefix (used in preview)
+        // Export url prefix (used in preview)y
+        // $isPreview=True;
         if ($isPreview) {
             $collection = $this->router->getRouteCollection();
             $routes = $collection->all();
             $apiFilesRoute = $routes['api_idevices_download_file_resources']->getPath();
-            $exportUrlPath = substr(UrlUtil::getOdeSessionExportUrl($odeSessionId, $dbUser), 5);
+            $exportUrlPath = substr(UrlUtil::getOdeSessionExportUrl($odeSessionId, $dbUser), 5).$tempPath.'/';
             $resourcesPrefix = $baseUrl.$apiFilesRoute.'?resource='.$exportUrlPath;
         } else {
             $resourcesPrefix = '';
@@ -571,7 +578,7 @@ class OdeExportService implements OdeExportServiceInterface
         );
 
         // Remove export dir
-        FileUtil::removeDirContent($exportDirPath);
+        FileUtil::removeDirContent($exportParentDirPath);
 
         // ///////////////////////////////////////////////////
         // COPY FILES
@@ -836,6 +843,7 @@ class OdeExportService implements OdeExportServiceInterface
         // Generate export type files
         // Create files: xml, html, etc. depending on the type of export
         $viewContentGenerated = false;
+
         if ($exportService) {
             try {
                 $viewContentGenerated = $exportService->generateExportFiles(

--- a/src/Service/net/exelearning/Service/Api/OdeService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeService.php
@@ -1554,6 +1554,14 @@ class OdeService implements OdeServiceInterface
                     $themeDirPath = $odeSessionDistDirPath.Constants::EXPORT_DIR_THEME;
                     if (is_dir($themeDirPath)) {
                         $odeResponse['themeDir'] = true;
+                        $themePath = $themeDirPath.DIRECTORY_SEPARATOR.'config.xml';
+                        $isInstallable = $this->fileHelper->xmlKeyValue($themePath, Constants::THEME_INSTALLABLE);
+                        if ($isInstallable) {
+                            $odeResponse['themeInstallable'] = true;
+                        } else {
+                            $odeResponse['themeInstallable'] = false;
+                        }
+
                         // Copy theme dir to new session dir
                         $this->copyThemeFilesToSession($newOdeSessionId, $odeSessionDistDirPath);
                     }

--- a/src/Service/net/exelearning/Service/Api/OdeService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeService.php
@@ -1501,7 +1501,6 @@ class OdeService implements OdeServiceInterface
         $odeNavStructureSync,
     ) {
         $destinationFilePathName = $odeSessionDistDirPath.$elpFileName;
-
         FileUtil::copyFile($elpFilePath, $destinationFilePathName);
 
         try {

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -1356,7 +1356,7 @@ class ExportXmlUtil
             $styleLink->addAttribute('rel', 'stylesheet');
             // TEMPORARY FIX: Added this to resolve the bug.
             // TODO: Replace with a final, more robust solution.
-            $styleLink->addAttribute('href', $styleUrl.'?'.bin2hex(random_bytes(8 / 2)));
+            $styleLink->addAttribute('href', $styleUrl);
         }
 
         return $headCss;

--- a/src/Util/net/exelearning/Util/ExportXmlUtil.php
+++ b/src/Util/net/exelearning/Util/ExportXmlUtil.php
@@ -1354,7 +1354,9 @@ class ExportXmlUtil
         foreach ($styleCssFiles as $styleUrl) {
             $styleLink = $headCss->addChild('link', '');
             $styleLink->addAttribute('rel', 'stylesheet');
-            $styleLink->addAttribute('href', $styleUrl);
+            // TEMPORARY FIX: Added this to resolve the bug.
+            // TODO: Replace with a final, more robust solution.
+            $styleLink->addAttribute('href', $styleUrl.'?'.bin2hex(random_bytes(8 / 2)));
         }
 
         return $headCss;

--- a/src/Util/net/exelearning/Util/SettingsUtil.php
+++ b/src/Util/net/exelearning/Util/SettingsUtil.php
@@ -52,6 +52,22 @@ class SettingsUtil
     }
 
     /**
+     * Checks if theme installation allowed in online.
+     */
+    public static function themeInstallationAllowed(): bool
+    {
+        return self::getParameter('app.online_themes_install');
+    }
+
+    /**
+     * Checks if idevices installation allowed in online.
+     */
+    public static function idevicesInstallationAllowed(): bool
+    {
+        return self::getParameter('app.online_idevices_install');
+    }
+
+    /**
      * Converts USER_STORAGE_MAX_DISK_SPACE from MB to Bytes.
      */
     public static function getUserStorageMaxDiskSpaceInBytes(): float


### PR DESCRIPTION
Add environment-based theme installation control.

- Restrict theme installation in online mode.
- Introduce ONLINE_THEMES_INSTALL env variable to override restriction.
- Update theme import logic to check environment configuration
- Add permission flag validation for themes.

.env
ONLINE_THEMES_INSTALL=0
The theme import/install process is completely disabled in online mode.
ONLINE_THEMES_INSTALL=1
Only themes with the necessary installation permissions will be imported/installed.
