### PR TITLE
Avoid frozen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - tikismaker
-      - 'release/3.1'
     tags:
       - '*'
   pull_request:
@@ -57,7 +56,7 @@ jobs:
           bun-version: latest
 
       - name: Install Dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Lint (Biome)
         run: make lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'release/3.1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - tikismaker
-      - 'release/3.1'
     tags:
       - '*'
   pull_request:
@@ -35,7 +34,7 @@ jobs:
           bun-version: latest
 
       - name: Install Dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Build CSS (prod)
         run: make css

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 ################################################################################
 FROM base AS deps
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+RUN bun install
 
 ################################################################################
 # Build stage - Compile TypeScript and assets
@@ -33,7 +33,7 @@ RUN bun run build:all && \
 
 # Prune dev dependencies after build
 RUN rm -rf node_modules && \
-    bun install --production --frozen-lockfile && \
+    bun install --production && \
     rm -rf ~/.bun/install/cache
 
 ################################################################################


### PR DESCRIPTION
This pull request updates the CI/CD workflow and Docker build process to simplify dependency installation and remove references to the deprecated `release/3.1` branch. The main focus is on improving maintainability and reducing potential issues with strict lockfile enforcement.

**Workflow configuration updates:**

* Removed the `release/3.1` branch from the workflow triggers in `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`, and `.github/workflows/e2e.yml` to prevent jobs from running on this outdated branch. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L7) [[3]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL8)

**Dependency installation improvements:**

* Changed all `bun install --frozen-lockfile` commands to `bun install` in workflow files and the `Dockerfile`, making dependency installation less strict and reducing the risk of workflow failures due to lockfile mismatches. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R59) [[2]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL38-R37) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L16-R16) [[4]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L36-R36)