### PR TITLE
Converted to text idevice

### DIFF
--- a/doc/contentv3-format.md
+++ b/doc/contentv3-format.md
@@ -301,7 +301,8 @@ Legacy iDevice types are mapped to modern ODE types:
 | `ImageMagnifierIdevice` | `magnifier` |
 | `GalleryIdevice` | `image-gallery` |
 | `CasestudyIdevice` | `casestudy` |
-| `FileAttachIdeviceInc` | `attached-files` |
+| `FileAttachIdevice` | `text` |
+| `AttachmentIdevice` | `text` |
 | `ExternalUrlIdevice` | `external-website` |
 | `QuizTestIdevice` | `quick-questions` |
 | `JsIdevice` | Uses `class_` attribute |

--- a/doc/conventions.md
+++ b/doc/conventions.md
@@ -308,7 +308,7 @@ When opening or importing a legacy `.elp` (`contentv3.xml`):
 | ImageMagnifierIdevice | magnifier |
 | GalleryIdevice | image-gallery |
 | CasestudyIdevice | casestudy |
-| FileAttachIdeviceInc | attached-files |
+| FileAttachIdevice, AttachmentIdevice | text (for editability) |
 | ExternalUrlIdevice | external-website |
 | QuizTestIdevice | quick-questions |
 

--- a/public/app/yjs/LegacyXmlParser.js
+++ b/public/app/yjs/LegacyXmlParser.js
@@ -857,6 +857,10 @@ class LegacyXmlParser {
       'WikipediaIdevice',
       'RssIdevice',
       'AppletIdevice', // Java applets - no modern support
+      // File attachment iDevices → text (as per Symfony OdeOldXmlFileAttachIdevice.php)
+      // The attached-files iDevice type has no editor, so we convert to editable 'text'
+      'FileAttachIdevice',    // Matches FileAttachIdevice and FileAttachIdeviceInc
+      'AttachmentIdevice',
     ];
 
     // Check if this is a text-based iDevice that should convert to 'text'
@@ -889,8 +893,7 @@ class LegacyXmlParser {
       'GalleryIdevice': 'image-gallery',
       // Case study
       'CasestudyIdevice': 'casestudy',
-      // File attachments
-      'FileAttachIdeviceInc': 'attached-files',
+      // Note: FileAttachIdevice moved to textBasedIdevices (converts to 'text' for editability)
       // External URL / website
       'ExternalUrlIdevice': 'external-website',
       // SCORM quiz/test

--- a/public/app/yjs/LegacyXmlParser.test.js
+++ b/public/app/yjs/LegacyXmlParser.test.js
@@ -3224,6 +3224,27 @@ describe('LegacyXmlParser', () => {
     });
   });
 
+  describe('FileAttachIdevice type mapping', () => {
+    // FileAttachIdevice converts to 'text' (not 'attached-files') because
+    // attached-files iDevice has no editor. This matches Symfony behavior.
+    // See FileAttachHandler.js and OdeOldXmlFileAttachIdevice.php
+
+    it('should map FileAttachIdevice to text type for editability', () => {
+      const type = parser.mapIdeviceType('exe.engine.fileattachidevice.FileAttachIdevice');
+      expect(type).toBe('text');
+    });
+
+    it('should map FileAttachIdeviceInc to text type for editability', () => {
+      const type = parser.mapIdeviceType('exe.engine.fileattachidevice.FileAttachIdeviceInc');
+      expect(type).toBe('text');
+    });
+
+    it('should map AttachmentIdevice to text type for editability', () => {
+      const type = parser.mapIdeviceType('exe.engine.attachmentidevice.AttachmentIdevice');
+      expect(type).toBe('text');
+    });
+  });
+
   describe('JsIdevice _iDeviceDir type mappings', () => {
     // Test all legacy _iDeviceDir values found in ELP fixtures
 

--- a/src/services/xml/legacy-xml-parser.spec.ts
+++ b/src/services/xml/legacy-xml-parser.spec.ts
@@ -1021,6 +1021,86 @@ describe('legacy-xml-parser', () => {
             }
         });
 
+        it('should convert FileAttachIdevice to text for editability', () => {
+            // FileAttachIdevice converted to text (not attached-files) because
+            // attached-files iDevice has no editor. This matches Symfony behavior.
+            // See FileAttachHandler.js and OdeOldXmlFileAttachIdevice.php
+            const parsed: LegacyInstanceXmlDocument = {
+                instance: {
+                    '@_class': 'exe.engine.package.Package',
+                    node: {
+                        '@_class': 'exe.engine.node.Node',
+                        '@_reference': 'node-1',
+                        dictionary: {
+                            unicode: { '@_value': 'Page' },
+                            list: {
+                                instance: {
+                                    '@_class': 'exe.engine.fileattachidevice.FileAttachIdevice',
+                                    '@_reference': 'idevice-1',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = parse(parsed);
+            const page = result.pages.find(p => p.id === 'node-1');
+            expect(page?.components[0]?.type).toBe('text');
+        });
+
+        it('should convert FileAttachIdeviceInc to text for editability', () => {
+            // FileAttachIdeviceInc is a variant that also converts to text
+            const parsed: LegacyInstanceXmlDocument = {
+                instance: {
+                    '@_class': 'exe.engine.package.Package',
+                    node: {
+                        '@_class': 'exe.engine.node.Node',
+                        '@_reference': 'node-1',
+                        dictionary: {
+                            unicode: { '@_value': 'Page' },
+                            list: {
+                                instance: {
+                                    '@_class': 'exe.engine.fileattachidevice.FileAttachIdeviceInc',
+                                    '@_reference': 'idevice-1',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = parse(parsed);
+            const page = result.pages.find(p => p.id === 'node-1');
+            expect(page?.components[0]?.type).toBe('text');
+        });
+
+        it('should convert AttachmentIdevice to text for editability', () => {
+            // AttachmentIdevice is another file attachment variant → text
+            const parsed: LegacyInstanceXmlDocument = {
+                instance: {
+                    '@_class': 'exe.engine.package.Package',
+                    node: {
+                        '@_class': 'exe.engine.node.Node',
+                        '@_reference': 'node-1',
+                        dictionary: {
+                            unicode: { '@_value': 'Page' },
+                            list: {
+                                instance: {
+                                    '@_class': 'exe.engine.attachmentidevice.AttachmentIdevice',
+                                    '@_reference': 'idevice-1',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = parse(parsed);
+            const page = result.pages.find(p => p.id === 'node-1');
+            expect(page?.components[0]?.type).toBe('text');
+        });
+
         it('should preserve content when converting to text', () => {
             const parsed: LegacyInstanceXmlDocument = {
                 instance: {

--- a/src/services/xml/legacy-xml-parser.ts
+++ b/src/services/xml/legacy-xml-parser.ts
@@ -627,7 +627,7 @@ function extractResourcePaths(inst: unknown): string[] {
  *   - ImageMagnifierIdevice → magnifier
  *   - GalleryIdevice → image-gallery
  *   - CasestudyIdevice → casestudy
- *   - FileAttachIdeviceInc → attached-files
+ *   - FileAttachIdevice, AttachmentIdevice → text (for editability)
  *   - ExternalUrlIdevice → external-website
  *   - QuizTestIdevice → quick-questions
  *
@@ -671,6 +671,10 @@ function mapIdeviceType(className: string): string {
         'WikipediaIdevice',
         'RssIdevice',
         'AppletIdevice', // Java applets - no modern support
+        // File attachment iDevices → text (as per Symfony OdeOldXmlFileAttachIdevice.php)
+        // The attached-files iDevice type has no editor, so we convert to editable 'text'
+        'FileAttachIdevice', // Matches FileAttachIdevice and FileAttachIdeviceInc
+        'AttachmentIdevice',
     ];
 
     // Check if this is a text-based iDevice that should convert to 'text'
@@ -703,8 +707,7 @@ function mapIdeviceType(className: string): string {
         'GalleryIdevice': 'image-gallery',
         // Case study
         'CasestudyIdevice': 'casestudy',
-        // File attachments
-        'FileAttachIdeviceInc': 'attached-files',
+        // Note: FileAttachIdevice moved to textBasedIdevices (converts to 'text' for editability)
         // External URL / website
         'ExternalUrlIdevice': 'external-website',
         // SCORM quiz/test


### PR DESCRIPTION
This pull request updates the mapping of legacy file attachment iDevices to improve editability when importing legacy `.elp` files. Instead of mapping `FileAttachIdevice`, `FileAttachIdeviceInc`, and `AttachmentIdevice` to the non-editable `attached-files` type, these are now converted to the editable `text` type, matching Symfony's behavior. The change is reflected in the documentation, parsing logic, and tests.

**Legacy iDevice type mapping improvements:**

* Updated documentation in `doc/contentv3-format.md` and `doc/conventions.md` to show that `FileAttachIdevice`, `FileAttachIdeviceInc`, and `AttachmentIdevice` now map to `text` instead of `attached-files` for editability. [[1]](diffhunk://#diff-662a2f78e96afd3a290fd25f39c01c4a7661dbcfa744680a18bf9eb2b40b7b45L304-R305) [[2]](diffhunk://#diff-be2f02b435323adb19555016d85a562773a97bbe06b75f7c6b9986b0085ce22eL311-R311) [[3]](diffhunk://#diff-d120946f463c3ba94199cddf005b01f66a84db5d790429c9b38587daab269db7L630-R630)

**Parser logic changes:**

* Modified `mapIdeviceType` in both `public/app/yjs/LegacyXmlParser.js` and `src/services/xml/legacy-xml-parser.ts` to treat file attachment iDevices as text-based, so they convert to `text` rather than `attached-files`. [[1]](diffhunk://#diff-b3f7f21d4e433dbdea5065a308cd21bacfb6f7b2e691e8c1c789e7ad83c7f0eeR860-R863) [[2]](diffhunk://#diff-d120946f463c3ba94199cddf005b01f66a84db5d790429c9b38587daab269db7R674-R677)
* Updated mapping tables in both parser files to remove the previous mapping of `FileAttachIdeviceInc` to `attached-files` and document the new behavior. [[1]](diffhunk://#diff-b3f7f21d4e433dbdea5065a308cd21bacfb6f7b2e691e8c1c789e7ad83c7f0eeL892-R896) [[2]](diffhunk://#diff-d120946f463c3ba94199cddf005b01f66a84db5d790429c9b38587daab269db7L706-R710)

**Test coverage:**

* Added and updated tests in `public/app/yjs/LegacyXmlParser.test.js` and `src/services/xml/legacy-xml-parser.spec.ts` to verify that `FileAttachIdevice`, `FileAttachIdeviceInc`, and `AttachmentIdevice` are correctly mapped to `text` for editability. [[1]](diffhunk://#diff-d46b0044d82954e3adf84b601445e3ba4898d4a0e48390a0ff8909e0542c735cR3227-R3247) [[2]](diffhunk://#diff-f85ffbb1d0d304ee1813c11e8b02eff152ae8df57c7907025fa1e6bd3ba6f98aR1024-R1103)