### PR TITLE
Fix references on ims-manifest and fix missing required file references

### DIFF
--- a/src/routes/resources.spec.ts
+++ b/src/routes/resources.spec.ts
@@ -445,14 +445,14 @@ describe('Resources Routes', () => {
             configure({
                 fs: {
                     existsSync: (filePath: string) => {
-                        if (filePath === 'public/files/perm/schemas/scorm12') return true;
+                        if (filePath === 'public/app/schemas/scorm12') return true;
                         return fs.existsSync(filePath);
                     },
                     readdirSync: (dirPath: any, options?: any) => {
                         if (typeof dirPath === 'string' && dirPath.includes('schemas/scorm12')) {
                             return [
-                                { name: 'imscp.xsd', isFile: () => true, isDirectory: () => false },
-                                { name: 'adlcp.xsd', isFile: () => true, isDirectory: () => false },
+                                { name: 'imscp_rootv1p1p2.xsd', isFile: () => true, isDirectory: () => false },
+                                { name: 'adlcp_rootv1p2.xsd', isFile: () => true, isDirectory: () => false },
                             ] as unknown as fs.Dirent[];
                         }
                         return fs.readdirSync(dirPath, options);
@@ -468,6 +468,110 @@ describe('Resources Routes', () => {
             expect(res.status).toBe(200);
             const body = await res.json();
             expect(body.length).toBe(2);
+            // Verify files have root-level paths (XSD files go in package root)
+            expect(body[0].path).toBe('imscp_rootv1p1p2.xsd');
+            expect(body[1].path).toBe('adlcp_rootv1p2.xsd');
+        });
+
+        it('should return SCORM 2004 schema files', async () => {
+            configure({
+                fs: {
+                    existsSync: (filePath: string) => {
+                        if (filePath === 'public/app/schemas/scorm2004') return true;
+                        return fs.existsSync(filePath);
+                    },
+                    readdirSync: (dirPath: any, options?: any) => {
+                        if (typeof dirPath === 'string' && dirPath.includes('schemas/scorm2004')) {
+                            return [
+                                { name: 'imscp_v1p1.xsd', isFile: () => true, isDirectory: () => false },
+                                { name: 'adlcp_v1p3.xsd', isFile: () => true, isDirectory: () => false },
+                                { name: 'imsss_v1p0.xsd', isFile: () => true, isDirectory: () => false },
+                            ] as unknown as fs.Dirent[];
+                        }
+                        return fs.readdirSync(dirPath, options);
+                    },
+                    statSync: fs.statSync,
+                    readFileSync: fs.readFileSync,
+                },
+            });
+            app = new Elysia().use(resourcesRoutes);
+
+            const res = await app.handle(new Request('http://localhost/api/resources/schemas/scorm2004'));
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.length).toBe(3);
+            expect(body[0].path).toBe('imscp_v1p1.xsd');
+            expect(body[1].path).toBe('adlcp_v1p3.xsd');
+            expect(body[2].path).toBe('imsss_v1p0.xsd');
+        });
+
+        it('should include schema files from subdirectories', async () => {
+            configure({
+                fs: {
+                    existsSync: (filePath: string) => {
+                        if (filePath.includes('schemas/scorm12')) return true;
+                        return fs.existsSync(filePath);
+                    },
+                    readdirSync: (dirPath: any, options?: any) => {
+                        if (typeof dirPath === 'string' && dirPath === 'public/app/schemas/scorm12') {
+                            return [
+                                { name: 'imscp_rootv1p1p2.xsd', isFile: () => true, isDirectory: () => false },
+                                { name: 'common', isFile: () => false, isDirectory: () => true },
+                            ] as unknown as fs.Dirent[];
+                        }
+                        if (typeof dirPath === 'string' && dirPath.includes('common')) {
+                            return [
+                                { name: 'dataTypes.xsd', isFile: () => true, isDirectory: () => false },
+                            ] as unknown as fs.Dirent[];
+                        }
+                        return fs.readdirSync(dirPath, options);
+                    },
+                    statSync: fs.statSync,
+                    readFileSync: fs.readFileSync,
+                },
+            });
+            app = new Elysia().use(resourcesRoutes);
+
+            const res = await app.handle(new Request('http://localhost/api/resources/schemas/scorm12'));
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.length).toBe(2);
+            // Root file
+            expect(body.some((f: { path: string }) => f.path === 'imscp_rootv1p1p2.xsd')).toBe(true);
+            // Subdirectory file preserves relative path
+            expect(body.some((f: { path: string }) => f.path === 'common/dataTypes.xsd')).toBe(true);
+        });
+
+        it('should generate correct URLs for schema files', async () => {
+            configure({
+                fs: {
+                    existsSync: (filePath: string) => {
+                        if (filePath === 'public/app/schemas/scorm12') return true;
+                        return fs.existsSync(filePath);
+                    },
+                    readdirSync: (dirPath: any, options?: any) => {
+                        if (typeof dirPath === 'string' && dirPath.includes('schemas/scorm12')) {
+                            return [
+                                { name: 'imscp_rootv1p1p2.xsd', isFile: () => true, isDirectory: () => false },
+                            ] as unknown as fs.Dirent[];
+                        }
+                        return fs.readdirSync(dirPath, options);
+                    },
+                    statSync: fs.statSync,
+                    readFileSync: fs.readFileSync,
+                },
+            });
+            app = new Elysia().use(resourcesRoutes);
+
+            const res = await app.handle(new Request('http://localhost/api/resources/schemas/scorm12'));
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.length).toBe(1);
+            // URL should point to the actual file location
+            expect(body[0].url).toContain('/app/schemas/scorm12/imscp_rootv1p1p2.xsd');
         });
     });
 

--- a/src/routes/resources.ts
+++ b/src/routes/resources.ts
@@ -329,13 +329,14 @@ export const resourcesRoutes = new Elysia({ name: 'resources-routes' })
     .get('/api/resources/schemas/:format', ({ params }) => {
         const { format } = params;
 
-        // Schema files are typically in public/files/perm/schemas/
-        const schemasPath = path.join('public/files/perm/schemas', format);
+        // Schema files are in public/app/schemas/ (scorm12, scorm2004, ims, epub3)
+        const schemasPath = path.join('public/app/schemas', format);
         if (!deps.fs.existsSync(schemasPath)) {
             return [];
         }
 
-        return buildFileList(schemasPath, `/files/perm/schemas/${format}`);
+        // Return files with root-level paths (XSD files go in package root)
+        return buildFileList(schemasPath, `/app/schemas/${format}`, '');
     })
 
     // GET /api/resources/content-css - Get content CSS files (base.css, etc.)

--- a/src/shared/export/exporters/BaseExporter.spec.ts
+++ b/src/shared/export/exporters/BaseExporter.spec.ts
@@ -124,8 +124,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/ComponentExporter.spec.ts
+++ b/src/shared/export/exporters/ComponentExporter.spec.ts
@@ -101,12 +101,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, Uint8Array>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: Uint8Array | string): void {
         if (typeof content === 'string') {
             this.files.set(path, new TextEncoder().encode(content));
         } else {
             this.files.set(path, content);
         }
+    }
+
+    addFiles(files: Map<string, Uint8Array | string>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
     }
 
     async generate(): Promise<Uint8Array> {

--- a/src/shared/export/exporters/ElpxExporter.spec.ts
+++ b/src/shared/export/exporters/ElpxExporter.spec.ts
@@ -108,12 +108,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
     }
 
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
     hasFile(path: string): boolean {
         return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/Epub3Exporter.spec.ts
+++ b/src/shared/export/exporters/Epub3Exporter.spec.ts
@@ -108,8 +108,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/Html5Exporter.spec.ts
+++ b/src/shared/export/exporters/Html5Exporter.spec.ts
@@ -122,8 +122,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/ImsExporter.spec.ts
+++ b/src/shared/export/exporters/ImsExporter.spec.ts
@@ -107,8 +107,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/ImsExporter.ts
+++ b/src/shared/export/exporters/ImsExporter.ts
@@ -171,10 +171,13 @@ export class ImsExporter extends Html5Exporter {
             // 6. Add project assets
             await this.addAssetsToZipWithResourcePath();
 
-            // 7. Generate imsmanifest.xml
+            // 7. Generate imsmanifest.xml with complete file list
+            // Get all files from the ZIP to ensure the manifest lists ALL resources
+            const allZipFiles = this.zip.getFilePaths();
             const manifestXml = this.manifestGenerator.generate({
                 commonFiles,
                 pageFiles,
+                allZipFiles,
             });
             this.zip.addFile('imsmanifest.xml', manifestXml);
 

--- a/src/shared/export/exporters/PageExporter.spec.ts
+++ b/src/shared/export/exporters/PageExporter.spec.ts
@@ -107,8 +107,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/Scorm12Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.spec.ts
@@ -293,6 +293,23 @@ describe('Scorm12Exporter', () => {
             expect(manifest).toContain('<resources');
             expect(manifest).toContain('<resource');
         });
+
+        it('should list imslrm.xml in COMMON_FILES resource', async () => {
+            await exporter.export();
+
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            // imslrm.xml should be listed as a file in COMMON_FILES
+            // (referenced by adlcp:location in metadata)
+            expect(manifest).toContain('identifier="COMMON_FILES"');
+            expect(manifest).toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should reference imslrm.xml in metadata', async () => {
+            await exporter.export();
+
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).toContain('<adlcp:location>imslrm.xml</adlcp:location>');
+        });
     });
 
     describe('LOM Metadata', () => {

--- a/src/shared/export/exporters/Scorm12Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.spec.ts
@@ -110,8 +110,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/Scorm12Exporter.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.ts
@@ -221,16 +221,19 @@ export class Scorm12Exporter extends Html5Exporter {
             // 7. Add project assets
             await this.addAssetsToZipWithResourcePath();
 
-            // 8. Generate imsmanifest.xml
+            // 8. Generate imslrm.xml (LOM metadata) - must be before manifest
+            const lomXml = this.lomGenerator.generate();
+            this.zip.addFile('imslrm.xml', lomXml);
+
+            // 9. Generate imsmanifest.xml with complete file list
+            // Get all files from the ZIP to ensure the manifest lists ALL resources
+            const allZipFiles = this.zip.getFilePaths();
             const manifestXml = this.manifestGenerator.generate({
                 commonFiles,
                 pageFiles,
+                allZipFiles,
             });
             this.zip.addFile('imsmanifest.xml', manifestXml);
-
-            // 9. Generate imslrm.xml (LOM metadata)
-            const lomXml = this.lomGenerator.generate();
-            this.zip.addFile('imslrm.xml', lomXml);
 
             // 10. Generate ZIP buffer
             const buffer = await this.zip.generateAsync();

--- a/src/shared/export/exporters/Scorm2004Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.spec.ts
@@ -110,8 +110,31 @@ class MockAssetProvider implements AssetProvider {
 class MockZipProvider implements ZipProvider {
     files = new Map<string, string | Buffer>();
 
+    createZip() {
+        this.files.clear();
+        return this;
+    }
+
     addFile(path: string, content: string | Buffer): void {
         this.files.set(path, content);
+    }
+
+    addFiles(files: Map<string, string | Buffer>): void {
+        for (const [path, content] of files) {
+            this.addFile(path, content);
+        }
+    }
+
+    hasFile(path: string): boolean {
+        return this.files.has(path);
+    }
+
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    async generate(): Promise<Buffer> {
+        return this.generateAsync();
     }
 
     async generateAsync(): Promise<Buffer> {

--- a/src/shared/export/exporters/Scorm2004Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.spec.ts
@@ -283,6 +283,23 @@ describe('Scorm2004Exporter', () => {
             const manifest = zip.files.get('imsmanifest.xml') as string;
             expect(manifest).toContain('Test SCORM 2004 Project');
         });
+
+        it('should list imslrm.xml in COMMON_FILES resource', async () => {
+            await exporter.export();
+
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            // imslrm.xml should be listed as a file in COMMON_FILES
+            // (referenced by adlcp:location in metadata)
+            expect(manifest).toContain('identifier="COMMON_FILES"');
+            expect(manifest).toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should reference imslrm.xml in metadata', async () => {
+            await exporter.export();
+
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).toContain('<adlcp:location>imslrm.xml</adlcp:location>');
+        });
     });
 
     describe('SCORM 2004 Page HTML', () => {

--- a/src/shared/export/exporters/Scorm2004Exporter.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.ts
@@ -221,16 +221,19 @@ export class Scorm2004Exporter extends Html5Exporter {
             // 7. Add project assets
             await this.addAssetsToZipWithResourcePath();
 
-            // 8. Generate imsmanifest.xml
+            // 8. Generate imslrm.xml (LOM metadata) - must be before manifest
+            const lomXml = this.lomGenerator.generate();
+            this.zip.addFile('imslrm.xml', lomXml);
+
+            // 9. Generate imsmanifest.xml with complete file list
+            // Get all files from the ZIP to ensure the manifest lists ALL resources
+            const allZipFiles = this.zip.getFilePaths();
             const manifestXml = this.manifestGenerator.generate({
                 commonFiles,
                 pageFiles,
+                allZipFiles,
             });
             this.zip.addFile('imsmanifest.xml', manifestXml);
-
-            // 9. Generate imslrm.xml (LOM metadata)
-            const lomXml = this.lomGenerator.generate();
-            this.zip.addFile('imslrm.xml', lomXml);
 
             // 10. Generate ZIP buffer
             const buffer = await this.zip.generateAsync();

--- a/src/shared/export/generators/ImsManifest.spec.ts
+++ b/src/shared/export/generators/ImsManifest.spec.ts
@@ -209,4 +209,102 @@ describe('ImsManifestGenerator', () => {
             expect(xml).toContain('</resources>');
         });
     });
+
+    describe('allZipFiles - complete file listing', () => {
+        it('should include all ZIP files in COMMON_FILES when allZipFiles is provided', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/jquery.js',
+                    'content/css/base.css',
+                    'theme/style.css',
+                    'content/resources/image1.png',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                    'page-2': { fileUrl: 'html/chapter-1.html' },
+                    'page-3': { fileUrl: 'html/section-11.html' },
+                },
+            });
+
+            // Common files should be included
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="content/css/base.css"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+            expect(xml).toContain('<file href="content/resources/image1.png"/>');
+
+            // imsmanifest.xml should be excluded
+            expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
+        });
+
+        it('should include asset files added after initial file tracking', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js'], // Old tracking (incomplete)
+                allZipFiles: [
+                    'index.html',
+                    'libs/jquery.js',
+                    'content/resources/asset-uuid-1/image.png',
+                    'content/resources/asset-uuid-2/video.mp4',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // Should include assets that weren't in the original commonFiles list
+            expect(xml).toContain('<file href="content/resources/asset-uuid-1/image.png"/>');
+            expect(xml).toContain('<file href="content/resources/asset-uuid-2/video.mp4"/>');
+        });
+
+        it('should fallback to commonFiles if allZipFiles is empty', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js', 'theme/style.css'],
+                allZipFiles: [],
+            });
+
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+        });
+
+        it('should use default page URLs when pageFiles not provided', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/common.js',
+                    'imsmanifest.xml',
+                ],
+            });
+
+            // libs/common.js should be in COMMON_FILES since page URLs are auto-generated
+            expect(xml).toContain('<file href="libs/common.js"/>');
+        });
+
+        it('should sort common files alphabetically', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'theme/z-file.css',
+                    'content/a-file.css',
+                    'libs/m-file.js',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            const contentIndex = xml.indexOf('content/a-file.css');
+            const libsIndex = xml.indexOf('libs/m-file.js');
+            const themeIndex = xml.indexOf('theme/z-file.css');
+
+            expect(contentIndex).toBeLessThan(libsIndex);
+            expect(libsIndex).toBeLessThan(themeIndex);
+        });
+    });
 });

--- a/src/shared/export/generators/ImsManifest.ts
+++ b/src/shared/export/generators/ImsManifest.ts
@@ -30,10 +30,18 @@ export interface PageFileInfo {
  * Options for manifest generation
  */
 export interface ImsGenerateOptions {
-    /** List of common files to include */
+    /** List of common files to include (legacy, used if allZipFiles not provided) */
     commonFiles?: string[];
     /** Map of pageId to file info */
     pageFiles?: Record<string, PageFileInfo>;
+    /**
+     * Complete list of all files in the ZIP archive.
+     * When provided, the generator will automatically categorize files:
+     * - Page HTML files go in their respective page resources
+     * - All other files go in COMMON_FILES
+     * This ensures the manifest contains ALL files in the export.
+     */
+    allZipFiles?: string[];
 }
 
 /**
@@ -70,16 +78,54 @@ export class ImsManifestGenerator {
      * @returns Complete XML string
      */
     generate(options: ImsGenerateOptions = {}): string {
-        const { commonFiles = [], pageFiles = {} } = options;
+        const { commonFiles = [], pageFiles = {}, allZipFiles } = options;
+
+        // If allZipFiles is provided, use it to build complete file lists
+        let effectiveCommonFiles = commonFiles;
+        if (allZipFiles && allZipFiles.length > 0) {
+            effectiveCommonFiles = this.categorizeFilesForCommon(allZipFiles, pageFiles);
+        }
 
         let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
         xml += this.generateManifestOpen();
         xml += this.generateMetadata();
         xml += this.generateOrganizations();
-        xml += this.generateResources(commonFiles, pageFiles);
+        xml += this.generateResources(effectiveCommonFiles, pageFiles);
         xml += '</manifest>\n';
 
         return xml;
+    }
+
+    /**
+     * Categorize files into COMMON_FILES based on complete ZIP file list.
+     * All files except page HTML files and imsmanifest.xml go into COMMON_FILES.
+     * @param allFiles - Complete list of files in the ZIP
+     * @param pageFiles - Map of page file info (to identify page HTML files)
+     * @returns List of files for COMMON_FILES resource
+     */
+    protected categorizeFilesForCommon(allFiles: string[], pageFiles: Record<string, PageFileInfo>): string[] {
+        // Build set of page HTML files
+        const pageHtmlFiles = new Set<string>();
+        for (const page of this.pages) {
+            const pageFile = pageFiles[page.id];
+            if (pageFile?.fileUrl) {
+                pageHtmlFiles.add(pageFile.fileUrl);
+            } else {
+                // Default file URL
+                const isIndex = this.pages.indexOf(page) === 0;
+                const defaultUrl = isIndex ? 'index.html' : `html/${this.sanitizeFilename(page.title)}.html`;
+                pageHtmlFiles.add(defaultUrl);
+            }
+        }
+
+        // Files that should be excluded from COMMON_FILES:
+        // - Page HTML files (they go in their own resource)
+        // - imsmanifest.xml (it's the manifest itself)
+        // - imslrm.xml (referenced separately in SCORM metadata)
+        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml', 'imslrm.xml']);
+
+        // All other files go to COMMON_FILES
+        return allFiles.filter(file => !excludedFiles.has(file)).sort();
     }
 
     /**

--- a/src/shared/export/generators/Scorm12Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm12Manifest.spec.ts
@@ -436,4 +436,68 @@ describe('Scorm12ManifestGenerator', () => {
             expect(matches?.length).toBe(1);
         });
     });
+
+    describe('XSD schema files handling', () => {
+        it('should include XSD files in COMMON_FILES when present', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'imscp_rootv1p1p2.xsd',
+                    'adlcp_rootv1p2.xsd',
+                    'imsmd_rootv1p2p1.xsd',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // XSD files should be in COMMON_FILES
+            expect(xml).toContain('<file href="imscp_rootv1p1p2.xsd"/>');
+            expect(xml).toContain('<file href="adlcp_rootv1p2.xsd"/>');
+            expect(xml).toContain('<file href="imsmd_rootv1p2p1.xsd"/>');
+            // imslrm.xml should also be included
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should include XSD files from subdirectories', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'imscp_rootv1p1p2.xsd',
+                    'common/dataTypes.xsd',
+                    'common/elementTypes.xsd',
+                    'vocab/custom.xsd',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // All XSD files including subdirectory ones should be in COMMON_FILES
+            expect(xml).toContain('<file href="imscp_rootv1p1p2.xsd"/>');
+            expect(xml).toContain('<file href="common/dataTypes.xsd"/>');
+            expect(xml).toContain('<file href="common/elementTypes.xsd"/>');
+            expect(xml).toContain('<file href="vocab/custom.xsd"/>');
+        });
+
+        it('should work correctly when no XSD files are present', () => {
+            const xml = generator.generate({
+                allZipFiles: ['index.html', 'libs/jquery.js', 'imslrm.xml', 'imsmanifest.xml'],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // Should still have valid COMMON_FILES with other files
+            expect(xml).toContain('identifier="COMMON_FILES"');
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+            // No XSD files
+            expect(xml).not.toContain('.xsd"/>');
+        });
+    });
 });

--- a/src/shared/export/generators/Scorm12Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm12Manifest.spec.ts
@@ -235,4 +235,149 @@ describe('Scorm12ManifestGenerator', () => {
             expect(xml).toContain('</resources>');
         });
     });
+
+    describe('allZipFiles - complete file listing', () => {
+        it('should include all ZIP files in COMMON_FILES when allZipFiles is provided', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/jquery.js',
+                    'content/css/base.css',
+                    'theme/style.css',
+                    'content/resources/image1.png',
+                    'content/resources/document.pdf',
+                    'imsmanifest.xml',
+                    'imslrm.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                    'page-2': { fileUrl: 'html/chapter-1.html' },
+                    'page-3': { fileUrl: 'html/section-11.html' },
+                },
+            });
+
+            // Common files should be included
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="content/css/base.css"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+            expect(xml).toContain('<file href="content/resources/image1.png"/>');
+            expect(xml).toContain('<file href="content/resources/document.pdf"/>');
+
+            // Page HTML files should NOT be in COMMON_FILES (they're in page resources)
+            // Check that they're not duplicated in COMMON_FILES section
+            const commonFilesStart = xml.indexOf('identifier="COMMON_FILES"');
+            const commonFilesSection = xml.substring(commonFilesStart);
+            expect(commonFilesSection).not.toContain('href="index.html"');
+
+            // imsmanifest.xml and imslrm.xml should be excluded
+            expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
+            expect(xml).not.toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should include asset files added after initial file tracking', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js'], // Old tracking (incomplete)
+                allZipFiles: [
+                    'index.html',
+                    'libs/jquery.js',
+                    'content/resources/asset-uuid-1/image.png', // Asset added later
+                    'content/resources/asset-uuid-2/video.mp4', // Asset added later
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // Should include assets that weren't in the original commonFiles list
+            expect(xml).toContain('<file href="content/resources/asset-uuid-1/image.png"/>');
+            expect(xml).toContain('<file href="content/resources/asset-uuid-2/video.mp4"/>');
+        });
+
+        it('should fallback to commonFiles if allZipFiles is empty', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js', 'theme/style.css'],
+                allZipFiles: [], // Empty array - should fallback
+            });
+
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+        });
+
+        it('should sort common files alphabetically', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'theme/z-file.css',
+                    'content/a-file.css',
+                    'libs/m-file.js',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            const contentIndex = xml.indexOf('content/a-file.css');
+            const libsIndex = xml.indexOf('libs/m-file.js');
+            const themeIndex = xml.indexOf('theme/z-file.css');
+
+            // Files should be sorted alphabetically
+            expect(contentIndex).toBeLessThan(libsIndex);
+            expect(libsIndex).toBeLessThan(themeIndex);
+        });
+
+        it('should properly categorize files for multi-page projects', () => {
+            const multiPageGenerator = new Scorm12ManifestGenerator('test', createTestPages(), {
+                title: 'Test',
+            });
+
+            const xml = multiPageGenerator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/common.js',
+                    'content/shared-asset.png',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                    'page-2': { fileUrl: 'html/chapter-1.html' },
+                    'page-3': { fileUrl: 'html/section-11.html' },
+                },
+            });
+
+            // All page resources should exist
+            expect(xml).toContain('identifier="RES-page-1"');
+            expect(xml).toContain('identifier="RES-page-2"');
+            expect(xml).toContain('identifier="RES-page-3"');
+
+            // COMMON_FILES should contain shared resources
+            expect(xml).toContain('<file href="libs/common.js"/>');
+            expect(xml).toContain('<file href="content/shared-asset.png"/>');
+        });
+
+        it('should handle iDevice resources in allZipFiles', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'idevices/text/text.css',
+                    'idevices/text/text.js',
+                    'idevices/quiz/quiz.css',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // iDevice files should be in COMMON_FILES
+            expect(xml).toContain('<file href="idevices/text/text.css"/>');
+            expect(xml).toContain('<file href="idevices/text/text.js"/>');
+            expect(xml).toContain('<file href="idevices/quiz/quiz.css"/>');
+        });
+    });
 });

--- a/src/shared/export/generators/Scorm12Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm12Manifest.spec.ts
@@ -271,9 +271,11 @@ describe('Scorm12ManifestGenerator', () => {
             const commonFilesSection = xml.substring(commonFilesStart);
             expect(commonFilesSection).not.toContain('href="index.html"');
 
-            // imsmanifest.xml and imslrm.xml should be excluded
+            // imsmanifest.xml should be excluded (it's the manifest itself)
             expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
-            expect(xml).not.toContain('<file href="imslrm.xml"/>');
+
+            // imslrm.xml SHOULD be included (it's referenced by adlcp:location in metadata)
+            expect(xml).toContain('<file href="imslrm.xml"/>');
         });
 
         it('should include asset files added after initial file tracking', () => {
@@ -378,6 +380,75 @@ describe('Scorm12ManifestGenerator', () => {
             expect(xml).toContain('<file href="idevices/text/text.css"/>');
             expect(xml).toContain('<file href="idevices/text/text.js"/>');
             expect(xml).toContain('<file href="idevices/quiz/quiz.css"/>');
+        });
+    });
+
+    describe('imslrm.xml handling', () => {
+        it('should include imslrm.xml in COMMON_FILES when present', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'libs/jquery.js',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // imslrm.xml should be included (referenced by adlcp:location in metadata)
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+            // imsmanifest.xml should NOT be included (it's the manifest itself)
+            expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
+        });
+
+        it('should reference imslrm.xml in metadata section', () => {
+            const xml = generator.generate();
+
+            // Metadata should reference imslrm.xml via adlcp:location
+            expect(xml).toContain('<adlcp:location>imslrm.xml</adlcp:location>');
+        });
+
+        it('should include imslrm.xml alongside other common files', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'libs/jquery.js',
+                    'theme/style.css',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // All common files should be in COMMON_FILES resource
+            const commonFilesStart = xml.indexOf('identifier="COMMON_FILES"');
+            const commonFilesEnd = xml.indexOf('</resource>', commonFilesStart);
+            const commonFilesSection = xml.substring(commonFilesStart, commonFilesEnd);
+
+            expect(commonFilesSection).toContain('href="imslrm.xml"');
+            expect(commonFilesSection).toContain('href="libs/jquery.js"');
+            expect(commonFilesSection).toContain('href="theme/style.css"');
+        });
+
+        it('should not duplicate imslrm.xml in page resources', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // imslrm.xml should only appear once (in COMMON_FILES)
+            const matches = xml.match(/<file href="imslrm\.xml"\/>/g);
+            expect(matches?.length).toBe(1);
         });
     });
 });

--- a/src/shared/export/generators/Scorm12Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm12Manifest.spec.ts
@@ -386,12 +386,7 @@ describe('Scorm12ManifestGenerator', () => {
     describe('imslrm.xml handling', () => {
         it('should include imslrm.xml in COMMON_FILES when present', () => {
             const xml = generator.generate({
-                allZipFiles: [
-                    'index.html',
-                    'libs/jquery.js',
-                    'imslrm.xml',
-                    'imsmanifest.xml',
-                ],
+                allZipFiles: ['index.html', 'libs/jquery.js', 'imslrm.xml', 'imsmanifest.xml'],
                 pageFiles: {
                     'page-1': { fileUrl: 'index.html' },
                 },
@@ -412,13 +407,7 @@ describe('Scorm12ManifestGenerator', () => {
 
         it('should include imslrm.xml alongside other common files', () => {
             const xml = generator.generate({
-                allZipFiles: [
-                    'index.html',
-                    'libs/jquery.js',
-                    'theme/style.css',
-                    'imslrm.xml',
-                    'imsmanifest.xml',
-                ],
+                allZipFiles: ['index.html', 'libs/jquery.js', 'theme/style.css', 'imslrm.xml', 'imsmanifest.xml'],
                 pageFiles: {
                     'page-1': { fileUrl: 'index.html' },
                 },
@@ -436,11 +425,7 @@ describe('Scorm12ManifestGenerator', () => {
 
         it('should not duplicate imslrm.xml in page resources', () => {
             const xml = generator.generate({
-                allZipFiles: [
-                    'index.html',
-                    'imslrm.xml',
-                    'imsmanifest.xml',
-                ],
+                allZipFiles: ['index.html', 'imslrm.xml', 'imsmanifest.xml'],
                 pageFiles: {
                     'page-1': { fileUrl: 'index.html' },
                 },

--- a/src/shared/export/generators/Scorm12Manifest.ts
+++ b/src/shared/export/generators/Scorm12Manifest.ts
@@ -34,10 +34,18 @@ export interface PageFileInfo {
  * Options for manifest generation
  */
 export interface Scorm12GenerateOptions {
-    /** List of common files to include */
+    /** List of common files to include (legacy, used if allZipFiles not provided) */
     commonFiles?: string[];
     /** Map of pageId to file info */
     pageFiles?: Record<string, PageFileInfo>;
+    /**
+     * Complete list of all files in the ZIP archive.
+     * When provided, the generator will automatically categorize files:
+     * - Page HTML files go in their respective page resources
+     * - All other files go in COMMON_FILES
+     * This ensures the manifest contains ALL files in the export.
+     */
+    allZipFiles?: string[];
 }
 
 /**
@@ -74,16 +82,54 @@ export class Scorm12ManifestGenerator {
      * @returns Complete XML string
      */
     generate(options: Scorm12GenerateOptions = {}): string {
-        const { commonFiles = [], pageFiles = {} } = options;
+        const { commonFiles = [], pageFiles = {}, allZipFiles } = options;
+
+        // If allZipFiles is provided, use it to build complete file lists
+        let effectiveCommonFiles = commonFiles;
+        if (allZipFiles && allZipFiles.length > 0) {
+            effectiveCommonFiles = this.categorizeFilesForCommon(allZipFiles, pageFiles);
+        }
 
         let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
         xml += this.generateManifestOpen();
         xml += this.generateMetadata();
         xml += this.generateOrganizations();
-        xml += this.generateResources(commonFiles, pageFiles);
+        xml += this.generateResources(effectiveCommonFiles, pageFiles);
         xml += '</manifest>\n';
 
         return xml;
+    }
+
+    /**
+     * Categorize files into COMMON_FILES based on complete ZIP file list.
+     * All files except page HTML files and imsmanifest.xml go into COMMON_FILES.
+     * @param allFiles - Complete list of files in the ZIP
+     * @param pageFiles - Map of page file info (to identify page HTML files)
+     * @returns List of files for COMMON_FILES resource
+     */
+    protected categorizeFilesForCommon(allFiles: string[], pageFiles: Record<string, PageFileInfo>): string[] {
+        // Build set of page HTML files
+        const pageHtmlFiles = new Set<string>();
+        for (const page of this.pages) {
+            const pageFile = pageFiles[page.id];
+            if (pageFile?.fileUrl) {
+                pageHtmlFiles.add(pageFile.fileUrl);
+            } else {
+                // Default file URL
+                const isIndex = this.pages.indexOf(page) === 0;
+                const defaultUrl = isIndex ? 'index.html' : `html/${this.sanitizeFilename(page.title)}.html`;
+                pageHtmlFiles.add(defaultUrl);
+            }
+        }
+
+        // Files that should be excluded from COMMON_FILES:
+        // - Page HTML files (they go in their own resource)
+        // - imsmanifest.xml (it's the manifest itself)
+        // - imslrm.xml (referenced separately in SCORM metadata)
+        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml', 'imslrm.xml']);
+
+        // All other files go to COMMON_FILES
+        return allFiles.filter(file => !excludedFiles.has(file)).sort();
     }
 
     /**

--- a/src/shared/export/generators/Scorm12Manifest.ts
+++ b/src/shared/export/generators/Scorm12Manifest.ts
@@ -125,8 +125,9 @@ export class Scorm12ManifestGenerator {
         // Files that should be excluded from COMMON_FILES:
         // - Page HTML files (they go in their own resource)
         // - imsmanifest.xml (it's the manifest itself)
-        // - imslrm.xml (referenced separately in SCORM metadata)
-        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml', 'imslrm.xml']);
+        // Note: imslrm.xml IS included in COMMON_FILES (it's a valid resource file
+        // referenced by adlcp:location in metadata)
+        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml']);
 
         // All other files go to COMMON_FILES
         return allFiles.filter(file => !excludedFiles.has(file)).sort();

--- a/src/shared/export/generators/Scorm2004Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.spec.ts
@@ -248,4 +248,58 @@ describe('Scorm2004ManifestGenerator', () => {
             expect(libsIndex).toBeLessThan(themeIndex);
         });
     });
+
+    describe('imslrm.xml handling', () => {
+        it('should include imslrm.xml in COMMON_FILES when present', () => {
+            const xml = generator.generate({
+                allZipFiles: ['index.html', 'libs/jquery.js', 'imslrm.xml', 'imsmanifest.xml'],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // imslrm.xml should be included (referenced by adlcp:location in metadata)
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+            // imsmanifest.xml should NOT be included (it's the manifest itself)
+            expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
+        });
+
+        it('should reference imslrm.xml in metadata section', () => {
+            const xml = generator.generate();
+
+            // Metadata should reference imslrm.xml via adlcp:location
+            expect(xml).toContain('<adlcp:location>imslrm.xml</adlcp:location>');
+        });
+
+        it('should include imslrm.xml alongside other common files', () => {
+            const xml = generator.generate({
+                allZipFiles: ['index.html', 'libs/jquery.js', 'theme/style.css', 'imslrm.xml', 'imsmanifest.xml'],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // All common files should be in COMMON_FILES resource
+            const commonFilesStart = xml.indexOf('identifier="COMMON_FILES"');
+            const commonFilesEnd = xml.indexOf('</resource>', commonFilesStart);
+            const commonFilesSection = xml.substring(commonFilesStart, commonFilesEnd);
+
+            expect(commonFilesSection).toContain('href="imslrm.xml"');
+            expect(commonFilesSection).toContain('href="libs/jquery.js"');
+            expect(commonFilesSection).toContain('href="theme/style.css"');
+        });
+
+        it('should not duplicate imslrm.xml in page resources', () => {
+            const xml = generator.generate({
+                allZipFiles: ['index.html', 'imslrm.xml', 'imsmanifest.xml'],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // imslrm.xml should only appear once (in COMMON_FILES)
+            const matches = xml.match(/<file href="imslrm\.xml"\/>/g);
+            expect(matches?.length).toBe(1);
+        });
+    });
 });

--- a/src/shared/export/generators/Scorm2004Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.spec.ts
@@ -148,4 +148,102 @@ describe('Scorm2004ManifestGenerator', () => {
             expect(xml).toContain('</organizations>');
         });
     });
+
+    describe('allZipFiles - complete file listing', () => {
+        it('should include all ZIP files in COMMON_FILES when allZipFiles is provided', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/jquery.js',
+                    'content/css/base.css',
+                    'theme/style.css',
+                    'content/resources/image1.png',
+                    'imsmanifest.xml',
+                    'imslrm.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                    'page-2': { fileUrl: 'html/chapter-1.html' },
+                    'page-3': { fileUrl: 'html/section-11.html' },
+                },
+            });
+
+            // Common files should be included
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="content/css/base.css"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+            expect(xml).toContain('<file href="content/resources/image1.png"/>');
+
+            // imsmanifest.xml and imslrm.xml should be excluded
+            expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
+            expect(xml).not.toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should include asset files added after initial file tracking', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js'],
+                allZipFiles: [
+                    'index.html',
+                    'libs/jquery.js',
+                    'content/resources/asset-uuid-1/image.png',
+                    'content/resources/asset-uuid-2/video.mp4',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            expect(xml).toContain('<file href="content/resources/asset-uuid-1/image.png"/>');
+            expect(xml).toContain('<file href="content/resources/asset-uuid-2/video.mp4"/>');
+        });
+
+        it('should fallback to commonFiles if allZipFiles is empty', () => {
+            const xml = generator.generate({
+                commonFiles: ['libs/jquery.js', 'theme/style.css'],
+                allZipFiles: [],
+            });
+
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="theme/style.css"/>');
+        });
+
+        it('should use default page URLs when pageFiles not provided', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'html/chapter-1.html',
+                    'html/section-11.html',
+                    'libs/common.js',
+                    'imsmanifest.xml',
+                ],
+            });
+
+            expect(xml).toContain('<file href="libs/common.js"/>');
+        });
+
+        it('should sort common files alphabetically', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'theme/z-file.css',
+                    'content/a-file.css',
+                    'libs/m-file.js',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            const contentIndex = xml.indexOf('content/a-file.css');
+            const libsIndex = xml.indexOf('libs/m-file.js');
+            const themeIndex = xml.indexOf('theme/z-file.css');
+
+            expect(contentIndex).toBeLessThan(libsIndex);
+            expect(libsIndex).toBeLessThan(themeIndex);
+        });
+    });
 });

--- a/src/shared/export/generators/Scorm2004Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.spec.ts
@@ -302,4 +302,72 @@ describe('Scorm2004ManifestGenerator', () => {
             expect(matches?.length).toBe(1);
         });
     });
+
+    describe('XSD schema files handling', () => {
+        it('should include SCORM 2004 XSD files in COMMON_FILES when present', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'imscp_v1p1.xsd',
+                    'adlcp_v1p3.xsd',
+                    'adlseq_v1p3.xsd',
+                    'adlnav_v1p3.xsd',
+                    'imsss_v1p0.xsd',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // XSD files should be in COMMON_FILES
+            expect(xml).toContain('<file href="imscp_v1p1.xsd"/>');
+            expect(xml).toContain('<file href="adlcp_v1p3.xsd"/>');
+            expect(xml).toContain('<file href="adlseq_v1p3.xsd"/>');
+            expect(xml).toContain('<file href="adlnav_v1p3.xsd"/>');
+            expect(xml).toContain('<file href="imsss_v1p0.xsd"/>');
+            // imslrm.xml should also be included
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+        });
+
+        it('should include XSD files from subdirectories', () => {
+            const xml = generator.generate({
+                allZipFiles: [
+                    'index.html',
+                    'imscp_v1p1.xsd',
+                    'common/dataTypes.xsd',
+                    'common/elementTypes.xsd',
+                    'vocab/custom.xsd',
+                    'imslrm.xml',
+                    'imsmanifest.xml',
+                ],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // All XSD files including subdirectory ones should be in COMMON_FILES
+            expect(xml).toContain('<file href="imscp_v1p1.xsd"/>');
+            expect(xml).toContain('<file href="common/dataTypes.xsd"/>');
+            expect(xml).toContain('<file href="common/elementTypes.xsd"/>');
+            expect(xml).toContain('<file href="vocab/custom.xsd"/>');
+        });
+
+        it('should work correctly when no XSD files are present', () => {
+            const xml = generator.generate({
+                allZipFiles: ['index.html', 'libs/jquery.js', 'imslrm.xml', 'imsmanifest.xml'],
+                pageFiles: {
+                    'page-1': { fileUrl: 'index.html' },
+                },
+            });
+
+            // Should still have valid COMMON_FILES with other files
+            expect(xml).toContain('identifier="COMMON_FILES"');
+            expect(xml).toContain('<file href="libs/jquery.js"/>');
+            expect(xml).toContain('<file href="imslrm.xml"/>');
+            // No XSD files
+            expect(xml).not.toContain('.xsd"/>');
+        });
+    });
 });

--- a/src/shared/export/generators/Scorm2004Manifest.spec.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.spec.ts
@@ -176,9 +176,11 @@ describe('Scorm2004ManifestGenerator', () => {
             expect(xml).toContain('<file href="theme/style.css"/>');
             expect(xml).toContain('<file href="content/resources/image1.png"/>');
 
-            // imsmanifest.xml and imslrm.xml should be excluded
+            // imsmanifest.xml should be excluded (it's the manifest itself)
             expect(xml).not.toContain('<file href="imsmanifest.xml"/>');
-            expect(xml).not.toContain('<file href="imslrm.xml"/>');
+
+            // imslrm.xml SHOULD be included (it's referenced by adlcp:location in metadata)
+            expect(xml).toContain('<file href="imslrm.xml"/>');
         });
 
         it('should include asset files added after initial file tracking', () => {

--- a/src/shared/export/generators/Scorm2004Manifest.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.ts
@@ -31,10 +31,18 @@ export interface PageFileInfo {
  * Options for manifest generation
  */
 export interface Scorm2004GenerateOptions {
-    /** List of common files to include */
+    /** List of common files to include (legacy, used if allZipFiles not provided) */
     commonFiles?: string[];
     /** Map of pageId to file info */
     pageFiles?: Record<string, PageFileInfo>;
+    /**
+     * Complete list of all files in the ZIP archive.
+     * When provided, the generator will automatically categorize files:
+     * - Page HTML files go in their respective page resources
+     * - All other files go in COMMON_FILES
+     * This ensures the manifest contains ALL files in the export.
+     */
+    allZipFiles?: string[];
 }
 
 /**
@@ -71,16 +79,54 @@ export class Scorm2004ManifestGenerator {
      * @returns Complete XML string
      */
     generate(options: Scorm2004GenerateOptions = {}): string {
-        const { commonFiles = [], pageFiles = {} } = options;
+        const { commonFiles = [], pageFiles = {}, allZipFiles } = options;
+
+        // If allZipFiles is provided, use it to build complete file lists
+        let effectiveCommonFiles = commonFiles;
+        if (allZipFiles && allZipFiles.length > 0) {
+            effectiveCommonFiles = this.categorizeFilesForCommon(allZipFiles, pageFiles);
+        }
 
         let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
         xml += this.generateManifestOpen();
         xml += this.generateMetadata();
         xml += this.generateOrganizations();
-        xml += this.generateResources(commonFiles, pageFiles);
+        xml += this.generateResources(effectiveCommonFiles, pageFiles);
         xml += '</manifest>\n';
 
         return xml;
+    }
+
+    /**
+     * Categorize files into COMMON_FILES based on complete ZIP file list.
+     * All files except page HTML files and imsmanifest.xml go into COMMON_FILES.
+     * @param allFiles - Complete list of files in the ZIP
+     * @param pageFiles - Map of page file info (to identify page HTML files)
+     * @returns List of files for COMMON_FILES resource
+     */
+    protected categorizeFilesForCommon(allFiles: string[], pageFiles: Record<string, PageFileInfo>): string[] {
+        // Build set of page HTML files
+        const pageHtmlFiles = new Set<string>();
+        for (const page of this.pages) {
+            const pageFile = pageFiles[page.id];
+            if (pageFile?.fileUrl) {
+                pageHtmlFiles.add(pageFile.fileUrl);
+            } else {
+                // Default file URL
+                const isIndex = this.pages.indexOf(page) === 0;
+                const defaultUrl = isIndex ? 'index.html' : `html/${this.sanitizeFilename(page.title)}.html`;
+                pageHtmlFiles.add(defaultUrl);
+            }
+        }
+
+        // Files that should be excluded from COMMON_FILES:
+        // - Page HTML files (they go in their own resource)
+        // - imsmanifest.xml (it's the manifest itself)
+        // - imslrm.xml (referenced separately in SCORM metadata)
+        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml', 'imslrm.xml']);
+
+        // All other files go to COMMON_FILES
+        return allFiles.filter(file => !excludedFiles.has(file)).sort();
     }
 
     /**

--- a/src/shared/export/generators/Scorm2004Manifest.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.ts
@@ -122,8 +122,9 @@ export class Scorm2004ManifestGenerator {
         // Files that should be excluded from COMMON_FILES:
         // - Page HTML files (they go in their own resource)
         // - imsmanifest.xml (it's the manifest itself)
-        // - imslrm.xml (referenced separately in SCORM metadata)
-        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml', 'imslrm.xml']);
+        // Note: imslrm.xml IS included in COMMON_FILES (it's a valid resource file
+        // referenced by adlcp:location in metadata)
+        const excludedFiles = new Set([...pageHtmlFiles, 'imsmanifest.xml']);
 
         // All other files go to COMMON_FILES
         return allFiles.filter(file => !excludedFiles.has(file)).sort();

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -275,6 +275,13 @@ export interface ZipArchive {
     hasFile(path: string): boolean;
 
     /**
+     * Get all file paths in the archive
+     * Used for generating complete manifest listings
+     * @returns Array of file paths
+     */
+    getFilePaths(): string[];
+
+    /**
      * Generate the ZIP archive
      * @returns ZIP content as buffer
      */

--- a/src/shared/export/providers/FflateZipProvider.spec.ts
+++ b/src/shared/export/providers/FflateZipProvider.spec.ts
@@ -111,6 +111,63 @@ describe('FflateZipProvider', () => {
             });
         });
 
+        describe('getFilePaths', () => {
+            it('should return empty array for empty archive', () => {
+                const archive = provider.createZip();
+                expect(archive.getFilePaths()).toEqual([]);
+            });
+
+            it('should return all file paths in the archive', () => {
+                const archive = provider.createZip();
+                archive.addFile('file1.txt', 'content1');
+                archive.addFile('folder/file2.txt', 'content2');
+                archive.addFile('folder/subfolder/file3.txt', 'content3');
+
+                const paths = archive.getFilePaths();
+
+                expect(paths).toContain('file1.txt');
+                expect(paths).toContain('folder/file2.txt');
+                expect(paths).toContain('folder/subfolder/file3.txt');
+                expect(paths.length).toBe(3);
+            });
+
+            it('should return paths in insertion order', () => {
+                const archive = provider.createZip();
+                archive.addFile('a.txt', 'a');
+                archive.addFile('b.txt', 'b');
+                archive.addFile('c.txt', 'c');
+
+                const paths = archive.getFilePaths();
+
+                expect(paths[0]).toBe('a.txt');
+                expect(paths[1]).toBe('b.txt');
+                expect(paths[2]).toBe('c.txt');
+            });
+
+            it('should work for manifest generation use case', () => {
+                const archive = provider.createZip();
+
+                // Add typical SCORM export files
+                archive.addFile('index.html', '<html>...</html>');
+                archive.addFile('html/chapter1.html', '<html>...</html>');
+                archive.addFile('libs/jquery.js', '// jquery');
+                archive.addFile('theme/style.css', '/* css */');
+                archive.addFile('content/resources/image1.png', new Uint8Array([1, 2, 3]));
+                archive.addFile('idevices/text/text.css', '/* idevice */');
+
+                const paths = archive.getFilePaths();
+
+                // Verify all files are listed for manifest generation
+                expect(paths.length).toBe(6);
+                expect(paths).toContain('index.html');
+                expect(paths).toContain('html/chapter1.html');
+                expect(paths).toContain('libs/jquery.js');
+                expect(paths).toContain('theme/style.css');
+                expect(paths).toContain('content/resources/image1.png');
+                expect(paths).toContain('idevices/text/text.css');
+            });
+        });
+
         describe('generate', () => {
             it('should generate a valid ZIP buffer', async () => {
                 const archive = provider.createZip();

--- a/src/shared/export/providers/FflateZipProvider.ts
+++ b/src/shared/export/providers/FflateZipProvider.ts
@@ -109,6 +109,14 @@ export class FflateZipProvider implements ZipProvider, ZipArchive {
     }
 
     /**
+     * Get all file paths in the archive
+     * Used for generating complete manifest listings (e.g., imsmanifest.xml)
+     */
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+
+    /**
      * Get file content (for testing)
      */
     getFile(path: string): Uint8Array | undefined {


### PR DESCRIPTION
This pull request updates the export and manifest generation logic to ensure that all files in the ZIP archive are accurately reflected in the generated IMS manifest, improving completeness and reliability of exported packages. The changes introduce a new mechanism for tracking all files added to the ZIP, update the manifest generator to use this complete file list, and add comprehensive tests for the new behavior.

### Manifest generation improvements

* Added an `allZipFiles` option to `ImsManifestGenerator`, allowing the manifest to include every file in the ZIP archive, and updated the file categorization logic to ensure only non-page and non-manifest files are listed as common files. [[1]](diffhunk://#diff-84e5d45916579705e56def15888e61fbe00b912cee66f325c63739145928ddfcL33-R44) [[2]](diffhunk://#diff-84e5d45916579705e56def15888e61fbe00b912cee66f325c63739145928ddfcL73-R130)
* Updated exporters (`ImsExporter`, `Scorm12Exporter`, and `Scorm2004Exporter`) to collect all ZIP file paths before generating the manifest, ensuring the manifest lists all resources in the export. [[1]](diffhunk://#diff-0e725e5ec90580edca12e7d7f83c5ba6e108689c96934d78555245a2727278e1L174-R180) [[2]](diffhunk://#diff-4dd0804e79df098cbabb1b005aafe15b7ea30f76dec3f9179375c4e58dffcf0dL224-L234) [[3]](diffhunk://#diff-2a95ea9ee6c80b630429b4a5131a774c8c60d01789bb49078d37312cd31d6950L224-L234)

### Mock ZIP provider enhancements

* Extended all `MockZipProvider` classes in spec files to support `createZip`, `addFiles`, `hasFile`, `getFilePaths`, and a synchronous `generate` method, enabling more realistic and flexible testing of ZIP contents. [[1]](diffhunk://#diff-8527fb3bc18c64babbc20c59ddc25ea8da4b57313e394fa2f34cb39397a664ffR127-R153) [[2]](diffhunk://#diff-c5b4654d3b312e247a9e4f3d273ba58d7b04473afe1f9e0568eddebaa6a13447R104-R108) [[3]](diffhunk://#diff-c5b4654d3b312e247a9e4f3d273ba58d7b04473afe1f9e0568eddebaa6a13447R117-R130) [[4]](diffhunk://#diff-4af03d50966df97675fc395d08036df2073a3f89853a897ce6d550ac93e65b7aR111-R137) [[5]](diffhunk://#diff-fd322a86a26ec71dc1adc2d77e3c170dd759cbff2c481269965d93d0aabb3608R111-R137) [[6]](diffhunk://#diff-4fef5693916d31371a010f0e635fbf67cc9f4b8905db1549ad134edf712fa936R125-R151) [[7]](diffhunk://#diff-2c7c5907f040e7c2199133338ef8327603c11ba8003e36a7c14fd402a430ac6fR110-R136) [[8]](diffhunk://#diff-040c1bceb94fb2d496306863a652ec4c0dab81eb6429455c1c55ad8bc842ccceR110-R136) [[9]](diffhunk://#diff-63f435495c9b411618548fd8f1ab66f9df7382e4e8f6c1b243c711cafddb8641R113-R139) [[10]](diffhunk://#diff-5e6fd326dde0df8a69280d89e9001dabef9131599baca8bcbda9689e41838a94R113-R139)

### Testing and validation

* Added new tests for the manifest generator to verify that all ZIP files are correctly included or excluded in the manifest, asset files added late are handled, fallback to legacy file tracking works, and common files are sorted alphabetically.