### PR TITLE
Hotfix/remove portable build

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,12 +126,6 @@
                     "arch": [
                         "x64"
                     ]
-                },
-                {
-                    "target": "portable",
-                    "arch": [
-                        "x64"
-                    ]
                 }
             ],
             "icon": "public/exelearning.ico",
@@ -152,9 +146,6 @@
             "oneClick": true,
             "runAfterFinish": true,
             "perMachine": false
-        },
-        "portable": {
-          "artifactName": "${productName}-${version}-portable.${ext}"
         },
         "linux": {
             "executableName": "exelearning",


### PR DESCRIPTION
This pull request makes a minor update to the Windows build configuration in the `package.json` file by removing the "portable" build target and its related settings. This streamlines the build process and eliminates the generation of a portable Windows executable.

- Windows build configuration:
  * Removed the "portable" target from the Windows build `targets` array, so portable Windows executables will no longer be generated.
  * Removed the "portable" artifact configuration from the Windows build options, further cleaning up unused build settings.