### PR TITLE
Fix true-false legacy import

### DIFF
--- a/public/app/common/exe_export.js
+++ b/public/app/common/exe_export.js
@@ -242,7 +242,10 @@ const $exeExport = window.$exeExport = {
             // to generate the complete interface. These iDevices have empty htmlView by design.
             // Other JSON iDevices (like text) may have pre-rendered content in htmlView.
             const isJsonIdevice = ideviceNode.getAttribute('data-idevice-component-type') === 'json';
-            const jsonOnlyIdevices = ['casestudy', 'form', 'image-gallery', 'magnifier'];
+            // JSON-only iDevices that store ALL content in jsonProperties (not in htmlView)
+            // and need renderView to generate the complete interface.
+            // 'trueorfalse' added for legacy imports that have empty htmlView.
+            const jsonOnlyIdevices = ['casestudy', 'form', 'image-gallery', 'magnifier', 'trueorfalse'];
             const ideviceType = ideviceNode.getAttribute('data-idevice-type');
             const needsJsonRender = isJsonIdevice && jsonOnlyIdevices.includes(ideviceType);
             if (needsJsonRender || ideviceNode.classList.contains('db-no-data')) {

--- a/public/app/yjs/LegacyXmlParser.js
+++ b/public/app/yjs/LegacyXmlParser.js
@@ -1136,7 +1136,8 @@ class LegacyXmlParser {
         // Use handler registry if available, otherwise fall back to inline logic
         if (typeof LegacyHandlerRegistry !== 'undefined') {
           const handler = LegacyHandlerRegistry.getHandler(className, ideviceType);
-          const handlerProps = handler.extractProperties(dict);
+          // Pass idevice.id for handlers that need it (e.g., TrueFalseHandler)
+          const handlerProps = handler.extractProperties(dict, idevice.id);
           if (handlerProps && Object.keys(handlerProps).length > 0) {
             idevice.properties = handlerProps;
             Logger.log(`[LegacyXmlParser] Extracted properties via ${handler.constructor.name}`);

--- a/public/app/yjs/legacy/handlers/TrueFalseHandler.js
+++ b/public/app/yjs/legacy/handlers/TrueFalseHandler.js
@@ -2,7 +2,7 @@
  * TrueFalseHandler
  *
  * Handles legacy TrueFalseIdevice.
- * Converts to modern 'form' iDevice with true-false questions.
+ * Converts to modern 'trueorfalse' iDevice with game-compatible format.
  *
  * Legacy XML structure:
  * - exe.engine.truefalseidevice.TrueFalseIdevice
@@ -30,34 +30,101 @@ class TrueFalseHandler extends BaseLegacyHandler {
   }
 
   /**
-   * Extract questionsData and eXeFormInstructions from the legacy format
+   * Get default messages for the game
+   * These match the messages used by edition/trueorfalse.js
    */
-  extractProperties(dict) {
-    const questionsData = this.extractQuestions(dict);
+  getDefaultMessages() {
+    return {
+      msgStartGame: 'Click here to start',
+      msgTime: 'Time per question',
+      msgNoImage: 'No picture question',
+      msgScoreScorm: "The score can't be saved because this page is not part of a SCORM package.",
+      msgEndGameScore: 'Please start the game before saving your score.',
+      msgOnlySaveScore: 'You can only save the score once!',
+      msgOnlySave: 'You can only save once',
+      msgYouScore: 'Your score',
+      msgAuthor: 'Authorship',
+      msgOnlySaveAuto: 'Your score will be saved after each question. You can only play once.',
+      msgSaveAuto: 'Your score will be automatically saved after each question.',
+      msgSeveralScore: 'You can save the score as many times as you want',
+      msgYouLastScore: 'The last score saved is',
+      msgActityComply: 'You have already done this activity.',
+      msgPlaySeveralTimes: 'You can do this activity as many times as you want',
+      msgUncompletedActivity: 'Incomplete activity',
+      msgSuccessfulActivity: 'Activity: Passed. Score: %s',
+      msgUnsuccessfulActivity: 'Activity: Not passed. Score: %s',
+      msgTypeGame: 'True or false',
+      msgFeedback: 'Feedback',
+      msgSuggestion: 'Suggestion',
+      msgSolution: 'Solution',
+      msgQuestion: 'Question',
+      msgTrue: 'True',
+      msgFalse: 'False',
+      msgOk: 'Correct',
+      msgKO: 'Incorrect',
+      msgShow: 'Show',
+      msgHide: 'Hide',
+      msgCheck: 'Check',
+      msgReboot: 'Try again!',
+      msgScore: 'Score',
+      msgWeight: 'Weight',
+      msgNext: 'Next',
+      msgPrevious: 'Previous'
+    };
+  }
+
+  /**
+   * Extract properties in the game-compatible format expected by the renderer.
+   * This generates the full format with typeGame, questionsGame, msgs, etc.
+   * to avoid the need for transformation at edit time.
+   */
+  extractProperties(dict, ideviceId) {
+    const questionsGame = this.extractQuestionsGame(dict);
     const instructions = this.extractHtmlView(dict);
 
-    if (questionsData.length > 0) {
-      const props = { questionsData };
-      if (instructions) {
-        props.eXeFormInstructions = instructions;
-      }
-      return props;
+    if (questionsGame.length > 0) {
+      return {
+        id: ideviceId || '',
+        typeGame: 'TrueOrFalse',
+        eXeGameInstructions: instructions || '',
+        eXeIdeviceTextAfter: '',
+        msgs: this.getDefaultMessages(),
+        questionsRandom: false,
+        percentageQuestions: 100,
+        isTest: false,
+        time: 0,
+        questionsGame: questionsGame,
+        isScorm: 0,
+        textButtonScorm: 'Save score',
+        repeatActivity: true,
+        weighted: 100,
+        evaluation: false,
+        evaluationID: '',
+        showSlider: false,
+        ideviceId: ideviceId || ''
+      };
     }
     return {};
   }
 
   /**
-   * Extract questions from legacy TrueFalseIdevice format
+   * Extract questions from legacy TrueFalseIdevice format in game-compatible format.
    *
    * Structure:
    * - list of TrueFalseQuestion instances
    * - TrueFalseQuestion has: questionTextArea, isCorrect, hintTextArea, feedbackTextArea
    *
+   * Output format matches what the renderer expects:
+   * - question: HTML content
+   * - feedback: HTML content
+   * - suggestion: HTML content (from hint)
+   * - solution: 1 for true, 0 for false
+   *
    * @param {Element} dict - Dictionary element of the TrueFalseIdevice
-   * @returns {Array} Array of question objects in form iDevice format
+   * @returns {Array} Array of question objects in game format
    */
-  extractQuestions(dict) {
-    const questionsData = [];
+  extractQuestionsGame(dict) {
+    const questionsGame = [];
 
     // Find the list containing TrueFalseQuestion instances
     // Look for <list> elements containing TrueFalseQuestion
@@ -80,7 +147,7 @@ class TrueFalseHandler extends BaseLegacyHandler {
       questionsList = this.findDictList(dict, 'questions');
     }
 
-    if (!questionsList) return questionsData;
+    if (!questionsList) return questionsGame;
 
     // Iterate each TrueFalseQuestion
     const questionInstances = questionsList.querySelectorAll(':scope > instance');
@@ -97,9 +164,9 @@ class TrueFalseHandler extends BaseLegacyHandler {
       // Get isCorrect flag (determines if statement is true or false)
       const isCorrect = this.findDictBoolValue(qDict, 'isCorrect');
 
-      // Extract hint (optional)
+      // Extract hint (optional) - maps to 'suggestion' in game format
       const hintTextArea = this.findDictInstance(qDict, 'hintTextArea');
-      const hint = hintTextArea ? this.extractTextAreaFieldContent(hintTextArea) : '';
+      const suggestion = hintTextArea ? this.extractTextAreaFieldContent(hintTextArea) : '';
 
       // Extract feedback (optional)
       const feedbackTextArea = this.findDictInstance(qDict, 'feedbackTextArea');
@@ -107,17 +174,16 @@ class TrueFalseHandler extends BaseLegacyHandler {
 
       // Only add if we have question text
       if (questionText) {
-        questionsData.push({
-          activityType: 'true-false',
-          baseText: questionText,
-          answer: isCorrect ? 'True' : 'False',
-          hint: hint,
-          feedback: feedback
+        questionsGame.push({
+          question: questionText,
+          feedback: feedback,
+          suggestion: suggestion,
+          solution: isCorrect ? 1 : 0
         });
       }
     }
 
-    return questionsData;
+    return questionsGame;
   }
 
   /**

--- a/public/app/yjs/legacy/handlers/TrueFalseHandler.test.js
+++ b/public/app/yjs/legacy/handlers/TrueFalseHandler.test.js
@@ -2,6 +2,7 @@
  * TrueFalseHandler Tests
  *
  * Unit tests for TrueFalseHandler - handles TrueFalseIdevice.
+ * Updated to test game-compatible format output.
  */
 
 // Load BaseLegacyHandler first and make it global
@@ -52,8 +53,19 @@ describe('TrueFalseHandler', () => {
     });
   });
 
+  describe('getDefaultMessages', () => {
+    it('returns all required message keys', () => {
+      const msgs = handler.getDefaultMessages();
+      expect(msgs.msgStartGame).toBe('Click here to start');
+      expect(msgs.msgTrue).toBe('True');
+      expect(msgs.msgFalse).toBe('False');
+      expect(msgs.msgCheck).toBe('Check');
+      expect(msgs.msgReboot).toBe('Try again!');
+    });
+  });
+
   describe('extractProperties', () => {
-    it('extracts questionsData from dictionary', () => {
+    it('returns game-compatible format with typeGame and questionsGame', () => {
       const dict = parseDictionary(`
         <dictionary>
           <list>
@@ -74,22 +86,58 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const result = handler.extractProperties(dict);
+      const result = handler.extractProperties(dict, 'idevice-123');
 
-      expect(result.questionsData).toBeDefined();
-      expect(result.questionsData.length).toBe(1);
-      expect(result.questionsData[0].activityType).toBe('true-false');
+      expect(result.typeGame).toBe('TrueOrFalse');
+      expect(result.questionsGame).toBeDefined();
+      expect(result.questionsGame.length).toBe(1);
+      expect(result.id).toBe('idevice-123');
+      expect(result.ideviceId).toBe('idevice-123');
+    });
+
+    it('includes all required game properties', () => {
+      const dict = parseDictionary(`
+        <dictionary>
+          <list>
+            <instance class="exe.engine.truefalseidevice.TrueFalseQuestion">
+              <dictionary>
+                <string role="key" value="questionTextArea"></string>
+                <instance class="TextAreaField">
+                  <dictionary>
+                    <string role="key" value="content_w_resourcePaths"></string>
+                    <unicode value="${escapeXml('<p>Test</p>')}"></unicode>
+                  </dictionary>
+                </instance>
+                <string role="key" value="isCorrect"></string>
+                <bool value="1"></bool>
+              </dictionary>
+            </instance>
+          </list>
+        </dictionary>
+      `);
+
+      const result = handler.extractProperties(dict, 'idevice-456');
+
+      expect(result.msgs).toBeDefined();
+      expect(result.msgs.msgTrue).toBe('True');
+      expect(result.isScorm).toBe(0);
+      expect(result.repeatActivity).toBe(true);
+      expect(result.questionsRandom).toBe(false);
+      expect(result.percentageQuestions).toBe(100);
+      expect(result.isTest).toBe(false);
+      expect(result.time).toBe(0);
+      expect(result.evaluation).toBe(false);
     });
 
     it('returns empty object when no questions found', () => {
       const dict = parseDictionary('<dictionary></dictionary>');
-      const result = handler.extractProperties(dict);
+      const result = handler.extractProperties(dict, 'idevice-789');
       expect(result).toEqual({});
     });
   });
 
-  describe('extractQuestions', () => {
-    it('extracts true answer correctly', () => {
+  describe('extractQuestionsGame', () => {
+    it('extracts true answer correctly (solution=1)', () => {
       const dict = parseDictionary(`
         <dictionary>
           <list>
@@ -110,14 +158,14 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
+      const questions = handler.extractQuestionsGame(dict);
 
       expect(questions.length).toBe(1);
-      expect(questions[0].baseText).toBe('<p>Water is wet</p>');
-      expect(questions[0].answer).toBe('True');
+      expect(questions[0].question).toBe('<p>Water is wet</p>');
+      expect(questions[0].solution).toBe(1);
     });
 
-    it('extracts false answer correctly', () => {
+    it('extracts false answer correctly (solution=0)', () => {
       const dict = parseDictionary(`
         <dictionary>
           <list>
@@ -138,11 +186,11 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
-      expect(questions[0].answer).toBe('False');
+      const questions = handler.extractQuestionsGame(dict);
+      expect(questions[0].solution).toBe(0);
     });
 
-    it('extracts hint and feedback', () => {
+    it('extracts suggestion (from hint) and feedback', () => {
       const dict = parseDictionary(`
         <dictionary>
           <list>
@@ -177,9 +225,10 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
+      const questions = handler.extractQuestionsGame(dict);
 
-      expect(questions[0].hint).toBe('<p>This is a hint</p>');
+      // hint maps to suggestion in game format
+      expect(questions[0].suggestion).toBe('<p>This is a hint</p>');
       expect(questions[0].feedback).toBe('<p>This is feedback</p>');
     });
 
@@ -217,8 +266,10 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
+      const questions = handler.extractQuestionsGame(dict);
       expect(questions.length).toBe(2);
+      expect(questions[0].solution).toBe(1);
+      expect(questions[1].solution).toBe(0);
     });
 
     it('looks for questions in "questions" key', () => {
@@ -243,7 +294,7 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
+      const questions = handler.extractQuestionsGame(dict);
       expect(questions.length).toBe(1);
     });
 
@@ -261,7 +312,7 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const questions = handler.extractQuestions(dict);
+      const questions = handler.extractQuestionsGame(dict);
       expect(questions).toEqual([]);
     });
   });
@@ -290,13 +341,12 @@ describe('TrueFalseHandler', () => {
     });
 
     it('handles null dict', () => {
-      // Handler should check for null
       expect(handler.extractHtmlView(null)).toBe('');
     });
   });
 
-  describe('eXeFormInstructions in extractProperties', () => {
-    it('includes eXeFormInstructions when instructions are present', () => {
+  describe('eXeGameInstructions in extractProperties', () => {
+    it('includes eXeGameInstructions when instructions are present', () => {
       const dict = parseDictionary(`
         <dictionary>
           <string role="key" value="instructionsForLearners"></string>
@@ -324,14 +374,14 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const result = handler.extractProperties(dict);
+      const result = handler.extractProperties(dict, 'idevice-test');
 
-      expect(result.eXeFormInstructions).toBe('<p>Mark each statement as true or false</p>');
-      expect(result.questionsData).toBeDefined();
-      expect(result.questionsData.length).toBe(1);
+      expect(result.eXeGameInstructions).toBe('<p>Mark each statement as true or false</p>');
+      expect(result.questionsGame).toBeDefined();
+      expect(result.questionsGame.length).toBe(1);
     });
 
-    it('does not include eXeFormInstructions when no instructions', () => {
+    it('has empty eXeGameInstructions when no instructions', () => {
       const dict = parseDictionary(`
         <dictionary>
           <list>
@@ -352,10 +402,10 @@ describe('TrueFalseHandler', () => {
         </dictionary>
       `);
 
-      const result = handler.extractProperties(dict);
+      const result = handler.extractProperties(dict, 'idevice-test');
 
-      expect(result.eXeFormInstructions).toBeUndefined();
-      expect(result.questionsData).toBeDefined();
+      expect(result.eXeGameInstructions).toBe('');
+      expect(result.questionsGame).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
This pull request updates the handling and migration of legacy "True/False" iDevices to ensure compatibility with the modern game-based "trueorfalse" iDevice format. The changes standardize the data structure, improve message handling, and enhance test coverage for the conversion process.

**Legacy "True/False" iDevice migration and compatibility:**

* The legacy "True/False" iDevice is now converted to the modern "trueorfalse" iDevice using a game-compatible format, including all required fields for the renderer and matching the expected structure. (`public/app/yjs/legacy/handlers/TrueFalseHandler.js` [[1]](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL5-R5) [[2]](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL33-R127) [[3]](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL83-R150) [[4]](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL100-R186)
* The list of JSON-only iDevices was updated to include "trueorfalse" for proper rendering during legacy imports. (`public/app/common/exe_export.js` [public/app/common/exe_export.jsL245-R248](diffhunk://#diff-90a227cc7ffe728be7ae9d3aa0df9ec911c571b2c3ed1633b8f225136fa89ad0L245-R248))
* The handler registry now passes the iDevice ID to handlers, supporting the new format for "trueorfalse". (`public/app/yjs/LegacyXmlParser.js` [public/app/yjs/LegacyXmlParser.jsL1139-R1140](diffhunk://#diff-b3f7f21d4e433dbdea5065a308cd21bacfb6f7b2e691e8c1c789e7ad83c7f0eeL1139-R1140))

**Game format and messaging improvements:**

* The new handler outputs all required properties for the game, such as `typeGame`, `questionsGame`, `msgs` (with default messages), and other configuration fields. (`public/app/yjs/legacy/handlers/TrueFalseHandler.js` [public/app/yjs/legacy/handlers/TrueFalseHandler.jsL33-R127](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL33-R127))
* Default game messages are now provided in a dedicated method, ensuring consistency with the renderer. (`public/app/yjs/legacy/handlers/TrueFalseHandler.js` [public/app/yjs/legacy/handlers/TrueFalseHandler.jsL33-R127](diffhunk://#diff-bbb6225e57a29fd0fc13d97b63b0347b1ade5c012885395be6ab0cc6787db68cL33-R127))

**Testing enhancements:**

* Unit tests for `TrueFalseHandler` were updated and expanded to cover the new game-compatible output, message keys, question extraction, and edge cases. (`public/app/yjs/legacy/handlers/TrueFalseHandler.test.js` [[1]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322R5) [[2]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322R56-R68) [[3]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L77-R140) [[4]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L113-R168) [[5]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L141-R193) [[6]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L180-R231) [[7]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L220-R272) [[8]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L246-R297) [[9]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L264-R315) [[10]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L293-R349) [[11]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L327-R384) [[12]](diffhunk://#diff-a3ea6875a4df3892d7be618a771cb4b74e2003a2619f4df8152454e215afb322L355-R408)