### PR TITLE
Upgrade to node22

### DIFF
--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -16,7 +16,7 @@
 # Usage: make up-legacy
 # =============================================================================
 
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the base Node.js version used in the `Dockerfile.legacy` to ensure compatibility with the latest features and security updates.

Dependency update:

* Changed the base image from `node:20-alpine` to `node:22-alpine` in `Dockerfile.legacy` to use a newer Node.js version.