### PR TITLE
Fix \r replace on import

### DIFF
--- a/public/app/yjs/legacy/BaseLegacyHandler.js
+++ b/public/app/yjs/legacy/BaseLegacyHandler.js
@@ -257,7 +257,7 @@ class BaseLegacyHandler {
       // Handle Python unicode escapes for common characters
       .replace(/\\n/g, '\n')
       .replace(/\\t/g, '\t')
-      .replace(/\\r/g, '\r');
+      .replace(/\\r(?![a-zA-Z])/g, '\r'); // Negative lookahead to preserve LaTeX commands like \right
 
     return decoded;
   }

--- a/public/app/yjs/legacy/BaseLegacyHandler.test.js
+++ b/public/app/yjs/legacy/BaseLegacyHandler.test.js
@@ -293,6 +293,23 @@ describe('BaseLegacyHandler', () => {
       expect(handler.decodeHtmlContent(encoded)).toBe('Line1\nLine2\tTabbed');
     });
 
+    it('preserves LaTeX commands containing backslash-r', () => {
+      // LaTeX commands like \right, \rfloor, \rceil, \rho, \rangle should NOT be converted
+      const latex = '\\left( \\frac{a}{b} \\right)';
+      expect(handler.decodeHtmlContent(latex)).toBe('\\left( \\frac{a}{b} \\right)');
+    });
+
+    it('preserves various LaTeX \\r commands', () => {
+      const commands = '\\rfloor \\rceil \\rho \\rangle \\rightarrow';
+      expect(handler.decodeHtmlContent(commands)).toBe('\\rfloor \\rceil \\rho \\rangle \\rightarrow');
+    });
+
+    it('converts standalone \\r to carriage return', () => {
+      // Actual carriage return escape (not followed by letters) should still convert
+      const withCR = 'Line1\\r\\nLine2';
+      expect(handler.decodeHtmlContent(withCR)).toBe('Line1\r\nLine2');
+    });
+
     it('returns empty string for null/empty input', () => {
       expect(handler.decodeHtmlContent(null)).toBe('');
       expect(handler.decodeHtmlContent('')).toBe('');


### PR DESCRIPTION
This pull request updates the handling of backslash-r (`\r`) escapes in the `BaseLegacyHandler` to better support LaTeX commands, and adds corresponding unit tests to ensure correct behavior. The main change is to avoid converting LaTeX commands like `\right` or `\rho` to carriage returns, while still converting standalone `\r` escapes.

Improvements to escape handling:

* Modified the regex in the `decodeHtmlContent` method of `BaseLegacyHandler.js` to use a negative lookahead, so that only standalone `\r` (not followed by letters) are converted to carriage returns, preserving LaTeX commands like `\right` and `\rho`.

Test coverage enhancements:

* Added tests to `BaseLegacyHandler.test.js` to verify that LaTeX commands containing backslash-r are preserved and not converted to carriage returns.
* Added a test to ensure standalone `\r` escapes are still correctly converted to carriage returns.