### PR TITLE
Refactor afterPack.js for platform and arch handling

### DIFF
--- a/afterPack.js
+++ b/afterPack.js
@@ -1,18 +1,39 @@
+// afterPack.js
 const path = require('path');
 const fs = require('fs');
 const AdmZip = require('adm-zip');
 
-exports.default = async function(context) {
-  const platform = context.electronPlatformName; // 'win32'|'darwin'|'linux'
-  const archName = context.arch === 3 ? 'arm64' : 'x64';
-  const platDir  = platform === 'win32' ? 'win' : platform === 'darwin' ? 'mac' : 'linux';
+exports.default = async function (context) {
+  // Platform mapping
+  const platform = context.electronPlatformName; // 'win32' | 'darwin' | 'linux'
+  const platDir = platform === 'win32' ? 'win' : platform === 'darwin' ? 'mac' : 'linux';
 
-  const zipPath = path.join(context.projectDir, 'vendor','nativephp','php-bin','bin', platDir, archName, 'php-8.4.zip');
+  // Arch mapping (electron-builder: ia32=1, x64=2, armv7l=3, arm64=4, universal=5)
+  const arch = context.arch;
+  const archName = arch === 4 ? 'arm64' : 'x64';
+
+  // Use packager.projectDir (projectDir no existe en context)
+  const projectDir = (context.packager && context.packager.projectDir) || process.cwd();
+
+  // Paths
+  const zipPath = path.join(projectDir, 'vendor', 'nativephp', 'php-bin', 'bin', platDir, archName, 'php-8.4.zip');
   const outDir  = path.join(context.appOutDir, 'resources', 'php-bin', 'php-8.4');
 
-  if (!fs.existsSync(zipPath)) return;
+  // Skip if the PHP bundle for this platform/arch is not present
+  if (!fs.existsSync(zipPath)) {
+    console.warn('[afterPack] php-bin zip not found, skipping:', zipPath);
+    return;
+  }
+
+  // Extract PHP runtime
   fs.mkdirSync(outDir, { recursive: true });
   new AdmZip(zipPath).extractAllTo(outDir, true);
-  if (platform !== 'win32') fs.chmodSync(path.join(outDir, 'php'), 0o755);
+
+  // Make PHP binary executable on unix
+  if (platform !== 'win32') {
+    const phpBin = path.join(outDir, 'php');
+    if (fs.existsSync(phpBin)) fs.chmodSync(phpBin, 0o755);
+  }
+
   console.log('[afterPack] PHP pre-extracted to', outDir);
 };


### PR DESCRIPTION
This pull request refactors and improves the `afterPack.js` script, which is responsible for extracting the PHP runtime during the packaging process. The changes focus on making platform and architecture detection more robust, handling missing files gracefully, and improving file extraction and permissions.

Platform and architecture handling:

* Improved platform and architecture mapping to correctly handle Electron Builder's architecture codes and ensure the correct PHP binary is extracted for each target.
* Fixed usage of `projectDir` by retrieving it from `context.packager.projectDir` or falling back to `process.cwd()` if unavailable.

Robustness and error handling:

* Added a check to skip extraction if the PHP zip bundle is missing, and logs a warning instead of failing silently.

File extraction and permissions:

* Ensured the output directory is created recursively before extraction, and set executable permissions on the PHP binary for non-Windows platforms only if the binary exists.