### PR TITLE
Refactor iDevice feedback handling and remove old rendering logic

### DIFF
--- a/public/files/perm/idevices/base/text/export/text.js
+++ b/public/files/perm/idevices/base/text/export/text.js
@@ -165,13 +165,6 @@ var $text = {
         const $node = $('#' + data.ideviceId);
         const isInExe = eXe.app.isInExe();
 
-        // Only render html old idevice
-        if (!isInExe && $node && $node.length === 1 && $node.find('.exe-text-template').length === 0) {
-            const html = $node.html();
-            this.renderHtmlOldIdevice(data, $node);
-
-        }
-
         const $btn = $(`#${data.ideviceId} input.feedbackbutton, #${data.ideviceId} input.feedbacktooglebutton`);
         if ($btn.length !== 1) return;
 

--- a/src/Service/net/exelearning/Service/Api/OdeService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeService.php
@@ -1546,7 +1546,7 @@ class OdeService implements OdeServiceInterface
         try {
             // Read XML
             if (!$isNewOdeXml) {
-                $odeResponse = OdeXmlUtil::readOldExeXml($newOdeSessionId, $elpContentFileContent);
+                $odeResponse = OdeXmlUtil::readOldExeXml($newOdeSessionId, $elpContentFileContent, $this->translator);
             } else {
                 if (!$isImportIdevices) {
                     $odeResponse = OdeXmlUtil::readOdeXml($newOdeSessionId, $elpContentFileContent);

--- a/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlFreeTextIdevice.php
+++ b/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlFreeTextIdevice.php
@@ -7,6 +7,7 @@ use App\Entity\net\exelearning\Entity\OdeComponentsSync;
 use App\Entity\net\exelearning\Entity\OdePagStructureSync;
 use App\Util\net\exelearning\Util\UrlUtil;
 use App\Util\net\exelearning\Util\Util;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * OdeOldXmlFreeTextIdevice.
@@ -34,7 +35,7 @@ class OdeOldXmlFreeTextIdevice
     // const OLD_ODE_XML_IDEVICE_TEXT = 'instance';
     public const OLD_ODE_XML_IDEVICE_TEXT_CONTENT = 'string role="key" value="content_w_resourcePaths"';
 
-    public static function oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $freeTextNodes, $generatedIds, $xpathNamespace)
+    public static function oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $freeTextNodes, $generatedIds, $xpathNamespace, TranslatorInterface $translator)
     {
         $result['odeComponentsSync'] = [];
         $result['srcRoutes'] = [];
@@ -125,15 +126,15 @@ class OdeOldXmlFreeTextIdevice
                                 $result['srcRoutes'][] = (string) $srcValue->value;
                             }
 
-                            $odeComponentsSync->setHtmlView($odeComponentsSyncHtmlView);
-
                             // Create json properties
                             $jsonProperties = self::JSON_PROPERTIES;
                             $jsonProperties['ideviceId'] = $odeIdeviceId;
                             $jsonProperties['textTextarea'] = $odeComponentsSyncHtmlView;
 
                             // Get feedback and button caption from idevice (only one)
-                            if (!empty($nodeFeedbackIdevice)) {
+                            if (!empty($nodeFeedbackIdevice) && (null != $nodeFeedbackIdevice) && (false != $nodeFeedbackIdevice)) {
+                                $textButtonCaption = $translator->trans('Show Feedback');
+
                                 $nodeFeedbackIdevice->registerXPathNamespace('f', $xpathNamespace);
 
                                 // Extract feedback HTML
@@ -151,6 +152,9 @@ class OdeOldXmlFreeTextIdevice
                                 );
                                 if (!empty($buttonCaptionNode)) {
                                     $jsonProperties['textFeedbackInput'] = (string) $buttonCaptionNode[0];
+                                    if ('' !== trim((string) $buttonCaptionNode[0])) {
+                                        $textButtonCaption = (string) $buttonCaptionNode[0];
+                                    } 
                                 }
 
                                 // Update srcRoutes for feedback
@@ -165,7 +169,21 @@ class OdeOldXmlFreeTextIdevice
 
                                 // Set feedback in properties json
                                 $jsonProperties['textFeedbackTextarea'] = $odeComponentsSyncFeedbackHtmlView;
+
+                                if ('' != trim($odeComponentsSyncFeedbackHtmlView)) {
+                                    $odeComponentsSyncHtmlView .=
+                                    '<div class="iDevice_buttons feedback-button js-required">
+                                    <input type="button" class="feedbacktooglebutton" value="'.$textButtonCaption.'" 
+                                    data-text-a="'.$textButtonCaption.'" data-text-b="'.$textButtonCaption.'">
+                                    </div>';
+
+                                    // Add feedback div
+                                    $odeComponentsSyncHtmlView .= '<div class="feedback js-feedback js-hidden" style="display: none;">'.$odeComponentsSyncFeedbackHtmlView.'</div>';
+                                }
                             }
+
+                            $odeComponentsSync->setHtmlView($odeComponentsSyncHtmlView);
+                            // $odeComponentsSync->setFeedbackHtmlView($odeComponentsSyncFeedbackHtmlView);
 
                             // Finalize jsonProperties
                             $odeComponentsSync->setJsonProperties(json_encode($jsonProperties));

--- a/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlFreeTextIdevice.php
+++ b/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlFreeTextIdevice.php
@@ -154,7 +154,7 @@ class OdeOldXmlFreeTextIdevice
                                     $jsonProperties['textFeedbackInput'] = (string) $buttonCaptionNode[0];
                                     if ('' !== trim((string) $buttonCaptionNode[0])) {
                                         $textButtonCaption = (string) $buttonCaptionNode[0];
-                                    } 
+                                    }
                                 }
 
                                 // Update srcRoutes for feedback

--- a/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlGenericIdevice.php
+++ b/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlGenericIdevice.php
@@ -7,6 +7,7 @@ use App\Entity\net\exelearning\Entity\OdeComponentsSync;
 use App\Entity\net\exelearning\Entity\OdePagStructureSync;
 use App\Util\net\exelearning\Util\UrlUtil;
 use App\Util\net\exelearning\Util\Util;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * OdeOldXmlGenericIdevice.
@@ -34,7 +35,7 @@ class OdeOldXmlGenericIdevice
     // const OLD_ODE_XML_IDEVICE_TEXT = 'instance';
     public const OLD_ODE_XML_IDEVICE_TEXT_CONTENT = 'string role="key" value="content_w_resourcePaths"';
 
-    public static function oldElpGenericIdeviceStructure($odeSessionId, $odePageId, $genericNodes, $generatedIds, $xpathNamespace)
+    public static function oldElpGenericIdeviceStructure($odeSessionId, $odePageId, $genericNodes, $generatedIds, $xpathNamespace, TranslatorInterface $translator)
     {
         $result['odeComponentsSync'] = [];
         $result['srcRoutes'] = [];
@@ -181,8 +182,6 @@ class OdeOldXmlGenericIdevice
             // Set type
             $odeComponentsSync->setOdeIdeviceTypeName('text');
 
-            $odeComponentsSync->setHtmlView($fullOdeComponentsSyncHtmlView);
-
             $jsonProperties = self::JSON_PROPERTIES;
             $jsonProperties['ideviceId'] = $odeIdeviceId;
             if (!empty($fullOdeComponentsSyncHtmlView)) {
@@ -190,7 +189,21 @@ class OdeOldXmlGenericIdevice
             }
             if (!empty($fullOdeComponentsSyncHtmlFeedbackView)) {
                 $jsonProperties['textFeedbackTextarea'] = $fullOdeComponentsSyncHtmlFeedbackView;
+                // Add button to show feedback
+                $textButtonCaption =  $translator->trans('Show Feedback');
+               
+                $fullOdeComponentsSyncHtmlView .=
+                '<div class="iDevice_buttons feedback-button js-required">
+                <input type="button" class="feedbacktooglebutton" value="'.$textButtonCaption.'" 
+                data-text-a="'.$textButtonCaption.'" data-text-b="'.$textButtonCaption.'">
+                </div>';
+
+                // Add feedback div
+                $fullOdeComponentsSyncHtmlView .= '<div class="feedback js-feedback js-hidden" style="display: none;">'.$fullOdeComponentsSyncHtmlFeedbackView.'</div>';
             }
+
+            $odeComponentsSync->setHtmlView($fullOdeComponentsSyncHtmlView);
+
             // Create jsonProperties for idevice
             $jsonProperties = json_encode($jsonProperties);
             $odeComponentsSync->setJsonProperties($jsonProperties);

--- a/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlGenericIdevice.php
+++ b/src/Util/net/exelearning/Util/OdeOldXmlIdevices/OdeOldXmlGenericIdevice.php
@@ -190,8 +190,8 @@ class OdeOldXmlGenericIdevice
             if (!empty($fullOdeComponentsSyncHtmlFeedbackView)) {
                 $jsonProperties['textFeedbackTextarea'] = $fullOdeComponentsSyncHtmlFeedbackView;
                 // Add button to show feedback
-                $textButtonCaption =  $translator->trans('Show Feedback');
-               
+                $textButtonCaption = $translator->trans('Show Feedback');
+
                 $fullOdeComponentsSyncHtmlView .=
                 '<div class="iDevice_buttons feedback-button js-required">
                 <input type="button" class="feedbacktooglebutton" value="'.$textButtonCaption.'" 

--- a/src/Util/net/exelearning/Util/OdeXmlUtil.php
+++ b/src/Util/net/exelearning/Util/OdeXmlUtil.php
@@ -13,6 +13,7 @@ use App\Entity\net\exelearning\Entity\OdeNavStructureSyncProperties;
 use App\Entity\net\exelearning\Entity\OdePagStructureSync;
 use App\Entity\net\exelearning\Entity\OdePagStructureSyncProperties;
 use App\Entity\net\exelearning\Entity\OdePropertiesSync;
+use App\Translation\net\exelearning\Translation;
 use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlCaseStudyIdevice;
 use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlDropdownIdevice;
 use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlExternalUrlIdevice;
@@ -32,6 +33,7 @@ use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlScormTestIdevice;
 use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlTrueFalseIdevice;
 use App\Util\net\exelearning\Util\OdeOldXmlIdevices\OdeOldXmlWikipediaIdevice;
 use App\Util\net\exelearning\Util\OdeOldXmlProperties\OdeOldXmlPropertiesGet;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * OdeXmlUtil.
@@ -762,7 +764,7 @@ class OdeXmlUtil
      *
      * @return OdeNavStructureSync[]
      */
-    public static function readOldExeXml($odeSessionId, $elpContentFileContent)
+    public static function readOldExeXml($odeSessionId, $elpContentFileContent, $translator)
     {
         // Array structure
         $odeResponse = [];
@@ -772,6 +774,9 @@ class OdeXmlUtil
         $odeResponse['odeNavStructureSyncs'] = [];
         $odeResponse['srcRoutes'] = [];
         $odeResponse['odeComponentsMapping'] = [];
+
+        // new translator for old ELPs to translate feedback buttons, info task, etc.
+        $translatorForOldIdevices = new Translation\Translator($translator);
 
         // odeNavSyncs
         $odeNavSyncs = [];
@@ -844,6 +849,18 @@ class OdeXmlUtil
         $elpNodeGeneralProperties = $xml->xpath('f:dictionary')[0];
         $odeGeneralProperties = OdeOldXmlPropertiesGet::oldElpGeneralPropertiesGet($odeSessionId, $elpNodeGeneralProperties, $xpathNamespace);
         $odeCatalogProperties['odeProperties'] = [];
+
+        $lang = null;
+        foreach ($odeGeneralProperties['odeProperties'] as $odeProperty) {
+            if ('pp_lang' === $odeProperty->getKey()) {
+                $lang = $odeProperty->getValue();
+                break;
+            }
+        }
+        // Set ELP language to translator for old iDevices
+        if (null !== $lang) {
+            $translatorForOldIdevices->switchTemporaryLocale($lang);
+        }
 
         // Get catalog properties elp
         if ('LOMES' == (string) $odeGeneralProperties['exportMetadata']) {
@@ -920,7 +937,7 @@ class OdeXmlUtil
         $nodes = $xml->xpath("//f:instance[@class='exe.engine.node.Node']");
         foreach ($nodes as $node) {
             // Get navStructure, references and routes to place content
-            $subPagesNav = self::oldElpStructureNewPage($odeSessionId, $generatedIds, $node, $xml, $xpathNamespace);
+            $subPagesNav = self::oldElpStructureNewPage($odeSessionId, $generatedIds, $node, $xml, $xpathNamespace, $translatorForOldIdevices);
             // Get references to assign the parent
             foreach ($subPagesNav['nodeReferences'] as $key => $parentReference) {
                 $references[$key] = $parentReference;
@@ -1007,6 +1024,9 @@ class OdeXmlUtil
 
         $odeResponse['odeNavStructureSyncs'] = self::changeOldExeNodeLink($odeResponse['odeNavStructureSyncs']);
 
+        // Restore previous locale
+        $translatorForOldIdevices->restorePreviousLocale();
+
         return $odeResponse;
     }
 
@@ -1074,7 +1094,7 @@ class OdeXmlUtil
      *
      * @return array $result
      */
-    private static function oldElpStructureNewPage($odeSessionId, $generatedIds, $oldXmlListInst, $xml, $xpathNamespace)
+    private static function oldElpStructureNewPage($odeSessionId, $generatedIds, $oldXmlListInst, $xml, $xpathNamespace, $translator)
     {
         // params
         $result = [];
@@ -1155,7 +1175,7 @@ class OdeXmlUtil
                     // Get component sync by node type
                     $types = $oldXmlListInstDictList->xpath('f:instance/@class');
                     $references = $oldXmlListInstDictList->xpath('f:instance/@reference');
-                    $results = self::getComponentSyncFromNode($types, $references, $oldXmlListInstDictList, $odeSessionId, $odePageId, $generatedIds, $xpathNamespace);
+                    $results = self::getComponentSyncFromNode($types, $references, $oldXmlListInstDictList, $odeSessionId, $odePageId, $generatedIds, $xpathNamespace, $translator);
                     if (!empty($results)) {
                         foreach ($results as $result) {
                             foreach ($result['odeComponentsSync'] as $odeComponentSync) {
@@ -2387,7 +2407,7 @@ class OdeXmlUtil
      *
      * @return array $result
      */
-    private static function getComponentSyncFromNode($types, $references, $oldXmlListInstDictList, $odeSessionId, $odePageId, $generatedIds, $xpathNamespace)
+    private static function getComponentSyncFromNode($types, $references, $oldXmlListInstDictList, $odeSessionId, $odePageId, $generatedIds, $xpathNamespace, TranslatorInterface $translator)
     {
         $result = [];
 
@@ -2413,13 +2433,13 @@ class OdeXmlUtil
 
                     // Get free text idevices and process
                 case 'exe.engine.freetextidevice.FreeTextIdevice':
-                    $odeComponentSyncResult = OdeOldXmlFreeTextIdevice::oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace);
+                    $odeComponentSyncResult = OdeOldXmlFreeTextIdevice::oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace, $translator);
                     array_push($result, $odeComponentSyncResult);
                     break;
 
                     // Get generic idevices and process
                 case 'exe.engine.genericidevice.GenericIdevice':
-                    $odeComponentSyncResult = OdeOldXmlGenericIdevice::oldElpGenericIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace);
+                    $odeComponentSyncResult = OdeOldXmlGenericIdevice::oldElpGenericIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace, $translator);
                     array_push($result, $odeComponentSyncResult);
                     break;
 
@@ -2532,7 +2552,7 @@ class OdeXmlUtil
                 case 'exe.engine.reflectionfpdmodifidevice.ReflectionfpdmodifIdevice':
                 case 'exe.engine.freetextfpdidevice.FreeTextfpdIdevice':
                     // Same as free text idevice
-                    $odeComponentSyncResult = OdeOldXmlFreeTextIdevice::oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace);
+                    $odeComponentSyncResult = OdeOldXmlFreeTextIdevice::oldElpFreeTextIdeviceStructure($odeSessionId, $odePageId, $node, $generatedIds, $xpathNamespace, $translator);
                     array_push($result, $odeComponentSyncResult);
                     break;
 

--- a/src/Util/net/exelearning/Util/OdeXmlUtil.php
+++ b/src/Util/net/exelearning/Util/OdeXmlUtil.php
@@ -1887,7 +1887,19 @@ class OdeXmlUtil
                                     $taskParticipantsInput = $taskIdeviceElements['taskParticipantsInput'];
                                     $textButtonFeedback = $taskIdeviceElements['textButtonFeedback'];
                                     $textFeedback = $taskIdeviceElements['textFeedback'];
-                                    $odeComponentsSyncHtmlView = $taskIdeviceElements['odeComponentsSyncHtmlView'];
+                                    $odeComponentsSyncHtmlViewTask = $taskIdeviceElements['odeComponentsSyncHtmlView'];
+                                    $odeComponentsSyncHtmlView = '<dl><div class="inline"> <dt><span title="'.$taskDurationInput.'">'.$taskDurationInput.'</span></dt><dd>'.
+                                    $taskDuration.'</dd></div><div class="inline"><dt><span title="'.$taskParticipantsInput.'"></span>'.$taskParticipantsInput.'</dt><dd>'.
+                                    $taskParticipants.'</dd></div></dl>'.$odeComponentsSyncHtmlViewTask;
+                                    if ('' != $textButtonFeedback) {
+                                        $odeComponentsSyncHtmlView .= '<div class="iDevice_buttons feedback-button js-required">
+                                        <input type="button" class="feedbacktooglebutton" value="'.$textButtonFeedback.'" 
+                                        data-text-a="'.$textButtonFeedback.'" data-text-b="'.$textButtonFeedback.'">
+                                        </div>';
+
+                                        // Add feedback div
+                                        $odeComponentsSyncHtmlView .= '<div class="feedback js-feedback js-hidden" style="display: none;">'.$textFeedback.'</div>';
+                                    }
                                 }
 
                                 foreach ($src as $srcValue) {
@@ -1910,6 +1922,10 @@ class OdeXmlUtil
                                 }
 
                                 $odeComponentsSync->setHtmlView($odeComponentsSyncHtmlView);
+                                if ($isTaskContent) {
+                                    $odeComponentsSyncHtmlView = $odeComponentsSyncHtmlViewTask;
+                                }
+
                                 // Different json for scrambled list
                                 if ('scrambled-list' !== $nodeIdeviceTextType) {
                                     // Rubric and download-source-file don't have json


### PR DESCRIPTION
Remove outdated HTML rendering for old iDevices and enhance feedback generation for text-type iDevices by adding feedback buttons and improving the structure of the generated HTML.

The same strategy has been followed in the translations as in eXe 2.9. However, in edit mode, eXe 3 does not take into account the translations that should be made.
Another minor issue is that in the task iDevice; task information in edit and display modes follows different styles: in edit mode it is aligned to the right and in display mode it is aligned to the left.

Consider removing the renderHtmlOldIdevice function in text.js.