### PR TITLE
Improve filemanager

### DIFF
--- a/assets/styles/components/_modals.scss
+++ b/assets/styles/components/_modals.scss
@@ -518,7 +518,8 @@
             }
         }
 
-        .media-library-sort-controls {
+        .media-library-sort-controls,
+        .media-library-filter-controls {
             display: flex;
             align-items: center;
             gap: 6px;
@@ -660,6 +661,15 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+    }
+
+    /* List view container */
+    .media-library-list-container {
+        flex: 1;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
     }
 
     /* List view (table) */
@@ -805,7 +815,7 @@
         background: var(--main-background-color);
         display: flex;
         flex-direction: column;
-        overflow-y: auto;
+        overflow: hidden;
         flex-shrink: 0;
     }
 
@@ -823,6 +833,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        overflow: hidden;
     }
 
     /* Preview */
@@ -863,6 +874,7 @@
         padding: var(--margin-l);
         flex: 1;
         overflow-y: auto;
+        min-height: 0;
 
         .metadata-row {
             display: flex;
@@ -898,6 +910,7 @@
         display: flex;
         gap: var(--margin-m);
         justify-content: space-between;
+        flex-shrink: 0;
 
         .btn {
             flex: 1;

--- a/public/app/workarea/modals/modals/pages/modalFileManager.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.js
@@ -22,6 +22,7 @@ export default class ModalFilemanager extends Modal {
         this.selectedAsset = null;
         this.onSelectCallback = null;
         this.acceptFilter = null; // 'image', 'audio', 'video', or null for all
+        this.typeFilter = ''; // User-selected type filter from dropdown
         this.assetManager = null;
 
         // View state
@@ -54,6 +55,7 @@ export default class ModalFilemanager extends Modal {
      */
     initElements() {
         this.grid = this.modalElement.querySelector('.media-library-grid');
+        this.listContainer = this.modalElement.querySelector('.media-library-list-container');
         this.listTable = this.modalElement.querySelector('.media-library-list');
         this.listTbody = this.listTable?.querySelector('tbody');
         this.sidebar = this.modalElement.querySelector('.media-library-sidebar');
@@ -68,6 +70,7 @@ export default class ModalFilemanager extends Modal {
         // View controls
         this.viewBtns = this.modalElement.querySelectorAll('.media-library-view-btn');
         this.sortSelect = this.modalElement.querySelector('.media-library-sort');
+        this.filterSelect = this.modalElement.querySelector('.media-library-filter');
 
         // Pagination
         this.paginationInfo = this.modalElement.querySelector('.media-library-page-info');
@@ -153,6 +156,15 @@ export default class ModalFilemanager extends Modal {
             });
         }
 
+        // Filter select
+        if (this.filterSelect) {
+            this.filterSelect.addEventListener('change', (e) => {
+                this.typeFilter = e.target.value;
+                this.currentPage = 1;
+                this.applyFiltersAndRender();
+            });
+        }
+
         // Pagination buttons
         if (this.prevBtn) {
             this.prevBtn.addEventListener('click', () => {
@@ -223,10 +235,10 @@ export default class ModalFilemanager extends Modal {
         // Show/hide appropriate view
         if (mode === 'grid') {
             if (this.grid) this.grid.style.display = 'grid';
-            if (this.listTable) this.listTable.style.display = 'none';
+            if (this.listContainer) this.listContainer.style.display = 'none';
         } else {
             if (this.grid) this.grid.style.display = 'none';
-            if (this.listTable) this.listTable.style.display = 'table';
+            if (this.listContainer) this.listContainer.style.display = 'flex';
         }
 
         this.renderCurrentView();
@@ -288,6 +300,7 @@ export default class ModalFilemanager extends Modal {
             this.assets = await this.assetManager.getProjectAssets();
             Logger.log(`[MediaLibrary] Loaded ${this.assets.length} assets`);
             this.currentPage = 1;
+            this.updateFilterOptions();
             this.applyFiltersAndRender();
         } catch (err) {
             console.error('[MediaLibrary] Failed to load assets:', err);
@@ -303,12 +316,17 @@ export default class ModalFilemanager extends Modal {
 
         // Filter
         this.filteredAssets = this.assets.filter(asset => {
-            // Filter by file type (accept filter)
+            // Filter by file type (accept filter - programmatic)
             if (this.acceptFilter) {
                 const mime = asset.mime || '';
                 if (this.acceptFilter === 'image' && !mime.startsWith('image/')) return false;
                 if (this.acceptFilter === 'audio' && !mime.startsWith('audio/')) return false;
                 if (this.acceptFilter === 'video' && !mime.startsWith('video/')) return false;
+            }
+            // Filter by type (user-selected filter)
+            if (this.typeFilter) {
+                const category = this.getAssetTypeCategory(asset.mime);
+                if (category !== this.typeFilter) return false;
             }
             // Filter by search term
             if (!searchTerm) return true;
@@ -516,6 +534,63 @@ export default class ModalFilemanager extends Modal {
         if (mime.startsWith('audio/')) return 'Audio';
         if (mime.includes('pdf')) return 'PDF';
         return 'File';
+    }
+
+    /**
+     * Get asset type category for filtering
+     */
+    getAssetTypeCategory(mime) {
+        if (!mime) return 'other';
+        if (mime.startsWith('image/')) return 'image';
+        if (mime.startsWith('video/')) return 'video';
+        if (mime.startsWith('audio/')) return 'audio';
+        if (mime === 'application/pdf') return 'pdf';
+        return 'other';
+    }
+
+    /**
+     * Update filter dropdown options based on available file types
+     */
+    updateFilterOptions() {
+        if (!this.filterSelect) return;
+
+        // Get unique type categories from assets
+        const typeCategories = new Set();
+        for (const asset of this.assets) {
+            const category = this.getAssetTypeCategory(asset.mime);
+            typeCategories.add(category);
+        }
+
+        // Clear existing options except "All"
+        this.filterSelect.innerHTML = `<option value="">${_('All')}</option>`;
+
+        // Type labels mapping
+        const typeLabels = {
+            image: _('Images'),
+            video: _('Videos'),
+            audio: _('Audio'),
+            pdf: _('PDF'),
+            other: _('Other')
+        };
+
+        // Type order for consistent display
+        const typeOrder = ['image', 'video', 'audio', 'pdf', 'other'];
+
+        // Add options for existing types
+        for (const type of typeOrder) {
+            if (typeCategories.has(type)) {
+                const option = document.createElement('option');
+                option.value = type;
+                option.textContent = typeLabels[type] || type;
+                this.filterSelect.appendChild(option);
+            }
+        }
+
+        // Reset filter if current filter type no longer exists
+        if (this.typeFilter && !typeCategories.has(this.typeFilter)) {
+            this.typeFilter = '';
+            this.filterSelect.value = '';
+        }
     }
 
     /**
@@ -844,10 +919,14 @@ export default class ModalFilemanager extends Modal {
         this.selectedAsset = null;
         this.onSelectCallback = null;
         this.acceptFilter = null;
+        this.typeFilter = '';
 
         // Reset search and view state
         if (this.searchInput) {
             this.searchInput.value = '';
+        }
+        if (this.filterSelect) {
+            this.filterSelect.value = '';
         }
         this.currentPage = 1;
 

--- a/public/app/workarea/modals/modals/pages/modalFileManager.test.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.test.js
@@ -39,7 +39,7 @@ describe('ModalFilemanager', () => {
     mockElement.id = 'modalFileManager';
     mockElement.innerHTML = `
       <div class="media-library-grid"></div>
-      <table class="media-library-list"><thead><th data-sort="name"></th></thead><tbody></tbody></table>
+      <div class="media-library-list-container" style="display:none;"><table class="media-library-list"><thead><th data-sort="name"></th></thead><tbody></tbody></table></div>
       <div class="media-library-sidebar">
         <div class="media-library-sidebar-empty"></div>
         <div class="media-library-sidebar-content"></div>
@@ -54,6 +54,11 @@ describe('ModalFilemanager', () => {
       <select class="media-library-sort">
         <option value="name-asc">name-asc</option>
         <option value="size-asc">size-asc</option>
+        <option value="type-asc">type-asc</option>
+        <option value="type-desc">type-desc</option>
+      </select>
+      <select class="media-library-filter">
+        <option value="">All</option>
       </select>
       <div class="media-library-page-info"></div>
       <button class="media-library-page-btn" data-action="prev"></button>
@@ -236,7 +241,7 @@ describe('ModalFilemanager', () => {
     it('should switch to list view', () => {
       modal.setViewMode('list');
       expect(modal.grid.style.display).toBe('none');
-      expect(modal.listTable.style.display).toBe('table');
+      expect(modal.listContainer.style.display).toBe('flex');
     });
   });
 
@@ -411,6 +416,169 @@ describe('ModalFilemanager', () => {
       expect(modal.acceptFilter).toBeNull();
       expect(modal.searchInput.value).toBe('');
       expect(modal.currentPage).toBe(1);
+    });
+
+    it('should reset typeFilter and filterSelect', () => {
+      modal.typeFilter = 'image';
+      modal.filterSelect.value = 'image';
+      modal.close();
+      expect(modal.typeFilter).toBe('');
+      expect(modal.filterSelect.value).toBe('');
+    });
+  });
+
+  describe('getAssetTypeCategory', () => {
+    it('should return image for image mime types', () => {
+      expect(modal.getAssetTypeCategory('image/png')).toBe('image');
+      expect(modal.getAssetTypeCategory('image/jpeg')).toBe('image');
+      expect(modal.getAssetTypeCategory('image/gif')).toBe('image');
+    });
+
+    it('should return video for video mime types', () => {
+      expect(modal.getAssetTypeCategory('video/mp4')).toBe('video');
+      expect(modal.getAssetTypeCategory('video/webm')).toBe('video');
+    });
+
+    it('should return audio for audio mime types', () => {
+      expect(modal.getAssetTypeCategory('audio/mpeg')).toBe('audio');
+      expect(modal.getAssetTypeCategory('audio/wav')).toBe('audio');
+    });
+
+    it('should return pdf for application/pdf', () => {
+      expect(modal.getAssetTypeCategory('application/pdf')).toBe('pdf');
+    });
+
+    it('should return other for unknown types', () => {
+      expect(modal.getAssetTypeCategory('application/json')).toBe('other');
+      expect(modal.getAssetTypeCategory('text/plain')).toBe('other');
+      expect(modal.getAssetTypeCategory('')).toBe('other');
+      expect(modal.getAssetTypeCategory(null)).toBe('other');
+      expect(modal.getAssetTypeCategory(undefined)).toBe('other');
+    });
+  });
+
+  describe('updateFilterOptions', () => {
+    it('should populate filter options based on available asset types', () => {
+      modal.assets = [
+        { id: '1', filename: 'a.png', mime: 'image/png' },
+        { id: '2', filename: 'b.mp4', mime: 'video/mp4' },
+        { id: '3', filename: 'c.pdf', mime: 'application/pdf' },
+      ];
+      modal.updateFilterOptions();
+
+      const options = modal.filterSelect.querySelectorAll('option');
+      expect(options.length).toBe(4); // All + image + video + pdf
+      expect(options[0].value).toBe('');
+      expect(options[1].value).toBe('image');
+      expect(options[2].value).toBe('video');
+      expect(options[3].value).toBe('pdf');
+    });
+
+    it('should only show types that exist', () => {
+      modal.assets = [
+        { id: '1', filename: 'a.png', mime: 'image/png' },
+      ];
+      modal.updateFilterOptions();
+
+      const options = modal.filterSelect.querySelectorAll('option');
+      expect(options.length).toBe(2); // All + image
+      expect(options[1].value).toBe('image');
+    });
+
+    it('should reset typeFilter if current filter type no longer exists', () => {
+      modal.typeFilter = 'video';
+      modal.assets = [
+        { id: '1', filename: 'a.png', mime: 'image/png' },
+      ];
+      modal.updateFilterOptions();
+
+      expect(modal.typeFilter).toBe('');
+      expect(modal.filterSelect.value).toBe('');
+    });
+  });
+
+  describe('type filtering', () => {
+    it('should filter assets by type', () => {
+      modal.assets = [
+        { id: '1', filename: 'a.png', mime: 'image/png' },
+        { id: '2', filename: 'b.mp4', mime: 'video/mp4' },
+        { id: '3', filename: 'c.mp3', mime: 'audio/mpeg' },
+      ];
+      modal.typeFilter = 'image';
+      const renderSpy = vi.spyOn(modal, 'renderCurrentView');
+      modal.applyFiltersAndRender();
+
+      expect(modal.filteredAssets.length).toBe(1);
+      expect(modal.filteredAssets[0].mime).toBe('image/png');
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it('should show all when typeFilter is empty', () => {
+      modal.assets = [
+        { id: '1', filename: 'a.png', mime: 'image/png' },
+        { id: '2', filename: 'b.mp4', mime: 'video/mp4' },
+      ];
+      modal.typeFilter = '';
+      modal.applyFiltersAndRender();
+
+      expect(modal.filteredAssets.length).toBe(2);
+    });
+
+    it('should combine typeFilter with search', () => {
+      modal.assets = [
+        { id: '1', filename: 'cat.png', mime: 'image/png' },
+        { id: '2', filename: 'dog.png', mime: 'image/png' },
+        { id: '3', filename: 'cat.mp4', mime: 'video/mp4' },
+      ];
+      modal.typeFilter = 'image';
+      modal.searchInput.value = 'cat';
+      modal.applyFiltersAndRender();
+
+      expect(modal.filteredAssets.length).toBe(1);
+      expect(modal.filteredAssets[0].filename).toBe('cat.png');
+    });
+
+    it('should update filter on select change', () => {
+      // Add image option to filter select (simulating updateFilterOptions)
+      const option = document.createElement('option');
+      option.value = 'image';
+      option.textContent = 'Images';
+      modal.filterSelect.appendChild(option);
+
+      const applySpy = vi.spyOn(modal, 'applyFiltersAndRender');
+      modal.filterSelect.value = 'image';
+      modal.filterSelect.dispatchEvent(new Event('change'));
+      expect(modal.typeFilter).toBe('image');
+      expect(modal.currentPage).toBe(1);
+      expect(applySpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('type sorting', () => {
+    it('should sort by type ascending', () => {
+      modal.sortBy = 'type-asc';
+      modal.filteredAssets = [
+        { filename: 'a', mime: 'video/mp4' },
+        { filename: 'b', mime: 'audio/mpeg' },
+        { filename: 'c', mime: 'image/png' },
+      ];
+      modal.sortAssets();
+      expect(modal.filteredAssets[0].mime).toBe('audio/mpeg');
+      expect(modal.filteredAssets[1].mime).toBe('image/png');
+      expect(modal.filteredAssets[2].mime).toBe('video/mp4');
+    });
+
+    it('should sort by type descending', () => {
+      modal.sortBy = 'type-desc';
+      modal.filteredAssets = [
+        { filename: 'a', mime: 'audio/mpeg' },
+        { filename: 'b', mime: 'video/mp4' },
+        { filename: 'c', mime: 'image/png' },
+      ];
+      modal.sortAssets();
+      expect(modal.filteredAssets[0].mime).toBe('video/mp4');
+      expect(modal.filteredAssets[1].mime).toBe('image/png');
+      expect(modal.filteredAssets[2].mime).toBe('audio/mpeg');
     });
   });
 });

--- a/views/workarea/modals/pages/filemanager.njk
+++ b/views/workarea/modals/pages/filemanager.njk
@@ -32,6 +32,15 @@
                             <option value="date-asc">Oldest first</option>
                             <option value="size-desc">Largest first</option>
                             <option value="size-asc">Smallest first</option>
+                            <option value="type-asc">Type A-Z</option>
+                            <option value="type-desc">Type Z-A</option>
+                        </select>
+                    </div>
+
+                    <div class="media-library-filter-controls">
+                        <label>Type:</label>
+                        <select class="form-control media-library-filter">
+                            <option value="">All</option>
                         </select>
                     </div>
 
@@ -43,18 +52,20 @@
                         <div class="media-library-grid">
                             <div class="media-library-loading">Loading assets...</div>
                         </div>
-                        <table class="media-library-list" style="display:none;">
-                            <thead>
-                                <tr>
-                                    <th class="col-thumb"></th>
-                                    <th class="col-name" data-sort="name">Name</th>
-                                    <th class="col-type" data-sort="type">Type</th>
-                                    <th class="col-size" data-sort="size">Size</th>
-                                    <th class="col-date" data-sort="date">Date</th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
+                        <div class="media-library-list-container" style="display:none;">
+                            <table class="media-library-list">
+                                <thead>
+                                    <tr>
+                                        <th class="col-thumb"></th>
+                                        <th class="col-name" data-sort="name">Name</th>
+                                        <th class="col-type" data-sort="type">Type</th>
+                                        <th class="col-size" data-sort="size">Size</th>
+                                        <th class="col-date" data-sort="date">Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
                         <div class="media-library-empty" style="display:none;">No media files yet. Click "Add file" to upload.</div>
 
                         <div class="media-library-pagination">


### PR DESCRIPTION
This pull request adds a file type filter and type-based sorting to the Media Library modal, improving usability when browsing large numbers of assets. It introduces a filter dropdown for asset type (image, video, audio, pdf, other), updates the UI and styles to support the new controls, and extends the test suite to cover filtering and sorting by type.
