### PR TITLE
Add public endpoint for templates

### DIFF
--- a/src/routes/config.spec.ts
+++ b/src/routes/config.spec.ts
@@ -392,4 +392,117 @@ describe('Config Routes', () => {
             }
         });
     });
+
+    describe('GET /api/templates/:id/download', () => {
+        it('should return 400 for invalid template ID', async () => {
+            const response = await app.handle(new Request('http://localhost/api/templates/invalid/download'));
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Bad Request');
+            expect(data.message).toBe('Invalid template ID');
+        });
+
+        it('should return 400 for negative template ID', async () => {
+            const response = await app.handle(new Request('http://localhost/api/templates/-1/download'));
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Bad Request');
+        });
+
+        it('should return 400 for zero template ID', async () => {
+            const response = await app.handle(new Request('http://localhost/api/templates/0/download'));
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Bad Request');
+        });
+
+        it('should return 404 for non-existent template', async () => {
+            const response = await app.handle(new Request('http://localhost/api/templates/99999/download'));
+
+            expect(response.status).toBe(404);
+            const data = await response.json();
+            expect(data.error).toBe('Not Found');
+            expect(data.message).toBe('Template not found');
+        });
+
+        it('should return 404 for disabled template (security)', async () => {
+            // Create a disabled template in database
+            const now = Date.now();
+            await db
+                .insertInto('templates')
+                .values({
+                    filename: 'test-disabled-template',
+                    display_name: 'Test Disabled Template',
+                    description: 'A disabled template for testing',
+                    locale: 'en',
+                    is_enabled: 0, // Disabled
+                    sort_order: 0,
+                    storage_path: 'templates/en/test-disabled-template.elpx',
+                    created_at: now,
+                    updated_at: now,
+                })
+                .execute();
+
+            // Get the ID of the just-created template
+            const template = await db
+                .selectFrom('templates')
+                .selectAll()
+                .where('filename', '=', 'test-disabled-template')
+                .executeTakeFirst();
+
+            expect(template).toBeDefined();
+
+            const response = await app.handle(new Request(`http://localhost/api/templates/${template!.id}/download`));
+
+            // Should return 404 to not reveal the template exists
+            expect(response.status).toBe(404);
+            const data = await response.json();
+            expect(data.error).toBe('Not Found');
+            expect(data.message).toBe('Template not found');
+
+            // Cleanup
+            await db.deleteFrom('templates').where('id', '=', template!.id).execute();
+        });
+
+        it('should return 404 when template file does not exist on disk', async () => {
+            // Create an enabled template but don't create the file
+            const now = Date.now();
+            await db
+                .insertInto('templates')
+                .values({
+                    filename: 'test-missing-file-template',
+                    display_name: 'Test Missing File Template',
+                    description: 'A template with missing file for testing',
+                    locale: 'en',
+                    is_enabled: 1, // Enabled
+                    sort_order: 0,
+                    storage_path: 'templates/en/test-missing-file-template.elpx',
+                    created_at: now,
+                    updated_at: now,
+                })
+                .execute();
+
+            // Get the ID
+            const template = await db
+                .selectFrom('templates')
+                .selectAll()
+                .where('filename', '=', 'test-missing-file-template')
+                .executeTakeFirst();
+
+            expect(template).toBeDefined();
+
+            const response = await app.handle(new Request(`http://localhost/api/templates/${template!.id}/download`));
+
+            expect(response.status).toBe(404);
+            const data = await response.json();
+            expect(data.error).toBe('Not Found');
+            expect(data.message).toBe('Template file not found');
+
+            // Cleanup
+            await db.deleteFrom('templates').where('id', '=', template!.id).execute();
+        });
+    });
 });

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -24,7 +24,9 @@ import {
     parseBoolean,
     parseNumber,
 } from '../services/app-settings';
-import { getEnabledTemplatesByLocale } from '../db/queries/templates';
+import { getEnabledTemplatesByLocale, findTemplateById } from '../db/queries/templates';
+import { getFilesDir } from '../utils/admin-route-helpers';
+import * as path from 'path';
 import { getDefaultTheme, getDefaultThemeRecord } from '../db/queries/themes';
 import { SUPPORTED_LOCALES } from '../services/admin-upload-validator';
 
@@ -811,7 +813,7 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
                 templates = templatesDb.map(t => ({
                     name: t.filename,
                     displayName: t.display_name,
-                    path: `/api/admin/templates/${t.id}/download`,
+                    path: `/api/templates/${t.id}/download`,
                     source: 'admin' as const,
                     description: t.description || undefined,
                 }));
@@ -831,6 +833,64 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
         {
             query: t.Object({
                 locale: t.String(),
+            }),
+        },
+    )
+
+    // GET /api/templates/:id/download - Public download of an enabled template
+    // No authentication required, but only serves enabled templates
+    .get(
+        '/api/templates/:id/download',
+        async ({ params, set }) => {
+            const id = Number(params.id);
+
+            if (isNaN(id) || id <= 0) {
+                set.status = 400;
+                return { error: 'Bad Request', message: 'Invalid template ID' };
+            }
+
+            // Find template by ID
+            let template;
+            try {
+                template = await findTemplateById(defaultDb, id);
+            } catch {
+                // Table doesn't exist yet
+                set.status = 404;
+                return { error: 'Not Found', message: 'Template not found' };
+            }
+
+            if (!template) {
+                set.status = 404;
+                return { error: 'Not Found', message: 'Template not found' };
+            }
+
+            // SECURITY: Only serve enabled templates publicly
+            // Disabled templates return 404 (don't reveal they exist)
+            if (!template.is_enabled) {
+                set.status = 404;
+                return { error: 'Not Found', message: 'Template not found' };
+            }
+
+            // Build file path
+            const filesDir = getFilesDir();
+            const filePath = path.join(filesDir, 'templates', template.locale, `${template.filename}.elpx`);
+
+            // Check if file exists
+            const file = Bun.file(filePath);
+            if (!(await file.exists())) {
+                set.status = 404;
+                return { error: 'Not Found', message: 'Template file not found' };
+            }
+
+            // Return file with proper headers
+            set.headers['Content-Type'] = 'application/zip';
+            set.headers['Content-Disposition'] = `attachment; filename="${template.filename}.elpx"`;
+
+            return file;
+        },
+        {
+            params: t.Object({
+                id: t.String(),
             }),
         },
     )


### PR DESCRIPTION
This pull request adds a new public API endpoint to allow downloading enabled templates by ID, along with comprehensive tests and related utility imports. The endpoint ensures proper validation, security, and error handling for various edge cases, such as invalid IDs, disabled templates, and missing files.

**New public template download endpoint:**

* Added `GET /api/templates/:id/download` route to allow public download of enabled templates, with strict validation and security checks to only serve enabled templates and to not reveal the existence of disabled ones. Returns appropriate error messages for invalid, missing, or disabled templates, and for missing files. (`src/routes/config.ts`)

**Testing improvements:**

* Added extensive tests for the new endpoint, covering invalid IDs, negative/zero IDs, non-existent templates, disabled templates, and missing files, ensuring robust error handling and security. (`src/routes/config.spec.ts`)

**Supporting code updates:**

* Updated imports to include `findTemplateById` and utility helpers required for the new endpoint. (`src/routes/config.ts`)
* Updated template download path in the returned template objects to use the new public route. (`src/routes/config.ts`)