### PR TITLE
Hotfix / Fix open file from user projects

### DIFF
--- a/src/Service/net/exelearning/Service/Api/OdeService.php
+++ b/src/Service/net/exelearning/Service/Api/OdeService.php
@@ -1302,10 +1302,11 @@ class OdeService implements OdeServiceInterface
      * @param string $newOdeSessionId
      * @param string $elpFileName
      * @param array  $checkElpFile
+     * @param bool   $isImportIdevices
      *
      * @return array
      */
-    private function openElp($newOdeSessionId, $elpFileName, $odeSessionDistDirPath, $checkElpFile)
+    private function openElp($newOdeSessionId, $elpFileName, $odeSessionDistDirPath, $checkElpFile, $isImportIdevices = false)
     {
         $destinationFilePathName = $odeSessionDistDirPath.$elpFileName;
         $elpCopied = FileUtil::copyFile($checkElpFile['elpFilePathName'], $destinationFilePathName);


### PR DESCRIPTION
This pull request introduces a small but important update to the `openElp` method in `OdeService.php`, adding a new parameter to support additional functionality.

- **API Enhancement:**
  * The `openElp` method now accepts an optional boolean parameter `$isImportIdevices`, defaulting to `false`. This allows callers to specify whether iDevices should be imported when opening a project from the user projects.