### PR TITLE
Fix image paths on Windows - normalize separators (#711)

### DIFF
--- a/src/Controller/net/exelearning/Controller/Filemanager/FilemanagerMethodController.php
+++ b/src/Controller/net/exelearning/Controller/Filemanager/FilemanagerMethodController.php
@@ -660,6 +660,9 @@ class FilemanagerMethodController extends DefaultApiController
         // Relative path
         $relativePath = $pathIni.DIRECTORY_SEPARATOR.$path;
 
+        // Hotfix #711: Normalize path separators for URLs (Windows compatibility)
+        $relativePath = str_replace('\\', '/', $relativePath);
+
         $data = [
             'path' => $relativePath,
         ];


### PR DESCRIPTION
### Problem
On Windows, images inserted via file manager retain backslashes in HTML src attributes, causing them to disappear in preview and export.

### Root Cause
`FilemanagerMethodController::getPath()` uses `DIRECTORY_SEPARATOR` to build paths. On Windows this inserts `\` characters that later fail to match in `replaceFilemanagerResourcesLinks()`.

### Solution
Normalize all path separators to forward slashes before returning to TinyMCE:
```php
$relativePath = str_replace('\\', '/', $relativePath);
```

Forward slashes work in URLs on all platforms and are correctly handled by PHP file operations on Windows.

Closes #711