### PR TITLE
Better cleanup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,10 +595,10 @@ package-windows-local-sign: fail-on-windows check-release-env eb-inject-config
 clean: check-docker
 	docker compose down -v --remove-orphans
 
-# Clean local cache
+# Clean local data (database + assets) for fresh start
 .PHONY: clean-local
 clean-local: check-bun
-	bun run predev
+	node scripts/setup-local.js --clean
 
 # Clean test artifacts
 .PHONY: test-clean

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "bundle:exporters": "node scripts/build-exporters-bundle.js",
         "bundle:resources": "node scripts/build-resource-bundles.js",
         "upload:bundles": "node scripts/upload-bundle-analysis.js",
-        "predev": "node scripts/setup-local.js && (kill-port 8080 || true)",
+        "predev": "node scripts/setup-local.js",
         "seed": "bun run src/db/seed.ts",
         "cli": "bun run dist/cli.js",
         "convert-elp": "bun run dist/cli.js elp:convert",

--- a/scripts/setup-local.js
+++ b/scripts/setup-local.js
@@ -1,8 +1,74 @@
 // scripts/setup-local.js
 const fs = require('fs-extra');
 const path = require('path');
+const { execSync } = require('child_process');
 
-console.log('Setting up local environment...');
+const isCleanMode = process.argv.includes('--clean');
+
+if (isCleanMode) {
+  console.log('Cleaning local environment...');
+} else {
+  console.log('Setting up local environment...');
+}
+
+const dataDir = path.join(__dirname, '..', 'data');
+
+// Cross-platform function to kill process on port
+function killPort(port) {
+  const isWindows = process.platform === 'win32';
+  try {
+    if (isWindows) {
+      // Windows: find PID and kill
+      const result = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+      const lines = result.trim().split('\n');
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        const pid = parts[parts.length - 1];
+        if (pid && /^\d+$/.test(pid)) {
+          execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+          console.log(`Killed process on port ${port} (PID: ${pid})`);
+        }
+      }
+    } else {
+      // Unix/Mac: use lsof to find and kill
+      const result = execSync(`lsof -ti:${port}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+      const pids = result.trim().split('\n').filter(Boolean);
+      for (const pid of pids) {
+        execSync(`kill -9 ${pid}`, { stdio: 'ignore' });
+        console.log(`Killed process on port ${port} (PID: ${pid})`);
+      }
+    }
+  } catch {
+    // No process found on port, or command failed - that's fine
+  }
+}
+
+// Clean mode: delete database and data files for fresh start
+if (isCleanMode) {
+  const dbPath = path.join(dataDir, 'exelearning.db');
+  const dirsToClean = ['assets', 'tmp', 'dist', 'chunks'];
+
+  // Delete database
+  if (fs.existsSync(dbPath)) {
+    console.log('Deleting database: data/exelearning.db');
+    fs.removeSync(dbPath);
+  }
+
+  // Delete data subdirectories
+  for (const dir of dirsToClean) {
+    const dirPath = path.join(dataDir, dir);
+    if (fs.existsSync(dirPath)) {
+      console.log(`Deleting directory: data/${dir}/`);
+      fs.removeSync(dirPath);
+    }
+  }
+
+  // Kill any process on port 8080
+  killPort(8080);
+
+  console.log('Local environment cleaned. Run "make up-local" for fresh start.');
+  process.exit(0);
+}
 
 // 1. Copy .env if it doesn't exist (replaces check-env from Makefile)
 const envPath = path.join(__dirname, '..', '.env');
@@ -19,7 +85,6 @@ if (!fs.existsSync(envPath)) {
 
 // 2. Create data directory for SQLite
 // Assuming SQLite by default for local
-const dataDir = path.join(__dirname, '..', 'data');
 if (!fs.existsSync(dataDir)) {
   console.log(`Creating data directory at: ${dataDir}`);
   fs.ensureDirSync(dataDir);
@@ -30,5 +95,8 @@ const cacheDir = path.join(__dirname, '..', 'dist', '.cache');
 if (fs.existsSync(cacheDir)) {
   fs.removeSync(cacheDir);
 }
+
+// 4. Kill any process on port 8080 before starting
+killPort(8080);
 
 console.log('Local setup complete.');


### PR DESCRIPTION
This pull request improves the local development setup workflow by enhancing the `scripts/setup-local.js` script to support a "clean" mode, making local resets more robust and cross-platform. It also updates related Makefile and package scripts to use this new functionality.

**Enhancements to local environment setup and cleaning:**

* Added a `--clean` mode to `scripts/setup-local.js` that deletes the local database and asset directories, and kills any process running on port 8080, providing a reliable fresh start for development environments.
* Refactored the Makefile's `clean-local` target to use `node scripts/setup-local.js --clean` instead of running the previous `predev` script, clarifying its purpose as a full environment reset.
* Updated the `predev` script in `package.json` to remove the port-killing logic, delegating that responsibility to the improved setup script.

**Cross-platform process management:**

* Implemented a robust, cross-platform function in `scripts/setup-local.js` to kill processes on a specified port (8080), supporting both Windows and Unix-like systems.

**General improvements and cleanup:**

* Ensured that the local setup always creates the required data directory and cleans up any previous cache, providing a consistent starting point for developers. [[1]](diffhunk://#diff-df1bcea5301eb6210f7abb75b4e80fc071a9a26e7c32dc43dda7750ec2c8fbe5L22) [[2]](diffhunk://#diff-df1bcea5301eb6210f7abb75b4e80fc071a9a26e7c32dc43dda7750ec2c8fbe5R99-R101)