### PR TITLE
Fix data dir and db test pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
 

--- a/src/services/file-helper.spec.ts
+++ b/src/services/file-helper.spec.ts
@@ -37,21 +37,19 @@ describe('File Helper Service', () => {
             expect(helper.getFilesDir()).toBe('/custom/elysia/files');
         });
 
-        it('should return FILES_DIR if set and not /mnt', () => {
+        it('should return FILES_DIR if set', () => {
             const helper = createFileHelper({
                 getEnv: key => (key === 'FILES_DIR' ? '/custom/files' : undefined),
             });
             expect(helper.getFilesDir()).toBe('/custom/files');
         });
 
-        it('should skip FILES_DIR if it starts with /mnt', () => {
+        it('should return FILES_DIR even if it starts with /mnt (Docker)', () => {
             const helper = createFileHelper({
-                getEnv: key => (key === 'FILES_DIR' ? '/mnt/shared/files' : undefined),
+                getEnv: key => (key === 'FILES_DIR' ? '/mnt/data/' : undefined),
                 getCwd: () => '/test/cwd',
             });
-            const result = helper.getFilesDir();
-            expect(result).not.toBe('/mnt/shared/files');
-            expect(result).toContain('data');
+            expect(helper.getFilesDir()).toBe('/mnt/data/');
         });
 
         it('should return default data directory if no env vars', () => {

--- a/src/services/file-helper.ts
+++ b/src/services/file-helper.ts
@@ -89,17 +89,17 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
     // ========================================================================
 
     const getFilesDir = (): string => {
-        // Check for explicit Elysia files dir first
+        // ELYSIA_FILES_DIR takes priority (used by tests)
         const elysiaFilesDir = getEnv('ELYSIA_FILES_DIR');
         if (elysiaFilesDir) {
             return elysiaFilesDir;
         }
-        // Check FILES_DIR but skip if it's the Docker /mnt path
+        // FILES_DIR from environment (Docker or make up-local)
         const filesDir = getEnv('FILES_DIR');
-        if (filesDir && !filesDir.startsWith('/mnt')) {
+        if (filesDir) {
             return filesDir;
         }
-        // Default to local data directory
+        // Fallback to local data directory
         return path.join(getCwd(), 'data');
     };
 


### PR DESCRIPTION
This pull request updates the logic for determining the files directory in the file helper service and improves the CI workflow by adding support for Bun. The main changes involve simplifying how the `FILES_DIR` environment variable is handled, ensuring it is always respected (even for Docker `/mnt` paths), and updating related tests. Additionally, Bun is now set up and used for dependency installation in the deployment workflow.

**File Helper Directory Logic Updates:**
- The `getFilesDir` function in `file-helper.ts` now always returns the `FILES_DIR` environment variable if set, regardless of whether it starts with `/mnt`, removing the previous special-case logic for Docker paths.
- Corresponding tests in `file-helper.spec.ts` have been updated to reflect this new logic: tests now expect `getFilesDir()` to return the `FILES_DIR` value even if it starts with `/mnt`.

**CI/CD Workflow Improvements:**
- The deployment workflow (`deploy.yml`) now sets up Bun using `oven-sh/setup-bun@v2` and installs dependencies with `bun install`, improving installation speed and reliability.