### PR TITLE
Fix: Serializer integration and request body hydration to prevent data loss on PUT requests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6676,16 +6676,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.3.4",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "0df5af266c6fe9a855af7db4fea86e13b9ca3ab1"
+                "reference": "5608b04d8daaf29432d76ecc618b0fac169c2dfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/0df5af266c6fe9a855af7db4fea86e13b9ca3ab1",
-                "reference": "0df5af266c6fe9a855af7db4fea86e13b9ca3ab1",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/5608b04d8daaf29432d76ecc618b0fac169c2dfb",
+                "reference": "5608b04d8daaf29432d76ecc618b0fac169c2dfb",
                 "shasum": ""
             },
             "require": {
@@ -6755,7 +6755,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.3.4"
+                "source": "https://github.com/symfony/serializer/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -6775,7 +6775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-15T13:39:02+00:00"
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\Component\Serializer\SerializerInterface: '@serializer'

--- a/src/Controller/net/exelearning/Controller/Api/CurrentOdeUsersApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/CurrentOdeUsersApiController.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/current-ode-users-management/current-ode-user')]
 class CurrentOdeUsersApiController extends DefaultApiController
@@ -30,13 +31,19 @@ class CurrentOdeUsersApiController extends DefaultApiController
     private $currentOdeUsersService;
     private $currentOdeUsersSyncChangesService;
 
-    public function __construct(EntityManagerInterface $entityManager, LoggerInterface $logger, UserHelper $userHelper, CurrentOdeUsersServiceInterface $currentOdeUsersService, CurrentOdeUsersSyncChangesServiceInterface $currentOdeUsersSyncChangesService)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        UserHelper $userHelper,
+        CurrentOdeUsersServiceInterface $currentOdeUsersService,
+        CurrentOdeUsersSyncChangesServiceInterface $currentOdeUsersSyncChangesService,
+        SerializerInterface $serializer,
+    ) {
         $this->userHelper = $userHelper;
         $this->currentOdeUsersService = $currentOdeUsersService;
         $this->currentOdeUsersSyncChangesService = $currentOdeUsersSyncChangesService;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/user/get', methods: ['GET'], name: 'api_current_ode_users_for_user_get')]

--- a/src/Controller/net/exelearning/Controller/Api/DropboxApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/DropboxApiController.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/dropbox')]
 class DropboxApiController extends DefaultApiController
@@ -29,14 +30,21 @@ class DropboxApiController extends DefaultApiController
     private $odeService;
     private $userHelper;
 
-    public function __construct(EntityManagerInterface $entityManager, LoggerInterface $logger, UrlGeneratorInterface $router, FileHelper $fileHelper, OdeServiceInterface $odeService, UserHelper $userHelper)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        UrlGeneratorInterface $router,
+        FileHelper $fileHelper,
+        OdeServiceInterface $odeService,
+        UserHelper $userHelper,
+        SerializerInterface $serializer,
+    ) {
         $this->router = $router;
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
         $this->userHelper = $userHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/oauth/login/url/get', methods: ['GET'], name: 'api_dropbox_oauth_login_url_get')]

--- a/src/Controller/net/exelearning/Controller/Api/GoogleApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/GoogleApiController.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/google')]
 class GoogleApiController extends DefaultApiController
@@ -28,14 +29,21 @@ class GoogleApiController extends DefaultApiController
     private $odeService;
     private $userHelper;
 
-    public function __construct(EntityManagerInterface $entityManager, LoggerInterface $logger, UrlGeneratorInterface $router, FileHelper $fileHelper, OdeServiceInterface $odeService, UserHelper $userHelper)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        UrlGeneratorInterface $router,
+        FileHelper $fileHelper,
+        OdeServiceInterface $odeService,
+        UserHelper $userHelper,
+        SerializerInterface $serializer,
+    ) {
         $this->router = $router;
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
         $this->userHelper = $userHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/oauth/login/url/get', methods: ['GET'], name: 'api_google_oauth_login_url_get')]

--- a/src/Controller/net/exelearning/Controller/Api/IdeviceApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/IdeviceApiController.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/idevice-management/idevices')]
@@ -63,6 +64,7 @@ class IdeviceApiController extends DefaultApiController
         ThumbnailServiceInterface $thumbnailService,
         OdeServiceInterface $odeService,
         HubInterface $hub,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->iDeviceHelper = $iDeviceHelper;
@@ -74,7 +76,7 @@ class IdeviceApiController extends DefaultApiController
         $this->thumbnailService = $thumbnailService;
         $this->odeService = $odeService;
 
-        parent::__construct($entityManager, $logger, $hub);
+        parent::__construct($entityManager, $logger, $serializer, $hub);
     }
 
     #[Route('/installed', methods: ['GET'], name: 'api_idevices_installed')]
@@ -490,6 +492,8 @@ class IdeviceApiController extends DefaultApiController
      */
     private function saveOdeComponentsSync(Request $request, $method)
     {
+        $this->hydrateRequestBody($request);
+
         $user = $this->getUser();
 
         // collect parameters
@@ -1063,6 +1067,8 @@ class IdeviceApiController extends DefaultApiController
     #[Route('/reorder/save', methods: ['PUT'], name: 'api_idevices_idevice_reorder')]
     public function reorderOdeComponentsSyncAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
         $responseData['odeComponentsSyncs'] = [];
 
@@ -1738,6 +1744,8 @@ class IdeviceApiController extends DefaultApiController
     #[Route('/properties/save', methods: ['PUT'], name: 'api_idevices_idevice_properties_save')]
     public function saveOdeComponentsSyncPropertiesAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
         $responseData['odeComponentsSync'] = null;
 

--- a/src/Controller/net/exelearning/Controller/Api/NavStructureApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/NavStructureApiController.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/nav-structure-management/nav-structures')]
@@ -36,12 +37,13 @@ class NavStructureApiController extends DefaultApiController
         TranslatorInterface $translator,
         CurrentOdeUsersServiceInterface $currentOdeUsersService,
         HubInterface $hub,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->userHelper = $userHelper;
         $this->translator = $translator;
         $this->currentOdeUsersService = $currentOdeUsersService;
-        parent::__construct($entityManager, $logger, $hub);
+        parent::__construct($entityManager, $logger, $serializer, $hub);
     }
 
     #[Route('/{odeVersionId}/{odeSessionId}/nav/structure/get', methods: ['GET'], name: 'api_nav_structures_nav_structure_get')]
@@ -104,6 +106,8 @@ class NavStructureApiController extends DefaultApiController
     #[Route('/nav/structure/data/save', methods: ['PUT'], name: 'api_nav_structures_nav_structure_data_save')]
     public function saveOdeNavStructureSyncDataAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = new OdeNavStructureSyncDataSaveDto();
 
         $odeNavStructureSyncId = $request->get('odeNavStructureSyncId');
@@ -356,6 +360,8 @@ class NavStructureApiController extends DefaultApiController
     #[Route('/reorder/save', methods: ['PUT'], name: 'api_nav_structures_nav_structure_reorder')]
     public function reorderOdeNavStructureSyncAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
 
         $responseData['odeNavStructureSyncs'] = [];
@@ -594,6 +600,8 @@ class NavStructureApiController extends DefaultApiController
     #[Route('/properties/save', methods: ['PUT'], name: 'api_nav_structures_nav_structure_properties_save')]
     public function saveOdeNavStructureSyncPropertiesAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
         $responseData['odeNavStructureSync'] = null;
 

--- a/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeApiController.php
@@ -30,6 +30,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/ode-management/odes')]
@@ -53,6 +54,7 @@ class OdeApiController extends DefaultApiController
         CurrentOdeUsersServiceInterface $currentOdeUsersService,
         CurrentOdeUsersSyncChangesServiceInterface $currentOdeUsersSyncChangesService,
         TranslatorInterface $translator,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
@@ -62,7 +64,7 @@ class OdeApiController extends DefaultApiController
         $this->currentOdeUsersSyncChangesService = $currentOdeUsersSyncChangesService;
         $this->translator = $translator;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/{odeId}/last-updated', methods: ['GET'], name: 'api_odes_last_updated')]
@@ -1193,6 +1195,8 @@ class OdeApiController extends DefaultApiController
     #[Route('/properties/save', methods: ['PUT'], name: 'api_odes_properties_save')]
     public function saveOdePropertiesAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
         $propertiesData = [];
 

--- a/src/Controller/net/exelearning/Controller/Api/OdeExportApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeExportApiController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/ode-export')]
@@ -42,6 +43,7 @@ class OdeExportApiController extends DefaultApiController
         UserHelper $userHelper,
         CurrentOdeUsersServiceInterface $currentOdeUsersService,
         TranslatorInterface $translator,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
@@ -51,7 +53,7 @@ class OdeExportApiController extends DefaultApiController
         $this->currentOdeUsersService = $currentOdeUsersService;
         $this->translator = $translator;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/{odeSessionId}/{exportType}/download', methods: ['GET'], name: 'api_ode_export_download')]

--- a/src/Controller/net/exelearning/Controller/Api/OdeOperationsLogApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/OdeOperationsLogApiController.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/ode-operations-management/ode-operations')]
 class OdeOperationsLogApiController extends DefaultApiController
@@ -33,6 +34,7 @@ class OdeOperationsLogApiController extends DefaultApiController
         UserHelper $userHelper,
         CurrentOdeUsersServiceInterface $currentOdeUsersService,
         OdeOperationsLogService $odeOperationsLogService,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
@@ -41,7 +43,7 @@ class OdeOperationsLogApiController extends DefaultApiController
         $this->currentOdeUsersService = $currentOdeUsersService;
         $this->odeOperationsLogService = $odeOperationsLogService;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/get/ode/operation/log', methods: ['POST'], name: 'api_ode_operations_ode_operation_log_get')]

--- a/src/Controller/net/exelearning/Controller/Api/PagStructureApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/PagStructureApiController.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/pag-structure-management/pag-structures')]
 class PagStructureApiController extends DefaultApiController
@@ -41,18 +42,21 @@ class PagStructureApiController extends DefaultApiController
         OdeComponentsSyncServiceInterface $odeComponentsSyncService,
         CurrentOdeUsersServiceInterface $currentOdeUsersService,
         HubInterface $hub,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->pagStructureApiService = $pagStructureApiService;
         $this->odeComponentsSyncService = $odeComponentsSyncService;
         $this->currentOdeUsersService = $currentOdeUsersService;
 
-        parent::__construct($entityManager, $logger, $hub);
+        parent::__construct($entityManager, $logger, $serializer, $hub);
     }
 
     #[Route('/pag/structure/data/save', methods: ['PUT'], name: 'api_pag_structures_pag_structure_data_save')]
     public function saveOdePagStructureSyncDataAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = new OdePagStructureSyncDataSaveDto();
 
         $odePagStructureSyncId = $request->get('odePagStructureSyncId');
@@ -303,6 +307,8 @@ class PagStructureApiController extends DefaultApiController
     #[Route('/reorder/save', methods: ['PUT'], name: 'api_pag_structures_pag_structure_reorder')]
     public function reorderOdePagStructureSyncAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
 
         $responseData['odePagStructureSyncs'] = [];
@@ -451,6 +457,8 @@ class PagStructureApiController extends DefaultApiController
     #[Route('/properties/save', methods: ['PUT'], name: 'api_pag_structures_pag_structure_properties_save')]
     public function saveOdePagStructureSyncPropertiesAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
         $responseData['odePagStructureSync'] = null;
 

--- a/src/Controller/net/exelearning/Controller/Api/ParameterApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/ParameterApiController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/parameter-management/parameters')]
@@ -22,13 +23,19 @@ class ParameterApiController extends DefaultApiController
     private $translator;
     private $userHelper;
 
-    public function __construct(EntityManagerInterface $entityManager, LoggerInterface $logger, UrlGeneratorInterface $router, TranslatorInterface $translator, UserHelper $userHelper)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        UrlGeneratorInterface $router,
+        TranslatorInterface $translator,
+        UserHelper $userHelper,
+        SerializerInterface $serializer,
+    ) {
         $this->router = $router;
         $this->translator = $translator;
         $this->userHelper = $userHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/data/list', methods: ['GET'], name: 'api_parameters_data_list')]

--- a/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/PlatformIntegrationApiController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PlatformIntegrationApiController extends DefaultApiController
@@ -47,6 +48,7 @@ class PlatformIntegrationApiController extends DefaultApiController
         RedirectController $redirectController,
         PlatformIntegrationServiceInterface $platformIntegrationService,
         OdeExportServiceInterface $odeExportService,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->odeService = $odeService;
@@ -58,7 +60,7 @@ class PlatformIntegrationApiController extends DefaultApiController
         $this->redirectController = $redirectController;
         $this->platformIntegrationService = $platformIntegrationService;
         $this->integrationUtil = new IntegrationUtil($logger);
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/new_ode', methods: ['GET'], name: 'api_platform_integration_new_ode')]

--- a/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/ThemeApiController.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/theme-management/themes')]
 class ThemeApiController extends DefaultApiController
@@ -29,12 +30,13 @@ class ThemeApiController extends DefaultApiController
         ThemeHelper $themeHelper,
         UserHelper $userHelper,
         FileHelper $fileHelper,
+        SerializerInterface $serializer,
     ) {
         $this->themeHelper = $themeHelper;
         $this->userHelper = $userHelper;
         $this->fileHelper = $fileHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('/installed', methods: ['GET'], name: 'api_themes_installed')]
@@ -297,6 +299,8 @@ class ThemeApiController extends DefaultApiController
     #[Route('/{themeDirName}/edit', methods: ['PUT'], name: 'api_themes_edit')]
     public function editTheme(Request $request, $themeDirName)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
 
         $user = $this->getUser();

--- a/src/Controller/net/exelearning/Controller/Api/TranslationApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/TranslationApiController.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/translation-management/translations')]
 class TranslationApiController extends DefaultApiController
@@ -19,12 +20,17 @@ class TranslationApiController extends DefaultApiController
     private $fileHelper;
     private $iDeviceHelper;
 
-    public function __construct(EntityManagerInterface $entityManager, LoggerInterface $logger, FileHelper $fileHelper, IdeviceHelper $iDeviceHelper)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        FileHelper $fileHelper,
+        IdeviceHelper $iDeviceHelper,
+        SerializerInterface $serializer,
+    ) {
         $this->fileHelper = $fileHelper;
         $this->iDeviceHelper = $iDeviceHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     #[Route('', methods: ['GET'], name: 'api_translations_lists')]

--- a/src/Controller/net/exelearning/Controller/Api/UserApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/UserApiController.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/api/user-management/user')]
 class UserApiController extends DefaultApiController
@@ -24,11 +25,12 @@ class UserApiController extends DefaultApiController
         LoggerInterface $logger,
         FileHelper $fileHelper,
         UserHelper $userHelper,
+        SerializerInterface $serializer,
     ) {
         $this->fileHelper = $fileHelper;
         $this->userHelper = $userHelper;
 
-        parent::__construct($entityManager, $logger);
+        parent::__construct($entityManager, $logger, $serializer);
     }
 
     /**
@@ -135,6 +137,8 @@ class UserApiController extends DefaultApiController
     #[Route('/preferences/save', methods: ['PUT'], name: 'api_user_preferences_save')]
     public function saveUserPreferencesAction(Request $request)
     {
+        $this->hydrateRequestBody($request);
+
         $responseData = [];
 
         $userLogged = $this->getUser();

--- a/src/Controller/net/exelearning/Controller/Filemanager/FilemanagerMethodController.php
+++ b/src/Controller/net/exelearning/Controller/Filemanager/FilemanagerMethodController.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -41,9 +42,16 @@ class FilemanagerMethodController extends DefaultApiController
 
     private $translator;
 
-    public function __construct(EntityManagerInterface $entityManager, FileHelper $fileHelper, Filesystem $storage, TmpfsInterface $tmpfs, LoggerInterface $logger, TranslatorInterface $translator)
-    {
-        parent::__construct($entityManager, $logger);
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FileHelper $fileHelper,
+        Filesystem $storage,
+        TmpfsInterface $tmpfs,
+        LoggerInterface $logger,
+        TranslatorInterface $translator,
+        SerializerInterface $serializer,
+    ) {
+        parent::__construct($entityManager, $logger, $serializer);
 
         $this->tmpfs = $tmpfs;
         $this->storage = $storage;

--- a/src/Entity/net/exelearning/Dto/IdeviceDataSaveDto.php
+++ b/src/Entity/net/exelearning/Dto/IdeviceDataSaveDto.php
@@ -2,6 +2,8 @@
 
 namespace App\Entity\net\exelearning\Dto;
 
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
 /**
  * IdeviceDataSaveDto.
  */
@@ -25,6 +27,7 @@ class IdeviceDataSaveDto extends BaseDto
     /**
      * @var bool
      */
+    #[SerializedName('newOdeComponentsSync')]
     protected $isNewOdeComponentsSync;
 
     /**
@@ -50,6 +53,7 @@ class IdeviceDataSaveDto extends BaseDto
     /**
      * @var bool
      */
+    #[SerializedName('newOdePagStructureSync')]
     protected $isNewOdePagStructureSync;
 
     /**
@@ -70,6 +74,7 @@ class IdeviceDataSaveDto extends BaseDto
     /**
      * @var bool
      */
+    #[SerializedName('newOdeNavStructureSync')]
     protected $isNewOdeNavStructureSync;
 
     public function __construct()

--- a/tests/Controller/FilemanagerMethodControllerTest.php
+++ b/tests/Controller/FilemanagerMethodControllerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Tests for FilemanagerMethodController functionality
@@ -34,6 +35,7 @@ class FilemanagerMethodControllerTest extends WebTestCase
     private MockObject $logger;
     private MockObject $translator;
     private MockObject $view;
+    private MockObject $serializer;
 
     /**
      * Set up test environment before each test
@@ -50,6 +52,10 @@ class FilemanagerMethodControllerTest extends WebTestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->view = $this->createMock(ViewInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->serializer->method('serialize')->willReturnCallback(static function ($data, $format, array $context = []) {
+            return json_encode($data);
+        });
 
         // Configure standard mock behavior
         $this->storage->method('getSessionPath')->willReturn('/tmp/session_path');
@@ -71,7 +77,8 @@ class FilemanagerMethodControllerTest extends WebTestCase
             $this->storage,
             $this->tmpfs,
             $this->logger,
-            $this->translator
+            $this->translator,
+            $this->serializer
         );
     }
 
@@ -138,7 +145,8 @@ class FilemanagerMethodControllerTest extends WebTestCase
                 $this->storage,
                 $this->tmpfs,
                 $this->logger,
-                $this->translator
+                $this->translator,
+                $this->serializer
             ])
             ->onlyMethods(['getParameter'])
             ->getMock();
@@ -181,7 +189,8 @@ class FilemanagerMethodControllerTest extends WebTestCase
                 $this->storage,
                 $this->tmpfs,
                 $this->logger,
-                $this->translator
+                $this->translator,
+                $this->serializer
             ])
             ->onlyMethods(['input', 'getOdeSessionId'])
             ->getMock();
@@ -254,7 +263,8 @@ class FilemanagerMethodControllerTest extends WebTestCase
                 $this->storage,
                 $this->tmpfs,
                 $this->logger,
-                $this->translator
+                $this->translator,
+                $this->serializer
             ])
             ->onlyMethods(['input', 'getOdeSessionId'])
             ->getMock();

--- a/tests/Integration/Api/IdeviceApiControllerTest.php
+++ b/tests/Integration/Api/IdeviceApiControllerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Api;
+
+use App\Entity\net\exelearning\Entity\User;
+use App\Helper\net\exelearning\Helper\IdeviceHelper;
+use App\Service\net\exelearning\Service\FilesDir\FilesDirServiceInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\ToolsException;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IdeviceApiControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private User $user;
+
+    public static function setUpBeforeClass(): void
+    {
+        $token = getenv('TEST_TOKEN') ?: getmypid();
+        $dbDir = sys_get_temp_dir().'/exelearning_test_db_'.$token;
+        if (!is_dir($dbDir)) {
+            mkdir($dbDir, 0777, true);
+        }
+        $dbPath = $dbDir.'/db.sqlite';
+        putenv('DB_PATH='.$dbPath);
+        $_ENV['DB_PATH'] = $dbPath;
+        $_SERVER['DB_PATH'] = $dbPath;
+
+        parent::setUpBeforeClass();
+    }
+
+    protected function setUp(): void
+    {
+        static::ensureKernelShutdown();
+        $this->client = static::createClient();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $this->resetDatabaseSchema($em);
+        /** @var FilesDirServiceInterface $filesDirService */
+        $filesDirService = static::getContainer()->get(FilesDirServiceInterface::class);
+        $checkResult = $filesDirService->checkFilesDir();
+        self::assertTrue($checkResult['checked'] ?? false, 'Failed to initialize FILES_DIR structure.');
+        $filesDir = rtrim((string) static::getContainer()->getParameter('filesdir'), DIRECTORY_SEPARATOR).
+            DIRECTORY_SEPARATOR;
+        self::assertDirectoryExists($filesDir.'perm/idevices/base');
+        /** @var IdeviceHelper $ideviceHelper */
+        $ideviceHelper = static::getContainer()->get(IdeviceHelper::class);
+        $baseList = $ideviceHelper->getInstalledBaseIdevices();
+        self::assertNotEmpty($baseList, 'No base idevices detected after initializing FILES_DIR.');
+        $this->user = $this->createAndPersistUser($em);
+
+        $this->client->loginUser($this->user);
+    }
+
+    private function resetDatabaseSchema(EntityManagerInterface $em): void
+    {
+        $metadata = $em->getMetadataFactory()->getAllMetadata();
+        if ($metadata === []) {
+            return;
+        }
+
+        $schemaTool = new SchemaTool($em);
+
+        try {
+            $schemaTool->dropSchema($metadata);
+        } catch (ToolsException $exception) {
+            // Ignore drop failures (e.g. tables not yet created in fresh database)
+        }
+
+        $schemaTool->createSchema($metadata);
+    }
+
+    private function createAndPersistUser(EntityManagerInterface $em): User
+    {
+        $user = new User();
+        $user->setEmail('idevice_int_'.bin2hex(random_bytes(4)).'@example.com');
+        $user->setUserId('usr_'.bin2hex(random_bytes(4)));
+        $user->setPassword('dummy-password');
+        $user->setIsLopdAccepted(true);
+        $user->setRoles(['ROLE_USER']);
+
+        $em->persist($user);
+        $em->flush();
+        $em->refresh($user);
+
+        return $user;
+    }
+
+    public function testInstalledIdevicesEndpointReturnsBaseIdevices(): void
+    {
+        $this->client->request(
+            'GET',
+            '/api/idevice-management/idevices/installed',
+            server: ['HTTP_ACCEPT' => 'application/json']
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = $this->client->getResponse()->getContent();
+        $payload = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('idevices', $payload);
+        self::assertNotEmpty($payload['idevices']);
+
+        $targetDevice = null;
+        $targetDirName = 'example';
+        foreach ($payload['idevices'] as $device) {
+            self::assertIsArray($device);
+            self::assertArrayHasKey('name', $device);
+            self::assertArrayHasKey('dirName', $device);
+            if ($device['dirName'] === $targetDirName) {
+                $targetDevice = $device;
+            }
+        }
+
+        self::assertNotNull(
+            $targetDevice,
+            sprintf('Expected to find the built-in "%s" idevice in the installed list', $targetDirName)
+        );
+        self::assertSame($targetDirName, $targetDevice['dirName']);
+        self::assertSame('/files/perm/idevices/base/'.$targetDirName, $targetDevice['url']);
+        self::assertArrayHasKey('downloadable', $targetDevice);
+        self::assertTrue((bool) ($targetDevice['downloadable'] ?? false));
+    }
+
+    public function testDownloadIdeviceEndpointReturnsZipPayload(): void
+    {
+        $sessionId = 'session1';
+        $ideviceDirName = 'example';
+
+        $this->client->request(
+            'GET',
+            sprintf('/api/idevice-management/idevices/%s/%s/download', $sessionId, $ideviceDirName),
+            server: ['HTTP_ACCEPT' => 'application/json']
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = $this->client->getResponse()->getContent();
+        $payload = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertSame($ideviceDirName.'.zip', $payload['zipFileName'] ?? null);
+
+        $binary = base64_decode($payload['zipBase64'] ?? '', true);
+        self::assertNotFalse($binary, 'Zip payload must be valid base64');
+        self::assertSame('PK', substr($binary, 0, 2));
+
+        if (class_exists(\ZipArchive::class)) {
+            $tmpZip = tempnam(sys_get_temp_dir(), 'idevice_zip_');
+            self::assertNotFalse($tmpZip);
+            file_put_contents($tmpZip, $binary);
+
+            $zip = new \ZipArchive();
+            self::assertTrue($zip->open($tmpZip) === true, 'Generated payload must be a valid ZIP archive');
+            self::assertNotFalse($zip->locateName('config.xml'), 'ZIP archive should contain the idevice config.xml file');
+            $zip->close();
+
+            @unlink($tmpZip);
+        }
+    }
+}

--- a/tests/Integration/SerializerNamingTest.php
+++ b/tests/Integration/SerializerNamingTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\net\exelearning\Dto\IdeviceDataSaveDto;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SerializerNamingTest extends KernelTestCase
+{
+    public function testIdeviceDataSaveDtoSerialization(): void
+    {
+        self::bootKernel();
+        $serializer = self::getContainer()->get(SerializerInterface::class);
+
+        $dto = new IdeviceDataSaveDto();
+        $dto->setResponseMessage('OK');
+        $dto->setIsNewOdeComponentsSync(true);
+        $dto->setIsNewOdePagStructureSync(true);
+
+        $json = $serializer->serialize($dto, 'json');
+        $this->assertJson($json);
+
+        $data = json_decode($json, true, JSON_THROW_ON_ERROR);
+        $this->assertArrayHasKey('newOdeComponentsSync', $data);
+        $this->assertTrue($data['newOdeComponentsSync']);
+        $this->assertArrayHasKey('newOdePagStructureSync', $data);
+        $this->assertTrue($data['newOdePagStructureSync']);
+    }
+}


### PR DESCRIPTION
This pull request fixes a regression caused by the recent `symfony/serializer` update (`bug #61887`), which changed how the `type` property is handled during normalization.
In our codebase, iDevices include a `type` field used internally as `odeIdeviceTypeName`. After the Symfony update, the serializer treated this field as a *discriminator type property* and ignored it when `ALLOW_EXTRA_ATTRIBUTES=false`, causing `"error: invalid data"` responses in `saveOdeComponentsSync()`.

### **Root cause**

* The Symfony patch allowed `type` to bypass the extra attributes check.
* Our controllers rely on manual `$request->get()` validation, expecting `odeIdeviceTypeName`.
* The `type` field was no longer present in the request data, breaking validation.

### **Changes**

* Unified all controllers to inject and use the Symfony `SerializerInterface` instead of local instances.
* Added `hydrateRequestBody()` in `DefaultApiController` to correctly populate request parameters from JSON/form payloads in PUT, PATCH, and DELETE requests.
* Updated all affected controllers to call this method where needed.
* Added `#[SerializedName(...)]` attributes in `IdeviceDataSaveDto` to ensure consistent serialized field names.
* Added tests (`IdeviceApiControllerTest`, `SerializerNamingTest`) to verify serialization and endpoint behavior.

### **Result**

* Fixes missing `type` / `odeIdeviceTypeName` data in PUT requests.
* Prevents `"error: invalid data"` on iDevice save.
* Standardizes serialization across all controllers and improves reliability for JSON payloads.
