### PR TITLE
340 remove virustotal upload step from pipeline

### DIFF
--- a/.github/workflows/build-electron-installers.yml
+++ b/.github/workflows/build-electron-installers.yml
@@ -136,21 +136,6 @@ jobs:
           make package VERSION=${{ steps.get_version.outputs.version }}  PUBLISH=${{ env.PUBLISH }}
         shell: bash
 
-      - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v4
-        continue-on-error: true
-        with:
-          vt_api_key: ${{ secrets.VT_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          update_release_body: true
-          files: |
-            .msi$
-            .exe$
-            .dmg$
-            .deb$
-            .rpm$
-            .zip$
-
       # Always upload installers as workflow artifacts so test job can use them.
       # If the trigger was a release and electron-builder already published, this
       # artifact is an extra safe copy; if it was a push/PR-merge, this is the only copy.


### PR DESCRIPTION
This pull request removes the VirusTotal scanning step from the Electron installer build workflow. This change streamlines the workflow by eliminating the automated malware scanning of installer artifacts before uploading them.

Workflow simplification:

* Removed the "VirusTotal Scan" job from `.github/workflows/build-electron-installers.yml`, which previously scanned installer files for malware before uploading them as artifacts.

Close #340 