### PR TITLE
Fix rubric idevice and add e2e test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,6 +499,107 @@ const previewPage = await popupPromise;
 await previewPage.waitForLoadState('networkidle');
 ```
 
+### Common E2E Workflows
+
+**1. Login Flow:**
+```javascript
+await page.goto('/login');
+await page.waitForLoadState('networkidle');
+await page.fill('input[type="email"]', 'user@exelearning.net');
+await page.fill('input[type="password"]', '1234');
+await page.click('button[type="submit"]');
+await page.waitForLoadState('networkidle');
+```
+
+**2. Create Project via API (faster than UI):**
+```javascript
+const response = await page.request.post('/api/project/create-quick', {
+    data: { title: 'My Test Project' }
+});
+const result = await response.json();
+const projectUuid = result.uuid;
+```
+
+**3. Navigate to Workarea and Wait for Initialization:**
+```javascript
+await page.goto(`/workarea?project=${projectUuid}`);
+await page.waitForLoadState('networkidle');
+
+// Wait for Yjs bridge initialization
+await page.waitForFunction(() => {
+    const app = window.eXeLearning?.app;
+    return app?.project?._yjsBridge !== undefined;
+}, { timeout: 30000 });
+
+// Wait for loading screen to disappear
+await page.waitForFunction(() => {
+    const loadScreen = document.querySelector('#load-screen-main');
+    return !loadScreen || loadScreen.getAttribute('data-visible') === 'false';
+}, { timeout: 15000 });
+```
+
+**4. Select a Page to Add iDevices (REQUIRED before adding any iDevice):**
+```javascript
+// Pages are inside nav-element nodes. Root node cannot have iDevices.
+// Must select a non-root page first:
+const pageNode = page.locator('.nav-element:not([nav-id="root"]) > .nav-element-text').first();
+await pageNode.scrollIntoViewIfNeeded();
+await pageNode.click({ force: true });
+await page.waitForTimeout(1500);
+
+// Wait for page content area to be ready (not showing project metadata)
+await page.waitForFunction(() => {
+    const nodeContent = document.querySelector('#node-content');
+    const metadata = document.querySelector('#properties-node-content-form');
+    return nodeContent && (!metadata || !metadata.closest('.show'));
+}, { timeout: 10000 }).catch(() => {});
+```
+
+**5. Expand iDevice Category and Add iDevice:**
+```javascript
+// Expand a category (e.g., Assessment)
+const category = page.locator('.idevice_category')
+    .filter({ has: page.locator('h3.idevice_category_name').filter({ hasText: /Assessment|Evaluación/i }) })
+    .first();
+if (await category.count() > 0) {
+    const isCollapsed = await category.evaluate(el => el.classList.contains('off'));
+    if (isCollapsed) {
+        await category.locator('.label').click();
+        await page.waitForTimeout(800);
+    }
+}
+
+// Click on an iDevice (e.g., rubric)
+const idevice = page.locator('.idevice_item[id="rubric"]').first();
+await idevice.scrollIntoViewIfNeeded();
+await idevice.click();
+
+// Wait for iDevice to appear in content area
+await page.locator('#node-content article .idevice_node.rubric').first().waitFor({ timeout: 15000 });
+```
+
+**6. Open Preview Panel (inline panel, not popup):**
+```javascript
+// Click preview button to open side panel
+await page.click('#head-bottom-preview');
+const previewPanel = page.locator('#previewsidenav');
+await previewPanel.waitFor({ state: 'visible', timeout: 15000 });
+
+// Access preview iframe content
+const iframe = page.frameLocator('#preview-iframe');
+await iframe.locator('article.spa-page.active').waitFor({ state: 'attached', timeout: 10000 });
+
+// Example: check content in preview
+const tableInPreview = iframe.locator('.exe-table');
+await expect(tableInPreview).toBeVisible();
+```
+
+**7. Save Project:**
+```javascript
+await page.click('#head-top-save-button');
+await page.waitForTimeout(2000); // Wait for save to complete
+```
+
 ### SPA Preview Navigation
 
 The preview is a Single Page Application. Navigation uses anchor links:

--- a/public/files/perm/idevices/base/rubric/edition/rubric.js
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.js
@@ -364,6 +364,27 @@ var $exeDevice = {
         eXe.app.alert(str);
     },
 
+    // Get translated string at runtime (when translations are loaded)
+    // This is needed because ci18n is initialized at load time when translations may not be ready
+    // Uses _() (GUI translations) instead of c_() because c_strings may not be loaded yet
+    getTranslatedString: function (key) {
+        var strings = {
+            activity: 'Activity',
+            name: 'Name',
+            date: 'Date',
+            score: 'Score',
+            notes: 'Notes',
+            reset: 'Reset',
+            print: 'Print',
+            apply: 'Apply',
+            newWindow: 'New Window',
+        };
+        if (strings[key]) {
+            return _(strings[key]);
+        }
+        return key;
+    },
+
     // Get a list of the available rubrics (only one for the moment, that's why there's just a "New rubric" button)
     getRubricModels: function () {
         var html = '';
@@ -573,11 +594,38 @@ var $exeDevice = {
                 info += '</p>';
             }
 
-            // Custom texts
+            // Custom texts - get fresh translations or custom values from form
+            // English defaults (for comparison to detect customization)
+            var englishDefaults = {
+                activity: 'Activity',
+                name: 'Name',
+                date: 'Date',
+                score: 'Score',
+                notes: 'Notes',
+                reset: 'Reset',
+                print: 'Print',
+                apply: 'Apply',
+                newWindow: 'New Window',
+            };
             var lang = '<ul class="exe-rubrics-strings">';
             for (var i in $exeDevice.ci18n) {
+                var customField = $('#ci18n_' + i);
+                var translatedValue = $exeDevice.getTranslatedString(i);
+                var value;
+                if (customField.length === 1 && customField.val() !== '') {
+                    var fieldValue = customField.val();
+                    // Use custom value only if it differs from both English default AND current translation
+                    // This ensures we use translated values when user hasn't customized
+                    if (fieldValue !== englishDefaults[i] && fieldValue !== translatedValue) {
+                        value = fieldValue;
+                    } else {
+                        value = translatedValue;
+                    }
+                } else {
+                    value = translatedValue;
+                }
                 lang +=
-                    '<li class="' + i + '">' + $exeDevice.ci18n[i] + '</li>';
+                    '<li class="' + i + '">' + value + '</li>';
             }
             lang += '</ul>';
 
@@ -880,17 +928,8 @@ var $exeDevice = {
         var license = $('#ri_RubricLicense').val();
         if (license != '') data.license = license;
 
-        // Get the custom strings
-        data.i18n = this.ci18n;
-        var strings = data.i18n;
-        for (var i in strings) {
-            var field = $('#ci18n_' + i);
-            var v = field.val();
-            data.i18n[i] = strings[i][1];
-            if (field.length == 1 && v != '') {
-                data.i18n[i] = v;
-            }
-        }
+        // Note: Custom strings (i18n) are now handled directly in jsonToTable('normal')
+        // by reading from the form fields at save time
 
         // Return the HTML to save
         return this.jsonToTable(data, 'normal');

--- a/public/files/perm/idevices/base/rubric/export/rubric.js
+++ b/public/files/perm/idevices/base/rubric/export/rubric.js
@@ -169,13 +169,24 @@ var $rubric = {
         if (window.location.host == 'localhost:41309') {
             return false; // To review (Electron)
         }
-        var isIndex = $('html').attr('id') == 'exe-index';
-        var basePath = 'idevices/rubric/';
-        if (!isIndex) basePath = '../' + basePath;
-        var rubricStyle = basePath + 'rubric.css';
-        var rubricScript = basePath + 'rubric.js';
-        var jqueryScript = 'libs/jquery/jquery.min.js';
-        if (!isIndex) jqueryScript = '../' + jqueryScript;
+        var rubricStyle, rubricScript, jqueryScript;
+        var isBlob = window.location.protocol === 'blob:';
+        if (isBlob) {
+            // Preview mode: use absolute paths to server assets
+            var origin = window.location.origin.replace('blob:', '');
+            rubricStyle = origin + '/files/perm/idevices/base/rubric/export/rubric.css';
+            rubricScript = origin + '/files/perm/idevices/base/rubric/export/rubric.js';
+            jqueryScript = origin + '/libs/jquery/jquery.min.js';
+        } else {
+            // Export mode: use relative paths
+            var isIndex = $('html').attr('id') == 'exe-index';
+            var basePath = 'idevices/rubric/';
+            if (!isIndex) basePath = '../' + basePath;
+            rubricStyle = basePath + 'rubric.css';
+            rubricScript = basePath + 'rubric.js';
+            jqueryScript = 'libs/jquery/jquery.min.js';
+            if (!isIndex) jqueryScript = '../' + jqueryScript;
+        }
         // Strings
         var i18n = this.ci18n;
         var a = window.open(tit);

--- a/test/e2e/playwright/specs/idevices/rubric.spec.ts
+++ b/test/e2e/playwright/specs/idevices/rubric.spec.ts
@@ -1,0 +1,411 @@
+import { test, expect, waitForLoadingScreenHidden } from '../../fixtures/auth.fixture';
+import { WorkareaPage } from '../../pages/workarea.page';
+import type { Page } from '@playwright/test';
+
+/**
+ * E2E Tests for Rubric iDevice
+ *
+ * Tests the Rubric iDevice functionality including:
+ * - Basic operations (add, create new rubric, edit, save)
+ * - Editing rubric content (title, criteria, levels, descriptors, weights)
+ * - Persistence after reload
+ * - Preview rendering with Apply button
+ */
+
+const TEST_DATA = {
+    projectTitle: 'Rubric E2E Test Project',
+    rubricTitle: 'E2E Test Rubric',
+    editedDescriptor: 'E2E edited descriptor content',
+    weight: '5',
+};
+
+/**
+ * Helper to add a Rubric iDevice by selecting the page and clicking the iDevice
+ */
+async function addRubricIdeviceFromPanel(page: Page): Promise<void> {
+    // First, select a page in the navigation tree
+    const pageNodeSelectors = [
+        '.nav-element-text:has-text("New page")',
+        '.nav-element-text:has-text("Nueva página")',
+        '[data-testid="nav-node-text"]',
+        '.structure-tree li .nav-element-text',
+    ];
+
+    let pageSelected = false;
+    for (const selector of pageNodeSelectors) {
+        const element = page.locator(selector).first();
+        if ((await element.count()) > 0) {
+            try {
+                await element.click({ force: true, timeout: 5000 });
+                pageSelected = true;
+                break;
+            } catch {
+                // Try next selector
+            }
+        }
+    }
+
+    if (!pageSelected) {
+        const treeItem = page.locator('#menu_structure .structure-tree li').first();
+        if ((await treeItem.count()) > 0) {
+            await treeItem.click({ force: true });
+        }
+    }
+
+    // Wait for the page content area to switch from metadata to page editor
+    await page.waitForTimeout(1000);
+
+    // Wait for node-content to show page content (not project metadata)
+    await page
+        .waitForFunction(
+            () => {
+                const nodeContent = document.querySelector('#node-content');
+                const metadata = document.querySelector('#properties-node-content-form');
+                return nodeContent && (!metadata || !metadata.closest('.show'));
+            },
+            { timeout: 10000 },
+        )
+        .catch(() => {
+            // Continue anyway
+        });
+
+    // Expand "Assessment and tracking" category in iDevices panel
+    const assessmentCategory = page
+        .locator('.idevice_category')
+        .filter({
+            has: page.locator('h3.idevice_category_name').filter({ hasText: /Assessment|Evaluación/i }),
+        })
+        .first();
+
+    if ((await assessmentCategory.count()) > 0) {
+        // Check if category is collapsed (has "off" class)
+        const isCollapsed = await assessmentCategory.evaluate(el => el.classList.contains('off'));
+        if (isCollapsed) {
+            // Click on the .label to expand
+            const label = assessmentCategory.locator('.label');
+            await label.click();
+            await page.waitForTimeout(800);
+        }
+    }
+
+    // Wait for the category content to be visible
+    await page.waitForTimeout(500);
+
+    // Find the Rubric iDevice
+    const rubricIdevice = page.locator('.idevice_item[id="rubric"], [data-testid="idevice-rubric"]').first();
+
+    // Wait for it to be visible and then click
+    await rubricIdevice.waitFor({ state: 'visible', timeout: 10000 });
+    await rubricIdevice.click();
+
+    // Wait for iDevice to appear in content area
+    await page.locator('#node-content article .idevice_node.rubric').first().waitFor({ timeout: 15000 });
+}
+
+/**
+ * Helper to create a new rubric by clicking the "New rubric" button
+ */
+async function createNewRubric(page: Page): Promise<void> {
+    // Click the "New rubric" button
+    const newRubricBtn = page.locator('#ri_CreateNewRubric');
+    await newRubricBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await newRubricBtn.click();
+
+    // Wait for the rubric table editor to appear
+    await page.locator('#ri_Table').waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/**
+ * Helper to edit rubric content
+ *
+ * Cell ID mapping for a 4x4 rubric:
+ * - #ri_Cell-0 = caption (title)
+ * - #ri_Cell-1 = empty thead th (top-left corner)
+ * - #ri_Cell-2 to #ri_Cell-5 = level headers (Level 1-4)
+ * - #ri_Cell-6 = first criteria TH (row 1)
+ * - #ri_Cell-7 to #ri_Cell-10 = first row descriptors (TDs with weights)
+ * - #ri_Cell-7-weight = weight for first descriptor
+ */
+async function editRubricContent(page: Page, title: string, descriptor?: string, weight?: string): Promise<void> {
+    // Edit the title (caption) - #ri_Cell-0
+    const titleInput = page.locator('#ri_Cell-0');
+    await titleInput.waitFor({ state: 'visible', timeout: 5000 });
+    await titleInput.clear();
+    await titleInput.fill(title);
+
+    // Optionally edit a descriptor cell (#ri_Cell-7 is first descriptor TD in row 1)
+    if (descriptor) {
+        const descriptorInput = page.locator('#ri_Cell-7');
+        if ((await descriptorInput.count()) > 0) {
+            await descriptorInput.clear();
+            await descriptorInput.fill(descriptor);
+        }
+    }
+
+    // Optionally edit a weight value (#ri_Cell-7-weight is weight for first descriptor)
+    if (weight) {
+        const weightInput = page.locator('#ri_Cell-7-weight');
+        if ((await weightInput.count()) > 0) {
+            await weightInput.clear();
+            await weightInput.fill(weight);
+        }
+    }
+}
+
+/**
+ * Helper to save the rubric iDevice
+ */
+async function saveRubricIdevice(page: Page): Promise<void> {
+    // Find and click the Save button
+    const saveBtn = page
+        .locator('#node-content article .idevice_node.rubric button')
+        .filter({ hasText: /^Save$|^Guardar$/i })
+        .first();
+    await saveBtn.click();
+
+    // Wait for edition mode to end (table should be normal, not editable)
+    await page.waitForFunction(
+        () => {
+            // The editable table has input fields; after save, it should be a normal table
+            const editableInputs = document.querySelectorAll('#ri_Table input');
+            const normalTable = document.querySelector('#node-content .rubric .exe-table');
+            return editableInputs.length === 0 && normalTable !== null;
+        },
+        { timeout: 15000 },
+    );
+}
+
+test.describe('Rubric iDevice', () => {
+    test.describe('Basic Operations', () => {
+        test('should add rubric iDevice and create new rubric', async ({ authenticatedPage, createProject }) => {
+            const page = authenticatedPage;
+
+            // Create a new project
+            const projectUuid = await createProject(page, 'Rubric Add Test');
+            await page.goto(`/workarea?project=${projectUuid}`);
+            await page.waitForLoadState('networkidle');
+
+            // Wait for app initialization
+            await page.waitForFunction(
+                () => {
+                    const app = (window as any).eXeLearning?.app;
+                    return app?.project?._yjsBridge !== undefined;
+                },
+                { timeout: 30000 },
+            );
+
+            await waitForLoadingScreenHidden(page);
+
+            // Add a rubric iDevice
+            await addRubricIdeviceFromPanel(page);
+
+            // Verify iDevice was added
+            const rubricIdevice = page.locator('#node-content article .idevice_node.rubric').first();
+            await expect(rubricIdevice).toBeVisible({ timeout: 10000 });
+
+            // Create a new rubric
+            await createNewRubric(page);
+
+            // Verify the rubric table editor appeared with default 4x4 structure
+            const rubricTable = page.locator('#ri_Table');
+            await expect(rubricTable).toBeVisible({ timeout: 10000 });
+
+            // Verify it has the expected structure (4 levels in thead + empty th)
+            const theadThs = page.locator('#ri_Table thead th');
+            await expect(theadThs).toHaveCount(5, { timeout: 5000 }); // 1 empty + 4 levels
+
+            // Verify it has 4 criteria rows
+            const tbodyTrs = page.locator('#ri_Table tbody tr');
+            await expect(tbodyTrs).toHaveCount(4, { timeout: 5000 });
+        });
+
+        test('should edit rubric content and save', async ({ authenticatedPage, createProject }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Edit Test');
+            await page.goto(`/workarea?project=${projectUuid}`);
+            await page.waitForLoadState('networkidle');
+
+            await page.waitForFunction(
+                () => {
+                    const app = (window as any).eXeLearning?.app;
+                    return app?.project?._yjsBridge !== undefined;
+                },
+                { timeout: 30000 },
+            );
+
+            await waitForLoadingScreenHidden(page);
+
+            // Add a rubric iDevice and create new rubric
+            await addRubricIdeviceFromPanel(page);
+            await createNewRubric(page);
+
+            // Edit the rubric content
+            await editRubricContent(page, TEST_DATA.rubricTitle, TEST_DATA.editedDescriptor, TEST_DATA.weight);
+
+            // Save the iDevice
+            await saveRubricIdevice(page);
+
+            // Verify the rubric displays correctly after save
+            const rubricTable = page.locator('#node-content .rubric .exe-table');
+            await expect(rubricTable).toBeVisible({ timeout: 10000 });
+
+            // Verify the title is displayed in the caption
+            const caption = page.locator('#node-content .rubric .exe-table caption');
+            await expect(caption).toContainText(TEST_DATA.rubricTitle, { timeout: 5000 });
+
+            // Verify the edited descriptor is visible
+            await expect(page.locator('#node-content .rubric')).toContainText(TEST_DATA.editedDescriptor, {
+                timeout: 5000,
+            });
+
+            // Verify the weight is displayed (format: "text (weight)")
+            await expect(page.locator('#node-content .rubric')).toContainText(`(${TEST_DATA.weight})`, {
+                timeout: 5000,
+            });
+        });
+
+        test('should persist rubric after reload', async ({ authenticatedPage, createProject }) => {
+            const page = authenticatedPage;
+            const workarea = new WorkareaPage(page);
+
+            const projectUuid = await createProject(page, 'Rubric Persistence Test');
+            await page.goto(`/workarea?project=${projectUuid}`);
+            await page.waitForLoadState('networkidle');
+
+            await page.waitForFunction(
+                () => {
+                    const app = (window as any).eXeLearning?.app;
+                    return app?.project?._yjsBridge !== undefined;
+                },
+                { timeout: 30000 },
+            );
+
+            await waitForLoadingScreenHidden(page);
+
+            // Add, create and edit rubric
+            await addRubricIdeviceFromPanel(page);
+            await createNewRubric(page);
+
+            const uniqueTitle = `Persistence Test Rubric ${Date.now()}`;
+            await editRubricContent(page, uniqueTitle);
+            await saveRubricIdevice(page);
+
+            // Save the project
+            await workarea.save();
+            await page.waitForTimeout(1000);
+
+            // Reload the page
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+
+            await page.waitForFunction(
+                () => {
+                    const app = (window as any).eXeLearning?.app;
+                    return app?.project?._yjsBridge !== undefined;
+                },
+                { timeout: 30000 },
+            );
+
+            await waitForLoadingScreenHidden(page);
+
+            // Navigate to the page
+            const pageNode = page
+                .locator('.nav-element-text')
+                .filter({ hasText: /New page|Nueva página/i })
+                .first();
+            if ((await pageNode.count()) > 0) {
+                await pageNode.click({ force: true, timeout: 5000 });
+                await page.waitForTimeout(1000);
+            }
+
+            // Verify rubric content persisted
+            await expect(page.locator('#node-content .rubric')).toContainText(uniqueTitle, { timeout: 15000 });
+
+            // Verify the table structure is intact
+            const rubricTable = page.locator('#node-content .rubric .exe-table');
+            await expect(rubricTable).toBeVisible({ timeout: 10000 });
+        });
+    });
+
+    test.describe('Preview', () => {
+        test('should display rubric table correctly in preview with Apply button', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+            const workarea = new WorkareaPage(page);
+
+            const projectUuid = await createProject(page, 'Rubric Preview Test');
+            await page.goto(`/workarea?project=${projectUuid}`);
+            await page.waitForLoadState('networkidle');
+
+            await page.waitForFunction(
+                () => {
+                    const app = (window as any).eXeLearning?.app;
+                    return app?.project?._yjsBridge !== undefined;
+                },
+                { timeout: 30000 },
+            );
+
+            await waitForLoadingScreenHidden(page);
+
+            // Add, create and edit rubric
+            await addRubricIdeviceFromPanel(page);
+            await createNewRubric(page);
+
+            const previewTitle = `Preview Test Rubric ${Date.now()}`;
+            await editRubricContent(page, previewTitle, 'Preview descriptor', '3');
+            await saveRubricIdevice(page);
+
+            // Save project
+            await workarea.save();
+            await page.waitForTimeout(1000);
+
+            // Open preview panel
+            await page.click('#head-bottom-preview');
+            const previewPanel = page.locator('#previewsidenav');
+            await expect(previewPanel).toBeVisible({ timeout: 15000 });
+
+            // Access preview iframe
+            const iframe = page.frameLocator('#preview-iframe');
+
+            // Wait for page to load
+            await iframe.locator('article.spa-page.active').waitFor({ state: 'attached', timeout: 10000 });
+
+            // Verify the rubric table is displayed
+            const rubricTable = iframe.locator('.rubric .exe-table, .idevice_node.rubric .exe-table');
+            await expect(rubricTable).toBeVisible({ timeout: 10000 });
+
+            // Verify the title/caption is correct
+            const caption = iframe.locator('.rubric .exe-table caption, .idevice_node.rubric .exe-table caption');
+            await expect(caption).toContainText(previewTitle, { timeout: 5000 });
+
+            // Verify the "Apply" button is present
+            const applyButton = iframe.locator('a.exe-rubrics-print');
+            await expect(applyButton).toBeVisible({ timeout: 10000 });
+            await expect(applyButton).toContainText(/Apply|Aplicar/i, { timeout: 5000 });
+
+            // Verify the edited descriptor is visible
+            await expect(iframe.locator('.rubric, .idevice_node.rubric')).toContainText('Preview descriptor', {
+                timeout: 5000,
+            });
+
+            // Verify the weight is displayed
+            await expect(iframe.locator('.rubric, .idevice_node.rubric')).toContainText('(3)', { timeout: 5000 });
+
+            // Verify the .exe-rubrics-strings list is present (needed for Apply popup i18n)
+            const rubricStrings = iframe.locator(
+                '.rubric .exe-rubrics-strings, .idevice_node.rubric .exe-rubrics-strings',
+            );
+            await expect(rubricStrings).toBeAttached({ timeout: 5000 });
+
+            // Verify the strings list contains the expected i18n keys
+            await expect(rubricStrings.locator('li.activity')).toBeAttached({ timeout: 2000 });
+            await expect(rubricStrings.locator('li.name')).toBeAttached({ timeout: 2000 });
+            await expect(rubricStrings.locator('li.date')).toBeAttached({ timeout: 2000 });
+            await expect(rubricStrings.locator('li.score')).toBeAttached({ timeout: 2000 });
+            await expect(rubricStrings.locator('li.apply')).toBeAttached({ timeout: 2000 });
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces improvements to the rubric iDevice's internationalization (i18n) handling, enhances E2E testing documentation, and fixes asset path resolution for rubric exports in preview mode. The main changes focus on ensuring that translated and custom strings are handled correctly at runtime, providing clearer E2E test workflow documentation, and making rubric exports work reliably in both preview and export contexts.

**Rubric iDevice Internationalization Improvements:**

* Added a `getTranslatedString` method to dynamically fetch translations for rubric labels at runtime, ensuring correct translations are used even if the translation files are loaded after initialization.
* Improved custom string handling in the rubric editor: now, when displaying or saving custom i18n fields, the code checks if the user-provided value actually differs from both the English default and the current translation, preventing unnecessary overrides and ensuring the correct value is shown.
* Refactored the rubric save logic so that custom i18n strings are handled directly in the `jsonToTable('normal')` method, simplifying the save process and reducing redundancy.

**E2E Testing Documentation:**

* Added a comprehensive "Common E2E Workflows" section to `CLAUDE.md`, detailing step-by-step Playwright scripts for login, project creation, workarea navigation, iDevice insertion, previewing, and saving, to aid in writing robust automated tests.

**Rubric Export Asset Path Fixes:**

* Updated the rubric export logic to correctly resolve asset paths when running in preview mode (served from a `blob:` URL), using absolute paths to server assets, while maintaining relative paths for standard export mode.