### PR TITLE
Fix attached-files legacy idevice

### DIFF
--- a/public/app/yjs/AssetManager.js
+++ b/public/app/yjs/AssetManager.js
@@ -871,15 +871,22 @@ class AssetManager {
     const assetMap = new Map();
     const assetFiles = [];
 
-    // Find all image/media files (zip is an object with path -> Uint8Array)
+    // Find all asset files (zip is an object with path -> Uint8Array)
     for (const [relativePath, fileData] of Object.entries(zip)) {
       // Skip directories (they end with /)
       if (relativePath.endsWith('/')) continue;
       if (relativePath.startsWith('__MACOSX')) continue;
       if (relativePath.endsWith('.xml')) continue;
 
+      // Include files from resources/ folder (attached files from FileAttachIdevice, etc.)
+      // These can be ANY file type (.elp, .txt, custom extensions, etc.)
+      const isResourceFile = relativePath.startsWith('resources/') ||
+                            relativePath.includes('/resources/');
+
       // Include images, video, audio, documents, 3D models and common media
-      if (/\.(png|jpg|jpeg|gif|svg|webp|bmp|ico|tiff?|mp4|m4v|webm|mov|avi|mkv|mp3|m4a|ogg|wav|aac|flac|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|7z|gltf|glb|stl)$/i.test(relativePath)) {
+      const isMediaFile = /\.(png|jpg|jpeg|gif|svg|webp|bmp|ico|tiff?|mp4|m4v|webm|mov|avi|mkv|mp3|m4a|ogg|wav|aac|flac|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|rar|7z|gltf|glb|stl|elp|elpx|txt|html?|css|js|json|csv|tsv|rtf|odt|ods|odp|epub|mobi)$/i.test(relativePath);
+
+      if (isResourceFile || isMediaFile) {
         assetFiles.push({ path: relativePath, fileData });
       }
     }
@@ -1226,7 +1233,24 @@ class AssetManager {
       stl: 'model/stl',
       // Code
       css: 'text/css',
-      js: 'application/javascript'
+      js: 'application/javascript',
+      // eXeLearning
+      elp: 'application/zip',
+      elpx: 'application/zip',
+      // Text
+      txt: 'text/plain',
+      html: 'text/html',
+      htm: 'text/html',
+      json: 'application/json',
+      csv: 'text/csv',
+      rtf: 'application/rtf',
+      // Open Document
+      odt: 'application/vnd.oasis.opendocument.text',
+      ods: 'application/vnd.oasis.opendocument.spreadsheet',
+      odp: 'application/vnd.oasis.opendocument.presentation',
+      // eBooks
+      epub: 'application/epub+zip',
+      mobi: 'application/x-mobipocket-ebook'
     };
     return mimeTypes[ext] || 'application/octet-stream';
   }

--- a/public/app/yjs/legacy/handlers/FileAttachHandler.js
+++ b/public/app/yjs/legacy/handlers/FileAttachHandler.js
@@ -11,8 +11,15 @@
  *
  * Based on Symfony OdeOldXmlFileAttachIdevice.php:
  * - Converts to 'text' iDevice (not download-source-file)
+ * - Extracts introHTML (instructions) and shows it before file links
  * - Creates HTML with links to attached files
  * - Links open in new tab (target="_blank")
+ *
+ * XML Structure for FileAttachIdeviceInc:
+ * - introHTML: TextAreaField with content_w_resourcePaths (instructions text)
+ * - fileAttachmentFields: list of FileField instances
+ *   - fileDescription: TextField with content (description for link text)
+ *   - fileResource: Resource with _storageName (filename in ZIP)
  *
  * Requires: BaseLegacyHandler.js to be loaded first
  */
@@ -34,26 +41,62 @@ class FileAttachHandler extends BaseLegacyHandler {
   }
 
   /**
-   * Extract HTML content with file links
+   * Extract HTML content with instructions (introHTML) + file links
    *
    * Matches Symfony OdeOldXmlFileAttachIdevice.php format:
-   * <p><a href="path" target="_blank">description</a></p>
+   * - First: introHTML content (instructions)
+   * - Then: <p><a href="path" target="_blank">description</a></p> for each file
    */
   extractHtmlView(dict) {
     if (!dict) return '';
 
-    // Extract files and generate links (Symfony format)
+    const parts = [];
+
+    // 1. Extract introHTML (instructions) - appears before file links
+    const introHtml = this.extractIntroHtml(dict);
+    if (introHtml) {
+      parts.push(introHtml);
+    }
+
+    // 2. Extract files and generate links (Symfony format)
     const files = this.extractFiles(dict);
-    if (files.length === 0) return '';
+    if (files.length > 0) {
+      // Generate HTML links with download attribute for attached files
+      // The download attribute forces browser to download instead of trying to display
+      const fileLinks = files.map(file => {
+        // Use description as link text, fallback to filename
+        const linkText = file.description || file.displayName || file.filename;
+        // Add download attribute with filename to force download
+        return `<p><a href="${file.path}" target="_blank" download="${file.filename}">${linkText}</a></p>`;
+      }).join('');
+      parts.push(fileLinks);
+    }
 
-    // Generate HTML links like Symfony does
-    const fileLinks = files.map(file => {
-      // Use description as link text, fallback to filename
-      const linkText = file.description || file.displayName || file.filename;
-      return `<p><a href="${file.path}" target="_blank">${linkText}</a></p>`;
-    }).join('');
+    return parts.join('');
+  }
 
-    return fileLinks;
+  /**
+   * Extract introHTML content (instructions text)
+   *
+   * Legacy structure:
+   * <string role="key" value="introHTML"/>
+   * <instance class="exe.engine.field.TextAreaField">
+   *   <dictionary>
+   *     <string role="key" value="content_w_resourcePaths"/>
+   *     <unicode value="<p>estas son las instrucciones</p>"/>
+   *   </dictionary>
+   * </instance>
+   *
+   * @param {Element} dict - Dictionary element of the iDevice
+   * @returns {string} HTML content from introHTML
+   */
+  extractIntroHtml(dict) {
+    // Look for introHTML instance
+    const introInstance = this.findDictInstance(dict, 'introHTML');
+    if (!introInstance) return '';
+
+    // Extract content from TextAreaField
+    return this.extractTextAreaFieldContent(introInstance);
   }
 
   /**
@@ -72,9 +115,9 @@ class FileAttachHandler extends BaseLegacyHandler {
   /**
    * Extract files from the legacy format
    *
-   * Structure:
-   * - list of FileField instances
-   * - Each has: _fileResource, _displayName, _description
+   * FileAttachIdeviceInc structure:
+   * - fileAttachmentFields: list of FileField instances
+   * - Each FileField has: fileDescription (TextField), fileResource (Resource)
    *
    * @param {Element} dict - Dictionary element of the FileAttachIdevice
    * @returns {Array} Array of file objects
@@ -82,22 +125,25 @@ class FileAttachHandler extends BaseLegacyHandler {
   extractFiles(dict) {
     const files = [];
 
-    // Find the list containing FileField instances
-    const lists = dict.querySelectorAll(':scope > list');
-    let filesList = null;
+    // Strategy 1: Look for fileAttachmentFields key (FileAttachIdeviceInc format)
+    let filesList = this.findDictList(dict, 'fileAttachmentFields');
 
-    for (const list of lists) {
-      const firstInst = list.querySelector(':scope > instance');
-      if (firstInst) {
-        const className = firstInst.getAttribute('class') || '';
-        if (className.includes('FileField') || className.includes('AttachmentField')) {
-          filesList = list;
-          break;
+    // Strategy 2: Look for direct list containing FileField instances
+    if (!filesList) {
+      const lists = dict.querySelectorAll(':scope > list');
+      for (const list of lists) {
+        const firstInst = list.querySelector(':scope > instance');
+        if (firstInst) {
+          const className = firstInst.getAttribute('class') || '';
+          if (className.includes('FileField') || className.includes('AttachmentField')) {
+            filesList = list;
+            break;
+          }
         }
       }
     }
 
-    // Alternative: files may be in a "files" or "_files" key
+    // Strategy 3: Alternative key names
     if (!filesList) {
       filesList = this.findDictList(dict, 'files') ||
                   this.findDictList(dict, '_files') ||
@@ -132,12 +178,14 @@ class FileAttachHandler extends BaseLegacyHandler {
   /**
    * Extract file info from a dictionary
    *
-   * Based on Symfony's extraction of:
-   * - fileResource -> _storageName (filename)
-   * - fileDescription -> content (description for link text)
+   * FileAttachIdeviceInc FileField structure:
+   * - fileResource: Resource with _storageName (filename in ZIP)
+   * - fileDescription: TextField with content (description for link text)
+   *
+   * Based on Symfony OdeOldXmlFileAttachIdevice.php extraction
    */
   extractFileFromDict(fDict) {
-    // Extract file resource path (Symfony: fileResource/_storageName)
+    // Extract file resource path (fileResource/_storageName)
     const filename = this.extractResourcePath(fDict, 'fileResource') ||
                     this.extractResourcePath(fDict, '_fileResource') ||
                     this.extractResourcePath(fDict, '_resource') ||
@@ -146,17 +194,27 @@ class FileAttachHandler extends BaseLegacyHandler {
 
     if (!filename) return null;
 
-    // Extract description from fileDescription TextAreaField (Symfony format)
+    // Extract description from fileDescription TextField
+    // FileAttachIdeviceInc structure:
+    // <string role="key" value="fileDescription"/>
+    // <instance class="exe.engine.field.TextField">
+    //   <dictionary>
+    //     <string role="key" value="content"/>
+    //     <unicode value="Description text"/>
+    //   </dictionary>
+    // </instance>
     let description = '';
     const descInst = this.findDictInstance(fDict, 'fileDescription');
     if (descInst) {
       const descDict = descInst.querySelector(':scope > dictionary');
       if (descDict) {
+        // TextField stores text in 'content' field
         description = this.findDictStringValue(descDict, 'content') ||
                      this.findDictStringValue(descDict, '_content') || '';
       }
     }
-    // Fallback to direct description field
+
+    // Fallback to direct description field (older formats)
     if (!description) {
       description = this.findDictStringValue(fDict, '_description') ||
                    this.findDictStringValue(fDict, 'description') || '';
@@ -173,8 +231,8 @@ class FileAttachHandler extends BaseLegacyHandler {
                        this.findDictStringValue(fDict, '_label') ||
                        this.findDictStringValue(fDict, 'label') || filename;
 
-    // Build path (will be updated by resource resolver)
-    // Symfony uses: sessionPath + ideviceId + "/" + filename
+    // Build path - uses resources/ prefix for asset path replacement
+    // ElpxImporter.importLegacyFormat replaces resources/filename with asset://uuid/filename
     const path = `resources/${filename}`;
 
     return {

--- a/public/app/yjs/legacy/handlers/FileAttachHandler.test.js
+++ b/public/app/yjs/legacy/handlers/FileAttachHandler.test.js
@@ -52,6 +52,31 @@ describe('FileAttachHandler', () => {
     });
   });
 
+  describe('extractIntroHtml', () => {
+    it('extracts instructions from introHTML TextAreaField', () => {
+      const dict = parseDictionary(`
+        <dictionary>
+          <string role="key" value="introHTML"></string>
+          <instance class="exe.engine.field.TextAreaField">
+            <dictionary>
+              <string role="key" value="content_w_resourcePaths"></string>
+              <unicode value="&lt;p&gt;estas son las instrucciones&lt;/p&gt;"></unicode>
+            </dictionary>
+          </instance>
+        </dictionary>
+      `);
+
+      const introHtml = handler.extractIntroHtml(dict);
+
+      expect(introHtml).toContain('<p>estas son las instrucciones</p>');
+    });
+
+    it('returns empty string when no introHTML', () => {
+      const dict = parseDictionary('<dictionary></dictionary>');
+      expect(handler.extractIntroHtml(dict)).toBe('');
+    });
+  });
+
   describe('extractHtmlView', () => {
     it('generates file links HTML (Symfony format)', () => {
       const dict = parseDictionary(`
@@ -78,11 +103,60 @@ describe('FileAttachHandler', () => {
 
       const html = handler.extractHtmlView(dict);
 
-      // Symfony format: <p><a href="path" target="_blank">description</a></p>
+      // Format: <p><a href="path" target="_blank" download="filename">description</a></p>
       expect(html).toContain('<p><a href=');
       expect(html).toContain('target="_blank"');
+      expect(html).toContain('download="document.pdf"');
       expect(html).toContain('document.pdf');
       expect(html).toContain('A PDF file'); // description used as link text
+    });
+
+    it('includes introHTML before file links', () => {
+      const dict = parseDictionary(`
+        <dictionary>
+          <string role="key" value="introHTML"></string>
+          <instance class="exe.engine.field.TextAreaField">
+            <dictionary>
+              <string role="key" value="content_w_resourcePaths"></string>
+              <unicode value="&lt;p&gt;Instructions text&lt;/p&gt;"></unicode>
+            </dictionary>
+          </instance>
+          <string role="key" value="fileAttachmentFields"></string>
+          <list>
+            <instance class="exe.engine.extendedfieldengine.FileField">
+              <dictionary>
+                <string role="key" value="fileResource"></string>
+                <instance class="exe.engine.resource.Resource">
+                  <dictionary>
+                    <string role="key" value="_storageName"></string>
+                    <unicode value="file.mp3"></unicode>
+                  </dictionary>
+                </instance>
+                <string role="key" value="fileDescription"></string>
+                <instance class="exe.engine.field.TextField">
+                  <dictionary>
+                    <string role="key" value="content"></string>
+                    <unicode value="Audio file description"></unicode>
+                  </dictionary>
+                </instance>
+              </dictionary>
+            </instance>
+          </list>
+        </dictionary>
+      `);
+
+      const html = handler.extractHtmlView(dict);
+
+      // Should have introHTML BEFORE file links
+      expect(html).toContain('<p>Instructions text</p>');
+      expect(html).toContain('<p><a href=');
+      expect(html).toContain('download="file.mp3"');
+      expect(html).toContain('Audio file description');
+
+      // Verify order: instructions before file links
+      const introIndex = html.indexOf('Instructions text');
+      const linkIndex = html.indexOf('Audio file description');
+      expect(introIndex).toBeLessThan(linkIndex);
     });
 
     it('returns empty string for null dict', () => {
@@ -92,6 +166,24 @@ describe('FileAttachHandler', () => {
     it('returns empty string when no files', () => {
       const dict = parseDictionary('<dictionary></dictionary>');
       expect(handler.extractHtmlView(dict)).toBe('');
+    });
+
+    it('returns only introHTML when no files', () => {
+      const dict = parseDictionary(`
+        <dictionary>
+          <string role="key" value="introHTML"></string>
+          <instance class="exe.engine.field.TextAreaField">
+            <dictionary>
+              <string role="key" value="content_w_resourcePaths"></string>
+              <unicode value="&lt;p&gt;Only instructions&lt;/p&gt;"></unicode>
+            </dictionary>
+          </instance>
+        </dictionary>
+      `);
+
+      const html = handler.extractHtmlView(dict);
+      expect(html).toContain('<p>Only instructions</p>');
+      expect(html).not.toContain('<a href=');
     });
   });
 
@@ -160,6 +252,62 @@ describe('FileAttachHandler', () => {
       expect(files[0].displayName).toBe('Annual Report');
       expect(files[0].description).toBe('PDF version');
       expect(files[0].path).toBe('resources/report.pdf');
+    });
+
+    it('extracts files from fileAttachmentFields key (FileAttachIdeviceInc format)', () => {
+      const dict = parseDictionary(`
+        <dictionary>
+          <string role="key" value="fileAttachmentFields"></string>
+          <list>
+            <instance class="exe.engine.extendedfieldengine.FileField">
+              <dictionary>
+                <string role="key" value="fileResource"></string>
+                <instance class="exe.engine.resource.Resource">
+                  <dictionary>
+                    <string role="key" value="_storageName"></string>
+                    <string value="file_example_MP3_700KB.mp3"></string>
+                  </dictionary>
+                </instance>
+                <string role="key" value="fileDescription"></string>
+                <instance class="exe.engine.field.TextField">
+                  <dictionary>
+                    <string role="key" value="content"></string>
+                    <unicode value="Audio file"></unicode>
+                  </dictionary>
+                </instance>
+              </dictionary>
+            </instance>
+            <instance class="exe.engine.extendedfieldengine.FileField">
+              <dictionary>
+                <string role="key" value="fileResource"></string>
+                <instance class="exe.engine.resource.Resource">
+                  <dictionary>
+                    <string role="key" value="_storageName"></string>
+                    <string value="El_Cid.elp"></string>
+                  </dictionary>
+                </instance>
+                <string role="key" value="fileDescription"></string>
+                <instance class="exe.engine.field.TextField">
+                  <dictionary>
+                    <string role="key" value="content"></string>
+                    <unicode value="ELP project file"></unicode>
+                  </dictionary>
+                </instance>
+              </dictionary>
+            </instance>
+          </list>
+        </dictionary>
+      `);
+
+      const files = handler.extractFiles(dict);
+
+      expect(files.length).toBe(2);
+      expect(files[0].filename).toBe('file_example_MP3_700KB.mp3');
+      expect(files[0].description).toBe('Audio file');
+      expect(files[0].path).toBe('resources/file_example_MP3_700KB.mp3');
+      expect(files[1].filename).toBe('El_Cid.elp');
+      expect(files[1].description).toBe('ELP project file');
+      expect(files[1].path).toBe('resources/El_Cid.elp');
     });
 
     it('handles multiple files', () => {


### PR DESCRIPTION
This pull request enhances support for file attachments in legacy content import, especially for the FileAttachIdeviceInc format, and broadens the range of recognized asset file types. The changes improve extraction and rendering of instructions and file links, ensure correct MIME types for more formats, and add thorough tests for the new behaviors.

**Legacy File Attachment Import Improvements:**

* Updated `FileAttachHandler` to support the FileAttachIdeviceInc format, extracting and displaying `introHTML` instructions before file links, and ensuring descriptions are correctly pulled from the new structure. File links now include a `download` attribute to force downloads and use the correct asset path convention. [[1]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcR14-R23) [[2]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcL37-R99) [[3]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcL75-R133) [[4]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcR144-R146) [[5]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcL135-R188) [[6]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcL149-R217) [[7]](diffhunk://#diff-086262581d1e0836565909ee63ed10932ea370af5a47df428b3aa69911e9e8bcL176-R235)

**Asset and MIME Type Handling:**

* Expanded the set of recognized asset file types in `AssetManager` to include additional document, eBook, and text formats, and ensured files in the `resources/` folder (regardless of extension) are treated as assets.
* Updated the MIME type mapping in `AssetManager` to include new supported file types, such as `.elp`, `.elpx`, `.txt`, `.html`, `.json`, `.csv`, `.rtf`, `.odt`, `.ods`, `.odp`, `.epub`, and `.mobi`.

**Testing Enhancements:**

* Added comprehensive tests to verify extraction of `introHTML`, correct rendering order of instructions and file links, proper handling of the new file attachment structure, and correct fallback behaviors. [[1]](diffhunk://#diff-704b1755fdb6ea70d94edf337788cef377989ca89e98d3bd22fbb44d15a68a8cR55-R79) [[2]](diffhunk://#diff-704b1755fdb6ea70d94edf337788cef377989ca89e98d3bd22fbb44d15a68a8cL81-R161) [[3]](diffhunk://#diff-704b1755fdb6ea70d94edf337788cef377989ca89e98d3bd22fbb44d15a68a8cR170-R187) [[4]](diffhunk://#diff-704b1755fdb6ea70d94edf337788cef377989ca89e98d3bd22fbb44d15a68a8cR257-R312)