### PR TITLE
Feature/new markdown idevice

### DIFF
--- a/public/app/common/app_common.js
+++ b/public/app/common/app_common.js
@@ -61,12 +61,40 @@ export default class Common {
   }
 
   /**
-   * Markdown to HTML converter
+   * Markdown to HTML converter.
+   *
+   * LaTeX delimiters (\(...\), \[...\], $$...$$, \begin{...}\end{...}) are
+   * stashed before Showdown runs so that markdown processing does not eat
+   * underscores, asterisks or backslashes inside formulas. They are restored
+   * verbatim afterwards so MathJax can pick them up at render time.
    */
   markdownToHTML(content) {
-    var converter = new showdown.Converter();
-    converter.setOption('noHeaderId', true);
-    return converter.makeHtml(content);
+    var src = String(content == null ? '' : content);
+    var store = [];
+    [
+      /\\\[[\s\S]*?\\\]/g,
+      /\$\$[\s\S]*?\$\$/g,
+      /\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}/g,
+      /\\\([\s\S]*?\\\)/g,
+    ].forEach(function (re) {
+      src = src.replace(re, function (match) {
+        store.push(match);
+        return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
+      });
+    });
+
+    var converter = new showdown.Converter({
+      noHeaderId: true,
+      tables: true,
+      tasklists: true,
+      strikethrough: true,
+      disableForced4SpacesIndentedSublists: true,
+    });
+    var html = converter.makeHtml(src);
+
+    return html.replace(/EXELATEXBEGIN(\d+)EXELATEXEND/g, function (_, i) {
+      return store[Number(i)] !== undefined ? store[Number(i)] : _;
+    });
   }
 
   /**

--- a/public/app/common/app_common.test.js
+++ b/public/app/common/app_common.test.js
@@ -264,6 +264,28 @@ describe('Common', () => {
       const result = common.markdownToHTML('test');
       expect(typeof result).toBe('string');
     });
+
+    it('preserves inline LaTeX \\(...\\) intact', () => {
+      const result = common.markdownToHTML('Equation \\(x^2 + y_1\\) here');
+      expect(result).toContain('\\(x^2 + y_1\\)');
+    });
+
+    it('preserves display LaTeX $$...$$ intact', () => {
+      const result = common.markdownToHTML('Block: $$\\int_0^1 dx$$ end');
+      expect(result).toContain('$$\\int_0^1 dx$$');
+    });
+
+    it('preserves \\[...\\] block math intact', () => {
+      const result = common.markdownToHTML('Block: \\[x_1 + x_2\\] end');
+      expect(result).toContain('\\[x_1 + x_2\\]');
+    });
+
+    it('preserves \\begin{...}...\\end{...} environments', () => {
+      const result = common.markdownToHTML(
+        'Aligned: \\begin{align}a_1 &= b_1 \\\\ c &= d\\end{align}'
+      );
+      expect(result).toContain('\\begin{align}a_1 &= b_1 \\\\ c &= d\\end{align}');
+    });
   });
 
   describe('initTooltips', () => {

--- a/public/files/perm/idevices/base/markdown-text/config.xml
+++ b/public/files/perm/idevices/base/markdown-text/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<idevice>
+    <name>markdown-text</name>
+    <title>Markdown text</title>
+    <css-class>markdown-text</css-class>
+    <category>Information and presentation</category>
+    <icon>
+        <name>markdown-text-icon</name>
+        <url>markdown-text-icon.svg</url>
+        <type>img</type>
+    </icon>
+    <version>1.0</version>
+    <api-version>3.0</api-version>
+    <component-type>json</component-type>
+    <location>location</location>
+    <location-type>location type</location-type>
+    <edition-js>
+        <filename>markdown-text.js</filename>
+    </edition-js>
+    <edition-css>
+        <filename>markdown-text.css</filename>
+    </edition-css>
+    <export-js>
+        <filename>markdown-text.js</filename>
+    </export-js>
+    <export-css>
+        <filename>markdown-text.css</filename>
+    </export-css>
+    <export-template-filename>markdown-text.html</export-template-filename>
+    <author>INTEF</author>
+    <author-url>https://exelearning.net</author-url>
+    <license>AGPL-3.0-or-later</license>
+    <license-url>https://www.gnu.org/licenses/agpl-3.0.html</license-url>
+    <description>Markdown component with GitHub style editing experience</description>
+    <downloadable>0</downloadable>
+</idevice>

--- a/public/files/perm/idevices/base/markdown-text/edition/markdown-text.css
+++ b/public/files/perm/idevices/base/markdown-text/edition/markdown-text.css
@@ -1,0 +1,169 @@
+/* Markdown Text iDevice (edition CSS) */
+#markdownTextForm .exe-field {
+    font-weight: bold;
+    padding: 5px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+#markdownTextForm fieldset .exe-text-legend {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: auto;
+}
+
+#markdownTextForm legend a {
+    text-decoration: none;
+    color: var(--dark-exe-color);
+    font-weight: bold;
+    transition: var(--tr-02);
+    width: 100%;
+}
+
+#markdownTextForm .exe-parent {
+    position: relative;
+}
+
+#markdownTextForm .grid-container {
+    display: grid;
+    column-gap: 20px;
+    grid-template-columns: repeat(2, minmax(200px, 1fr));
+}
+
+#markdownTextForm .grid-container input {
+    width: calc(100% - var(--margin-l));
+}
+
+#markdownTextForm .exe-markdown-editor {
+    font-weight: normal;
+    border: 1px solid var(--color-border, #d0d7de);
+    border-radius: 6px;
+    padding: 0;
+    background-color: #fff;
+}
+
+#markdownTextForm .exe-markdown-editor + .exe-markdown-editor {
+    margin-top: 1rem;
+}
+
+#markdownTextForm .exe-markdown-editor__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0.75rem 0;
+}
+
+#markdownTextForm .exe-markdown-editor__header label {
+    font-weight: 600;
+    margin-bottom: 0;
+}
+
+#markdownTextForm .exe-markdown-editor__tabs {
+    display: flex;
+    border-bottom: 1px solid var(--color-border, #d0d7de);
+    padding: 0 0.5rem;
+    gap: 0.25rem;
+}
+
+#markdownTextForm .exe-markdown-editor__tab {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--dark-exe-color);
+    cursor: pointer;
+}
+
+#markdownTextForm .exe-markdown-editor__tab.is-active {
+    border-color: var(--dark-exe-color);
+    color: var(--dark-exe-color);
+}
+
+#markdownTextForm .exe-markdown-editor__tab:focus {
+    outline: 2px solid var(--dark-exe-color);
+    outline-offset: 2px;
+}
+
+#markdownTextForm .exe-markdown-editor__panels {
+    display: flex;
+    flex-direction: column;
+}
+
+#markdownTextForm .exe-markdown-editor__textarea {
+    min-height: 240px;
+    border: none;
+    border-top: 1px solid var(--color-border, #d0d7de);
+    padding: 0.75rem;
+    font-family: var(--font-family-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace);
+    font-size: 0.95rem;
+    resize: vertical;
+}
+
+#markdownTextForm .exe-markdown-editor__textarea:focus {
+    outline: none;
+}
+
+#markdownTextForm .exe-markdown-preview {
+    border-top: 1px solid var(--color-border, #d0d7de);
+    padding: 0.75rem;
+    min-height: 240px;
+    overflow-y: auto;
+    background-color: #f6f8fa;
+}
+
+#markdownTextForm .exe-markdown-preview p {
+    margin-bottom: 0.75rem;
+}
+
+#markdownTextForm .exe-markdown-preview pre,
+#markdownTextForm .exe-markdown-preview code {
+    font-family: var(--font-family-monospace, ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace);
+    font-size: 0.9em;
+    text-shadow: none;
+}
+
+#markdownTextForm .exe-markdown-preview pre {
+    background-color: #0d1117;
+    color: #e6edf3;
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+}
+
+#markdownTextForm .exe-markdown-preview code {
+    background-color: rgba(175, 184, 193, 0.2);
+    border-radius: 4px;
+    padding: 0.2em 0.4em;
+}
+
+#markdownTextForm .exe-markdown-preview pre code {
+    background-color: transparent;
+    padding: 0;
+    color: inherit;
+}
+
+#markdownTextForm .exe-markdown-preview ul.task-list,
+#markdownTextForm .exe-markdown-preview ul li.task-list-item {
+    list-style: none;
+    padding-left: 0;
+}
+
+#markdownTextForm .exe-markdown-preview li.task-list-item input[type="checkbox"] {
+    margin-right: 0.4em;
+}
+
+#markdownTextForm .exe-markdown-preview table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1rem;
+}
+
+#markdownTextForm .exe-markdown-preview th,
+#markdownTextForm .exe-markdown-preview td {
+    border: 1px solid #d0d7de;
+    padding: 0.5rem;
+}

--- a/public/files/perm/idevices/base/markdown-text/edition/markdown-text.js
+++ b/public/files/perm/idevices/base/markdown-text/edition/markdown-text.js
@@ -1,0 +1,521 @@
+/* eslint-disable no-undef */
+/**
+ * Markdown Text iDevice
+ *
+ * Provides a GitHub-like Markdown editor with live preview.
+ */
+var $exeDevice = {
+    // ::: i18n :::
+    name: _('Markdown text'),
+    textareaTitle: _('Markdown content'),
+    infoTitle: _('Task information (optional)'),
+    feedbackTitle: _('Feedback'),
+    feedbackInputTitle: _('Button text'),
+    infoDurationInputTitle: _('Estimated duration'),
+    infoDurationTextInputTitle: _('Text to display'),
+    infoParticipantsInputTitle: _('Participants'),
+    infoParticipantsTextInputTitle: _('Text to display'),
+    writeTabLabel: _('Write'),
+    previewTabLabel: _('Preview'),
+
+    // ::: Identifiers :::
+    prefix: 'markdown',
+    textareaId: 'markdownTextarea',
+    feedbackId: 'markdownFeedback',
+    feedbackInputId: 'markdownFeedbackInput',
+    feedbackTextareaId: 'markdownFeedbackTextarea',
+    infoId: 'markdownInfo',
+    infoInputDurationId: 'markdownInfoDurationInput',
+    infoInputDurationTextId: 'markdownInfoDurationTextInput',
+    infoInputParticipantsId: 'markdownInfoParticipantsInput',
+    infoInputParticipantsTextId: 'markdownInfoParticipantsTextInput',
+    editorGroupId: 'markdownEditorGroup',
+    htmlSuffix: 'Html',
+
+    // ::: Default values :::
+    feedbackInputValue: c_('Show Feedback'),
+    feedbackInputInstructions: '',
+    infoDurationInputValue: '',
+    infoDurationInputPlaceholder: _('00:00'),
+    infoDurationTextInputValue: _('Duration'),
+    infoParticipantsInputValue: '',
+    infoParticipantsInputPlaceholder: _('Number or description'),
+    infoParticipantsTextInputValue: _('Grouping'),
+
+    // ::: Runtime collections :::
+    dataIds: [],
+    markdownEditors: null,
+    markdownConverter: null,
+
+    /**
+     * Initialize the iDevice editor
+     *
+     * @param {HTMLElement} element
+     * @param {Object} previousData
+     */
+    init: function (element, previousData) {
+        this.ideviceBody = element;
+        this.idevicePreviousData = previousData || {};
+        this.createForm();
+    },
+
+    /**
+     * Save the current state and return the JSON payload.
+     *
+     * @returns {Object|boolean}
+     */
+    save: function () {
+        this.dataIds = [];
+        const dataElements = this.ideviceBody.querySelectorAll(
+            `[id^="${this.prefix}"]`
+        );
+
+        dataElements.forEach((element) => {
+            if (
+                element.nodeName === 'TEXTAREA' ||
+                element.nodeName === 'INPUT'
+            ) {
+                this.dataIds.push(element.id);
+                this[element.id] = element.value;
+            }
+        });
+
+        this.markdownEditors.forEach((editorState) => {
+            this[editorState.htmlKey] = editorState.computeHtml();
+        });
+
+        if (this.checkFormValues()) {
+            return this.getDataJson();
+        }
+        return false;
+    },
+
+    /**
+     * Render the form and attach behaviors.
+     */
+    createForm: function () {
+        let html = `<div id="markdownTextForm">`;
+        html += this.createEditorGroup();
+        html += `</div>`;
+
+        this.ideviceBody.innerHTML = html;
+        this.setBehaviour();
+        this.loadPreviousValues();
+        this.refreshMarkdownPreviews();
+    },
+
+    /**
+     * Ensure mandatory fields contain data.
+     *
+     * @returns {boolean}
+     */
+    checkFormValues: function () {
+        const content = this[this.textareaId]
+            ? this[this.textareaId].trim()
+            : '';
+        if (content === '') {
+            eXe.app.alert(_('Please write some text.'));
+            return false;
+        }
+        return true;
+    },
+
+    /**
+     * Build the JSON object that stores the idevice data.
+     *
+     * @returns {Object}
+     */
+    getDataJson: function () {
+        const data = {};
+        data.ideviceId = this.ideviceBody.getAttribute('idevice-id');
+
+        this.dataIds.forEach((key) => {
+            data[key] = this[key];
+        });
+
+        this.markdownEditors.forEach((editorState) => {
+            data[editorState.htmlKey] = editorState.computeHtml();
+        });
+
+        return data;
+    },
+
+    /**
+     * Restore values that were previously saved.
+     */
+    loadPreviousValues: function () {
+        const isValid = (val) =>
+            val != null && !(typeof val === 'string' && val.trim() === '');
+
+        const data = this.idevicePreviousData || {};
+        const defaults = {
+            [this.infoInputDurationId]: this.infoDurationInputValue,
+            [this.infoInputDurationTextId]: this.infoDurationTextInputValue,
+            [this.infoInputParticipantsId]: this.infoParticipantsInputValue,
+            [this.infoInputParticipantsTextId]:
+                this.infoParticipantsTextInputValue,
+            [this.feedbackInputId]: this.feedbackInputValue,
+            [this.feedbackTextareaId]: this.feedbackInputInstructions,
+        };
+
+        const unionKeys = new Set([
+            ...Object.keys(defaults),
+            ...Object.keys(data),
+        ]);
+
+        unionKeys.forEach((key) => {
+            if (!key || key === 'ideviceId') {
+                return;
+            }
+
+            const element = this.ideviceBody.querySelector(`#${key}`);
+            if (!element) {
+                return;
+            }
+
+            const originalValue = data[key];
+            const hasDefault = Object.prototype.hasOwnProperty.call(
+                defaults,
+                key
+            );
+            let finalValue = '';
+
+            if (isValid(originalValue)) {
+                finalValue = originalValue;
+            } else if (hasDefault) {
+                finalValue = defaults[key];
+            }
+
+            if (element.tagName === 'TEXTAREA') {
+                element.value = finalValue;
+            } else if (element.tagName === 'INPUT') {
+                const useTranslation = isValid(originalValue);
+                const displayValue = useTranslation
+                    ? c_(finalValue)
+                    : finalValue;
+                element.setAttribute('value', displayValue);
+                element.value = displayValue;
+            }
+        });
+    },
+
+    /**
+     * Attach Markdown editor behaviors to the form.
+     */
+    setBehaviour: function () {
+        this.markdownEditors = new Map();
+        const containers = this.ideviceBody.querySelectorAll(
+            '.exe-markdown-editor'
+        );
+        containers.forEach((container) => {
+            this.setupMarkdownEditor(container);
+        });
+    },
+
+    /**
+     * Initialize a single Markdown editor widget.
+     *
+     * @param {HTMLElement} container
+     */
+    setupMarkdownEditor: function (container) {
+        const textarea = container.querySelector('textarea');
+        const preview = container.querySelector('.exe-markdown-preview');
+        const writeTab = container.querySelector('[data-tab="write"]');
+        const previewTab = container.querySelector('[data-tab="preview"]');
+
+        if (!textarea || !preview || !writeTab || !previewTab) {
+            return;
+        }
+
+        const editorState = {
+            textarea,
+            preview,
+            writeTab,
+            previewTab,
+            htmlKey: `${textarea.id}${this.htmlSuffix}`,
+            computeHtml: () => this.computeMarkdownHtml(textarea.value),
+            refreshPreview: () => {
+                preview.innerHTML = editorState.computeHtml();
+            },
+            showWrite: () => {
+                textarea.hidden = false;
+                preview.hidden = true;
+                writeTab.classList.add('is-active');
+                previewTab.classList.remove('is-active');
+                writeTab.setAttribute('aria-selected', 'true');
+                previewTab.setAttribute('aria-selected', 'false');
+                textarea.focus();
+            },
+            showPreview: () => {
+                editorState.refreshPreview();
+                textarea.hidden = true;
+                preview.hidden = false;
+                previewTab.classList.add('is-active');
+                writeTab.classList.remove('is-active');
+                previewTab.setAttribute('aria-selected', 'true');
+                writeTab.setAttribute('aria-selected', 'false');
+            },
+        };
+
+        const handleTabClick = (event) => {
+            event.preventDefault();
+            const target = event.currentTarget.getAttribute('data-tab');
+            if (target === 'write') {
+                editorState.showWrite();
+            } else {
+                editorState.showPreview();
+            }
+        };
+
+        writeTab.addEventListener('click', handleTabClick);
+        previewTab.addEventListener('click', handleTabClick);
+
+        textarea.addEventListener('input', () => {
+            if (!preview.hidden) {
+                editorState.refreshPreview();
+            }
+        });
+
+        editorState.showWrite();
+        this.markdownEditors.set(textarea.id, editorState);
+    },
+
+    /**
+     * Force all previews to update so they match the latest textarea values.
+     */
+    refreshMarkdownPreviews: function () {
+        if (!this.markdownEditors) {
+            return;
+        }
+        this.markdownEditors.forEach((editorState) => {
+            editorState.refreshPreview();
+        });
+    },
+
+    /**
+     * Convert Markdown into HTML using eXe helpers or Showdown.
+     *
+     * LaTeX delimiters are protected from Showdown so that subscripts,
+     * line breaks and other backslash sequences inside formulas survive.
+     *
+     * @param {string} value
+     * @returns {string}
+     */
+    computeMarkdownHtml: function (value) {
+        const content = value || '';
+        if (
+            typeof eXe !== 'undefined' &&
+            eXe.app &&
+            eXe.app.common &&
+            typeof eXe.app.common.markdownToHTML === 'function'
+        ) {
+            return eXe.app.common.markdownToHTML(content);
+        }
+        const converter = this.getMarkdownConverter();
+        if (!converter) {
+            return this.escapeHtml(content);
+        }
+        const stash = this.stashLatex(content);
+        const html = converter.makeHtml(stash.text);
+        return this.restoreLatex(html, stash.store);
+    },
+
+    stashLatex: function (text) {
+        const store = [];
+        let src = String(text == null ? '' : text);
+        [
+            /\\\[[\s\S]*?\\\]/g,
+            /\$\$[\s\S]*?\$\$/g,
+            /\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}/g,
+            /\\\([\s\S]*?\\\)/g,
+        ].forEach(function (re) {
+            src = src.replace(re, function (match) {
+                store.push(match);
+                return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
+            });
+        });
+        return { text: src, store: store };
+    },
+
+    restoreLatex: function (html, store) {
+        return String(html || '').replace(
+            /EXELATEXBEGIN(\d+)EXELATEXEND/g,
+            function (match, i) {
+                const idx = Number(i);
+                return store[idx] !== undefined ? store[idx] : match;
+            }
+        );
+    },
+
+    /**
+     * Lazily instantiate a Showdown converter if needed.
+     *
+     * @returns {showdown.Converter|null}
+     */
+    getMarkdownConverter: function () {
+        if (this.markdownConverter) {
+            return this.markdownConverter;
+        }
+        if (typeof showdown === 'undefined') {
+            return null;
+        }
+        this.markdownConverter = new showdown.Converter({
+            noHeaderId: true,
+            tables: true,
+            tasklists: true,
+            strikethrough: true,
+            disableForced4SpacesIndentedSublists: true,
+        });
+        return this.markdownConverter;
+    },
+
+    /**
+     * Escape HTML special characters in a string.
+     *
+     * @param {string} str
+     * @returns {string}
+     */
+    escapeHtml: function (str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    },
+
+    /**
+     * Compose the editor group HTML with information and feedback sections.
+     *
+     * @returns {string}
+     */
+    createEditorGroup: function () {
+        let infoContent = `<div>`;
+        infoContent += this.createInputHTML(
+            this.infoInputDurationId,
+            this.infoDurationInputTitle,
+            '',
+            this.infoDurationInputValue,
+            this.infoDurationInputPlaceholder
+        );
+        infoContent += this.createInputHTML(
+            this.infoInputDurationTextId,
+            this.infoDurationTextInputTitle,
+            '',
+            `${this.infoDurationTextInputValue}:`,
+            ''
+        );
+        infoContent += `</div>`;
+        infoContent += `<div>`;
+        infoContent += this.createInputHTML(
+            this.infoInputParticipantsId,
+            this.infoParticipantsInputTitle,
+            '',
+            this.infoParticipantsInputValue,
+            this.infoParticipantsInputPlaceholder
+        );
+        infoContent += this.createInputHTML(
+            this.infoInputParticipantsTextId,
+            this.infoParticipantsTextInputTitle,
+            '',
+            `${this.infoParticipantsTextInputValue}:`,
+            ''
+        );
+        infoContent += `</div>`;
+        const infoFieldset = this.createInformationFieldsetHTML(
+            this.infoId,
+            this.infoTitle,
+            '',
+            infoContent
+        );
+
+        let feedbackContent = this.createInputHTML(
+            this.feedbackInputId,
+            this.feedbackInputTitle,
+            this.feedbackInputInstructions,
+            this.feedbackInputValue
+        );
+        feedbackContent += this.createMarkdownEditorHTML(
+            this.feedbackTextareaId
+        );
+        const feedbackFieldset = this.createFieldsetHTML(
+            this.feedbackId,
+            this.feedbackTitle,
+            '',
+            feedbackContent
+        );
+
+        let content = `<div class="exe-parent">${infoFieldset}</div>`;
+        content += this.createMarkdownEditorHTML(
+            this.textareaId,
+            this.textareaTitle
+        );
+        content += `<div class="exe-parent">${feedbackFieldset}</div>`;
+
+        let html = `<div id="${this.editorGroupId}_parent" class="exe-parent">`;
+        html += content;
+        html += `</div>`;
+
+        return html;
+    },
+
+    /**
+     * Markdown editor markup with tabs and preview pane.
+     */
+    createMarkdownEditorHTML: function (id, title) {
+        const label = title || '';
+        return `
+      <div class="exe-field exe-text-field exe-markdown-editor">
+        <div class="exe-markdown-editor__header">
+          <label for="${id}">${label}</label>
+        </div>
+        <div class="exe-markdown-editor__tabs" role="tablist">
+          <button type="button" class="exe-markdown-editor__tab is-active" data-tab="write" aria-selected="true">${this.writeTabLabel}</button>
+          <button type="button" class="exe-markdown-editor__tab" data-tab="preview" aria-selected="false">${this.previewTabLabel}</button>
+        </div>
+        <div class="exe-markdown-editor__panels">
+          <textarea id="${id}" class="exe-markdown-editor__textarea" aria-label="${label}"></textarea>
+          <div class="exe-markdown-preview" hidden></div>
+        </div>
+      </div>`;
+    },
+
+    /**
+     * Fieldset factory. Pass `wrapperClass = 'grid-container'` for the
+     * info block layout, omit it for the generic single-column variant.
+     */
+    createFieldsetHTML: function (id, title, affix, content, wrapperClass) {
+        const wrapper = wrapperClass ? ` class="${wrapperClass}"` : '';
+        return `
+      <fieldset id="${id}" class="exe-advanced exe-fieldset exe-fieldset-closed">
+        <legend class="exe-text-legend">
+          <a href="#">${title}${affix || ''}</a>
+        </legend>
+        <div${wrapper}>
+          ${content}
+        </div>
+      </fieldset>`;
+    },
+
+    createInformationFieldsetHTML: function (id, title, affix, content) {
+        return this.createFieldsetHTML(id, title, affix, content, 'grid-container');
+    },
+
+    /**
+     * Plain text input generator.
+     */
+    createInputHTML: function (id, title, instructions, value, placeholder) {
+        const instructionsSpan = instructions
+            ? `<span class="exe-field-instructions">${instructions}</span>`
+            : '';
+        const placeholderAttrib = placeholder
+            ? `placeholder="${this.escapeHtml(placeholder)}"`
+            : '';
+        return `
+      <div class="exe-field exe-text-field">
+        <label for="${id}">${title}:</label>
+        <input type="text" value="${this.escapeHtml(value || '')}" ${placeholderAttrib} class="ideviceTextfield" name="${id}" id="${id}" onfocus="this.select()" />
+        ${instructionsSpan}
+      </div>`;
+    },
+};

--- a/public/files/perm/idevices/base/markdown-text/edition/markdown-text.test.js
+++ b/public/files/perm/idevices/base/markdown-text/edition/markdown-text.test.js
@@ -1,0 +1,841 @@
+/**
+ * Unit tests for markdown-text iDevice (edition)
+ *
+ * Tests with real jQuery DOM manipulation:
+ * - init: Form creation and DOM structure
+ * - loadPreviousValues: Loading saved data into form
+ * - checkFormValues: Validation with eXe.app.alert history
+ * - save: Full save cycle with markdown editors
+ * - getDataJson: Data structure generation
+ * - computeMarkdownHtml: Markdown to HTML conversion
+ * - escapeHtml: HTML escaping
+ * - HTML generation functions
+ */
+
+/* eslint-disable no-undef */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Helper to load iDevice file and expose $exeDevice globally.
+ * Replaces 'var $exeDevice' with 'global.$exeDevice' to make it accessible.
+ */
+function loadIdevice(code) {
+  const modifiedCode = code.replace(/var\s+\$exeDevice\s*=/, 'global.$exeDevice =');
+  // eslint-disable-next-line no-eval
+  (0, eval)(modifiedCode);
+  return global.$exeDevice;
+}
+
+describe('markdown-text iDevice', () => {
+  let $exeDevice;
+  let mockElement;
+
+  beforeEach(() => {
+    // Reset $exeDevice before loading
+    global.$exeDevice = undefined;
+
+    // Clear eXe.app history
+    eXe.app.clearHistory();
+
+    // Create mock element for the iDevice (simulates the DOM container)
+    mockElement = document.createElement('div');
+    mockElement.setAttribute('idevice-id', 'test-idevice-123');
+    document.body.appendChild(mockElement);
+
+    // Read and execute the iDevice file
+    const filePath = join(__dirname, 'markdown-text.js');
+    const code = readFileSync(filePath, 'utf-8');
+
+    // Load iDevice and get reference
+    $exeDevice = loadIdevice(code);
+  });
+
+  afterEach(() => {
+    // DOM cleanup is handled by vitest.setup.js afterEach
+    mockElement = null;
+  });
+
+  describe('i18n and configuration', () => {
+    it('has name defined', () => {
+      expect($exeDevice.name).toBeDefined();
+    });
+
+    it('has textarea ID defined', () => {
+      expect($exeDevice.textareaId).toBe('markdownTextarea');
+    });
+
+    it('has feedback ID defined', () => {
+      expect($exeDevice.feedbackId).toBe('markdownFeedback');
+    });
+
+    it('has default feedback button value', () => {
+      expect($exeDevice.feedbackInputValue).toBeDefined();
+    });
+
+    it('has prefix defined', () => {
+      expect($exeDevice.prefix).toBe('markdown');
+    });
+
+    it('has htmlSuffix defined', () => {
+      expect($exeDevice.htmlSuffix).toBe('Html');
+    });
+
+    it('has write and preview tab labels', () => {
+      expect($exeDevice.writeTabLabel).toBeDefined();
+      expect($exeDevice.previewTabLabel).toBeDefined();
+    });
+  });
+
+  describe('init', () => {
+    it('creates the form structure in ideviceBody', () => {
+      $exeDevice.init(mockElement, {});
+
+      // Verify form was created
+      const form = mockElement.querySelector('#markdownTextForm');
+      expect(form).toBeTruthy();
+    });
+
+    it('creates the main textarea element', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      expect(textarea).toBeTruthy();
+      expect(textarea.classList.contains('exe-markdown-editor__textarea')).toBe(true);
+    });
+
+    it('creates markdown editor container', () => {
+      $exeDevice.init(mockElement, {});
+
+      const editor = mockElement.querySelector('.exe-markdown-editor');
+      expect(editor).toBeTruthy();
+    });
+
+    it('creates write and preview tabs', () => {
+      $exeDevice.init(mockElement, {});
+
+      const writeTab = mockElement.querySelector('[data-tab="write"]');
+      const previewTab = mockElement.querySelector('[data-tab="preview"]');
+      expect(writeTab).toBeTruthy();
+      expect(previewTab).toBeTruthy();
+    });
+
+    it('creates preview pane', () => {
+      $exeDevice.init(mockElement, {});
+
+      const preview = mockElement.querySelector('.exe-markdown-preview');
+      expect(preview).toBeTruthy();
+    });
+
+    it('creates feedback fieldset', () => {
+      $exeDevice.init(mockElement, {});
+
+      const feedbackFieldset = mockElement.querySelector('#markdownFeedback');
+      expect(feedbackFieldset).toBeTruthy();
+    });
+
+    it('creates info fieldset', () => {
+      $exeDevice.init(mockElement, {});
+
+      const infoFieldset = mockElement.querySelector('#markdownInfo');
+      expect(infoFieldset).toBeTruthy();
+    });
+
+    it('creates feedback input field', () => {
+      $exeDevice.init(mockElement, {});
+
+      const feedbackInput = mockElement.querySelector('#markdownFeedbackInput');
+      expect(feedbackInput).toBeTruthy();
+      expect(feedbackInput.type).toBe('text');
+    });
+
+    it('creates duration input fields', () => {
+      $exeDevice.init(mockElement, {});
+
+      const durationInput = mockElement.querySelector('#markdownInfoDurationInput');
+      const durationTextInput = mockElement.querySelector('#markdownInfoDurationTextInput');
+
+      expect(durationInput).toBeTruthy();
+      expect(durationTextInput).toBeTruthy();
+    });
+
+    it('creates participants input fields', () => {
+      $exeDevice.init(mockElement, {});
+
+      const participantsInput = mockElement.querySelector('#markdownInfoParticipantsInput');
+      const participantsTextInput = mockElement.querySelector('#markdownInfoParticipantsTextInput');
+
+      expect(participantsInput).toBeTruthy();
+      expect(participantsTextInput).toBeTruthy();
+    });
+
+    it('sets ideviceBody reference', () => {
+      $exeDevice.init(mockElement, {});
+
+      expect($exeDevice.ideviceBody).toBe(mockElement);
+    });
+
+    it('stores previousData reference', () => {
+      const previousData = { test: 'data' };
+      $exeDevice.init(mockElement, previousData);
+
+      expect($exeDevice.idevicePreviousData).toBe(previousData);
+    });
+
+    it('initializes markdownEditors map', () => {
+      $exeDevice.init(mockElement, {});
+
+      expect($exeDevice.markdownEditors).toBeInstanceOf(Map);
+      expect($exeDevice.markdownEditors.size).toBeGreaterThan(0);
+    });
+  });
+
+  describe('loadPreviousValues', () => {
+    it('loads previous textarea content into textarea value', () => {
+      const previousData = {
+        markdownTextarea: '# Hello World',
+      };
+
+      $exeDevice.init(mockElement, previousData);
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      expect(textarea.value).toBe('# Hello World');
+    });
+
+    it('loads previous feedback input value', () => {
+      const previousData = {
+        markdownFeedbackInput: 'Custom Feedback Button',
+      };
+
+      $exeDevice.init(mockElement, previousData);
+
+      const feedbackInput = mockElement.querySelector('#markdownFeedbackInput');
+      expect(feedbackInput.value).toBe('Custom Feedback Button');
+    });
+
+    it('loads duration values', () => {
+      const previousData = {
+        markdownInfoDurationInput: '00:30',
+        markdownInfoDurationTextInput: 'Time:',
+      };
+
+      $exeDevice.init(mockElement, previousData);
+
+      const durationInput = mockElement.querySelector('#markdownInfoDurationInput');
+      const durationTextInput = mockElement.querySelector('#markdownInfoDurationTextInput');
+
+      expect(durationInput.value).toBe('00:30');
+      expect(durationTextInput.value).toBe('Time:');
+    });
+
+    it('handles missing previousData gracefully', () => {
+      $exeDevice.init(mockElement, undefined);
+
+      // Should not throw
+      const form = mockElement.querySelector('#markdownTextForm');
+      expect(form).toBeTruthy();
+    });
+
+    it('uses default values when previousData has empty fields', () => {
+      const previousData = {
+        markdownInfoDurationTextInput: '', // Empty should use default
+      };
+
+      $exeDevice.init(mockElement, previousData);
+
+      const durationTextInput = mockElement.querySelector('#markdownInfoDurationTextInput');
+      // Should use default value
+      expect(durationTextInput.value).toBe('Duration');
+    });
+  });
+
+  describe('checkFormValues', () => {
+    it('returns false and shows alert when textarea is empty string', () => {
+      $exeDevice.init(mockElement, {});
+      // Set empty content
+      $exeDevice.markdownTextarea = '';
+
+      const result = $exeDevice.checkFormValues();
+
+      expect(result).toBe(false);
+      expect(eXe.app.alert).toHaveBeenCalled();
+      expect(eXe.app.getLastAlert()).toContain('write some text');
+    });
+
+    it('returns true when textarea has content', () => {
+      $exeDevice.init(mockElement, {});
+      $exeDevice.markdownTextarea = '# Some content';
+
+      const result = $exeDevice.checkFormValues();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when textarea is only whitespace', () => {
+      $exeDevice.init(mockElement, {});
+      $exeDevice.markdownTextarea = '   ';
+
+      const result = $exeDevice.checkFormValues();
+
+      expect(result).toBe(false);
+    });
+
+    it('tracks multiple validation failures in alert history', () => {
+      $exeDevice.init(mockElement, {});
+      $exeDevice.markdownTextarea = '';
+
+      $exeDevice.checkFormValues();
+      $exeDevice.checkFormValues();
+
+      expect(eXe.app._alertHistory.length).toBe(2);
+    });
+  });
+
+  describe('save', () => {
+    it('returns data object when form is valid', () => {
+      $exeDevice.init(mockElement, {});
+
+      // Set content in textarea
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '# Test content';
+
+      const result = $exeDevice.save();
+
+      expect(result).toBeDefined();
+      expect(result).not.toBe(false);
+      expect(result.ideviceId).toBe('test-idevice-123');
+    });
+
+    it('returns false when form is invalid', () => {
+      $exeDevice.init(mockElement, {});
+
+      // Empty content
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '';
+
+      const result = $exeDevice.save();
+
+      expect(result).toBe(false);
+    });
+
+    it('collects textarea content', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '# Markdown content';
+
+      const result = $exeDevice.save();
+
+      expect($exeDevice.dataIds).toContain('markdownTextarea');
+      expect($exeDevice.markdownTextarea).toBe('# Markdown content');
+    });
+
+    it('saves computed HTML for markdown content', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '# Header';
+
+      const result = $exeDevice.save();
+
+      // Should have HTML version saved
+      expect(result.markdownTextareaHtml).toBeDefined();
+    });
+
+    it('collects input values from DOM', () => {
+      const previousData = {
+        markdownFeedbackInput: 'Custom Button',
+      };
+      $exeDevice.init(mockElement, previousData);
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '# Content';
+
+      const result = $exeDevice.save();
+
+      expect($exeDevice.dataIds).toContain('markdownFeedbackInput');
+      expect($exeDevice.markdownFeedbackInput).toBe('Custom Button');
+    });
+  });
+
+  describe('getDataJson', () => {
+    it('returns object with ideviceId', () => {
+      $exeDevice.init(mockElement, {});
+      $exeDevice.dataIds = ['markdownTextarea'];
+      $exeDevice.markdownTextarea = '# Content';
+
+      const result = $exeDevice.getDataJson();
+
+      expect(result.ideviceId).toBe('test-idevice-123');
+    });
+
+    it('includes all dataIds in result', () => {
+      $exeDevice.init(mockElement, {});
+      $exeDevice.dataIds = ['markdownTextarea', 'markdownFeedbackInput'];
+      $exeDevice.markdownTextarea = '# Content';
+      $exeDevice.markdownFeedbackInput = 'Button';
+
+      const result = $exeDevice.getDataJson();
+
+      expect(result.markdownTextarea).toBe('# Content');
+      expect(result.markdownFeedbackInput).toBe('Button');
+    });
+
+    it('includes computed HTML from markdown editors', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '**bold**';
+
+      const result = $exeDevice.getDataJson();
+
+      expect(result.markdownTextareaHtml).toBeDefined();
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('escapes ampersand', () => {
+      expect($exeDevice.escapeHtml('foo & bar')).toBe('foo &amp; bar');
+    });
+
+    it('escapes less than', () => {
+      expect($exeDevice.escapeHtml('1 < 2')).toBe('1 &lt; 2');
+    });
+
+    it('escapes greater than', () => {
+      expect($exeDevice.escapeHtml('2 > 1')).toBe('2 &gt; 1');
+    });
+
+    it('escapes double quotes', () => {
+      expect($exeDevice.escapeHtml('say "hello"')).toBe('say &quot;hello&quot;');
+    });
+
+    it('escapes single quotes', () => {
+      expect($exeDevice.escapeHtml("it's")).toBe('it&#39;s');
+    });
+
+    it('escapes multiple special characters', () => {
+      const input = '<script>alert("xss")</script>';
+      const expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;';
+      expect($exeDevice.escapeHtml(input)).toBe(expected);
+    });
+
+    it('handles empty string', () => {
+      expect($exeDevice.escapeHtml('')).toBe('');
+    });
+
+    it('handles null/undefined by converting to string', () => {
+      expect($exeDevice.escapeHtml(null)).toBe('null');
+      expect($exeDevice.escapeHtml(undefined)).toBe('undefined');
+    });
+  });
+
+  describe('getMarkdownConverter', () => {
+    it('returns null when showdown is not available', () => {
+      const originalShowdown = global.showdown;
+      global.showdown = undefined;
+
+      const result = $exeDevice.getMarkdownConverter();
+
+      expect(result).toBeNull();
+
+      global.showdown = originalShowdown;
+    });
+
+    it('returns converter when showdown is available', () => {
+      // Mock showdown
+      global.showdown = {
+        Converter: class {
+          setOption() {}
+          makeHtml(text) {
+            return `<p>${text}</p>`;
+          }
+        },
+      };
+
+      const result = $exeDevice.getMarkdownConverter();
+
+      expect(result).not.toBeNull();
+      expect(typeof result.makeHtml).toBe('function');
+
+      delete global.showdown;
+    });
+
+    it('caches the converter instance', () => {
+      global.showdown = {
+        Converter: class {
+          setOption() {}
+          makeHtml(text) {
+            return `<p>${text}</p>`;
+          }
+        },
+      };
+
+      const first = $exeDevice.getMarkdownConverter();
+      const second = $exeDevice.getMarkdownConverter();
+
+      expect(first).toBe(second);
+
+      delete global.showdown;
+    });
+  });
+
+  describe('computeMarkdownHtml', () => {
+    it('uses eXe.app.common.markdownToHTML when available', () => {
+      const mockResult = '<p>Converted</p>';
+      eXe.app.common = {
+        markdownToHTML: vi.fn().mockReturnValue(mockResult),
+      };
+
+      const result = $exeDevice.computeMarkdownHtml('# Test');
+
+      expect(eXe.app.common.markdownToHTML).toHaveBeenCalledWith('# Test');
+      expect(result).toBe(mockResult);
+
+      delete eXe.app.common;
+    });
+
+    it('falls back to showdown converter', () => {
+      delete eXe.app.common;
+
+      global.showdown = {
+        Converter: class {
+          setOption() {}
+          makeHtml(text) {
+            return `<p>${text}</p>`;
+          }
+        },
+      };
+
+      const result = $exeDevice.computeMarkdownHtml('Hello');
+
+      expect(result).toBe('<p>Hello</p>');
+
+      delete global.showdown;
+    });
+
+    it('protects LaTeX delimiters from Showdown in fallback path', () => {
+      delete eXe.app.common;
+
+      global.showdown = {
+        Converter: class {
+          setOption() {}
+          makeHtml(text) {
+            // Pretend Showdown mangles underscores into <em>
+            return `<p>${text.replace(/_([^_]+)_/g, '<em>$1</em>')}</p>`;
+          }
+        },
+      };
+
+      const result = $exeDevice.computeMarkdownHtml(
+        'Result: \\(x_1 + y_1\\) end'
+      );
+
+      expect(result).toContain('\\(x_1 + y_1\\)');
+      expect(result).not.toContain('<em>1 + y</em>');
+
+      delete global.showdown;
+    });
+
+    it('falls back to escapeHtml when no converter available', () => {
+      delete eXe.app.common;
+      global.showdown = undefined;
+
+      const result = $exeDevice.computeMarkdownHtml('<script>');
+
+      expect(result).toBe('&lt;script&gt;');
+    });
+
+    it('handles empty content', () => {
+      const result = $exeDevice.computeMarkdownHtml('');
+
+      expect(result).toBeDefined();
+    });
+
+    it('handles null content', () => {
+      delete eXe.app.common;
+      global.showdown = undefined;
+
+      const result = $exeDevice.computeMarkdownHtml(null);
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('createMarkdownEditorHTML', () => {
+    it('creates container with correct id', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('id="myId"');
+    });
+
+    it('creates container with exe-markdown-editor class', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('exe-markdown-editor');
+    });
+
+    it('creates textarea with exe-markdown-editor__textarea class', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('exe-markdown-editor__textarea');
+    });
+
+    it('includes title in label', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('My Title');
+      expect(html).toContain('<label');
+    });
+
+    it('creates write and preview tabs', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('data-tab="write"');
+      expect(html).toContain('data-tab="preview"');
+    });
+
+    it('creates preview pane', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');
+
+      expect(html).toContain('exe-markdown-preview');
+    });
+
+    it('handles missing title', () => {
+      const html = $exeDevice.createMarkdownEditorHTML('myId');
+
+      expect(html).toContain('id="myId"');
+      expect(html).toContain('<textarea');
+    });
+  });
+
+  describe('createInputHTML', () => {
+    it('creates input with correct id', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Input Title');
+
+      expect(html).toContain('id="inputId"');
+      expect(html).toContain('name="inputId"');
+    });
+
+    it('creates input with title in label', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Input Title');
+
+      expect(html).toContain('Input Title');
+      expect(html).toContain('<label');
+    });
+
+    it('includes instructions span when provided', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Title', 'Help text');
+
+      expect(html).toContain('exe-field-instructions');
+      expect(html).toContain('Help text');
+    });
+
+    it('sets value attribute', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Title', '', 'default value');
+
+      expect(html).toContain('value="default value"');
+    });
+
+    it('sets placeholder attribute', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Title', '', '', 'Placeholder');
+
+      expect(html).toContain('placeholder="Placeholder"');
+    });
+
+    it('creates text type input', () => {
+      const html = $exeDevice.createInputHTML('inputId', 'Title');
+
+      expect(html).toContain('type="text"');
+    });
+  });
+
+  describe('createFieldsetHTML', () => {
+    it('creates fieldset with correct id', () => {
+      const html = $exeDevice.createFieldsetHTML('fsId', 'Fieldset Title', '', '<p>Content</p>');
+
+      expect(html).toContain('id="fsId"');
+    });
+
+    it('creates fieldset with title in legend', () => {
+      const html = $exeDevice.createFieldsetHTML('fsId', 'Fieldset Title', '', '<p>Content</p>');
+
+      expect(html).toContain('Fieldset Title');
+      expect(html).toContain('<legend');
+    });
+
+    it('includes content inside fieldset', () => {
+      const html = $exeDevice.createFieldsetHTML('fsId', 'Title', '', '<p>Inner content</p>');
+
+      expect(html).toContain('<p>Inner content</p>');
+    });
+
+    it('adds exe-fieldset-closed class by default', () => {
+      const html = $exeDevice.createFieldsetHTML('fsId', 'Title', '', 'Content');
+
+      expect(html).toContain('exe-fieldset-closed');
+    });
+
+    it('appends affix to title', () => {
+      const html = $exeDevice.createFieldsetHTML('fsId', 'Title', ' (Optional)', 'Content');
+
+      expect(html).toContain('Title (Optional)');
+    });
+  });
+
+  describe('createInformationFieldsetHTML', () => {
+    it('creates fieldset with grid-container', () => {
+      const html = $exeDevice.createInformationFieldsetHTML('infoId', 'Info Title', '', '<p>Content</p>');
+
+      expect(html).toContain('grid-container');
+    });
+
+    it('creates fieldset with correct id', () => {
+      const html = $exeDevice.createInformationFieldsetHTML('infoId', 'Info Title', '', 'Content');
+
+      expect(html).toContain('id="infoId"');
+    });
+
+    it('creates fieldset with exe-advanced class', () => {
+      const html = $exeDevice.createInformationFieldsetHTML('infoId', 'Info Title', '', 'Content');
+
+      expect(html).toContain('exe-advanced');
+    });
+  });
+
+  describe('createEditorGroup', () => {
+    it('returns HTML with editor group parent', () => {
+      const html = $exeDevice.createEditorGroup();
+
+      expect(html).toContain($exeDevice.editorGroupId);
+      expect(html).toContain('exe-parent');
+    });
+
+    it('includes info fieldset', () => {
+      const html = $exeDevice.createEditorGroup();
+
+      expect(html).toContain($exeDevice.infoId);
+    });
+
+    it('includes feedback fieldset', () => {
+      const html = $exeDevice.createEditorGroup();
+
+      expect(html).toContain($exeDevice.feedbackId);
+    });
+
+    it('includes main textarea', () => {
+      const html = $exeDevice.createEditorGroup();
+
+      expect(html).toContain($exeDevice.textareaId);
+    });
+  });
+
+  describe('DOM integration with jQuery', () => {
+    it('jQuery can find elements after init', () => {
+      $exeDevice.init(mockElement, {});
+
+      const $form = $('#markdownTextForm');
+      expect($form.length).toBe(1);
+    });
+
+    it('jQuery can manipulate textarea value', () => {
+      $exeDevice.init(mockElement, {});
+
+      const $textarea = $('#markdownTextarea');
+      $textarea.val('# jQuery set value');
+
+      expect($textarea.val()).toBe('# jQuery set value');
+    });
+
+    it('jQuery can add/remove classes', () => {
+      $exeDevice.init(mockElement, {});
+
+      const $fieldset = $('#markdownFeedback');
+      $fieldset.removeClass('exe-fieldset-closed');
+      $fieldset.addClass('exe-fieldset-open');
+
+      expect($fieldset.hasClass('exe-fieldset-open')).toBe(true);
+      expect($fieldset.hasClass('exe-fieldset-closed')).toBe(false);
+    });
+
+    it('jQuery find works within container', () => {
+      $exeDevice.init(mockElement, {});
+
+      const $inputs = $(mockElement).find('input[type="text"]');
+      expect($inputs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Tab behavior', () => {
+    it('write tab is active by default', () => {
+      $exeDevice.init(mockElement, {});
+
+      const writeTab = mockElement.querySelector('[data-tab="write"]');
+      expect(writeTab.classList.contains('is-active')).toBe(true);
+      expect(writeTab.getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('textarea is visible by default', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      expect(textarea.hidden).toBe(false);
+    });
+
+    it('preview is hidden by default', () => {
+      $exeDevice.init(mockElement, {});
+
+      const preview = mockElement.querySelector('.exe-markdown-preview');
+      expect(preview.hidden).toBe(true);
+    });
+
+    it('clicking preview tab switches visibility', () => {
+      $exeDevice.init(mockElement, {});
+
+      const previewTab = mockElement.querySelector('[data-tab="preview"]');
+      previewTab.click();
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      const preview = mockElement.querySelector('.exe-markdown-preview');
+      expect(textarea.hidden).toBe(true);
+      expect(preview.hidden).toBe(false);
+    });
+
+    it('clicking write tab switches back', () => {
+      $exeDevice.init(mockElement, {});
+
+      const previewTab = mockElement.querySelector('[data-tab="preview"]');
+      const writeTab = mockElement.querySelector('[data-tab="write"]');
+
+      previewTab.click();
+      writeTab.click();
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      expect(textarea.hidden).toBe(false);
+    });
+  });
+
+  describe('refreshMarkdownPreviews', () => {
+    it('does not throw when markdownEditors is null', () => {
+      $exeDevice.markdownEditors = null;
+
+      expect(() => $exeDevice.refreshMarkdownPreviews()).not.toThrow();
+    });
+
+    it('updates preview content when called', () => {
+      $exeDevice.init(mockElement, {});
+
+      const textarea = mockElement.querySelector('#markdownTextarea');
+      textarea.value = '# New content';
+
+      $exeDevice.refreshMarkdownPreviews();
+
+      const preview = mockElement.querySelector('.exe-markdown-preview');
+      expect(preview.innerHTML).not.toBe('');
+    });
+  });
+});

--- a/public/files/perm/idevices/base/markdown-text/export/markdown-text.css
+++ b/public/files/perm/idevices/base/markdown-text/export/markdown-text.css
@@ -1,0 +1,80 @@
+/* Markdown Text iDevice (export CSS) */
+.exe-markdown-activity .markdown-body {
+    padding: 0.5rem 0;
+}
+
+.exe-markdown-activity .markdown-body pre,
+.exe-markdown-activity .markdown-body code {
+    font-family: var(--font-family-monospace, ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace);
+    font-size: 0.9em;
+    text-shadow: none;
+}
+
+.exe-markdown-activity .markdown-body pre [class*="language-"],
+.exe-markdown-activity .markdown-body code[class*="language-"] {
+    text-shadow: none;
+    background: none;
+}
+
+.exe-markdown-activity .markdown-body pre {
+    background-color: #0d1117;
+    color: #e6edf3;
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.45;
+}
+
+.exe-markdown-activity .markdown-body code {
+    background-color: rgba(175, 184, 193, 0.2);
+    border-radius: 4px;
+    padding: 0.2em 0.4em;
+}
+
+.exe-markdown-activity .markdown-body pre code {
+    background-color: transparent;
+    padding: 0;
+    color: inherit;
+}
+
+.exe-markdown-activity .markdown-body ul.task-list,
+.exe-markdown-activity .markdown-body ul li.task-list-item {
+    list-style: none;
+    padding-left: 0;
+}
+
+.exe-markdown-activity .markdown-body li.task-list-item {
+    padding-left: 0;
+}
+
+.exe-markdown-activity .markdown-body li.task-list-item input[type="checkbox"] {
+    margin-right: 0.4em;
+}
+
+.exe-markdown-activity .markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1rem;
+}
+
+.exe-markdown-activity .markdown-body th,
+.exe-markdown-activity .markdown-body td {
+    border: 1px solid #d0d7de;
+    padding: 0.5rem;
+}
+
+.exe-markdown-activity div.inline {
+    display: flex;
+}
+
+.exe-markdown-activity div.inline dt {
+    margin: 0 0 0 auto;
+}
+
+.exe-markdown-activity div.inline dd {
+    margin-left: 10px;
+}
+
+.idevice_node.markdown-text .iDevice_buttons.feedback-button {
+    margin-bottom: 1em;
+}

--- a/public/files/perm/idevices/base/markdown-text/export/markdown-text.html
+++ b/public/files/perm/idevices/base/markdown-text/export/markdown-text.html
@@ -1,0 +1,3 @@
+<div class="exe-markdown-template">
+    {content}
+</div>

--- a/public/files/perm/idevices/base/markdown-text/export/markdown-text.js
+++ b/public/files/perm/idevices/base/markdown-text/export/markdown-text.js
@@ -1,0 +1,214 @@
+/* eslint-disable no-undef */
+/**
+ * Markdown Text iDevice (export code)
+ */
+var $markdowntext = {
+    ideviceClass: 'markdownTextIdeviceContent',
+    working: false,
+    durationId: 'markdownInfoDurationInput',
+    durationTextId: 'markdownInfoDurationTextInput',
+    participantsId: 'markdownInfoParticipantsInput',
+    participantsTextId: 'markdownInfoParticipantsTextInput',
+    mainContentId: 'markdownTextarea',
+    mainContentHtmlId: 'markdownTextareaHtml',
+    feedbackTitleId: 'markdownFeedbackInput',
+    feedbackContentId: 'markdownFeedbackTextarea',
+    feedbackContentHtmlId: 'markdownFeedbackTextareaHtml',
+    defaultBtnFeedbackText: $exe_i18n.showFeedback,
+
+    renderView(data, accessibility, template, ideviceId, pathMedia) {
+        const htmlData = this.getHTMLView(data, pathMedia);
+        return template.replace('{content}', htmlData);
+    },
+
+    getHTMLView(data, pathMedia) {
+        const isInExe = eXe.app.isInExe();
+        const durationTextRaw = data[this.durationTextId] || '';
+        const participantsTextRaw = data[this.participantsTextId] || '';
+        const durationText = isInExe ? c_(durationTextRaw) : durationTextRaw;
+        const participantsText = isInExe
+            ? c_(participantsTextRaw)
+            : participantsTextRaw;
+
+        let infoContentHTML = '';
+        if (data[this.durationId] || data[this.participantsId]) {
+            infoContentHTML = this.createInfoHTML(
+                data[this.durationId] === '' ? '' : durationText,
+                data[this.durationId] || '',
+                data[this.participantsId] === '' ? '' : participantsText,
+                data[this.participantsId] || ''
+            );
+        }
+
+        const remap = (rawKey, htmlKey) => {
+            const html = this.extractMarkdownHtml(data, rawKey, htmlKey);
+            return !isInExe && pathMedia
+                ? this.replaceResourceDirectoryPaths(pathMedia, html)
+                : html;
+        };
+        const contentHtml = remap(this.mainContentId, this.mainContentHtmlId);
+        const feedbackHtml = remap(
+            this.feedbackContentId,
+            this.feedbackContentHtmlId
+        );
+
+        let buttonFeedbackText = data[this.feedbackTitleId] || '';
+        if (feedbackHtml) {
+            buttonFeedbackText =
+                buttonFeedbackText === ''
+                    ? this.defaultBtnFeedbackText
+                    : buttonFeedbackText;
+            if (isInExe) {
+                buttonFeedbackText = c_(buttonFeedbackText);
+            }
+        }
+
+        const feedbackContentHTML = feedbackHtml
+            ? this.createFeedbackHTML(buttonFeedbackText, feedbackHtml)
+            : '';
+        const activityContent =
+            infoContentHTML +
+            contentHtml +
+            feedbackContentHTML +
+            '<p class="clearfix"></p>';
+
+        let htmlContent = `<div class="${this.ideviceClass}">`;
+        htmlContent += this.createMainContent(activityContent);
+        htmlContent += `</div>`;
+
+        return htmlContent;
+    },
+
+    renderBehaviour(data, accessibility, ideviceId) {
+        const $node = $('#' + data.ideviceId);
+        const $btn = $(
+            `#${data.ideviceId} input.feedbackbutton, #${data.ideviceId} input.feedbacktooglebutton`
+        );
+
+        if ($btn.length === 1) {
+            const [textA, textB = textA] = $btn.val().split('|');
+            $btn.val(textA)
+                .attr('data-text-a', textA)
+                .attr('data-text-b', textB);
+            $btn.off('click').closest('.feedback-button').removeClass('clearfix');
+
+            $btn.on('click', (event) => {
+                event.preventDefault();
+                if ($markdowntext.working) {
+                    return false;
+                }
+                $markdowntext.working = true;
+                const btn = $(event.currentTarget);
+                const feedbackEl = btn
+                    .closest('.feedback-button')
+                    .next('.feedback');
+
+                if (feedbackEl.is(':visible')) {
+                    btn.val(btn.attr('data-text-a'));
+                    feedbackEl.fadeOut(() => {
+                        $markdowntext.working = false;
+                    });
+                } else {
+                    btn.val(btn.attr('data-text-b'));
+                    feedbackEl.fadeIn(() => {
+                        $markdowntext.working = false;
+                    });
+                }
+                $exeDevices.iDevice.gamification.math.updateLatex(
+                    '.exe-markdown-template'
+                );
+            });
+        }
+
+        const dataString = $node.html() || '';
+        if (!$exeDevices.iDevice.gamification.math.hasLatex(dataString)) {
+            return;
+        }
+        if (typeof window.MathJax === 'undefined') {
+            $exeDevices.iDevice.gamification.math.loadMathJax();
+        } else {
+            $exeDevices.iDevice.gamification.math.updateLatex(
+                '.exe-markdown-template'
+            );
+        }
+    },
+
+    init(data, accessibility) {},
+
+    extractMarkdownHtml(data, rawKey, htmlKey) {
+        const html = data[htmlKey];
+        if (html && typeof html === 'string' && html.trim() !== '') {
+            return html;
+        }
+        // Fallback: if no pre-computed HTML, escape raw content
+        const raw = data[rawKey] || '';
+        return this.escapeHtml(raw);
+    },
+
+    escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    },
+
+    createMainContent(content) {
+        return `
+            <div class="exe-markdown-activity">
+                <div class="markdown-body">${content}</div>
+            </div>`;
+    },
+
+    createInfoHTML(
+        durationText,
+        durationValue,
+        participantsText,
+        participantsValue
+    ) {
+        const dt = this.escapeHtml(durationText);
+        const dv = this.escapeHtml(durationValue);
+        const pt = this.escapeHtml(participantsText);
+        const pv = this.escapeHtml(participantsValue);
+        return `
+            <dl>
+                <div class="inline"><dt><span title="${dt}">${dt}</span></dt><dd>${dv}</dd></div>
+                <div class="inline"><dt><span title="${pt}">${pt}</span></dt><dd>${pv}</dd></div>
+            </dl>`;
+    },
+
+    createFeedbackHTML(title, content) {
+        return `
+            <div class="iDevice_buttons feedback-button js-required">
+                <input type="button" class="feedbacktooglebutton" value="${this.escapeHtml(title)}" />
+            </div>
+            <div class="feedback js-feedback js-hidden">${content}</div>`;
+    },
+
+    replaceResourceDirectoryPaths(newDir, htmlString) {
+        let dir = newDir.trim();
+        if (!dir.endsWith('/')) {
+            dir += '/';
+        }
+        const custom = $('html').is('#exe-index') ? 'custom/' : '../custom/';
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlString, 'text/html');
+        doc.querySelectorAll(
+            'img[src], video[src], audio[src], a[href]'
+        ).forEach((el) => {
+            const attr = el.hasAttribute('src') ? 'src' : 'href';
+            const val = el.getAttribute(attr).trim();
+            if (/^\/?files\//.test(val)) {
+                const filename = val.split('/').pop() || '';
+                if (val.indexOf('file_manager') === -1) {
+                    el.setAttribute(attr, dir + filename);
+                } else {
+                    el.setAttribute(attr, custom + filename);
+                }
+            }
+        });
+        return doc.body.innerHTML;
+    },
+};

--- a/public/files/perm/idevices/base/markdown-text/export/markdown-text.test.js
+++ b/public/files/perm/idevices/base/markdown-text/export/markdown-text.test.js
@@ -1,0 +1,449 @@
+/**
+ * Unit tests for markdown-text iDevice (export/runtime)
+ *
+ * Tests configuration and basic functions.
+ */
+
+/* eslint-disable no-undef */
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Helper to load export iDevice file and expose $markdowntext globally.
+ */
+function loadExportIdevice(code) {
+  // Mock $exe_i18n which is used at load time
+  global.$exe_i18n = {
+    showFeedback: 'Show feedback',
+  };
+  const modifiedCode = code.replace(/var\s+\$markdowntext\s*=/, 'global.$markdowntext =');
+  // eslint-disable-next-line no-eval
+  (0, eval)(modifiedCode);
+  return global.$markdowntext;
+}
+
+describe('markdown-text iDevice export', () => {
+  let $markdowntext;
+
+  beforeEach(() => {
+    global.$markdowntext = undefined;
+    global.$exe_i18n = undefined;
+
+    // Mock eXe.app.isInExe for getHTMLView tests
+    if (!global.eXe) {
+      global.eXe = { app: {} };
+    }
+    global.eXe.app.isInExe = vi.fn(() => true);
+
+    // Mock c_ translation function
+    global.c_ = vi.fn((str) => str);
+
+    const filePath = join(__dirname, 'markdown-text.js');
+    const code = readFileSync(filePath, 'utf-8');
+
+    $markdowntext = loadExportIdevice(code);
+  });
+
+  describe('ideviceClass', () => {
+    it('has expected class name', () => {
+      expect($markdowntext.ideviceClass).toBe('markdownTextIdeviceContent');
+    });
+  });
+
+  describe('working', () => {
+    it('is initially false', () => {
+      expect($markdowntext.working).toBe(false);
+    });
+  });
+
+  describe('id constants', () => {
+    it('has durationId', () => {
+      expect($markdowntext.durationId).toBe('markdownInfoDurationInput');
+    });
+
+    it('has durationTextId', () => {
+      expect($markdowntext.durationTextId).toBe('markdownInfoDurationTextInput');
+    });
+
+    it('has participantsId', () => {
+      expect($markdowntext.participantsId).toBe('markdownInfoParticipantsInput');
+    });
+
+    it('has participantsTextId', () => {
+      expect($markdowntext.participantsTextId).toBe('markdownInfoParticipantsTextInput');
+    });
+
+    it('has mainContentId', () => {
+      expect($markdowntext.mainContentId).toBe('markdownTextarea');
+    });
+
+    it('has mainContentHtmlId', () => {
+      expect($markdowntext.mainContentHtmlId).toBe('markdownTextareaHtml');
+    });
+
+    it('has feedbackTitleId', () => {
+      expect($markdowntext.feedbackTitleId).toBe('markdownFeedbackInput');
+    });
+
+    it('has feedbackContentId', () => {
+      expect($markdowntext.feedbackContentId).toBe('markdownFeedbackTextarea');
+    });
+
+    it('has feedbackContentHtmlId', () => {
+      expect($markdowntext.feedbackContentHtmlId).toBe('markdownFeedbackTextareaHtml');
+    });
+
+    it('has defaultBtnFeedbackText from i18n', () => {
+      expect($markdowntext.defaultBtnFeedbackText).toBe('Show feedback');
+    });
+  });
+
+  describe('renderView', () => {
+    it('replaces {content} in template', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Test</p>',
+      };
+      const template = '<div class="wrapper">{content}</div>';
+
+      const result = $markdowntext.renderView(data, false, template, 'idevice-1', null);
+
+      expect(result).toContain('markdownTextIdeviceContent');
+      expect(result).toContain('Test');
+      expect(result).not.toContain('{content}');
+    });
+  });
+
+  describe('getHTMLView', () => {
+    it('returns HTML with ideviceClass', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain($markdowntext.ideviceClass);
+    });
+
+    it('includes main content', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Main content here</p>',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('Main content here');
+    });
+
+    it('includes feedback when provided', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+        markdownFeedbackTextareaHtml: '<p>Feedback content</p>',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('Feedback content');
+      expect(result).toContain('feedbacktooglebutton');
+    });
+
+    it('uses default feedback button text when not provided', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+        markdownFeedbackTextareaHtml: '<p>Feedback</p>',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('Show feedback');
+    });
+
+    it('uses custom feedback button text when provided', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+        markdownFeedbackTextareaHtml: '<p>Feedback</p>',
+        markdownFeedbackInput: 'Custom Button',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('Custom Button');
+    });
+
+    it('includes info section when duration is provided', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+        markdownInfoDurationInput: '10 min',
+        markdownInfoDurationTextInput: 'Duration',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('10 min');
+      expect(result).toContain('Duration');
+    });
+
+    it('includes info section when participants is provided', () => {
+      const data = {
+        markdownTextareaHtml: '<p>Content</p>',
+        markdownInfoParticipantsInput: '2-4',
+        markdownInfoParticipantsTextInput: 'Participants',
+      };
+
+      const result = $markdowntext.getHTMLView(data, null);
+
+      expect(result).toContain('2-4');
+      expect(result).toContain('Participants');
+    });
+
+    it('does not mutate the input data object', () => {
+      const data = {
+        markdownTextarea: '# raw',
+        markdownTextareaHtml: '<h1>raw</h1>',
+        markdownFeedbackTextarea: '> note',
+        markdownFeedbackTextareaHtml: '<blockquote>note</blockquote>',
+        markdownFeedbackInput: 'Show',
+        markdownInfoDurationInput: '10',
+        markdownInfoDurationTextInput: 'Duration',
+        markdownInfoParticipantsInput: '2',
+        markdownInfoParticipantsTextInput: 'People',
+      };
+      const snapshot = JSON.parse(JSON.stringify(data));
+
+      $markdowntext.getHTMLView(data, null);
+
+      expect(data).toEqual(snapshot);
+    });
+  });
+
+  describe('init', () => {
+    it('does not throw when called', () => {
+      expect(() => $markdowntext.init({}, false)).not.toThrow();
+    });
+  });
+
+  describe('extractMarkdownHtml', () => {
+    it('returns pre-computed HTML when available', () => {
+      const data = {
+        markdownTextarea: '# Raw markdown',
+        markdownTextareaHtml: '<h1>Pre-computed</h1>',
+      };
+
+      const result = $markdowntext.extractMarkdownHtml(data, 'markdownTextarea', 'markdownTextareaHtml');
+
+      expect(result).toBe('<h1>Pre-computed</h1>');
+    });
+
+    it('falls back to escaped raw content when HTML is empty', () => {
+      const data = {
+        markdownTextarea: '# Raw markdown',
+        markdownTextareaHtml: '',
+      };
+
+      const result = $markdowntext.extractMarkdownHtml(data, 'markdownTextarea', 'markdownTextareaHtml');
+
+      expect(result).toBe('# Raw markdown');
+    });
+
+    it('falls back to escaped raw content when HTML is missing', () => {
+      const data = {
+        markdownTextarea: '<script>alert("xss")</script>',
+      };
+
+      const result = $markdowntext.extractMarkdownHtml(data, 'markdownTextarea', 'markdownTextareaHtml');
+
+      expect(result).toContain('&lt;script&gt;');
+    });
+
+    it('falls back to escaped raw content when HTML is whitespace only', () => {
+      const data = {
+        markdownTextarea: '# Content',
+        markdownTextareaHtml: '   ',
+      };
+
+      const result = $markdowntext.extractMarkdownHtml(data, 'markdownTextarea', 'markdownTextareaHtml');
+
+      expect(result).toBe('# Content');
+    });
+
+    it('returns empty string when both raw and HTML are missing', () => {
+      const data = {};
+
+      const result = $markdowntext.extractMarkdownHtml(data, 'markdownTextarea', 'markdownTextareaHtml');
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('escapes ampersand', () => {
+      expect($markdowntext.escapeHtml('foo & bar')).toBe('foo &amp; bar');
+    });
+
+    it('escapes less than', () => {
+      expect($markdowntext.escapeHtml('1 < 2')).toBe('1 &lt; 2');
+    });
+
+    it('escapes greater than', () => {
+      expect($markdowntext.escapeHtml('2 > 1')).toBe('2 &gt; 1');
+    });
+
+    it('escapes double quotes', () => {
+      expect($markdowntext.escapeHtml('say "hello"')).toBe('say &quot;hello&quot;');
+    });
+
+    it('escapes single quotes', () => {
+      expect($markdowntext.escapeHtml("it's")).toBe('it&#39;s');
+    });
+
+    it('escapes multiple special characters', () => {
+      const input = '<script>alert("xss")</script>';
+      const expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;';
+      expect($markdowntext.escapeHtml(input)).toBe(expected);
+    });
+
+    it('handles empty string', () => {
+      expect($markdowntext.escapeHtml('')).toBe('');
+    });
+
+    it('handles null/undefined by converting to string', () => {
+      expect($markdowntext.escapeHtml(null)).toBe('null');
+      expect($markdowntext.escapeHtml(undefined)).toBe('undefined');
+    });
+  });
+
+  describe('createMainContent', () => {
+    it('wraps content in exe-markdown-activity div', () => {
+      const result = $markdowntext.createMainContent('<p>Test</p>');
+
+      expect(result).toContain('exe-markdown-activity');
+    });
+
+    it('wraps content in markdown-body div', () => {
+      const result = $markdowntext.createMainContent('<p>Test</p>');
+
+      expect(result).toContain('markdown-body');
+    });
+
+    it('includes the content', () => {
+      const result = $markdowntext.createMainContent('<p>My content</p>');
+
+      expect(result).toContain('My content');
+    });
+  });
+
+  describe('createInfoHTML', () => {
+    it('creates dl element with duration and participants', () => {
+      const result = $markdowntext.createInfoHTML('Duration', '10 min', 'Participants', '2-4');
+
+      expect(result).toContain('<dl>');
+      expect(result).toContain('Duration');
+      expect(result).toContain('10 min');
+      expect(result).toContain('Participants');
+      expect(result).toContain('2-4');
+      expect(result).toContain('title="Duration"');
+      expect(result).toContain('title="Participants"');
+    });
+
+    it('escapes quotes in label so attribute is not broken', () => {
+      const result = $markdowntext.createInfoHTML('Say "hi"', '10 min', 'P', '2');
+
+      expect(result).not.toContain('title="Say "hi""');
+      expect(result).toContain('title="Say &quot;hi&quot;"');
+    });
+
+    it('escapes HTML in duration value so chrome cannot leak', () => {
+      const result = $markdowntext.createInfoHTML('Duration', '<img src=x onerror=alert(1)>', 'P', '2');
+
+      expect(result).not.toContain('<img src=x');
+      expect(result).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    });
+  });
+
+  describe('createFeedbackHTML', () => {
+    it('returns HTML with toggle button and hidden feedback panel', () => {
+      const result = $markdowntext.createFeedbackHTML('Show Feedback', '<p>Feedback content</p>');
+
+      expect(result).toContain('feedbacktooglebutton');
+      expect(result).toContain('value="Show Feedback"');
+      expect(result).toContain('Feedback content');
+      expect(result).toContain('class="feedback js-feedback js-hidden"');
+      expect(result).toContain('js-required');
+    });
+
+    it('escapes quotes in title so value attribute is not broken', () => {
+      const result = $markdowntext.createFeedbackHTML('Click "me"', '<p>Feedback</p>');
+
+      expect(result).not.toContain('value="Click "me""');
+      expect(result).toContain('value="Click &quot;me&quot;"');
+    });
+
+    it('escapes HTML in title but preserves rendered feedback HTML', () => {
+      const result = $markdowntext.createFeedbackHTML('<script>x</script>', '<p>Body</p>');
+
+      expect(result).toContain('value="&lt;script&gt;x&lt;/script&gt;"');
+      expect(result).toContain('<p>Body</p>');
+    });
+  });
+
+  describe('replaceResourceDirectoryPaths', () => {
+    it('replaces files/ paths in img src', () => {
+      const html = '<img src="files/image.png" alt="test">';
+      const result = $markdowntext.replaceResourceDirectoryPaths('resources/', html);
+
+      expect(result).toContain('src="resources/image.png"');
+    });
+
+    it('replaces files/ paths in video src', () => {
+      const html = '<video src="files/video.mp4"></video>';
+      const result = $markdowntext.replaceResourceDirectoryPaths('media/', html);
+
+      expect(result).toContain('src="media/video.mp4"');
+    });
+
+    it('replaces files/ paths in audio src', () => {
+      const html = '<audio src="files/audio.mp3"></audio>';
+      const result = $markdowntext.replaceResourceDirectoryPaths('sounds/', html);
+
+      expect(result).toContain('src="sounds/audio.mp3"');
+    });
+
+    it('replaces files/ paths in a href', () => {
+      const html = '<a href="files/document.pdf">Download</a>';
+      const result = $markdowntext.replaceResourceDirectoryPaths('docs/', html);
+
+      expect(result).toContain('href="docs/document.pdf"');
+    });
+
+    it('adds trailing slash to directory if missing', () => {
+      const html = '<img src="files/image.png">';
+      const result = $markdowntext.replaceResourceDirectoryPaths('resources', html);
+
+      expect(result).toContain('src="resources/image.png"');
+    });
+
+    it('does not modify non-files paths', () => {
+      const html = '<img src="https://example.com/image.png">';
+      const result = $markdowntext.replaceResourceDirectoryPaths('resources/', html);
+
+      expect(result).toContain('src="https://example.com/image.png"');
+    });
+
+    it('handles empty HTML string', () => {
+      const result = $markdowntext.replaceResourceDirectoryPaths('resources/', '');
+
+      expect(result).toBe('');
+    });
+
+    it('preserves other HTML content', () => {
+      const html = '<p>Text content</p><img src="files/image.png"><span>More text</span>';
+      const result = $markdowntext.replaceResourceDirectoryPaths('resources/', html);
+
+      expect(result).toContain('Text content');
+      expect(result).toContain('More text');
+    });
+  });
+});

--- a/public/files/perm/idevices/base/markdown-text/markdown-text-icon.svg
+++ b/public/files/perm/idevices/base/markdown-text/markdown-text-icon.svg
@@ -1,0 +1,1 @@
+<svg height="250" viewBox="0 0 250 250" width="250" xmlns="http://www.w3.org/2000/svg"><g fill="#295394"><path d="m24 184v-118h39l34 41 34-41h39v118h-35v-65l-38 45-38-45v65z"/><path d="m194 66h34v59h22l-39 59-39-59h22z"/></g></svg>

--- a/src/shared/export/browser/idevice-config-browser.spec.ts
+++ b/src/shared/export/browser/idevice-config-browser.spec.ts
@@ -142,6 +142,9 @@ describe('idevice-config-browser', () => {
             expect(getIdeviceConfig('text').componentType).toBe('json');
             expect(getIdeviceConfig('freetext').componentType).toBe('json');
             expect(getIdeviceConfig('reflection').componentType).toBe('json');
+            // markdown-text shares the text feedback toggle wiring; without
+            // componentType="json" exe_export.js never binds the toggle.
+            expect(getIdeviceConfig('markdown-text').componentType).toBe('json');
 
             // HTML idevices (no JS initialization needed)
             expect(getIdeviceConfig('multi-choice').componentType).toBe('html');

--- a/src/shared/export/browser/idevice-config-browser.ts
+++ b/src/shared/export/browser/idevice-config-browser.ts
@@ -68,6 +68,7 @@ export function getIdeviceConfig(type: string): IdeviceConfigCache {
         'true-or-false',
         'scrambled-list',
         'magnifier',
+        'markdown-text',
     ];
     const isJson = jsonIdevices.includes(cssClass) || jsonIdevices.includes(normalized);
 

--- a/src/shared/export/constants.ts
+++ b/src/shared/export/constants.ts
@@ -122,10 +122,12 @@ export const LIBRARY_PATTERNS: LibraryPattern[] = [
     },
 
     // Code highlighting
+    // Matches the legacy TinyMCE class (`highlighted-code`) and the
+    // `language-<lang>` classes produced by Showdown for fenced code blocks.
     {
         name: 'exe_highlighter',
-        type: 'class',
-        pattern: 'highlighted-code',
+        type: 'regex',
+        pattern: /class\s*=\s*["'][^"']*\b(?:highlighted-code|language-[a-z0-9_+-]+)\b/i,
         files: ['exe_highlighter/exe_highlighter.js', 'exe_highlighter/exe_highlighter.css'],
     },
 

--- a/test/e2e/playwright/helpers/workarea-helpers.ts
+++ b/test/e2e/playwright/helpers/workarea-helpers.ts
@@ -786,7 +786,10 @@ export async function addIdevice(page: Page, ideviceType: string): Promise<void>
  * @param ideviceId - iDevice element ID
  */
 export async function editIdevice(page: Page, ideviceId: string): Promise<void> {
-    const idevice = page.locator(`#${ideviceId}`);
+    // The engine sets the same `id` on both the wrapper (.idevice_node) and
+    // the body (.idevice_body), so scope to the wrapper to avoid Playwright's
+    // strict-mode "resolved to 2 elements" failure.
+    const idevice = page.locator(`.idevice_node[id="${ideviceId}"]`);
     const editBtn = idevice.locator('.btn-edit-idevice');
     await idevice.waitFor({ state: 'visible', timeout: 10000 });
 
@@ -838,7 +841,7 @@ export async function editIdevice(page: Page, ideviceId: string): Promise<void> 
  * @param ideviceId - iDevice element ID
  */
 export async function saveIdevice(page: Page, ideviceId: string): Promise<void> {
-    const idevice = page.locator(`#${ideviceId}`);
+    const idevice = page.locator(`.idevice_node[id="${ideviceId}"]`);
     const saveBtn = idevice.locator('.btn-save-idevice');
     await saveBtn.click();
 
@@ -853,7 +856,7 @@ export async function saveIdevice(page: Page, ideviceId: string): Promise<void> 
  * @param ideviceId - iDevice element ID
  */
 export async function deleteIdevice(page: Page, ideviceId: string): Promise<void> {
-    const idevice = page.locator(`#${ideviceId}`);
+    const idevice = page.locator(`.idevice_node[id="${ideviceId}"]`);
     const deleteBtn = idevice.locator('.btn-delete-idevice');
     await deleteBtn.click();
 

--- a/test/e2e/playwright/specs/idevices/markdown-text.spec.ts
+++ b/test/e2e/playwright/specs/idevices/markdown-text.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import type { Page } from '@playwright/test';
+import {
+    addIdevice,
+    editIdevice,
+    expandIdeviceCategory,
+    getPreviewFrame,
+    gotoWorkarea,
+    openPreviewPanel,
+    reloadPage,
+    saveIdevice,
+    saveProject,
+    selectFirstPage,
+    waitForAppReady,
+    waitForPreviewContent,
+} from '../../helpers/workarea-helpers';
+
+/**
+ * E2E coverage for the Markdown Text iDevice.
+ *
+ * - Add → edit → save → reload preserves content.
+ * - Preview tab renders the markdown.
+ * - Feedback section saved values render in preview iframe and
+ *   user-supplied button text is HTML-escaped in the value attribute.
+ */
+
+const IDEVICE_TYPE = 'markdown-text';
+const IDEVICE_ARTICLE = `#node-content article .idevice_node.${IDEVICE_TYPE}`;
+
+async function addMarkdownIdevice(page: Page): Promise<string> {
+    await selectFirstPage(page);
+    await expandIdeviceCategory(page, /Information|Información/i);
+    await addIdevice(page, IDEVICE_TYPE);
+
+    const article = page.locator(IDEVICE_ARTICLE).first();
+    await article.waitFor({ state: 'visible', timeout: 10000 });
+    const id = await article.getAttribute('id');
+    if (!id) throw new Error('Markdown iDevice rendered without id');
+    return id;
+}
+
+async function setEditorValue(page: Page, ideviceId: string, selector: string, value: string): Promise<void> {
+    const textarea = page.locator(`#${ideviceId} ${selector}`).first();
+    await textarea.waitFor({ state: 'visible', timeout: 5000 });
+    await textarea.fill(value);
+}
+
+async function openFieldset(page: Page, ideviceId: string, fieldsetId: string): Promise<void> {
+    // Closed fieldsets (`exe-fieldset-closed`) hide their content via CSS.
+    // Click the legend link to toggle and wait for the class to disappear.
+    const fieldset = page.locator(`#${ideviceId} #${fieldsetId}`).first();
+    await fieldset.locator('legend a').click();
+    await page.waitForFunction(
+        ({ id, fid }) => {
+            const node = document.querySelector(`.idevice_node[id="${id}"]`);
+            const fs = node?.querySelector(`#${fid}`);
+            return fs ? !fs.classList.contains('exe-fieldset-closed') : false;
+        },
+        { id: ideviceId, fid: fieldsetId },
+        { timeout: 5000 },
+    );
+}
+
+test.describe('Markdown Text iDevice', () => {
+    test('persists main markdown content through save and reload', async ({ authenticatedPage, createProject }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Markdown Persistence');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        const ideviceId = await addMarkdownIdevice(page);
+        await editIdevice(page, ideviceId);
+
+        const unique = `markdown content ${Date.now()}`;
+        await setEditorValue(page, ideviceId, '#markdownTextarea', `# Heading\n\n${unique}`);
+
+        await saveIdevice(page, ideviceId);
+        await saveProject(page);
+
+        await reloadPage(page);
+        await waitForAppReady(page);
+
+        const pageNode = page.locator('.nav-element:not([nav-id="root"]) > .nav-element-text').first();
+        await pageNode.click({ force: true });
+
+        await expect(page.locator(IDEVICE_ARTICLE)).toContainText(unique, { timeout: 15000 });
+    });
+
+    test('preview tab renders authored markdown as HTML', async ({ authenticatedPage, createProject }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Markdown Preview Tab');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        const ideviceId = await addMarkdownIdevice(page);
+        await editIdevice(page, ideviceId);
+
+        await setEditorValue(page, ideviceId, '#markdownTextarea', '## subtitle');
+
+        const editor = page.locator(`#${ideviceId} .exe-markdown-editor`).first();
+        await editor.locator('[data-tab="preview"]').click();
+
+        const previewPane = editor.locator('.exe-markdown-preview');
+        await expect(previewPane.locator('h2')).toBeVisible();
+        await expect(previewPane).toContainText('subtitle');
+    });
+
+    test('feedback section renders in preview and escapes attribute values', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Markdown Feedback');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        const ideviceId = await addMarkdownIdevice(page);
+        await editIdevice(page, ideviceId);
+
+        await setEditorValue(page, ideviceId, '#markdownTextarea', 'Main body');
+
+        // Feedback fieldset is collapsed by default; open it before
+        // touching the inner inputs.
+        await openFieldset(page, ideviceId, 'markdownFeedback');
+        await setEditorValue(page, ideviceId, '#markdownFeedbackTextarea', 'Feedback body');
+
+        const buttonInput = page.locator(`#${ideviceId} #markdownFeedbackInput`);
+        await buttonInput.fill('Click "me" <x>');
+
+        await saveIdevice(page, ideviceId);
+        await saveProject(page);
+
+        await openPreviewPanel(page);
+        await waitForPreviewContent(page);
+
+        const iframe = getPreviewFrame(page);
+        const button = iframe.locator('input.feedbacktooglebutton').first();
+        await expect(button).toBeVisible();
+        // The literal characters survive intact: the attribute is escaped, not broken.
+        await expect(button).toHaveAttribute('value', 'Click "me" <x>');
+        await expect(iframe.locator('.feedback.js-feedback')).toContainText('Feedback body');
+    });
+
+    test('feedback toggle button shows and hides feedback panel on click', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Markdown Feedback Toggle');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        const ideviceId = await addMarkdownIdevice(page);
+        await editIdevice(page, ideviceId);
+
+        await setEditorValue(page, ideviceId, '#markdownTextarea', 'Body content');
+
+        await openFieldset(page, ideviceId, 'markdownFeedback');
+        await setEditorValue(page, ideviceId, '#markdownFeedbackTextarea', 'Hidden feedback');
+
+        await saveIdevice(page, ideviceId);
+        await saveProject(page);
+
+        await openPreviewPanel(page);
+        await waitForPreviewContent(page);
+
+        const iframe = getPreviewFrame(page);
+        const button = iframe.locator('input.feedbacktooglebutton').first();
+        const feedback = iframe.locator('.feedback.js-feedback').first();
+
+        await expect(button).toBeVisible();
+        // exe_export.js wires the click handler asynchronously after the static
+        // HTML loads; wait for the "loaded" class so subsequent clicks bind.
+        await expect(iframe.locator('.idevice_node.markdown-text').first()).toHaveClass(/loaded/, {
+            timeout: 10000,
+        });
+        await expect(feedback).toBeHidden();
+
+        await button.click();
+        await expect(feedback).toBeVisible();
+        await expect(feedback).toContainText('Hidden feedback');
+
+        // The toggle uses jQuery fadeIn/fadeOut; the second click is ignored
+        // while $markdowntext.working is true. Wait for the animation to settle.
+        await page.waitForFunction(
+            () => {
+                const node = document.querySelector('iframe#preview-iframe') as HTMLIFrameElement | null;
+                const win = node?.contentWindow as (Window & { $markdowntext?: { working?: boolean } }) | null;
+                return win?.$markdowntext?.working === false;
+            },
+            null,
+            { timeout: 10000 },
+        );
+
+        await button.click();
+        await expect(feedback).toBeHidden();
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new **Markdown Text iDevice** that lets authors compose content in Markdown with a tabbed write/preview editor. The Markdown engine is the project's existing Showdown bundle, hardened a bit so that GitHub-style features and LaTeX both work end-to-end.

## What's in this PR

- New iDevice under `public/files/perm/idevices/base/markdown-text/` with edition (form + live preview) and export (runtime render + feedback toggle).
- `eXe.app.common.markdownToHTML` now enables Showdown's GFM options (tables, task lists, strikethrough, GFM-style sublist indentation) and protects LaTeX delimiters from being mangled by Markdown processing.
- `LIBRARY_PATTERNS.exe_highlighter` extended to also detect Showdown's `language-<lang>` classes, so Prism gets bundled in preview/export wherever fenced code blocks exist (not only TinyMCE-flagged blocks).
- Unit tests (vitest) for edition and export, plus a Playwright E2E spec covering add → edit → save → reload, preview tab, feedback rendering and attribute-escape behaviour.

## Improvements vs the initial version

- **GFM rendering**: tables, task-list checkboxes, strikethrough now render correctly.
- **Code blocks**: monospace fonts and `text-shadow: none` so dark-themed code doesn't look bold; Prism kicks in for fenced blocks in workarea, preview and export.
- **Lists**: ordered, unordered and nested lists work consistently.
- **LaTeX**: `\(...\)`, `\[...\]`, `$$...$$` and `\begin{}...\end{}` are preserved through the markdown pass and rendered by the existing MathJax integration in `renderBehaviour`.
- **Security**: user-supplied values that land inside HTML attributes (feedback button text, duration / participants labels and values) are HTML-escaped.
- **Bug fixes carried in**: LaTeX rendering no longer skipped when there's no feedback button, and the no-op mutation of the `data` argument inside `getHTMLView` (inherited from the text iDevice) is gone.

## How to test

Add the new "Markdown text" iDevice to a page, paste this content into the editor, and confirm the preview tab plus the saved view both render it as expected:

````markdown
# Main Title

## Subtitle

This is a paragraph with **bold text**, *italic text*, ***bold and italic text***, `inline code`, a [link](https://example.com), and an image:

![Random image from Picsum](https://picsum.photos/200/300)

---

## Lists

### Unordered List

- First item
- Second item
  - Nested item
  - Another nested item
- Third item

### Ordered List

1. First step
2. Second step
3. Third step

---

## Checkboxes

- [x] Create the repository
- [x] Add the README file
- [ ] Configure CI/CD
- [ ] Publish the first release

---

## Table

| Name | Role | Status | Priority |
|---|---|---:|:---:|
| Alice | Backend Developer | In progress | High |
| Bob | Frontend Developer | Pending | Medium |
| Carol | DevOps Engineer | Completed | Low |

---

## Quotes

> This is a quote.
>
> It can span multiple lines and highlight important ideas.

---

## Code Blocks

### Bash

```bash
#!/usr/bin/env bash

echo "Hello, world!"
```

### JSON

```json
{
  "name": "example-project",
  "version": "1.0.0",
  "private": true
}
```

### PHP

```php
<?php
/**
 * Return a greeting message.
 *
 * @param string $name User name.
 * @return string
 */
function get_greeting( string $name ): string {
    return sprintf( 'Hello, %s!', $name );
}
```

---

## Collapsible Details

<details>
<summary>Show more information</summary>

This content is hidden until the user expands the block.

- It can contain lists
- Code
- Tables
- Rich text

</details>

---

## Formula

A simple formula:

```text
total = price * quantity
```

LaTeX example for platforms that support it:

\(\cfrac{1}{1 + \cfrac{1}{2 + \cfrac{1}{3}}}\)

---

## Final Line

End of document.
````

## Test plan

- [x] `make fix && make test-unit && make test-integration` are green.
- [ ] `make test-e2e` (or at least `markdown-text.spec.ts` under chromium) passes.
- [ ] Manual smoke with the markdown above: tables render, task-list checkboxes appear, fenced code is colourised in workarea / preview / export, the LaTeX continued-fraction renders via MathJax, and saving + reloading the project preserves everything.