### PR TITLE
Align asset paths with `BASE_PATH` when deploying behind Nginx subdirectory

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -36,7 +36,7 @@ framework:
         strict_requirements: null     # Disable the cache for dynamic routes
 
     assets:
-        base_path: 'assets/%app.version%'  # Base path for assets based on version for avoid cache
+        base_path: '%assets.base_path%'  # Base path for assets based on version to avoid cache
 
 parameters:
     default_cache_dir: '%kernel.project_dir%/var/cache'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,7 @@ parameters:
 
     auth_temp_email_domain_default: 'domain.local'
     base_path: '%env(string:BASE_PATH)%'
+    assets.base_path: '%env(default::string:BASE_PATH)%/assets/%app.version%'
 
     app.online_mode: '%env(bool:APP_ONLINE_MODE)%'
     app.auth_methods: '%env(csv:APP_AUTH_METHODS)%'


### PR DESCRIPTION
When the application is served behind a reverse proxy that exposes it under a subdirectory (e.g. `/jellyfish/exelearning`), Symfony continued generating asset URLs from the root (`/assets/...`). This caused 404 errors for CSS/JS when accessing the application behind Nginx.

This PR introduces a dynamic asset base path derived from `BASE_PATH`, ensuring all asset URLs resolve correctly under a deployment subdirectory.

### Changes

* Introduced a new parameter `assets.base_path` that prefixes the versioned asset directory with `BASE_PATH` (if defined), avoiding double slashes when empty.
* Updated `framework.assets.base_path` to use this parameter so that all `asset()` calls automatically inherit the deployment prefix.

### How to reproduce

1. Start the stack using the provided `docker-compose.yml`, ensuring `exelearning` exposes port `8080` and defines:

   ```
   BASE_PATH="/jellyfish/exelearning"
   ```
2. Start the Nginx reverse proxy that forwards `/jellyfish/exelearning` to the Symfony backend.
3. Before applying this patch, load:

   ```
   http://localhost/jellyfish/exelearning/
   ```

   or run:

   ```
   curl -s http://localhost/jellyfish/exelearning/workarea | grep assets
   ```

   You will see asset URLs generated as `/assets/...`, resulting in 404 errors.
   
4. Apply this change, clear the cache (`php bin/console cache:clear`) or rebuild the container, and reload the page.
   Asset URLs now correctly resolve under:

   ```
   /jellyfish/exelearning/assets/...
   ```

### Verification

```
php bin/console cache:clear
curl -s http://localhost/jellyfish/exelearning/workarea | grep assets
```
---

### Acknowledgments

Thanks to @eduhernandezm for helping identify the issue.


The docker-compose.yml

```yaml
services:
  exelearning:
    image: ghcr.io/exelearning/exelearning:${TAG:-latest}
    ports:
      - "8080:8080"
    environment:
      APP_ENV: prod
      APP_DEBUG: 0
      BASE_PATH: "/jellyfish/exelearning"
      APP_ONLINE_MODE: 1
      XDEBUG_MODE: off

      # SQLite
      DB_DRIVER: pdo_sqlite
      DB_PATH: /mnt/data/exelearning.db
      DB_SERVER_VERSION: 3.32

      FILES_DIR: "/mnt/data/"

      # Auth
      APP_AUTH_METHODS: password
      AUTH_CREATE_USERS: true

      TEST_USER_EMAIL: user@example.net
      TEST_USER_USERNAME: user
      TEST_USER_PASSWORD: "1234"

      API_JWT_SECRET: example123

    restart: unless-stopped
    volumes:
      - exelearning-data:/mnt/data
    networks:
      - internal

  nginx:
    image: nginx:1.22-alpine
    ports:
      - "80:80"
    volumes: 
      - ./default.conf:/etc/nginx/conf.d/default.conf

    depends_on:
      - exelearning
    networks:
      - internal

volumes:
  exelearning-data:

networks:
  internal:
```
The default.conf for nginx

```nginx
server {
    listen 80;
    server_name _;

    location ^~ /jellyfish/exelearning {
        proxy_pass http://exelearning:8080;

        proxy_set_header Host $http_host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Port $server_port;

        proxy_redirect off;
    }

}
```
