### PR TITLE
519 missing confirmation before closing a project

### DIFF
--- a/src/Controller/net/exelearning/Controller/Api/NavStructureApiController.php
+++ b/src/Controller/net/exelearning/Controller/Api/NavStructureApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\net\exelearning\Controller\Api;
 
+use App\Constants;
 use App\Entity\net\exelearning\Dto\OdeNavStructureSyncDataSaveDto;
 use App\Entity\net\exelearning\Dto\OdeNavStructureSyncDto;
 use App\Entity\net\exelearning\Dto\OdeNavStructureSyncListDto;
@@ -148,7 +149,7 @@ class NavStructureApiController extends DefaultApiController
                 $request->setLocale($localeUserPreferences);
                 $request->setDefaultLocale($localeUserPreferences);
                 $this->translator->setLocale($request->getLocale());
-                $pageName = $this->translator->trans('New page');
+                $pageName = $this->translator->trans(Constants::ODE_PAGE_NAME);
                 $firstNode = true;
                 if (empty($odeNavStructureSyncIdParent) || (null == $odeNavStructureSyncIdParent) || ('' == $odeNavStructureSyncIdParent)) {
                     $odeNavStructureSyncIdParent = 'root';


### PR DESCRIPTION
This PR prevents data loss when creating a new resource if:
- The default node name is changed (New page).
- A page is added to the resource.
- Some metadata is changed (title, author, description, and custom code).

The user is not notified if only the export options, license, language, or default page properties are changed. In these cases, data loss is minimal and complicates the operating logic. Although it is really easy to add them, should I do it?