### PR TITLE
Fix legacy `exe-node:` links when root titles contain colons

### DIFF
--- a/public/app/yjs/LegacyXmlParser.js
+++ b/public/app/yjs/LegacyXmlParser.js
@@ -591,11 +591,63 @@ class LegacyXmlParser {
   }
 
   /**
+   * Check if a page is a descendant of another page
+   *
+   * @param {Object} page - The page to check
+   * @param {string} ancestorId - The potential ancestor page ID
+   * @param {Map} pageIdMap - Map of page ID to page info
+   * @returns {boolean} True if page is a descendant of ancestor
+   */
+  _isDescendantOf(page, ancestorId, pageIdMap) {
+    let currentParentId = page.parent_id;
+    while (currentParentId) {
+      if (currentParentId === ancestorId) {
+        return true;
+      }
+      const parent = pageIdMap.get(currentParentId);
+      if (!parent) break;
+      currentParentId = parent.parent_id;
+    }
+    return false;
+  }
+
+  /**
+   * Build path from a promoted parent to a descendant page
+   *
+   * @param {Object} page - The descendant page
+   * @param {string} promotedParentId - The ID of the promoted parent
+   * @param {Map} pageIdMap - Map of page ID to page info
+   * @returns {string} Path from promoted parent to page (inclusive of both)
+   */
+  _buildPathFromPromotedParent(page, promotedParentId, pageIdMap) {
+    const pathParts = [page.name];
+    let currentParentId = page.parent_id;
+
+    // Walk up until we reach the promoted parent (inclusive)
+    while (currentParentId) {
+      const parent = pageIdMap.get(currentParentId);
+      if (!parent) break;
+      pathParts.unshift(parent.name);
+      if (currentParentId === promotedParentId) {
+        break;
+      }
+      currentParentId = parent.parent_id;
+    }
+
+    return pathParts.join(':');
+  }
+
+  /**
    * Build a map of full page paths to page IDs
    *
    * Example: "Root:Chapter1:Page1" -> "page-abc123"
    *
    * Based on Symfony OdeXmlUtil.php changeOldExeNodeLink()
+   *
+   * This method handles the LEGACY V2.X ROOT NODE FLATTENING CONVENTION:
+   * When direct children of root are promoted to top-level (parent_id = null),
+   * we also add paths that include the root title prefix, since links in the
+   * original content still reference paths with the root name.
    *
    * @param {Array} pages - Array of page objects
    * @returns {Map} Map of full path -> page ID
@@ -613,7 +665,7 @@ class LegacyXmlParser {
       });
     }
 
-    // Second pass: build full paths
+    // Second pass: build full paths (based on current parent_id structure)
     for (const page of pages) {
       const pathParts = [page.title];
       let currentParentId = page.parent_id;
@@ -636,6 +688,45 @@ class LegacyXmlParser {
         }
       } catch (e) {
         // Ignore decoding errors
+      }
+    }
+
+    // Third pass: Add root-prefixed paths for promoted children
+    // This handles the case where links in content still reference paths
+    // including the root name, but the children have been promoted to top-level
+    const rootPage = pages.find(p => p.parent_id === null && p.position === 0);
+    if (rootPage) {
+      const rootTitle = rootPage.title;
+
+      // Find promoted children (top-level pages that aren't the root)
+      const promotedChildren = pages.filter(p =>
+        p.parent_id === null && p.id !== rootPage.id
+      );
+
+      for (const promoted of promotedChildren) {
+        // Add path: RootTitle:PromotedChildTitle -> promoted.id
+        const pathWithRoot = `${rootTitle}:${promoted.title}`;
+        if (!fullPathMap.has(pathWithRoot)) {
+          fullPathMap.set(pathWithRoot, promoted.id);
+          Logger.log(`[LegacyXmlParser] Added root-prefixed path: ${pathWithRoot}`);
+        }
+
+        // Add paths for all descendants of this promoted child
+        // Format: RootTitle:PromotedChildTitle:Grandchild:... -> descendant.id
+        for (const page of pages) {
+          if (page.id !== promoted.id && this._isDescendantOf(page, promoted.id, pageIdMap)) {
+            const pathFromPromoted = this._buildPathFromPromotedParent(
+              pageIdMap.get(page.id),
+              promoted.id,
+              pageIdMap
+            );
+            const fullPathWithRoot = `${rootTitle}:${pathFromPromoted}`;
+            if (!fullPathMap.has(fullPathWithRoot)) {
+              fullPathMap.set(fullPathWithRoot, page.id);
+              Logger.log(`[LegacyXmlParser] Added root-prefixed path: ${fullPathWithRoot}`);
+            }
+          }
+        }
       }
     }
 

--- a/public/app/yjs/LegacyXmlParser.test.js
+++ b/public/app/yjs/LegacyXmlParser.test.js
@@ -2263,6 +2263,178 @@ describe('LegacyXmlParser', () => {
       const map = parser.buildFullPathMap([]);
       expect(map.size).toBe(0);
     });
+
+    it('builds root-prefixed paths for promoted children after flattening', () => {
+      // Simulates the structure after LEGACY V2.X ROOT NODE FLATTENING CONVENTION:
+      // Original: Root -> Child A -> Grandchild A1
+      // After flattening: Root (parent_id=null), Child A (parent_id=null, promoted), Grandchild A1 (parent_id=Child A)
+      const pages = [
+        { id: 'page-root', title: 'My Project', parent_id: null, position: 0 },
+        { id: 'page-child', title: 'Chapter 1', parent_id: null, position: 1 }, // Promoted
+        { id: 'page-grandchild', title: 'Section A', parent_id: 'page-child', position: 2 },
+      ];
+
+      const map = parser.buildFullPathMap(pages);
+
+      // Standard paths (based on current parent_id structure)
+      expect(map.get('My Project')).toBe('page-root');
+      expect(map.get('Chapter 1')).toBe('page-child');
+      expect(map.get('Chapter 1:Section A')).toBe('page-grandchild');
+
+      // Root-prefixed paths (for links that still reference original hierarchy)
+      expect(map.get('My Project:Chapter 1')).toBe('page-child');
+      expect(map.get('My Project:Chapter 1:Section A')).toBe('page-grandchild');
+    });
+
+    it('handles titles with colons in root-prefixed paths', () => {
+      // Test case like "Dialecto, jerga y norma: diversidad del español"
+      const pages = [
+        { id: 'page-root', title: 'Dialecto, jerga y norma: diversidad del español', parent_id: null, position: 0 },
+        { id: 'page-child', title: 'Secuencia competencial', parent_id: null, position: 1 }, // Promoted
+        { id: 'page-grandchild', title: 'Norma y variedades lingüísticas', parent_id: 'page-child', position: 2 },
+      ];
+
+      const map = parser.buildFullPathMap(pages);
+
+      // The root-prefixed path should work even with colons in title
+      expect(map.get('Dialecto, jerga y norma: diversidad del español:Secuencia competencial')).toBe('page-child');
+      expect(map.get('Dialecto, jerga y norma: diversidad del español:Secuencia competencial:Norma y variedades lingüísticas')).toBe('page-grandchild');
+    });
+
+    it('handles multiple promoted children', () => {
+      const pages = [
+        { id: 'page-root', title: 'Root', parent_id: null, position: 0 },
+        { id: 'page-child1', title: 'Child 1', parent_id: null, position: 1 }, // Promoted
+        { id: 'page-child2', title: 'Child 2', parent_id: null, position: 2 }, // Promoted
+        { id: 'page-grandchild1', title: 'Grandchild 1', parent_id: 'page-child1', position: 3 },
+        { id: 'page-grandchild2', title: 'Grandchild 2', parent_id: 'page-child2', position: 4 },
+      ];
+
+      const map = parser.buildFullPathMap(pages);
+
+      // All root-prefixed paths should be present
+      expect(map.get('Root:Child 1')).toBe('page-child1');
+      expect(map.get('Root:Child 2')).toBe('page-child2');
+      expect(map.get('Root:Child 1:Grandchild 1')).toBe('page-grandchild1');
+      expect(map.get('Root:Child 2:Grandchild 2')).toBe('page-grandchild2');
+    });
+
+    it('handles deep nesting with promoted children', () => {
+      const pages = [
+        { id: 'page-root', title: 'Root', parent_id: null, position: 0 },
+        { id: 'page-child', title: 'Child', parent_id: null, position: 1 }, // Promoted
+        { id: 'page-grandchild', title: 'Grandchild', parent_id: 'page-child', position: 2 },
+        { id: 'page-great-grandchild', title: 'Great Grandchild', parent_id: 'page-grandchild', position: 3 },
+      ];
+
+      const map = parser.buildFullPathMap(pages);
+
+      // Deep nesting should work
+      expect(map.get('Root:Child:Grandchild:Great Grandchild')).toBe('page-great-grandchild');
+    });
+  });
+
+  describe('_isDescendantOf', () => {
+    it('returns true for direct child', () => {
+      const pageIdMap = new Map([
+        ['page-parent', { id: 'page-parent', name: 'Parent', parent_id: null }],
+        ['page-child', { id: 'page-child', name: 'Child', parent_id: 'page-parent' }],
+      ]);
+      const childPage = { id: 'page-child', parent_id: 'page-parent' };
+
+      expect(parser._isDescendantOf(childPage, 'page-parent', pageIdMap)).toBe(true);
+    });
+
+    it('returns true for deep descendant', () => {
+      const pageIdMap = new Map([
+        ['page-root', { id: 'page-root', name: 'Root', parent_id: null }],
+        ['page-child', { id: 'page-child', name: 'Child', parent_id: 'page-root' }],
+        ['page-grandchild', { id: 'page-grandchild', name: 'Grandchild', parent_id: 'page-child' }],
+      ]);
+      const grandchildPage = { id: 'page-grandchild', parent_id: 'page-child' };
+
+      expect(parser._isDescendantOf(grandchildPage, 'page-root', pageIdMap)).toBe(true);
+    });
+
+    it('returns false for non-descendant', () => {
+      const pageIdMap = new Map([
+        ['page-a', { id: 'page-a', name: 'A', parent_id: null }],
+        ['page-b', { id: 'page-b', name: 'B', parent_id: null }],
+      ]);
+      const pageB = { id: 'page-b', parent_id: null };
+
+      expect(parser._isDescendantOf(pageB, 'page-a', pageIdMap)).toBe(false);
+    });
+
+    it('returns false for root page', () => {
+      const pageIdMap = new Map([
+        ['page-root', { id: 'page-root', name: 'Root', parent_id: null }],
+      ]);
+      const rootPage = { id: 'page-root', parent_id: null };
+
+      expect(parser._isDescendantOf(rootPage, 'page-root', pageIdMap)).toBe(false);
+    });
+
+    it('returns false when ancestor not in chain', () => {
+      const pageIdMap = new Map([
+        ['page-a', { id: 'page-a', name: 'A', parent_id: null }],
+        ['page-b', { id: 'page-b', name: 'B', parent_id: 'page-a' }],
+        ['page-c', { id: 'page-c', name: 'C', parent_id: null }],
+      ]);
+      const pageB = { id: 'page-b', parent_id: 'page-a' };
+
+      expect(parser._isDescendantOf(pageB, 'page-c', pageIdMap)).toBe(false);
+    });
+  });
+
+  describe('_buildPathFromPromotedParent', () => {
+    it('builds path for direct child of promoted parent', () => {
+      const pageIdMap = new Map([
+        ['page-promoted', { id: 'page-promoted', name: 'Promoted', parent_id: null }],
+        ['page-child', { id: 'page-child', name: 'Child', parent_id: 'page-promoted' }],
+      ]);
+      const childPage = pageIdMap.get('page-child');
+
+      const result = parser._buildPathFromPromotedParent(childPage, 'page-promoted', pageIdMap);
+
+      expect(result).toBe('Promoted:Child');
+    });
+
+    it('builds path for deep descendant of promoted parent', () => {
+      const pageIdMap = new Map([
+        ['page-promoted', { id: 'page-promoted', name: 'Promoted', parent_id: null }],
+        ['page-child', { id: 'page-child', name: 'Child', parent_id: 'page-promoted' }],
+        ['page-grandchild', { id: 'page-grandchild', name: 'Grandchild', parent_id: 'page-child' }],
+      ]);
+      const grandchildPage = pageIdMap.get('page-grandchild');
+
+      const result = parser._buildPathFromPromotedParent(grandchildPage, 'page-promoted', pageIdMap);
+
+      expect(result).toBe('Promoted:Child:Grandchild');
+    });
+
+    it('handles titles with colons', () => {
+      const pageIdMap = new Map([
+        ['page-promoted', { id: 'page-promoted', name: 'Section: Introduction', parent_id: null }],
+        ['page-child', { id: 'page-child', name: 'Topic: Basics', parent_id: 'page-promoted' }],
+      ]);
+      const childPage = pageIdMap.get('page-child');
+
+      const result = parser._buildPathFromPromotedParent(childPage, 'page-promoted', pageIdMap);
+
+      expect(result).toBe('Section: Introduction:Topic: Basics');
+    });
+
+    it('returns just page name when parent not found', () => {
+      const pageIdMap = new Map([
+        ['page-orphan', { id: 'page-orphan', name: 'Orphan', parent_id: 'page-missing' }],
+      ]);
+      const orphanPage = pageIdMap.get('page-orphan');
+
+      const result = parser._buildPathFromPromotedParent(orphanPage, 'page-missing', pageIdMap);
+
+      expect(result).toBe('Orphan');
+    });
   });
 
   describe('convertInternalLinks', () => {


### PR DESCRIPTION
This pull request fixes an issue reported by @jgblasco where internal `exe-node:` links from legacy `.elp` files (`contentv3.xml`) were not resolved correctly after import.

#### Problem

In some legacy projects, internal links use a path-based format like:

```
exe-node:Project title:Parent page:Child page
```

When:

* the legacy root node is flattened during import, and
* the project (root) title contains colons (`:`),

the current path resolution logic fails to match these links, so clicking them does not navigate to the target page in the app.

A real example is the project *“Dialecto, jerga y norma: diversidad del español”*, where links in the *Secuencia competencial* page did not work after import.

#### Solution

The legacy path mapping logic has been improved to:

* Preserve and register **root-prefixed paths** even after root children are promoted to top-level pages.
* Correctly resolve paths when titles contain colons.
* Ensure backward compatibility with legacy `exe-node:` links that still reference the original hierarchy.

Additional tests were added to cover:

* Root-prefixed paths after legacy flattening.
* Titles containing colons.
* Multiple promoted children and deep nesting.

#### How to test

1. Import a legacy `.elp` file with `contentv3.xml` (for example, the one reported by jgblasco).
2. Open a page containing internal links like those in *Secuencia competencial*.
3. Click the links and verify they navigate correctly to the referenced pages.
4. You can also reproduce the scenario using legacy content similar to:
   [https://descargas.intef.es/recursos_educativos/RED_ES/04_Bachillerato/2/B_2_065_2025_1173/archivo_fuente.html](https://descargas.intef.es/recursos_educativos/RED_ES/04_Bachillerato/2/B_2_065_2025_1173/archivo_fuente.html)

This restores correct navigation for affected legacy projects without changing current behavior for newer formats.
