### PR TITLE
Better openfile options to delete all projects

### DIFF
--- a/assets/styles/components/_modals.scss
+++ b/assets/styles/components/_modals.scss
@@ -1614,16 +1614,37 @@
                         }
                     }
                     .ode-filter-wrap {
-                        width: 35%;
-                        position: relative;
-                        .ode-search-field {
-                            height: 20px;
-                            width: 20px;
-                            position: absolute;
-                            top: 8px;
-                            left: 10px;
-                            pointer-events: none;
+                        width: 45%;
+                        display: flex;
+                        align-items: center;
+                        gap: 12px;
+
+                        .ode-select-all-wrap {
+                            display: flex;
+                            align-items: center;
+                            flex-shrink: 0;
+
+                            .ode-select-all-checkbox {
+                                width: 16px;
+                                height: 16px;
+                                cursor: pointer;
+                                accent-color: var(--brand-primary-400, #0BA1A1);
+                            }
                         }
+
+                        .ode-search-field {
+                            position: relative;
+                            flex: 1;
+
+                            .search-icon {
+                                position: absolute;
+                                top: 50%;
+                                left: 10px;
+                                transform: translateY(-50%);
+                                pointer-events: none;
+                            }
+                        }
+
                         .ode-filter-input {
                             padding-inline-start: 40px;
                             width: 100%;

--- a/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
@@ -232,6 +232,23 @@ export default class modalOpenUserOdeFiles extends Modal {
             tab.classList.toggle('active', tab.getAttribute('data-tab') === tabName);
         });
 
+        // Show/hide Select All checkbox based on tab
+        const selectAllWrap = this.modalElementBodyContent.querySelector('.ode-select-all-wrap');
+        if (selectAllWrap) {
+            selectAllWrap.style.display = tabName === 'my-projects' ? 'flex' : 'none';
+        }
+
+        // Reset Select All checkbox state
+        const selectAllCheckbox = this.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+        if (selectAllCheckbox) {
+            selectAllCheckbox.checked = false;
+            selectAllCheckbox.indeterminate = false;
+        }
+
+        // Clear selection when switching tabs
+        this.odeFiles = [];
+        this.removeDeleteButtonFooter(this.odeFiles);
+
         // Remove existing list container
         const existingList = this.modalElementBodyContent.querySelector('.ode-files-list-container');
         if (existingList) {
@@ -377,11 +394,13 @@ export default class modalOpenUserOdeFiles extends Modal {
             const projectUuid = ode.odeId;
             if (check.checked) {
                 if (!this.odeFiles.includes(projectUuid)) this.odeFiles.push(projectUuid);
-                this.makeDeleteButtonFooter(this.odeFiles);
             } else {
                 this.odeFiles = this.odeFiles.filter((id) => id !== projectUuid);
-                this.removeDeleteButtonFooter(this.odeFiles);
             }
+            // Update button state based on selection
+            this.updateDeleteButtonState();
+            // Update the Select All checkbox state
+            this.updateSelectAllCheckbox();
         });
 
         let label = document.createElement('label');
@@ -547,6 +566,22 @@ export default class modalOpenUserOdeFiles extends Modal {
     makeFilterForList(selector, placeholder) {
         const wrap = document.createElement('div');
         wrap.classList.add('ode-filter-wrap');
+
+        // Select All checkbox (only visible for "My Projects" tab)
+        const selectAllWrap = document.createElement('div');
+        selectAllWrap.classList.add('ode-select-all-wrap');
+        selectAllWrap.style.display = this.currentTab === 'my-projects' ? 'flex' : 'none';
+
+        const selectAllCheckbox = document.createElement('input');
+        selectAllCheckbox.type = 'checkbox';
+        selectAllCheckbox.id = 'ode-select-all-checkbox';
+        selectAllCheckbox.classList.add('ode-select-all-checkbox');
+        selectAllCheckbox.title = _('Select all');
+        selectAllCheckbox.setAttribute('aria-label', _('Select all'));
+        selectAllCheckbox.addEventListener('change', () => this.toggleSelectAll(selectAllCheckbox.checked));
+
+        selectAllWrap.append(selectAllCheckbox);
+        wrap.append(selectAllWrap);
 
         const input = document.createElement('input');
         input.type = 'text';
@@ -772,6 +807,74 @@ export default class modalOpenUserOdeFiles extends Modal {
     }
 
     /**
+     * Toggle selection of all projects in the current tab
+     * Only works for "My Projects" tab (owned projects)
+     * @param {boolean} checked - Whether to select or deselect all
+     */
+    toggleSelectAll(checked) {
+        // Only allow selection in "My Projects" tab
+        if (this.currentTab !== 'my-projects') {
+            return;
+        }
+
+        const checkboxes = this.modalElementBodyContent.querySelectorAll(
+            '.ode-files-list .ode-row.principal-version .ode-check'
+        );
+
+        this.odeFiles = [];
+
+        checkboxes.forEach((checkbox) => {
+            checkbox.checked = checked;
+            if (checked) {
+                const row = checkbox.closest('.ode-row');
+                const projectUuid = row?.getAttribute('ode-id');
+                if (projectUuid && !this.odeFiles.includes(projectUuid)) {
+                    this.odeFiles.push(projectUuid);
+                }
+            }
+        });
+
+        // Update button state
+        this.updateDeleteButtonState();
+    }
+
+    /**
+     * Update the delete/open button state based on current selection
+     * This ensures the button always reflects the current odeFiles array
+     */
+    updateDeleteButtonState() {
+        if (this.odeFiles.length > 0) {
+            this.makeDeleteButtonFooter([...this.odeFiles]); // Pass a copy to avoid reference issues
+        } else {
+            this.removeDeleteButtonFooter(this.odeFiles);
+        }
+    }
+
+    /**
+     * Update the Select All checkbox state based on individual selections
+     */
+    updateSelectAllCheckbox() {
+        const selectAllCheckbox = this.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+        if (!selectAllCheckbox) return;
+
+        const checkboxes = this.modalElementBodyContent.querySelectorAll(
+            '.ode-files-list .ode-row.principal-version .ode-check'
+        );
+        const checkedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
+
+        if (checkedCount === 0) {
+            selectAllCheckbox.checked = false;
+            selectAllCheckbox.indeterminate = false;
+        } else if (checkedCount === checkboxes.length) {
+            selectAllCheckbox.checked = true;
+            selectAllCheckbox.indeterminate = false;
+        } else {
+            selectAllCheckbox.checked = false;
+            selectAllCheckbox.indeterminate = true;
+        }
+    }
+
+    /**
      * Select a project in the list by its UUID
      * @param {string} projectUuid - The project UUID to select
      */
@@ -982,14 +1085,48 @@ export default class modalOpenUserOdeFiles extends Modal {
     }
 
     makeDeleteButtonFooter(odeFiles) {
-        this.confirmButton.innerHTML = 'Delete';
-        this.setConfirmExec(() => this.massiveDeleteOdeFileEvent(odeFiles));
+        this.confirmButton.innerHTML = _('Delete');
+        this.confirmButton.disabled = false;
+        this.confirmButton.classList.remove('disabled');
+        this.setConfirmExec(() => this.showMassDeleteConfirmation(odeFiles));
+    }
+
+    /**
+     * Show confirmation dialog before mass deleting projects
+     * @param {string[]} projectUuids - Array of project UUIDs to delete
+     */
+    showMassDeleteConfirmation(projectUuids) {
+        const count = projectUuids.length;
+        const message = count === 1
+            ? _('Are you sure you want to delete this project?')
+            : _('Are you sure you want to delete %s projects?').replace('%s', count);
+
+        eXeLearning.app.modals.confirm.show({
+            title: _('Delete projects'),
+            body: `<p>${message}</p><p class="text-danger"><strong>${_('This action cannot be undone.')}</strong></p>`,
+            confirmExec: async () => {
+                await this.massiveDeleteOdeFileEvent(projectUuids);
+                // Reset Select All checkbox after deletion
+                const selectAllCheckbox = this.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+                if (selectAllCheckbox) {
+                    selectAllCheckbox.checked = false;
+                    selectAllCheckbox.indeterminate = false;
+                }
+            },
+            confirmLabel: _('Delete'),
+            confirmClass: 'btn-danger',
+        });
     }
 
     removeDeleteButtonFooter(odeFiles) {
         if (odeFiles.length === 0) {
             this.confirmButton.innerHTML = _('Open');
             this.setConfirmExec(() => this.openSelectedOdeFile());
+            // Disable the button if no project is selected for opening
+            if (!this.selectedProjectUuid) {
+                this.confirmButton.disabled = true;
+                this.confirmButton.classList.add('disabled');
+            }
         }
     }
 

--- a/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.test.js
+++ b/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.test.js
@@ -791,19 +791,466 @@ describe('modalOpenUserOdeFiles', () => {
   });
 
   describe('makeDeleteButtonFooter', () => {
-    it('should set delete mode and wire confirm', () => {
+    it('should set delete mode, enable button, and wire confirm to show confirmation', () => {
       const confirmSpy = vi.spyOn(modal, 'setConfirmExec');
+      modal.confirmButton.disabled = true;
+      modal.confirmButton.classList.add('disabled');
+
       modal.makeDeleteButtonFooter(['a']);
+
       expect(modal.confirmButton.textContent).toBe('Delete');
+      expect(modal.confirmButton.disabled).toBe(false);
+      expect(modal.confirmButton.classList.contains('disabled')).toBe(false);
       expect(confirmSpy).toHaveBeenCalled();
     });
   });
 
+  describe('showMassDeleteConfirmation', () => {
+    it('should show confirm modal with single project message', () => {
+      modal.showMassDeleteConfirmation(['proj-1']);
+      expect(window.eXeLearning.app.modals.confirm.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Delete projects',
+          confirmLabel: 'Delete',
+          confirmClass: 'btn-danger',
+        })
+      );
+    });
+
+    it('should show confirm modal with multiple projects message', () => {
+      modal.showMassDeleteConfirmation(['proj-1', 'proj-2', 'proj-3']);
+      expect(window.eXeLearning.app.modals.confirm.show).toHaveBeenCalled();
+      const call = window.eXeLearning.app.modals.confirm.show.mock.calls[0][0];
+      expect(call.body).toContain('3');
+    });
+
+    it('should call massiveDeleteOdeFileEvent on confirm', async () => {
+      const deleteSpy = vi.spyOn(modal, 'massiveDeleteOdeFileEvent').mockResolvedValue();
+      let confirmCallback;
+      window.eXeLearning.app.modals.confirm.show.mockImplementation(({ confirmExec }) => {
+        confirmCallback = confirmExec;
+      });
+
+      modal.showMassDeleteConfirmation(['proj-1']);
+      await confirmCallback();
+
+      expect(deleteSpy).toHaveBeenCalledWith(['proj-1']);
+    });
+  });
+
+  describe('updateDeleteButtonState', () => {
+    it('should call makeDeleteButtonFooter when odeFiles is not empty', () => {
+      const makeSpy = vi.spyOn(modal, 'makeDeleteButtonFooter');
+      modal.odeFiles = ['a', 'b'];
+      modal.updateDeleteButtonState();
+      expect(makeSpy).toHaveBeenCalledWith(['a', 'b']);
+    });
+
+    it('should call removeDeleteButtonFooter when odeFiles is empty', () => {
+      const removeSpy = vi.spyOn(modal, 'removeDeleteButtonFooter');
+      modal.odeFiles = [];
+      modal.updateDeleteButtonState();
+      expect(removeSpy).toHaveBeenCalledWith([]);
+    });
+
+    it('should pass a copy of odeFiles to avoid reference issues', () => {
+      const makeSpy = vi.spyOn(modal, 'makeDeleteButtonFooter');
+      modal.odeFiles = ['a', 'b'];
+      modal.updateDeleteButtonState();
+
+      // Verify it was called with a different array (copy)
+      const passedArray = makeSpy.mock.calls[0][0];
+      expect(passedArray).toEqual(['a', 'b']);
+      expect(passedArray).not.toBe(modal.odeFiles); // Should be a different reference
+    });
+
+    it('should update delete button with correct list after deselecting one item', () => {
+      // Setup: render projects
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project A',
+            fileName: 'a.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          b1: {
+            odeId: 'b',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project B',
+            fileName: 'b.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          c1: {
+            odeId: 'c',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project C',
+            fileName: 'c.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      // Spy on makeDeleteButtonFooter to capture the arrays passed
+      const makeSpy = vi.spyOn(modal, 'makeDeleteButtonFooter');
+
+      // Select all (3 projects)
+      modal.toggleSelectAll(true);
+      expect(modal.odeFiles.length).toBe(3);
+
+      // Verify makeDeleteButtonFooter was called with all 3 projects
+      expect(makeSpy).toHaveBeenLastCalledWith(expect.arrayContaining(['a', 'b', 'c']));
+
+      // Manually deselect one checkbox
+      const checkboxB = modal.modalElementBodyContent.querySelector('#check-b');
+      checkboxB.checked = false;
+      checkboxB.dispatchEvent(new Event('change'));
+
+      // Should now have only 2 projects
+      expect(modal.odeFiles.length).toBe(2);
+      expect(modal.odeFiles).toContain('a');
+      expect(modal.odeFiles).toContain('c');
+      expect(modal.odeFiles).not.toContain('b');
+
+      // Verify makeDeleteButtonFooter was called again with only 2 projects
+      const lastCall = makeSpy.mock.calls[makeSpy.mock.calls.length - 1][0];
+      expect(lastCall).toHaveLength(2);
+      expect(lastCall).toContain('a');
+      expect(lastCall).toContain('c');
+      expect(lastCall).not.toContain('b');
+    });
+  });
+
+  describe('toggleSelectAll', () => {
+    it('should check all project checkboxes when called with true', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project A',
+            fileName: 'a.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          b1: {
+            odeId: 'b',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project B',
+            fileName: 'b.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      modal.toggleSelectAll(true);
+
+      const checkboxes = modal.modalElementBodyContent.querySelectorAll('.ode-check');
+      checkboxes.forEach((cb) => {
+        expect(cb.checked).toBe(true);
+      });
+      expect(modal.odeFiles).toContain('a');
+      expect(modal.odeFiles).toContain('b');
+    });
+
+    it('should uncheck all project checkboxes when called with false', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project A',
+            fileName: 'a.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      modal.toggleSelectAll(true);
+      modal.toggleSelectAll(false);
+
+      const checkboxes = modal.modalElementBodyContent.querySelectorAll('.ode-check');
+      checkboxes.forEach((cb) => {
+        expect(cb.checked).toBe(false);
+      });
+      expect(modal.odeFiles).toEqual([]);
+    });
+
+    it('should do nothing for shared-with-me tab', () => {
+      modal.currentTab = 'shared-with-me';
+      modal.odeFiles = [];
+      modal.toggleSelectAll(true);
+      expect(modal.odeFiles).toEqual([]);
+    });
+  });
+
+  describe('updateSelectAllCheckbox', () => {
+    it('should set indeterminate when some are selected', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project A',
+            fileName: 'a.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          b1: {
+            odeId: 'b',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project B',
+            fileName: 'b.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      // Check only one checkbox
+      const firstCheckbox = modal.modalElementBodyContent.querySelector('.ode-check');
+      firstCheckbox.checked = true;
+      firstCheckbox.dispatchEvent(new Event('change'));
+
+      const selectAll = modal.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+      expect(selectAll.indeterminate).toBe(true);
+    });
+
+    it('should set checked when all are selected', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Project A',
+            fileName: 'a.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      // Check the only checkbox
+      const checkbox = modal.modalElementBodyContent.querySelector('.ode-check');
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new Event('change'));
+
+      const selectAll = modal.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+      expect(selectAll.checked).toBe(true);
+      expect(selectAll.indeterminate).toBe(false);
+    });
+  });
+
+  describe('Select All visibility in tabs', () => {
+    it('should show Select All checkbox for my-projects tab', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: { odeId: 'a', role: 'owner' },
+        },
+      };
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+
+      const selectAllWrap = modal.modalElementBodyContent.querySelector('.ode-select-all-wrap');
+      expect(selectAllWrap.style.display).toBe('flex');
+    });
+
+    it('should hide Select All checkbox for shared-with-me tab', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: { odeId: 'a', role: 'editor' },
+        },
+      };
+      modal.currentTab = 'shared-with-me';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+
+      const selectAllWrap = modal.modalElementBodyContent.querySelector('.ode-select-all-wrap');
+      expect(selectAllWrap.style.display).toBe('none');
+    });
+
+    it('should toggle Select All visibility when switching tabs', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Owned Project',
+            fileName: 'owned.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          b1: {
+            odeId: 'b',
+            role: 'editor',
+            versionName: '1',
+            title: 'Shared Project',
+            fileName: 'shared.elp',
+            sizeFormatted: '2 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'public',
+            ownerEmail: 'owner@example.com',
+            isManualSave: false,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      modal.switchTab('shared-with-me');
+
+      const selectAllWrap = modal.modalElementBodyContent.querySelector('.ode-select-all-wrap');
+      expect(selectAllWrap.style.display).toBe('none');
+
+      modal.switchTab('my-projects');
+      expect(selectAllWrap.style.display).toBe('flex');
+    });
+
+    it('should reset Select All checkbox when switching tabs', () => {
+      modal.allOdeFilesData = {
+        odeFilesSync: {
+          a1: {
+            odeId: 'a',
+            role: 'owner',
+            versionName: '1',
+            title: 'Owned Project',
+            fileName: 'owned.elp',
+            sizeFormatted: '1 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'private',
+            isManualSave: true,
+          },
+          b1: {
+            odeId: 'b',
+            role: 'editor',
+            versionName: '1',
+            title: 'Shared Project',
+            fileName: 'shared.elp',
+            sizeFormatted: '2 MB',
+            updatedAt: new Date().toISOString(),
+            visibility: 'public',
+            ownerEmail: 'owner@example.com',
+            isManualSave: false,
+          },
+        },
+      };
+
+      modal.currentTab = 'my-projects';
+      const actions = modal.makeModalActions();
+      modal.setBodyElement(actions);
+      const list = modal.makeElementListOdeFiles(modal.allOdeFilesData);
+      modal.setBodyElement(list);
+
+      // Select all
+      modal.toggleSelectAll(true);
+      const selectAllCheckbox = modal.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+      selectAllCheckbox.checked = true;
+
+      // Switch tabs
+      modal.switchTab('shared-with-me');
+
+      // Switch back
+      modal.switchTab('my-projects');
+
+      const newSelectAllCheckbox = modal.modalElementBodyContent.querySelector('#ode-select-all-checkbox');
+      expect(newSelectAllCheckbox.checked).toBe(false);
+      expect(modal.odeFiles).toEqual([]);
+    });
+  });
+
   describe('removeDeleteButtonFooter', () => {
-    it('should restore open button when empty', () => {
+    it('should restore open button and disable when empty and no project selected', () => {
       const confirmSpy = vi.spyOn(modal, 'setConfirmExec');
+      modal.selectedProjectUuid = null;
+      modal.confirmButton.disabled = false;
+      modal.confirmButton.classList.remove('disabled');
+
       modal.removeDeleteButtonFooter([]);
+
       expect(modal.confirmButton.textContent).toBe('Open');
+      expect(modal.confirmButton.disabled).toBe(true);
+      expect(modal.confirmButton.classList.contains('disabled')).toBe(true);
+      expect(confirmSpy).toHaveBeenCalled();
+    });
+
+    it('should restore open button but keep enabled when a project is selected', () => {
+      const confirmSpy = vi.spyOn(modal, 'setConfirmExec');
+      modal.selectedProjectUuid = 'proj-1';
+      modal.confirmButton.disabled = false;
+      modal.confirmButton.classList.remove('disabled');
+
+      modal.removeDeleteButtonFooter([]);
+
+      expect(modal.confirmButton.textContent).toBe('Open');
+      expect(modal.confirmButton.disabled).toBe(false);
+      expect(modal.confirmButton.classList.contains('disabled')).toBe(false);
       expect(confirmSpy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
This pull request introduces a "Select All" checkbox and related UI/UX improvements to the "Open User ODE Files" modal, making it easier for users to select and delete multiple projects at once. It also refines the modal's appearance and logic for handling project selection and deletion confirmation.

**Major UI/UX improvements for project selection:**

* Added a "Select All" checkbox to the `.ode-filter-wrap` in the modal, visible only on the "My Projects" tab, allowing users to quickly select or deselect all their projects. [[1]](diffhunk://#diff-12a920222dceca388be5aa870832dd805b75cd04afb41ac88e8d7bc9cc2299d7R570-R585) [[2]](diffhunk://#diff-204deb677315a03f3456d8871a0741bd6efbdb8f81cc700c2ce8eb1f1760e64eL1617-R1647)
* Implemented logic to update the "Select All" checkbox state (checked, unchecked, indeterminate) based on individual project selections, and to toggle all checkboxes when "Select All" is used.
* The "Select All" checkbox and project selections are reset when switching tabs, and the checkbox is only shown for the relevant tab.

**Project deletion workflow enhancements:**

* Added a confirmation dialog before mass deletion, displaying a warning and the number of projects to be deleted, and ensuring the "Select All" checkbox resets after deletion.
* Improved enable/disable logic for the delete/open button based on current selection, ensuring buttons reflect the current state and are disabled when no projects are selected. [[1]](diffhunk://#diff-12a920222dceca388be5aa870832dd805b75cd04afb41ac88e8d7bc9cc2299d7R809-R876) [[2]](diffhunk://#diff-12a920222dceca388be5aa870832dd805b75cd04afb41ac88e8d7bc9cc2299d7L985-R1129)

**Styling and layout adjustments:**

* Updated `.ode-filter-wrap` styles to use flex layout and increased width for better alignment and spacing, improving the modal's visual structure.