### PR TITLE
Fix mercure version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,9 +103,9 @@ COPY --chown=nobody subdir.conf.template /etc/nginx/server-conf.d/subdir.conf.te
 COPY --chown=nobody nginx-logging-map.conf /etc/nginx/conf.d/logging-map.conf
 
 # Copy Mercure binary and configuration from the official container because Mercure is not yet available as an Alpine package
-COPY --from=dunglas/mercure:latest /usr/bin/caddy /usr/bin/mercure
-COPY --from=dunglas/mercure:latest /etc/caddy/Caddyfile /etc/caddy/Caddyfile
-COPY --from=dunglas/mercure:latest /etc/caddy/dev.Caddyfile /etc/caddy/dev.Caddyfile
+COPY --from=dunglas/mercure:v0.21.2 /usr/bin/caddy /usr/bin/mercure
+COPY --from=dunglas/mercure:v0.21.2 /etc/caddy/Caddyfile /etc/caddy/Caddyfile
+COPY --from=dunglas/mercure:v0.21.2 /etc/caddy/dev.Caddyfile /etc/caddy/dev.Caddyfile
 
 # Create symbolic link to the php84 binary
 RUN ln -sf /usr/bin/php84 /usr/local/bin/php


### PR DESCRIPTION
This pull request updates the Mercure binary and configuration files used in the Docker image to a specific version (`v0.21.2`) instead of always pulling the latest version. This change ensures more predictable and stable builds by avoiding unexpected updates from upstream changes.

Dependency version pinning:

* Updated the `COPY --from` instructions in the `Dockerfile` to use `dunglas/mercure:v0.21.2` for copying the Mercure binary and configuration files, replacing the previous usage of the `latest` tag.