### PR TITLE
Simplify share button (fix #775)

### DIFF
--- a/public/app/workarea/interface/elements/shareButton.js
+++ b/public/app/workarea/interface/elements/shareButton.js
@@ -7,9 +7,6 @@ export default class ShareProjectButton {
         this.visibilityIcon = this.shareButton?.querySelector(
             '.share-visibility-icon'
         );
-        this.visibilityText = this.shareButton?.querySelector(
-            '.share-visibility-text'
-        );
         this.currentVisibility = 'private'; // Default
     }
 
@@ -52,16 +49,14 @@ export default class ShareProjectButton {
      * @param {string} visibility - 'public' or 'private'
      */
     updateVisibilityPill(visibility) {
-        if (!this.visibilityIcon || !this.visibilityText) return;
+        if (!this.visibilityIcon) return;
 
         this.currentVisibility = visibility;
 
         if (visibility === 'public') {
             this.visibilityIcon.textContent = 'public';
-            this.visibilityText.textContent = _('Public');
         } else {
             this.visibilityIcon.textContent = 'lock';
-            this.visibilityText.textContent = _('Private');
         }
     }
 

--- a/public/app/workarea/modals/modals/pages/modalShare.js
+++ b/public/app/workarea/modals/modals/pages/modalShare.js
@@ -323,6 +323,8 @@ export default class ModalShare extends Modal {
     renderVisibilitySection() {
         if (!this.projectData || !this.visibilitySelect) return;
 
+        this.updateVisibilityOptionLabels();
+
         // Set current visibility
         this.visibilitySelect.value = this.projectData.visibility || 'public';
 
@@ -331,6 +333,23 @@ export default class ModalShare extends Modal {
 
         // Show/hide help text
         this.updateVisibilityHelp(this.projectData.visibility);
+    }
+
+    /**
+     * Ensure visibility option labels include icons and no public/private suffix.
+     */
+    updateVisibilityOptionLabels() {
+        if (!this.visibilitySelect) return;
+
+        const privateOption = this.visibilitySelect.querySelector(
+            'option[value="private"]'
+        );
+        const publicOption = this.visibilitySelect.querySelector(
+            'option[value="public"]'
+        );
+
+        if (privateOption) privateOption.textContent = '🔒 Restricted (Private)';
+        if (publicOption) publicOption.textContent = '🌐 Anyone with the link (Public)';
     }
 
     /**

--- a/test/integration/export-unified.spec.ts
+++ b/test/integration/export-unified.spec.ts
@@ -330,11 +330,11 @@ describe('Unified Export System Integration', () => {
             const files = Object.keys(zipFile);
 
             // Check that some XSD files are included
-            const xsdFiles = files.filter((f) => f.endsWith('.xsd'));
+            const xsdFiles = files.filter(f => f.endsWith('.xsd'));
             expect(xsdFiles.length).toBeGreaterThan(0);
 
             // Should have core SCORM 1.2 schemas
-            expect(files.some((f) => f.includes('imscp'))).toBe(true);
+            expect(files.some(f => f.includes('imscp'))).toBe(true);
         });
 
         it('should include imslrm.xml (LOM metadata)', async () => {
@@ -406,7 +406,7 @@ describe('Unified Export System Integration', () => {
             const files = Object.keys(zipFile);
 
             // Check that XSD files are included
-            const xsdFiles = files.filter((f) => f.endsWith('.xsd'));
+            const xsdFiles = files.filter(f => f.endsWith('.xsd'));
             expect(xsdFiles.length).toBeGreaterThan(0);
         });
 

--- a/test/integration/export/scorm12-exporter.spec.ts
+++ b/test/integration/export/scorm12-exporter.spec.ts
@@ -271,9 +271,7 @@ describe('Scorm12Exporter Integration', () => {
                 const result = await exporter.export();
 
                 const unzipped = fflateUnzipSync(result.data!);
-                const htmlFiles = Object.keys(unzipped).filter(
-                    f => f.endsWith('.html') && !f.includes('idevices/'),
-                );
+                const htmlFiles = Object.keys(unzipped).filter(f => f.endsWith('.html') && !f.includes('idevices/'));
 
                 // Should have index.html and 5 sub-pages
                 expect(htmlFiles).toContain('index.html');

--- a/test/integration/export/scorm2004-exporter.spec.ts
+++ b/test/integration/export/scorm2004-exporter.spec.ts
@@ -304,9 +304,7 @@ describe('Scorm2004Exporter Integration', () => {
                 const result = await exporter.export();
 
                 const unzipped = fflateUnzipSync(result.data!);
-                const htmlFiles = Object.keys(unzipped).filter(
-                    f => f.endsWith('.html') && !f.includes('idevices/'),
-                );
+                const htmlFiles = Object.keys(unzipped).filter(f => f.endsWith('.html') && !f.includes('idevices/'));
 
                 // Should have index.html and 5 sub-pages
                 expect(htmlFiles).toContain('index.html');

--- a/views/workarea/menus/menuHeadTop.njk
+++ b/views/workarea/menus/menuHeadTop.njk
@@ -27,9 +27,7 @@
                     aria-label="{{ t.share or 'Share' }}">
                 <span class="share-visibility-indicator d-flex align-items-center">
                     <div class="auto-icon share-visibility-icon" aria-hidden="true">lock</div>
-                    <span class="share-visibility-text">{{ t.private or 'Private' }}</span>
                 </span>
-                <span class="share-button-divider"></span>
                 <span class="share-button-text">{{ t.share or 'Share' }}</span>
             </button>
             <div id="exe-last-edition" class="btn">

--- a/views/workarea/modals/pages/modalShare.njk
+++ b/views/workarea/modals/pages/modalShare.njk
@@ -39,8 +39,8 @@
                     <select id="share-visibility-select"
                             class="form-select"
                             aria-label="General access">
-                        <option value="private">Restricted (Private)</option>
-                        <option value="public">Anyone with the link (Public)</option>
+                        <option value="private">🔒 Restricted (Private)</option>
+                        <option value="public">🌐 Anyone with the link (Public)</option>
                     </select>
                     <small id="share-visibility-help" class="form-text text-muted d-none">
                         Anyone who has the link can view and edit in real time


### PR DESCRIPTION
This pull request primarily updates the sharing UI to simplify the visibility indicator in the share button and improve the clarity and consistency of visibility option labels in the share modal. Additionally, it includes minor code style cleanups in integration tests.

