### PR TITLE
Fix the .elpx extension on save as dialog

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,23 +75,36 @@ let customEnv;
 let env;
 
 // ──────────────  Save/Export helpers  ──────────────
+const KNOWN_EXTENSIONS = new Set(['.elpx', '.zip', '.epub', '.xml']);
+
 // Returns a known extension (including the leading dot) inferred from a suggested name.
 function inferKnownExt(suggestedName) {
   try {
-    const ext = (path.extname(suggestedName || '') || '').toLowerCase().replace(/^\./, '');
+    const ext = path.extname(suggestedName || '') || '';
     if (!ext) return null;
-    if (ext === 'elpx' || ext === 'zip' || ext === 'epub' || ext === 'xml') return `.${ext}`;
-    return null;
+    const lower = ext.toLowerCase();
+    return KNOWN_EXTENSIONS.has(lower) ? lower : null;
   } catch (_e) {
     return null;
   }
 }
 
-// Ensures the filePath has an extension; if missing, appends one inferred from suggestedName.
+function extractKnownExt(filePath) {
+  try {
+    const ext = path.extname(filePath || '') || '';
+    if (!ext) return null;
+    const lower = ext.toLowerCase();
+    return KNOWN_EXTENSIONS.has(lower) ? lower : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+// Ensures the filePath has an extension; if missing or unknown, appends one inferred from suggestedName.
 function ensureExt(filePath, suggestedName) {
   if (!filePath) return filePath;
-  const hasExt = !!path.extname(filePath);
-  if (hasExt) return filePath;
+  const known = extractKnownExt(filePath);
+  if (known) return filePath;
   const inferred = inferKnownExt(suggestedName);
   return inferred ? (filePath + inferred) : filePath;
 }


### PR DESCRIPTION
This pull request improves the handling of file extensions for export and save-as operations, ensuring that files are consistently named with the correct and recognized extensions, even in edge cases such as project titles with dots. The changes also add a new test to verify this behavior.

**File extension handling improvements:**

* Introduced a `KNOWN_EXTENSIONS` set in `main.js` and refactored extension logic to use it, ensuring only recognized extensions (`.elpx`, `.zip`, `.epub`, `.xml`) are appended or inferred for exports. Added new helper functions `inferKnownExt` and `extractKnownExt` for robust extension checking.
* Updated the `ensureExt` function in `main.js` to append an extension only if the file path doesn't already have a recognized extension, improving reliability when users provide custom file names.
* Added a `KNOWN_EXPORT_EXTENSIONS` set in `navbarFile.js` and enhanced the `normalizeSuggestedName` method to handle generic or dotted project titles, ensuring suggested filenames end with the correct extension and replace any unrecognized or mismatched extensions.

**Testing enhancements:**

* Added a new end-to-end test in `MenuOfflineFileOpsTest.php` to verify that the "Save As Offline" operation appends the `.elpx` extension when the project title contains dots, preventing issues with ambiguous or missing extensions.