### PR TITLE
Fix: Correct file naming on export

### DIFF
--- a/src/Service/net/exelearning/Service/Api/OdeExportService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeExportService.php
@@ -1935,7 +1935,7 @@ class OdeExportService implements OdeExportServiceInterface
         $newFileName = str_replace($special_chars, '', $newFileName);
         $newFileName = str_replace(' ', '-', $newFileName);
         $newFileName = preg_replace('/_+/', '_', $newFileName);
-		$newFileName = preg_replace('/[\x00-\x1F\x7F\x{1F600}-\x{1F6FF}]/u', '', $newFileName);
+        $newFileName = preg_replace('/[\x00-\x1F\x7F\x{1F600}-\x{1F6FF}]/u', '', $newFileName);
         $newFileName = preg_replace('/[\-\.]+/', '-', $newFileName);
         $newFileName = trim($newFileName, '-.');
 


### PR DESCRIPTION
This PR fixes a bug where the exported file names were generated using incorrect characters/symbols