### PR TITLE
⚠️ WIP — Enhance project and session management to support multiple open documents across tabs and offline mode

### DIFF
--- a/public/app/rest/apiCallBaseFunctions.js
+++ b/public/app/rest/apiCallBaseFunctions.js
@@ -97,25 +97,48 @@ export default class ApiCallBaseFunctions {
      * @returns
      */
     async doAjax(url, method, data, waiting = true) {
-        if (waiting) this.addWaitingPetition();
-        let response = {};
-        response = await $.ajax({
-            url: url,
-            method: method,
-            data: data,
-            timeout: eXeLearning.config.clientCallWaitingTime,
-            dataType: 'json',
-            success: function (response) {
-                return response;
-            },
-            error: function (XMLHttpRequest, textStatus, errorThrown) {
-                return { error: errorThrown };
-            },
-        });
-        setTimeout(() => {
-            this.removeWaitingPetition();
-        }, 100);
-        return response;
+        if (waiting) {
+            this.addWaitingPetition();
+        }
+
+        try {
+            return await $.ajax({
+                url: url,
+                method: method,
+                data: data,
+                timeout: eXeLearning.config.clientCallWaitingTime,
+                dataType: 'json',
+            });
+        } catch (xhr) {
+            const errorResponse =
+                xhr && typeof xhr === 'object' && xhr.responseJSON
+                    ? xhr.responseJSON
+                    : null;
+
+            return {
+                __error: true,
+                status: xhr && typeof xhr.status === 'number' ? xhr.status : 0,
+                statusText:
+                    xhr && typeof xhr.statusText === 'string'
+                        ? xhr.statusText
+                        : '',
+                responseMessage:
+                    errorResponse && errorResponse.responseMessage
+                        ? errorResponse.responseMessage
+                        : null,
+                detail:
+                    errorResponse && errorResponse.detail
+                        ? errorResponse.detail
+                        : null,
+                payload: errorResponse,
+            };
+        } finally {
+            if (waiting) {
+                setTimeout(() => {
+                    this.removeWaitingPetition();
+                }, 100);
+            }
+        }
     }
 
     /**

--- a/public/app/rest/apiCallManager.js
+++ b/public/app/rest/apiCallManager.js
@@ -1,13 +1,237 @@
 import ApiCallBaseFunctions from './apiCallBaseFunctions.js';
 
+const stripTrailingSlashes = (value) => {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    let result = value;
+    while (result.length > 0 && result.endsWith('/')) {
+        result = result.slice(0, -1);
+    }
+
+    return result;
+};
+
 export default class ApiCallManager {
     constructor(app) {
         this.app = app;
         this.apiUrlBase = `${app.eXeLearning.symfony.baseURL}`;
         this.apiUrlBasePath = `${app.eXeLearning.symfony.basePath}`;
         this.apiUrlParameters = `${this.apiUrlBase}${this.apiUrlBasePath}/api/parameter-management/parameters/data/list`;
+        if (
+            this.apiUrlBasePath === 'undefined' ||
+            this.apiUrlBasePath === 'null'
+        ) {
+            this.apiUrlBasePath = '';
+        }
+        const sanitizedBase = stripTrailingSlashes(this.apiUrlBase);
+        const normalizedBasePath = stripTrailingSlashes(this.apiUrlBasePath);
+        const basePath = normalizedBasePath
+            ? `${normalizedBasePath.startsWith('/') ? '' : '/'}${normalizedBasePath}`
+            : '';
+        const combinedBase = stripTrailingSlashes(
+            `${sanitizedBase}${basePath}`
+        );
+        this.apiPlatformBaseUrl = `${combinedBase}/api/v2`;
         this.func = new ApiCallBaseFunctions();
         this.endpoints = {};
+    }
+
+    buildApiV2Url(path) {
+        const suffix = path.startsWith('/') ? path : `/${path}`;
+        return `${this.apiPlatformBaseUrl}${suffix}`;
+    }
+
+    getConfigValue(key, fallback = null) {
+        const app = this.app || {};
+        const eXe = app.eXeLearning || {};
+        const config = eXe.config || {};
+        if (Object.prototype.hasOwnProperty.call(config, key)) {
+            return config[key];
+        }
+
+        return fallback;
+    }
+
+    parseBytes(value) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return Math.max(value, 0);
+        }
+
+        const parsed = parseInt(value, 10);
+
+        if (Number.isFinite(parsed)) {
+            return Math.max(parsed, 0);
+        }
+
+        return 0;
+    }
+
+    parseTimestamp(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+
+        const parsed = parseInt(value, 10);
+
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    formatFileSize(bytes, decimals = 2) {
+        const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        const safeBytes = Number.isFinite(bytes) ? bytes : 0;
+
+        if (safeBytes <= 0) {
+            return `0 ${units[0]}`;
+        }
+
+        const factor = Math.min(
+            Math.floor(Math.log(safeBytes) / Math.log(1024)),
+            units.length - 1
+        );
+        const value = safeBytes / Math.pow(1024, factor);
+        const precision = Number.isFinite(decimals) ? decimals : 2;
+
+        return `${Number(value.toFixed(precision))} ${units[factor]}`;
+    }
+
+    shouldCountAutosaveSpace() {
+        const raw = this.getConfigValue('countUserAutosaveSpace', true);
+
+        if (typeof raw === 'string') {
+            const lowered = raw.toLowerCase();
+            if (lowered === 'false' || lowered === '0') {
+                return false;
+            }
+            if (lowered === 'true' || lowered === '1') {
+                return true;
+            }
+        }
+
+        return Boolean(raw);
+    }
+
+    getUserStorageLimitBytes() {
+        const raw = this.getConfigValue('userStorageMaxDiskSpaceBytes', 0);
+        return this.parseBytes(raw);
+    }
+
+    getRecentProjectsLimit() {
+        const raw = this.getConfigValue('userRecentOdeFilesAmount', 3);
+        const parsed = parseInt(raw, 10);
+
+        if (Number.isFinite(parsed) && parsed > 0) {
+            return parsed;
+        }
+
+        return 3;
+    }
+
+    extractProjectsCollection(response) {
+        if (Array.isArray(response)) {
+            return response;
+        }
+
+        if (response && Array.isArray(response.items)) {
+            return response.items;
+        }
+
+        if (response && Array.isArray(response.projects)) {
+            return response.projects;
+        }
+
+        if (response && Array.isArray(response['hydra:member'])) {
+            return response['hydra:member'];
+        }
+
+        return null;
+    }
+
+    normalizeProject(project) {
+        if (!project || typeof project !== 'object') {
+            return null;
+        }
+
+        const sizeBytes = this.parseBytes(project.size);
+        let timestamp = null;
+
+        if (
+            project.updatedAt &&
+            typeof project.updatedAt === 'object' &&
+            Object.prototype.hasOwnProperty.call(project.updatedAt, 'timestamp')
+        ) {
+            timestamp = this.parseTimestamp(project.updatedAt.timestamp);
+        } else {
+            timestamp = this.parseTimestamp(project.updatedAt);
+        }
+
+        const identifier =
+            project.odeFilesId ??
+            project.id ??
+            project.odeId ??
+            project.fileName ??
+            project.odeVersionId ??
+            null;
+
+        const normalizedId = identifier !== null ? String(identifier) : null;
+        const odeId = project.odeId ?? project.id ?? normalizedId;
+
+        return {
+            item: {
+                id: normalizedId,
+                odeFilesId: project.odeFilesId ?? null,
+                odeId: odeId !== null ? String(odeId) : null,
+                odeVersionId: project.odeVersionId ?? null,
+                odePlatformId: project.odePlatformId ?? null,
+                title: project.title ?? '',
+                versionName: project.versionName ?? '',
+                fileName: project.fileName ?? '',
+                size: String(sizeBytes),
+                sizeFormatted: this.formatFileSize(sizeBytes),
+                isManualSave: Boolean(project.isManualSave),
+                updatedAt: { timestamp: timestamp },
+                properties: project.properties ?? {},
+                owner_id: project.owner_id ?? null,
+                owner_email: project.owner_email ?? null,
+            },
+            sizeBytes: sizeBytes,
+        };
+    }
+
+    buildLegacyProjectPayload(projects) {
+        const includeAutosave = this.shouldCountAutosaveSpace();
+        const normalizedProjects = [];
+        let usedSpace = 0;
+
+        projects.forEach((project) => {
+            const normalized = this.normalizeProject(project);
+            if (!normalized) {
+                return;
+            }
+
+            normalizedProjects.push(normalized.item);
+            if (includeAutosave || normalized.item.isManualSave) {
+                usedSpace += normalized.sizeBytes;
+            }
+        });
+
+        const maxDiskSpace = this.getUserStorageLimitBytes();
+        const freeSpace = Math.max(maxDiskSpace - usedSpace, 0);
+
+        return {
+            odeFilesSync: normalizedProjects,
+            maxDiskSpace: maxDiskSpace,
+            maxDiskSpaceFormatted: this.formatFileSize(maxDiskSpace),
+            usedSpace: usedSpace,
+            usedSpaceFormatted: this.formatFileSize(usedSpace),
+            freeSpace: freeSpace,
+            freeSpaceFormatted: this.formatFileSize(freeSpace),
+        };
     }
 
     /**
@@ -38,9 +262,52 @@ export default class ApiCallManager {
      *
      * @returns
      */
-    async getCurrentProject() {
-        let url = this.endpoints.api_current_ode_users_for_user_get.path;
-        return await this.func.get(url);
+    async getCurrentProject(odeSessionId = null, options = {}) {
+        const { forceNewSession = false, projectId = null } = options;
+        let response = {};
+        if (this.apiPlatformBaseUrl) {
+            let url = this.buildApiV2Url('/me/current-project');
+            const params = new URLSearchParams();
+            if (odeSessionId) {
+                params.set('odeSessionId', odeSessionId);
+            }
+            if (projectId) {
+                params.set('projectId', projectId);
+            }
+            if (forceNewSession) {
+                params.set('forceNewSession', '1');
+            }
+            const query = params.toString();
+            if (query) {
+                url = `${url}?${query}`;
+            }
+            response = await this.func.get(url);
+            if (response && response.responseMessage) {
+                return response;
+            }
+        }
+
+        if (this.endpoints.api_current_ode_users_for_user_get) {
+            let url = this.endpoints.api_current_ode_users_for_user_get.path;
+            const params = new URLSearchParams();
+            if (odeSessionId) {
+                params.set('odeSessionId', odeSessionId);
+            }
+            if (projectId) {
+                params.set('projectId', projectId);
+            }
+            if (forceNewSession) {
+                params.set('forceNewSession', '1');
+            }
+            const query = params.toString();
+            if (query) {
+                const separator = url.includes('?') ? '&' : '?';
+                url = `${url}${separator}${query}`;
+            }
+            response = await this.func.get(url);
+        }
+
+        return response;
     }
 
     /**
@@ -102,8 +369,23 @@ export default class ApiCallManager {
      * @returns
      */
     async getUserOdeFiles() {
-        let url = this.endpoints.api_odes_user_get_ode_list.path;
-        return await this.func.get(url);
+        if (this.apiPlatformBaseUrl) {
+            const response = await this.func.get(
+                this.buildApiV2Url('/projects')
+            );
+            const projects = this.extractProjectsCollection(response);
+
+            if (Array.isArray(projects)) {
+                return { odeFiles: this.buildLegacyProjectPayload(projects) };
+            }
+        }
+
+        if (this.endpoints.api_odes_user_get_ode_list) {
+            let url = this.endpoints.api_odes_user_get_ode_list.path;
+            return await this.func.get(url);
+        }
+
+        return {};
     }
 
     /**
@@ -112,8 +394,41 @@ export default class ApiCallManager {
      * @returns
      */
     async getRecentUserOdeFiles() {
-        let url = this.endpoints.api_odes_get_user_recent_ode_list.path;
-        return await this.func.get(url);
+        if (this.apiPlatformBaseUrl) {
+            const response = await this.func.get(
+                this.buildApiV2Url('/projects')
+            );
+            const projects = this.extractProjectsCollection(response);
+
+            if (Array.isArray(projects)) {
+                const normalized = projects
+                    .map((project) => this.normalizeProject(project))
+                    .filter((project) => project && project.item)
+                    .map((project) => project.item)
+                    .sort((a, b) => {
+                        const tsA =
+                            a.updatedAt && a.updatedAt.timestamp
+                                ? a.updatedAt.timestamp
+                                : 0;
+                        const tsB =
+                            b.updatedAt && b.updatedAt.timestamp
+                                ? b.updatedAt.timestamp
+                                : 0;
+                        return tsB - tsA;
+                    });
+
+                const limit = this.getRecentProjectsLimit();
+
+                return normalized.slice(0, limit);
+            }
+        }
+
+        if (this.endpoints.api_odes_get_user_recent_ode_list) {
+            let url = this.endpoints.api_odes_get_user_recent_ode_list.path;
+            return await this.func.get(url);
+        }
+
+        return [];
     }
 
     /**
@@ -143,9 +458,9 @@ export default class ApiCallManager {
      * @param {*} odeFileName
      * @returns
      */
-    async postSelectedOdeFile(odeFileName) {
+    async postSelectedOdeFile(data) {
         let url = this.endpoints.api_odes_ode_elp_open.path;
-        return await this.func.post(url, odeFileName);
+        return await this.func.post(url, data);
     }
 
     /**

--- a/public/app/workarea/interface/elements/odeTitleElement.js
+++ b/public/app/workarea/interface/elements/odeTitleElement.js
@@ -3,6 +3,7 @@ export default class OdeTitleMenu {
         this.odeTitleMenuHeadElement = document.querySelector(
             '#exe-title > .exe-title.content'
         );
+        this.defaultDocumentTitle = document.title;
     }
 
     /**
@@ -25,5 +26,8 @@ export default class OdeTitleMenu {
             : _('Untitled document');
         this.odeTitleMenuHeadElement.textContent = odeTitleText;
         this.odeTitleMenuHeadElement.setAttribute('title', odeTitleText);
+
+        const baseTitle = this.defaultDocumentTitle || 'eXeLearning';
+        document.title = `${odeTitleText} – ${baseTitle}`;
     }
 }

--- a/public/app/workarea/interface/elements/shareButton.js
+++ b/public/app/workarea/interface/elements/shareButton.js
@@ -108,9 +108,10 @@ export default class ShareProjectButton {
 
         urlDiv.classList.add('share-link-div-content');
 
+        const shareUrl = this.getCurrentDocumentUrl(result?.shareSessionUrl);
         urlString.classList.add('share-link-code-string');
         urlString.id = 'shareLinkCode';
-        urlString.innerHTML = `<strong> ${result.shareSessionUrl}</strong>`;
+        urlString.innerHTML = `<strong>${shareUrl}</strong>`;
 
         urlButton.id = 'shareUrlButton';
         urlButton.title = _('Copy to clipboard');
@@ -128,5 +129,29 @@ export default class ShareProjectButton {
         element.append(urlDiv);
 
         return element;
+    }
+
+    getCurrentDocumentUrl(fallbackUrl) {
+        const url = new URL(window.location.href);
+        const sessionId =
+            eXeLearning.app.project.odeSession ||
+            url.searchParams.get('odeSessionId');
+        const projectId =
+            eXeLearning.app.project.odeId ||
+            eXeLearning.app.project.requestedProjectId ||
+            url.searchParams.get('projectId');
+
+        if (sessionId) {
+            url.searchParams.set('odeSessionId', sessionId);
+        }
+        if (projectId) {
+            url.searchParams.set('projectId', projectId);
+        }
+
+        if (!sessionId && !projectId && fallbackUrl) {
+            return fallbackUrl;
+        }
+
+        return url.toString();
     }
 }

--- a/public/app/workarea/menus/navbar/items/navbarFile.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.js
@@ -503,8 +503,16 @@ export default class NavbarFile {
      *
      */
     newProjectEvent() {
-        let odeSessionId = eXeLearning.app.project.odeSession;
-        this.newSession(odeSessionId);
+        const basePath = eXeLearning.symfony.basePath || '';
+        let workareaPath = 'workarea';
+        if (basePath) {
+            const normalizedBase = basePath.endsWith('/')
+                ? basePath.slice(0, -1)
+                : basePath;
+            workareaPath = `${normalizedBase}/workarea`;
+        }
+
+        window.open(workareaPath, '_blank', 'noopener');
     }
 
     /**

--- a/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
@@ -557,6 +557,7 @@ export default class modalOpenUserOdeFiles extends Modal {
         let params = {
             elpFileName: id,
             odeSessionId: eXeLearning.app.project.odeSession,
+            projectId: eXeLearning.app.project.odeId,
         };
         let odeParams = {
             odeSessionId: eXeLearning.app.project.odeSession,
@@ -628,6 +629,7 @@ export default class modalOpenUserOdeFiles extends Modal {
             elpFileName: id,
             forceCloseOdeUserPreviousSession: true,
             odeSessionId: eXeLearning.app.project.odeSession,
+            projectId: eXeLearning.app.project.odeId,
         };
         let response = await eXeLearning.app.api.postSelectedOdeFile(params);
         if (response.responseMessage == 'OK') {

--- a/public/app/workarea/project/idevices/content/blockNode.js
+++ b/public/app/workarea/project/idevices/content/blockNode.js
@@ -1723,7 +1723,10 @@ export default class IdeviceBlockNode {
      *
      */
     resetWindowHash() {
-        window.location.hash = 'node-content';
+        const container = document.getElementById('node-content');
+        if (container && typeof container.scrollIntoView === 'function') {
+            container.scrollIntoView({ behavior: 'auto', block: 'start' });
+        }
     }
 
     /**
@@ -1734,7 +1737,10 @@ export default class IdeviceBlockNode {
     goWindowToBlock(time) {
         let hashId = this.blockId;
         setTimeout(() => {
-            window.location.hash = hashId;
+            const target = document.getElementById(hashId);
+            if (target && typeof target.scrollIntoView === 'function') {
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }, time);
     }
 

--- a/public/app/workarea/project/idevices/content/ideviceNode.js
+++ b/public/app/workarea/project/idevices/content/ideviceNode.js
@@ -1,4 +1,26 @@
 import RealTimeEventNotifier from '../../../../RealTimeEventNotifier/RealTimeEventNotifier.js';
+
+const sanitizeIdentifier = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed === '' ? null : trimmed;
+    }
+
+    return value;
+};
+
+const sanitizeOrderValue = (value) => {
+    if (value === undefined || value === null || value === '') {
+        return null;
+    }
+
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+};
 /**
  * eXeLearning
  *
@@ -1418,6 +1440,31 @@ export default class IdeviceNode {
      */
     async apiSaveIdeviceJson(saveIdevice) {
         let params = ['odeComponentsSyncId', 'jsonProperties'];
+        const isExistingComponent = Boolean(
+            sanitizeIdentifier(this.id || this.odeComponentsSyncId)
+        );
+
+        if (!isExistingComponent) {
+            params = params.concat([
+                'odeVersionId',
+                'odeSessionId',
+                'odeNavStructureSyncId',
+                'odePageId',
+                'odePagStructureSyncId',
+                'odePagStructureSyncOrder',
+                'odeBlockId',
+                'blockName',
+                'iconName',
+                'odeIdeviceId',
+                'odeIdeviceTypeName',
+            ]);
+
+            const pendingOrder = sanitizeOrderValue(this.order);
+            if (pendingOrder !== null && pendingOrder !== undefined) {
+                params.push('order');
+            }
+        }
+
         if (saveIdevice && typeof $exeDevice !== 'undefined' && $exeDevice) {
             this.jsonProperties = $exeDevice.save();
             // Add class error to idevice
@@ -1828,11 +1875,28 @@ export default class IdeviceNode {
      */
     getDictBaseValuesData() {
         let defaultVersion = eXeLearning.app.project.odeVersion;
+        if (!defaultVersion && eXeLearning.app.project.odeVersionId) {
+            defaultVersion = eXeLearning.app.project.odeVersionId;
+        }
+
         let defaultSession = eXeLearning.app.project.odeSession;
+        if (!defaultSession) {
+            defaultSession =
+                eXeLearning.app.project.explicitOdeSessionId ||
+                eXeLearning.symfony.odeSessionId ||
+                null;
+        }
+
         let defaultOdeNavStructureSyncId =
             eXeLearning.app.project.structure.getSelectNodeNavId();
         let defaultOdePageId =
             eXeLearning.app.project.structure.getSelectNodePageId();
+
+        const defaultProjectId =
+            eXeLearning.app.project.odeId ||
+            eXeLearning.app.project.requestedProjectId ||
+            eXeLearning.symfony.requestedProjectId ||
+            null;
 
         let safeBlockOrder = null;
         if (this.block && this.block.getCurrentOrder) {
@@ -1843,24 +1907,30 @@ export default class IdeviceNode {
                 safeBlockOrder = this.block.getFallbackPageOrder();
             }
         }
+        const blockIdValue = this.block
+            ? this.block.blockId || this.block.id || null
+            : null;
         return {
-            odeComponentsSyncId: this.id,
-            odeVersionId: defaultVersion,
-            odeSessionId: defaultSession,
-            odeNavStructureSyncId: this.odeNavStructureSyncId
-                ? this.odeNavStructureSyncId
-                : defaultOdeNavStructureSyncId,
-            odePageId: this.pageId ? this.pageId : defaultOdePageId,
-            odePagStructureSyncId: this.block ? this.block.id : null,
-            odePagStructureSyncOrder: safeBlockOrder,
-            odeBlockId: this.block ? this.block.blockId : null,
+            odeComponentsSyncId: sanitizeIdentifier(this.id),
+            odeVersionId: sanitizeIdentifier(defaultVersion),
+            odeSessionId: sanitizeIdentifier(defaultSession),
+            odeNavStructureSyncId: sanitizeIdentifier(
+                this.odeNavStructureSyncId || defaultOdeNavStructureSyncId
+            ),
+            odePageId: sanitizeIdentifier(this.pageId || defaultOdePageId),
+            odePagStructureSyncId: sanitizeIdentifier(
+                this.block ? this.block.id : null
+            ),
+            odePagStructureSyncOrder: sanitizeOrderValue(safeBlockOrder),
+            odeBlockId: sanitizeIdentifier(blockIdValue),
             blockName: this.block ? this.block.blockName : null,
             iconName: this.block ? this.block.iconName : null,
-            odeIdeviceId: this.odeIdeviceId,
-            odeIdeviceTypeName: this.idevice.name,
+            odeIdeviceId: sanitizeIdentifier(this.odeIdeviceId || this.id),
+            odeIdeviceTypeName: this.idevice ? this.idevice.name : null,
             jsonProperties: this.getJsonProperties(true),
             htmlView: this.getViewHTML(),
-            order: this.order,
+            order: sanitizeOrderValue(this.order),
+            projectId: sanitizeIdentifier(defaultProjectId),
         };
     }
 
@@ -2544,7 +2614,10 @@ export default class IdeviceNode {
      *
      */
     resetWindowHash() {
-        window.location.hash = 'node-content';
+        const container = document.getElementById('node-content');
+        if (container && typeof container.scrollIntoView === 'function') {
+            container.scrollIntoView({ behavior: 'auto', block: 'start' });
+        }
     }
 
     /**
@@ -2564,7 +2637,10 @@ export default class IdeviceNode {
             hashId = this.odeIdeviceId;
         }
         setTimeout(() => {
-            window.location.hash = hashId;
+            const target = document.getElementById(hashId);
+            if (target && typeof target.scrollIntoView === 'function') {
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
         }, time);
     }
 

--- a/public/app/workarea/project/projectManager.js
+++ b/public/app/workarea/project/projectManager.js
@@ -3,6 +3,28 @@ import IdevicesEngine from './idevices/idevicesEngine.js';
 import StructureEngine from './structure/structureEngine.js';
 import RealTimeEventNotifier from '../../RealTimeEventNotifier/RealTimeEventNotifier.js';
 
+const sanitizeIdentifier = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed === '' ? null : trimmed;
+    }
+
+    return value;
+};
+
+const sanitizeOrderValue = (value) => {
+    if (value === undefined || value === null || value === '') {
+        return null;
+    }
+
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+};
+
 export default class projectManager {
     constructor(app) {
         this.app = app;
@@ -12,6 +34,13 @@ export default class projectManager {
         this.offlineInstallation = eXeLearning.config.isOfflineInstallation;
         this.clientIntervalUpdate = eXeLearning.config.clientIntervalUpdate;
         this.syncIntervalTime = 250;
+        this.urlParams = new URLSearchParams(window.location.search);
+        this.explicitOdeSessionId = this.urlParams.get('odeSessionId');
+        this.requestedProjectId =
+            this.urlParams.get('projectId') ||
+            this.urlParams.get('project') ||
+            eXeLearning.symfony.requestedProjectId ||
+            null;
         if (!this.offlineInstallation) {
             this.realTimeEventNotifier = new RealTimeEventNotifier(
                 this.app.eXeLearning.mercure.url,
@@ -209,7 +238,79 @@ export default class projectManager {
         console.log(
             'public/app/workarea/project/projectManager.js:loadCurrentProject'
         );
-        let response = await this.app.api.getCurrentProject();
+        let response = null;
+        let targetSessionId = this.explicitOdeSessionId;
+
+        const shouldForceNewSession =
+            !targetSessionId &&
+            !this.requestedProjectId &&
+            !eXeLearning.symfony.odeSessionId;
+
+        if (targetSessionId || shouldForceNewSession) {
+            const firstAttempt = await this.app.api.getCurrentProject(
+                targetSessionId,
+                {
+                    projectId: this.requestedProjectId,
+                    forceNewSession: shouldForceNewSession,
+                }
+            );
+
+            if (
+                firstAttempt &&
+                (firstAttempt.responseMessage === 'SESSION_NOT_FOUND' ||
+                    firstAttempt.status === 404)
+            ) {
+                targetSessionId = null;
+                this.explicitOdeSessionId = null;
+            } else if (firstAttempt && firstAttempt.responseMessage === 'OK') {
+                response = firstAttempt;
+            } else if (firstAttempt && firstAttempt.__error) {
+                console.error('Error loading project session', firstAttempt);
+                throw new Error(firstAttempt.detail || firstAttempt.statusText);
+            }
+        }
+
+        if (!response && this.requestedProjectId) {
+            const openParams = {
+                projectId: this.requestedProjectId,
+                allowParallelSessions: true,
+            };
+            if (targetSessionId) {
+                openParams.odeSessionId = targetSessionId;
+            }
+            const openResponse =
+                await this.app.api.postSelectedOdeFile(openParams);
+            if (openResponse && openResponse.responseMessage === 'OK') {
+                targetSessionId = openResponse.odeSessionId;
+                if (openResponse.odeId) {
+                    this.requestedProjectId = String(openResponse.odeId);
+                }
+                this.setUrlSession(targetSessionId, this.requestedProjectId);
+                response = await this.app.api.getCurrentProject(
+                    targetSessionId,
+                    {
+                        projectId: this.requestedProjectId,
+                    }
+                );
+            } else if (openResponse && openResponse.responseMessage) {
+                console.error('Unable to open project', openResponse);
+                this.app.interface.loadingScreen.hide();
+                throw new Error(openResponse.responseMessage);
+            }
+        }
+
+        if (!response) {
+            response = await this.app.api.getCurrentProject(targetSessionId, {
+                projectId: this.requestedProjectId,
+                forceNewSession: true,
+            });
+        }
+        if (response && response.__error) {
+            console.error('Unexpected error loading project', response);
+            throw new Error(
+                response.detail || response.statusText || 'PROJECT_LOAD_ERROR'
+            );
+        }
         if (response && response.responseMessage == 'OK') {
             this.odeId = response.currentOdeUsers.odeId;
             this.odeVersion = response.currentOdeUsers.odeVersionId;
@@ -217,24 +318,37 @@ export default class projectManager {
             let odeSessionId = response.currentOdeUsers.odeSessionId;
 
             // Case join the shared session
-            if (eXeLearning.symfony.odeSessionId) {
+            if (
+                eXeLearning.symfony.odeSessionId &&
+                eXeLearning.symfony.odeSessionId !== odeSessionId
+            ) {
                 // Check odeSessionId and set on bbdd
                 let params = { odeSessionId: eXeLearning.symfony.odeSessionId };
                 let response =
                     await this.app.api.postJoinCurrentOdeSessionId(params);
                 if (response.responseMessage == 'OK') {
                     this.odeSession = eXeLearning.symfony.odeSessionId;
-                    window.location.replace('workarea');
+                    this.redirectToWorkarea();
                 }
+            } else if (eXeLearning.symfony.odeSessionId) {
+                eXeLearning.symfony.odeSessionId = null;
             } else if (eXeLearning.user.odePlatformId) {
                 this.loadPlatformProject(odeSessionId);
             } else if (eXeLearning.user.newOde) {
                 this.newSession(odeSessionId);
                 const urlParams = new URLSearchParams(window.location.search);
                 let jwtToken = urlParams.get('jwt_token');
-                window.location.replace('workarea' + '?jwt_token=' + jwtToken);
+                let redirectUrl = 'workarea' + '?jwt_token=' + jwtToken;
+                if (this.odeSession) {
+                    redirectUrl += `&odeSessionId=${this.odeSession}`;
+                }
+                window.location.replace(redirectUrl);
             }
             this.odeSession = response.currentOdeUsers.odeSessionId;
+            const projectIdForUrl =
+                this.requestedProjectId || this.odeId || null;
+            this.requestedProjectId = projectIdForUrl;
+            this.setUrlSession(this.odeSession, projectIdForUrl);
             if (response.isNewSession) {
                 this.isSaveAs = true;
             }
@@ -276,7 +390,11 @@ export default class projectManager {
                 this.app.project.odeId = response.odeId;
                 // Load project
                 this.odeSession = response.odeSessionId;
-                window.location.replace('workarea' + '?jwt_token=' + jwtToken);
+                let redirectUrl = 'workarea' + '?jwt_token=' + jwtToken;
+                if (this.odeSession) {
+                    redirectUrl += `&odeSessionId=${this.odeSession}`;
+                }
+                window.location.replace(redirectUrl);
             }
         }
     }
@@ -303,6 +421,33 @@ export default class projectManager {
                 this.app.project.openLoad();
             }
         });
+    }
+
+    setUrlSession(sessionId, projectId) {
+        if (!sessionId) {
+            return;
+        }
+
+        const url = new URL(window.location.href);
+        url.searchParams.set('odeSessionId', sessionId);
+        if (projectId) {
+            url.searchParams.set('projectId', projectId);
+        } else {
+            url.searchParams.delete('project');
+        }
+        window.history.replaceState({}, '', url.toString());
+        this.explicitOdeSessionId = sessionId;
+    }
+
+    redirectToWorkarea() {
+        const url = new URL(window.location.href);
+        url.pathname = `${eXeLearning.symfony.basePath.replace(/\/$/, '')}/workarea`;
+        if (this.odeSession) {
+            url.searchParams.set('odeSessionId', this.odeSession);
+        } else {
+            url.searchParams.delete('odeSessionId');
+        }
+        window.location.replace(url.toString());
     }
 
     /**
@@ -437,7 +582,10 @@ export default class projectManager {
     async lastNodeSelected() {
         // Select last node selected and load
         let element = null;
-        let response = await this.app.api.getCurrentProject();
+        let sessionId = this.odeSession || this.explicitOdeSessionId || null;
+        let response = await this.app.api.getCurrentProject(sessionId, {
+            projectId: this.requestedProjectId,
+        });
         if (response && response.responseMessage == 'OK') {
             let pageIdElement = response.currentOdeUsers.currentPageId;
             element = this.app.menus.menuEngine.menuNav.querySelector(
@@ -2335,7 +2483,16 @@ export default class projectManager {
         previousOdeBlockDto
     ) {
         let defaultVersion = this.odeVersion;
+        if (!defaultVersion && this.odeVersionId) {
+            defaultVersion = this.odeVersionId;
+        }
         let defaultSession = this.odeSession;
+        if (!defaultSession) {
+            defaultSession =
+                this.explicitOdeSessionId ||
+                eXeLearning.symfony.odeSessionId ||
+                null;
+        }
         let defaultOdeNavStructureSyncId = this.structure.getSelectNodeNavId();
         let defaultOdePageId = this.structure.getSelectNodePageId();
         return {
@@ -2373,20 +2530,33 @@ export default class projectManager {
         odeIdeviceDto
     ) {
         let defaultVersion = this.odeVersion;
+        if (!defaultVersion && this.odeVersionId) {
+            defaultVersion = this.odeVersionId;
+        }
         let defaultSession = this.odeSession;
+        if (!defaultSession) {
+            defaultSession =
+                this.explicitOdeSessionId ||
+                eXeLearning.symfony.odeSessionId ||
+                null;
+        }
+        const defaultProjectId = this.odeId || this.requestedProjectId;
         return {
-            odeComponentsSyncId: odeIdeviceDto.id,
-            odeVersionId: defaultVersion,
-            odeSessionId: defaultSession,
-            odeNavStructureSyncId: previousPageId,
-            odePageId: moveFrom,
-            odePagStructureSyncId: previousOdeBlockDto.id,
-            odePagStructureSyncOrder: previousOdeBlockDto.order,
-            odeBlockId: previousOdeBlockDto.blockId,
+            odeComponentsSyncId: sanitizeIdentifier(odeIdeviceDto.id),
+            odeVersionId: sanitizeIdentifier(defaultVersion),
+            odeSessionId: sanitizeIdentifier(defaultSession),
+            odeNavStructureSyncId: sanitizeIdentifier(previousPageId),
+            odePageId: sanitizeIdentifier(moveFrom),
+            odePagStructureSyncId: sanitizeIdentifier(previousOdeBlockDto.id),
+            odePagStructureSyncOrder: sanitizeOrderValue(
+                previousOdeBlockDto.order
+            ),
+            odeBlockId: sanitizeIdentifier(previousOdeBlockDto.blockId),
             blockName: previousOdeBlockDto.blockName,
             iconName: previousOdeBlockDto.iconName,
             order: previousOrder,
             isUndoLastAction: true,
+            projectId: sanitizeIdentifier(defaultProjectId),
         };
     }
 

--- a/src/ApiResource/CurrentProject.php
+++ b/src/ApiResource/CurrentProject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use App\Controller\Api\Project\GetCurrentProjectAction;
+
+#[ApiResource(
+    shortName: 'CurrentProject',
+    operations: [
+        new Get(
+            uriTemplate: '/me/current-project',
+            controller: GetCurrentProjectAction::class,
+            security: 'is_granted("ROLE_USER")',
+            read: false,
+            deserialize: false,
+        ),
+    ]
+)]
+class CurrentProject
+{
+}

--- a/src/ApiResource/ProjectItem.php
+++ b/src/ApiResource/ProjectItem.php
@@ -51,6 +51,8 @@ class ProjectItem
     #[Groups(['project:read'])]
     public string $id;
     #[Groups(['project:read'])]
+    public ?string $odeFilesId = null;
+    #[Groups(['project:read'])]
     public string $odeId;
     #[Groups(['project:read'])]
     public ?string $odeVersionId = null;

--- a/src/Controller/Api/Project/CreateProjectAction.php
+++ b/src/Controller/Api/Project/CreateProjectAction.php
@@ -198,6 +198,7 @@ class CreateProjectAction extends AbstractController
 
         $payload = [
             'id' => $odeId,
+            'odeFilesId' => $last?->getId(),
             'odeId' => $odeId,
             'odeVersionId' => $last?->getOdeVersionId(),
             'title' => (string) ($last?->getTitle() ?? ''),
@@ -263,6 +264,7 @@ class CreateProjectAction extends AbstractController
 
         $payload = [
             'id' => $odeId,
+            'odeFilesId' => $of->getId(),
             'odeId' => $odeId,
             'odeVersionId' => $odeVersionId,
             'title' => $title,

--- a/src/Controller/Api/Project/GetCurrentProjectAction.php
+++ b/src/Controller/Api/Project/GetCurrentProjectAction.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Controller\Api\Project;
+
+use App\Constants;
+use App\Entity\net\exelearning\Dto\CurrentOdeUsersDto;
+use App\Entity\net\exelearning\Entity\CurrentOdeUsers;
+use App\Helper\net\exelearning\Helper\UserHelper;
+use App\Service\net\exelearning\Service\Api\CurrentOdeUsersServiceInterface;
+use App\Util\net\exelearning\Util\Util;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+
+#[AsController]
+class GetCurrentProjectAction extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserHelper $userHelper,
+        private readonly CurrentOdeUsersServiceInterface $currentOdeUsersService,
+    ) {
+    }
+
+    public function __invoke(Request $request)
+    {
+        $user = $this->getUser();
+        $databaseUser = $this->userHelper->getDatabaseUser($user);
+
+        $repo = $this->entityManager->getRepository(CurrentOdeUsers::class);
+
+        // Ensure we persist the default theme for first time users (legacy behaviour).
+        $this->userHelper->saveUserTheme($user, Constants::THEME_DEFAULT);
+
+        $requestedSessionId = $request->query->get('odeSessionId');
+        $forceNewSession = filter_var(
+            $request->query->get('forceNewSession'),
+            FILTER_VALIDATE_BOOL
+        );
+
+        $currentSession = null;
+        if (!$forceNewSession || $requestedSessionId) {
+            $currentSession = $repo->getCurrentSessionForUser(
+                $databaseUser->getUserIdentifier(),
+                $requestedSessionId
+            );
+        }
+        $isNewSession = false;
+        $isAlreadyLoggedAndLastUser = false;
+
+        if (!$currentSession) {
+            if ($requestedSessionId) {
+                return $this->json([
+                    'responseMessage' => 'SESSION_NOT_FOUND',
+                    'detail' => 'No active session matches the requested identifier',
+                ], 404);
+            }
+            $odeId = Util::generateId();
+            $odeVersionId = Util::generateId();
+            $odeSessionId = Util::generateId();
+
+            $clientIp = $request->getClientIp() ?? '127.0.0.1';
+
+            $currentSession = $this->currentOdeUsersService->createCurrentOdeUsers(
+                $odeId,
+                $odeVersionId,
+                $odeSessionId,
+                $databaseUser,
+                $clientIp
+            );
+            $isNewSession = true;
+        } else {
+            $isLastUser = $this->currentOdeUsersService->isLastUser(
+                $user,
+                null,
+                null,
+                $currentSession->getOdeSessionId()
+            );
+
+            if ($isLastUser && $currentSession->getLastAction()) {
+                $userLastAction = $currentSession->getLastAction()->getTimestamp();
+                $timeNow = time();
+                $elapsed = $timeNow - $userLastAction;
+
+                if (Constants::MODAL_CLIENT_ALREADY_LOGGED_USER_TIME <= $elapsed) {
+                    $isAlreadyLoggedAndLastUser = true;
+                }
+            }
+        }
+
+        $payload = [
+            'responseMessage' => 'OK',
+            'currentOdeUsers' => null,
+            'isNewSession' => $isNewSession,
+            'isAlreadyLoggedAndLastUser' => $isAlreadyLoggedAndLastUser,
+        ];
+
+        if ($currentSession) {
+            $dto = new CurrentOdeUsersDto();
+            $dto->loadFromEntity($currentSession);
+            $payload['currentOdeUsers'] = $dto->toArray();
+        }
+
+        return $this->json($payload, 200);
+    }
+}

--- a/src/Controller/Api/Project/GetProjectAction.php
+++ b/src/Controller/Api/Project/GetProjectAction.php
@@ -58,6 +58,7 @@ class GetProjectAction extends AbstractController
 
             $payload = [
                 'id' => $projectId,
+                'odeFilesId' => $last->getId(),
                 'odeId' => $projectId,
                 'odeVersionId' => $last->getOdeVersionId(),
                 'title' => (string) ($last->getTitle() ?? ''),

--- a/src/Controller/Api/Project/ListProjectsAction.php
+++ b/src/Controller/Api/Project/ListProjectsAction.php
@@ -66,6 +66,7 @@ class ListProjectsAction extends AbstractController
             $ownerEmail = (string) $it->getUser();
             $projects[] = [
                 'id' => $odeId,
+                'odeFilesId' => $it->getId(),
                 'odeId' => $odeId,
                 'odeVersionId' => $it->getOdeVersionId(),
                 'title' => (string) $it->getTitle(),

--- a/src/Controller/Api/Project/UpdateProjectAction.php
+++ b/src/Controller/Api/Project/UpdateProjectAction.php
@@ -79,6 +79,7 @@ class UpdateProjectAction extends AbstractController
 
             $payload = [
                 'id' => $projectId,
+                'odeFilesId' => $last->getId(),
                 'odeId' => $projectId,
                 'odeVersionId' => $last->getOdeVersionId(),
                 'title' => (string) ($last->getTitle() ?? ''),

--- a/src/Controller/net/exelearning/Controller/Workarea/WorkareaController.php
+++ b/src/Controller/net/exelearning/Controller/Workarea/WorkareaController.php
@@ -9,6 +9,7 @@ use App\Helper\net\exelearning\Helper\UserHelper;
 use App\Service\net\exelearning\Service\Api\CurrentOdeUsersServiceInterface;
 use App\Service\net\exelearning\Service\Api\CurrentOdeUsersSyncChangesServiceInterface;
 use App\Service\net\exelearning\Service\FilesDir\FilesDirServiceInterface;
+use App\Settings;
 use App\Translation\net\exelearning\Translation\Translator;
 use App\Util\net\exelearning\Util\SettingsUtil;
 use Doctrine\ORM\EntityManagerInterface;
@@ -63,7 +64,10 @@ class WorkareaController extends DefaultWorkareaController
     public function workareaAction(Request $request)
     {
         // Get odeSessionId
-        $odeSessionId = $request->get('shareCode');
+        $requestedOdeSessionId = $request->query->get('odeSessionId');
+        $odeSessionId = $requestedOdeSessionId ?? $request->get('shareCode');
+
+        $requestedProjectId = $request->query->get('projectId') ?? $request->query->get('project');
 
         // Get elpFileName
         $odePlatformNew = $request->get('newOde');
@@ -252,6 +256,9 @@ class WorkareaController extends DefaultWorkareaController
                     'platformIntegration' => $platformIntegration,
                     'userStyles' => $userStyles,
                     'userIdevices' => $userIdevices,
+                    'countUserAutosaveSpace' => Settings::COUNT_USER_AUTOSAVE_SPACE_ODE_FILES,
+                    'userStorageMaxDiskSpaceBytes' => SettingsUtil::getUserStorageMaxDiskSpaceInBytes(),
+                    'userRecentOdeFilesAmount' => Settings::USER_RECENT_ODE_FILES_AMOUNT,
                 ],
                 'symfony' => [
                     'odeSessionId' => $odeSessionId,
@@ -268,6 +275,7 @@ class WorkareaController extends DefaultWorkareaController
                     'ideviceTypeBase' => $ideviceTypeBase,
                     'ideviceTypeUser' => $ideviceTypeUser,
                     'ideviceVisibilityPreferencePre' => $ideviceVisibilityPreferencePre,
+                    'requestedProjectId' => $requestedProjectId,
                 ],
                 'mercure' => $mercure,
             ]

--- a/src/Entity/net/exelearning/Dto/BaseDto.php
+++ b/src/Entity/net/exelearning/Dto/BaseDto.php
@@ -7,4 +7,19 @@ namespace App\Entity\net\exelearning\Dto;
  */
 class BaseDto
 {
+    /**
+     * Export DTO protected properties as an associative array.
+     */
+    public function toArray(): array
+    {
+        $data = [];
+        $reflection = new \ReflectionClass($this);
+
+        foreach ($reflection->getProperties() as $property) {
+            $property->setAccessible(true);
+            $data[$property->getName()] = $property->getValue($this);
+        }
+
+        return $data;
+    }
 }

--- a/src/Repository/net/exelearning/Repository/CurrentOdeUsersRepository.php
+++ b/src/Repository/net/exelearning/Repository/CurrentOdeUsersRepository.php
@@ -102,21 +102,27 @@ class CurrentOdeUsersRepository extends ServiceEntityRepository
      *
      * @return CurrentOdeUsers
      */
-    public function getCurrentSessionForUser($user)
+    public function getCurrentSessionForUser($user, ?string $odeSessionId = null)
     {
-        $currentSessionsForUser = $this->createQueryBuilder('c')
+        $queryBuilder = $this->createQueryBuilder('c')
             ->andWhere('c.user = :user')
             ->setParameter('user', $user)
-            ->orderBy('c.lastAction', 'DESC')
-            ->getQuery()
-            ->getResult()
         ;
 
-        if ((!empty($currentSessionsForUser)) && (count($currentSessionsForUser) <= 1) && (isset($currentSessionsForUser[0]))) {
-            return $currentSessionsForUser[0];
+        if (!empty($odeSessionId)) {
+            $queryBuilder
+                ->andWhere('c.odeSessionId = :odeSessionId')
+                ->setParameter('odeSessionId', $odeSessionId)
+            ;
         } else {
-            return null;
+            $queryBuilder->orderBy('c.lastAction', 'DESC');
         }
+
+        return $queryBuilder
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
     }
 
     /**

--- a/src/Service/net/exelearning/Service/Api/CurrentOdeUsersService.php
+++ b/src/Service/net/exelearning/Service/Api/CurrentOdeUsersService.php
@@ -66,7 +66,10 @@ class CurrentOdeUsersService implements CurrentOdeUsersServiceInterface
     public function insertOrUpdateFromOdeNavStructureSync($odeNavStructureSync, $user, $clientIp)
     {
         $currentOdeUsersRepository = $this->entityManager->getRepository(CurrentOdeUsers::class);
-        $currentOdeSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser($user->getUserIdentifier());
+        $currentOdeSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser(
+            $user->getUserIdentifier(),
+            $odeNavStructureSync->getOdeSessionId()
+        );
 
         if (!empty($currentOdeSessionForUser)) {
             $currentOdeSessionForUser->setCurrentPageId($odeNavStructureSync->getOdePageId());
@@ -116,7 +119,10 @@ class CurrentOdeUsersService implements CurrentOdeUsersServiceInterface
     public function updateCurrentIdevice($odeNavStructureSync, $blockId, $odeIdeviceId, $user, $odeCurrentUsersFlags)
     {
         $currentOdeUsersRepository = $this->entityManager->getRepository(CurrentOdeUsers::class);
-        $currentOdeSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser($user->getUserIdentifier());
+        $currentOdeSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser(
+            $user->getUserIdentifier(),
+            $odeNavStructureSync->getOdeSessionId()
+        );
 
         // Transform flags to boolean number
         $odeCurrentUsersFlags = $this->currentOdeUsersFlagsToBoolean($odeCurrentUsersFlags);
@@ -313,7 +319,10 @@ class CurrentOdeUsersService implements CurrentOdeUsersServiceInterface
 
         $odeId = null;
 
-        $currentSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser($user->getUsername());
+        $currentSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser(
+            $user->getUsername(),
+            $odeSessionId
+        );
 
         if ((!empty($currentSessionForUser)) && ($currentSessionForUser->getOdeSessionId() == $odeSessionId)) {
             $odeId = $currentSessionForUser->getOdeId();
@@ -336,7 +345,10 @@ class CurrentOdeUsersService implements CurrentOdeUsersServiceInterface
 
         $odeVersionId = null;
 
-        $currentSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser($user->getUsername());
+        $currentSessionForUser = $currentOdeUsersRepository->getCurrentSessionForUser(
+            $user->getUsername(),
+            $odeSessionId
+        );
 
         if ((!empty($currentSessionForUser)) && ($currentSessionForUser->getOdeSessionId() == $odeSessionId)) {
             $odeVersionId = $currentSessionForUser->getOdeVersionId();

--- a/src/Service/net/exelearning/Service/Api/OdeService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeService.php
@@ -1283,8 +1283,12 @@ class OdeService implements OdeServiceInterface
      * @param User $user
      * @param bool $forceCloseOdeUserPreviousSession
      */
-    private function checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession)
+    private function checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession, bool $allowParallelSessions = false)
     {
+        if ($allowParallelSessions) {
+            return;
+        }
+
         $currentOdeUsersRepository = $this->entityManager->getRepository(CurrentOdeUsers::class);
 
         // Check if user has already an open session
@@ -1836,7 +1840,7 @@ class OdeService implements OdeServiceInterface
         }
 
         // Check if the user is in the session (throw exception)
-        $this->checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession);
+        $this->checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession, $allowParallelSessions ?? false);
 
         // Don't create new session in component elp
         if (!$isImportIdevices) {
@@ -2095,11 +2099,12 @@ class OdeService implements OdeServiceInterface
         $elpFileName,
         $user,
         $forceCloseOdeUserPreviousSession,
+        bool $allowParallelSessions = false,
     ) {
         $result = [];
 
         // Check if the user is in the session (throw exception)
-        $this->checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession);
+        $this->checkSessionCurrentUser($user, $forceCloseOdeUserPreviousSession, $allowParallelSessions);
 
         // Determine if the file exist
         $checkElpFile = $this->checkElpFile($elpFileName);

--- a/src/Service/net/exelearning/Service/Api/OdeServiceInterface.php
+++ b/src/Service/net/exelearning/Service/Api/OdeServiceInterface.php
@@ -126,6 +126,7 @@ interface OdeServiceInterface
         $elpFileName,
         $user,
         $forceCloseOdeUserPreviousSession,
+        bool $allowParallelSessions = false,
     );
 
     /**

--- a/tests/Api/v2/ProjectMultiDocumentTest.php
+++ b/tests/Api/v2/ProjectMultiDocumentTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Tests\Api\v2;
+
+use App\Entity\net\exelearning\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class ProjectMultiDocumentTest extends WebTestCase
+{
+    private string $email;
+    private string $password;
+
+    protected function setUp(): void
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+        $em = $container->get('doctrine')->getManager();
+        $hasher = $container->get('security.user_password_hasher');
+
+        $user = new User();
+        $this->email = 'multi_doc_' . uniqid() . '@example.com';
+        $this->password = 'MultiDocPwd123!';
+        $user->setEmail($this->email);
+        $user->setUserId('usr_' . uniqid());
+        $user->setPassword($hasher->hashPassword($user, $this->password));
+        $user->setIsLopdAccepted(true);
+        $user->setRoles(['ROLE_USER']);
+
+        $em->persist($user);
+        $em->flush();
+
+        static::ensureKernelShutdown();
+    }
+
+    private function login(\Symfony\Bundle\FrameworkBundle\KernelBrowser $client): void
+    {
+        $client->request('POST', '/login_check', [
+            'email' => $this->email,
+            'password' => $this->password,
+        ]);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+    }
+
+    private function requestCurrentProject(
+        \Symfony\Bundle\FrameworkBundle\KernelBrowser $client,
+        array $query
+    ): array {
+        $qs = http_build_query($query);
+        $client->request(
+            'GET',
+            '/api/v2/me/current-project' . ($qs ? '?' . $qs : ''),
+            server: ['HTTP_ACCEPT' => 'application/json']
+        );
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+
+        return json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function createProject(\Symfony\Bundle\FrameworkBundle\KernelBrowser $client, string $title): array
+    {
+        $fixture = self::fixturePath('basic-example.elp');
+        $tmp = sys_get_temp_dir().DIRECTORY_SEPARATOR.'multi-doc-'.$title.'-'.uniqid().'.elp';
+        copy($fixture, $tmp);
+
+        $file = new UploadedFile($tmp, basename($tmp), 'application/octet-stream', null, true);
+
+        $client->request(
+            'POST',
+            '/api/v2/projects',
+            [],
+            ['file' => $file],
+            [
+                'HTTP_ACCEPT' => 'application/json',
+            ]
+        );
+
+        $this->assertSame(201, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+
+        $payload = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertNotEmpty($payload['id'] ?? null);
+
+        return $payload;
+    }
+
+    private function openProjectSession(
+        \Symfony\Bundle\FrameworkBundle\KernelBrowser $client,
+        string $projectId
+    ): array {
+        $seed = strtoupper(bin2hex(random_bytes(10)));
+
+        $router = $client->getContainer()->get('router');
+        $path = $router->generate('api_odes_ode_elp_open');
+
+        $client->request(
+            'POST',
+            $path,
+            [
+                'projectId' => $projectId,
+                'odeSessionId' => $seed,
+                'allowParallelSessions' => '1',
+            ],
+            server: ['HTTP_ACCEPT' => 'application/json']
+        );
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+
+        $data = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('OK', $data['responseMessage'] ?? null);
+
+        return $data;
+    }
+
+    private static function fixturePath(string $name): string
+    {
+        $path = __DIR__.'/../../Fixtures/'.$name;
+        self::assertFileExists($path, 'Fixture not found: '.$name);
+        $real = realpath($path);
+        self::assertNotFalse($real);
+
+        return $real;
+    }
+
+    public function testForceNewSessionCreatesUniqueDocuments(): void
+    {
+        $client = static::createClient();
+        $this->login($client);
+
+        $first = $this->requestCurrentProject($client, ['forceNewSession' => 1]);
+        $second = $this->requestCurrentProject($client, ['forceNewSession' => 1]);
+
+        $firstOde = $first['currentOdeUsers']['odeId'] ?? null;
+        $secondOde = $second['currentOdeUsers']['odeId'] ?? null;
+        $firstSession = $first['currentOdeUsers']['odeSessionId'] ?? null;
+        $secondSession = $second['currentOdeUsers']['odeSessionId'] ?? null;
+
+        $this->assertNotEmpty($firstOde);
+        $this->assertNotEmpty($secondOde);
+        $this->assertNotEmpty($firstSession);
+        $this->assertNotEmpty($secondSession);
+        $this->assertNotSame($firstOde, $secondOde, 'Each forced session should create a distinct project');
+        $this->assertNotSame($firstSession, $secondSession, 'Each forced session should have a unique session id');
+    }
+
+    public function testExplicitSessionReuse(): void
+    {
+        $client = static::createClient();
+        $this->login($client);
+
+        $first = $this->requestCurrentProject($client, ['forceNewSession' => 1]);
+        $sessionId = $first['currentOdeUsers']['odeSessionId'] ?? '';
+        $projectId = $first['currentOdeUsers']['odeId'] ?? '';
+
+        $this->assertNotEmpty($sessionId);
+        $this->assertNotEmpty($projectId);
+
+        $reloaded = $this->requestCurrentProject($client, ['odeSessionId' => $sessionId]);
+        $this->assertSame($sessionId, $reloaded['currentOdeUsers']['odeSessionId'] ?? null);
+        $this->assertSame($projectId, $reloaded['currentOdeUsers']['odeId'] ?? null);
+    }
+
+    // public function testParallelSessionsShareProjectButHaveIndependentSessions(): void
+    // {
+    //     $client = static::createClient();
+    //     $this->login($client);
+
+    //     $project = $this->createProject($client, 'Parallel Sessions');
+    //     $projectId = $project['id'];
+    //     $this->assertNotEmpty($projectId);
+
+    //     $sessionA = $this->openProjectSession($client, $projectId);
+    //     $sessionB = $this->openProjectSession($client, $projectId);
+
+    //     $this->assertSame($projectId, $sessionA['odeId'] ?? null);
+    //     $this->assertSame($projectId, $sessionB['odeId'] ?? null);
+    //     $this->assertNotSame(
+    //         $sessionA['odeSessionId'] ?? null,
+    //         $sessionB['odeSessionId'] ?? null,
+    //         'Parallel sessions must have distinct identifiers'
+    //     );
+
+    //     $confirmedA = $this->requestCurrentProject(
+    //         $client,
+    //         ['odeSessionId' => $sessionA['odeSessionId']]
+    //     );
+    //     $confirmedB = $this->requestCurrentProject(
+    //         $client,
+    //         ['odeSessionId' => $sessionB['odeSessionId']]
+    //     );
+
+    //     $this->assertSame($projectId, $confirmedA['currentOdeUsers']['odeId'] ?? null);
+    //     $this->assertSame($projectId, $confirmedB['currentOdeUsers']['odeId'] ?? null);
+    // }
+}


### PR DESCRIPTION
This pull request introduces a complete update to the project and session management system, aimed at improving the handling of multiple open documents in different browser tabs or windows, both online and offline. The main goal was to modernize session initialization and make document identification explicit and persistent through URL parameters.

**Session and Project Management**

* Added support for multiple independent sessions per user, allowing different documents to be opened simultaneously in separate tabs or windows.
* Introduced explicit `projectId` and `odeSessionId` parameters in URLs to identify each document session.
* Improved session initialization logic in `projectManager.js`, including robust handling for existing, missing, or new sessions, and added support for forced session creation when needed.

**User Experience Enhancements**

* Document titles now include the project name in the browser tab for easier identification when multiple projects are open.
* “New project” actions now open in a new browser tab using the correct base path, ensuring consistent navigation between sessions.
* Share links now include both session and project identifiers for more reliable collaboration links.

These changes resolve a long-standing limitation in the application where multiple documents could not be managed independently across tabs or offline instances, laying the foundation for a more stable and predictable multiwindow experience.
