### PR TITLE
Push docker image on tikismaker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=tikismaker,enable=${{ github.ref == 'refs/heads/tikismaker' }}
 
       # Verification of unauthorized changes in the workflows
       - name: Check ci.yml and app.yml
@@ -138,7 +139,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        if: github.repository == 'exelearning/exelearning' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        if: github.repository == 'exelearning/exelearning' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/tikismaker' || startsWith(github.ref, 'refs/tags/'))
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This pull request updates the CI workflow to add support for a new branch, `tikismaker`, ensuring that Docker images are built and tagged appropriately when changes are pushed to this branch. The main changes involve modifying the workflow conditions to include `tikismaker` alongside `main` and tags.

**CI workflow updates:**

* Added a new Docker image tag condition for the `tikismaker` branch in `.github/workflows/ci.yml`, so images are tagged as `tikismaker` when this branch is built.
* Updated the build and push step to trigger when changes are pushed to the `tikismaker` branch, in addition to `main` and tags.