### PR TITLE
Disable caching for Node.js setup in workflow

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '22'  # Use the version you need
-          cache: false
+          package-manager-cache: false 
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This pull request makes a small change to the Node.js setup step in the GitHub Actions workflow. The change disables caching for Node.js dependencies by setting the `cache` option to `false`.