### PR TITLE
Upgrade to latest 3.22 version instead of fix to 3.22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=
 ARG VERSION=v0.0.0-alpha
 
-FROM ${ARCH}erseco/alpine-php-webserver:3.22.0
+FROM ${ARCH}erseco/alpine-php-webserver:3.22
 
 LABEL maintainer="INTEF <cedec@educacion.gob.es>"
 LABEL org.opencontainers.image.title="eXeLearning"


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile`, specifically changing the base image version for the PHP webserver from `3.22.0` to `3.22`. This is a small change that likely improves compatibility or consistency with available image tags.