### PR TITLE
Fix indentation in create-user command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ create-user: check-docker check-env upd
 	@read -p "Enter email: " email; \
 	read -p "Enter password: " password; \
 	read -p "Enter username: " username; \
-	@docker compose exec exelearning php bin/console app:create-user $$email $$password $$username --no-fail;
+	docker compose exec exelearning php bin/console app:create-user $$email $$password $$username --no-fail;
 
 # Grant an arbitrary role to a user
 # Usage: make grant-role EMAIL=user@example.com ROLE=ROLE_MANAGER


### PR DESCRIPTION
This pull request makes a minor update to the `create-user` target in the `Makefile`, specifically affecting how the user creation command is run.

* Removed the `@` symbol before the `docker compose exec` command in the `create-user` target, so the command will now be printed to the terminal when executed.