### PR TITLE
Upgraded to alpine-php-webserver 3.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=
 ARG VERSION=v0.0.0-alpha
 
-FROM ${ARCH}erseco/alpine-php-webserver:3.22
+FROM ${ARCH}erseco/alpine-php-webserver:3.23
 
 LABEL maintainer="INTEF <cedec@educacion.gob.es>"
 LABEL org.opencontainers.image.title="eXeLearning"


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` to a newer version. This ensures the application benefits from the latest security patches and improvements available in the updated image.

* Docker base image updated from `erseco/alpine-php-webserver:3.22` to `erseco/alpine-php-webserver:3.23` in `Dockerfile`