### PR TITLE
Hotfix/increse e2e test time

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
             "*": "dist"
         },
         "sort-packages": true,
+        "process-timeout": 600,
         "allow-plugins": {
             "symfony/flex": true,
             "symfony/runtime": true


### PR DESCRIPTION
This pull request makes a minor configuration update to the Composer settings to improve reliability for long-running  processes.

* Increased the `process-timeout` value to 600 seconds in `composer.json`, allowing Composer commands more time to complete before timing out.