### PR TITLE
Refactor to use Context per Domain pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ eXeLearning is an open-source educational content authoring tool (AGPL-3.0) that
 ```
 src/
 ├── index.ts              # Elysia entry point
+├── contexts/             # Dependency injection contexts
+│   ├── config.context.ts # Centralized configuration (env vars)
+│   ├── logger.context.ts # Structured logging abstraction
+│   └── ...
 ├── routes/               # API routes (Elysia plugins)
 │   ├── auth.ts           # JWT authentication
 │   ├── project.ts        # Project CRUD, session management
@@ -54,7 +58,8 @@ src/
 ├── websocket/            # WebSocket handlers
 │   ├── yjs-websocket.ts  # Yjs collaboration
 │   ├── room-manager.ts   # Connection management
-│   └── asset-coordinator.ts # Asset sync
+│   ├── asset-coordinator.ts # Asset sync
+│   └── collaboration.context.ts # WebSocket DI context
 ├── cli/                  # CLI commands
 │   └── commands/
 └── utils/                # Utility functions
@@ -238,6 +243,41 @@ describe('MyService', () => {
 });
 ```
 
+#### WebSocket Module Testing with CollaborationContext
+
+For WebSocket modules (room-manager, yjs-persistence, yjs-websocket), use `CollaborationContext` to configure all dependencies at once:
+
+```typescript
+import {
+    createTestCollaborationContext,
+    configureAllModules,
+    resetAllModules,
+} from './collaboration.context';
+import { createTestDb, destroyTestDb } from '../../test/helpers/test-db';
+import { silentLogger } from '../contexts/logger.context';
+
+describe('WebSocketFeature', () => {
+    let testDb: Kysely<Database>;
+
+    beforeEach(async () => {
+        testDb = await createTestDb();
+        const ctx = createTestCollaborationContext({
+            db: testDb,
+            // Override specific queries or services as needed
+            queries: { findProjectByUuid: mockFindProject },
+        });
+        configureAllModules(ctx);
+    });
+
+    afterEach(async () => {
+        resetAllModules();
+        await destroyTestDb(testDb);
+    });
+});
+```
+
+This replaces the need to call `configure()` on each module individually.
+
 ### Test Structure
 
 ```
@@ -406,6 +446,113 @@ export const myFeatureRoutes = new Elysia({ prefix: '/api/my-feature' })
 // Register in src/index.ts
 app.use(myFeatureRoutes);
 ```
+
+### Context System (Dependency Injection)
+
+The codebase uses a **Context per Domain** architecture for cross-cutting concerns. Contexts provide centralized, typed, and testable access to infrastructure and domain services.
+
+#### ConfigContext (`src/contexts/config.context.ts`)
+
+Centralized configuration from environment variables with validation:
+
+```typescript
+import { getConfig, createConfigContext } from '../contexts/config.context';
+
+// Use singleton (reads from process.env)
+const config = getConfig();
+console.log(config.port);        // Typed: number
+console.log(config.db.dialect);  // 'sqlite' | 'postgres' | 'mysql'
+console.log(config.redis.enabled); // boolean
+
+// For testing with custom config
+const testConfig = createConfigContext({
+    APP_PORT: '3000',
+    DB_DRIVER: 'pdo_sqlite',
+    DB_PATH: ':memory:',
+});
+```
+
+**Key properties:** `env`, `debug`, `port`, `basePath`, `filesDir`, `publicDir`, `db.*`, `redis.*`, `auth.*`, `cas.*`, `oidc.*`, `storage.*`, `autosave.*`, `cleanup.*`, `features.*`
+
+#### LoggerContext (`src/contexts/logger.context.ts`)
+
+Structured logging abstraction replacing direct `console.*` calls:
+
+```typescript
+import { getLogger, silentLogger, CapturingLogger } from '../contexts/logger.context';
+
+// Production usage
+const logger = getLogger().child({ component: 'my-service' });
+logger.info('Operation completed', { userId: 123, duration: 45 });
+logger.error('Operation failed', error, { context: 'details' });
+
+// In tests - silent logger (no output)
+configure({ logger: silentLogger });
+
+// In tests - capturing logger (for assertions)
+const capturingLogger = new CapturingLogger();
+configure({ logger: capturingLogger });
+// ... run code ...
+expect(capturingLogger.logs).toHaveLength(1);
+expect(capturingLogger.logs[0].level).toBe('error');
+```
+
+**Log levels:** `debug`, `info`, `warn`, `error`
+**Output formats:** JSON (production), legacy format (development)
+
+#### CollaborationContext (`src/websocket/collaboration.context.ts`)
+
+Unified context for WebSocket/collaboration modules:
+
+```typescript
+import {
+    createTestCollaborationContext,
+    configureAllModules,
+    resetAllModules,
+    createMockPubSub,
+    createMockPriorityQueue,
+} from '../websocket/collaboration.context';
+
+// In tests - configure all WebSocket modules at once
+describe('MyWebSocketTest', () => {
+    beforeEach(async () => {
+        const testDb = await createTestDb();
+        const ctx = createTestCollaborationContext({
+            db: testDb,
+            logger: silentLogger,
+            queries: { findProjectByUuid: mockFindProject },
+        });
+        configureAllModules(ctx);
+    });
+
+    afterEach(() => {
+        resetAllModules();
+    });
+});
+```
+
+**Configures:** `room-manager`, `yjs-persistence`, `yjs-websocket`
+**Mock utilities:** `createMockPubSub()`, `createMockPriorityQueue()`
+
+#### Lint Rule: noConsole
+
+Biome warns on `console.*` usage in server code. Use LoggerContext instead:
+
+```typescript
+// BAD - triggers lint warning
+console.log('Something happened');
+console.error('Error:', err);
+
+// GOOD - use LoggerContext
+logger.info('Something happened');
+logger.error('Error occurred', err);
+```
+
+**Exceptions (console allowed):**
+- `src/cli/**/*.ts` - CLI tools (terminal output)
+- `src/db/migrations/**/*.ts` - Migration CLI
+- `src/shared/export/browser/**/*.ts` - Browser code
+- `**/*.spec.ts` - Test files
 
 ### Internationalization (i18n)
 

--- a/biome.json
+++ b/biome.json
@@ -61,7 +61,8 @@
                 "noGlobalIsFinite": "off",
                 "noAssignInExpressions": "off",
                 "noAsyncPromiseExecutor": "off",
-                "useIterableCallbackReturn": "off"
+                "useIterableCallbackReturn": "off",
+                "noConsole": "warn"
             },
             "style": {
                 "useConst": "error",
@@ -93,10 +94,31 @@
             "linter": {
                 "rules": {
                     "suspicious": {
-                        "noExplicitAny": "off"
+                        "noExplicitAny": "off",
+                        "noConsole": "off"
                     },
                     "correctness": {
                         "noEmptyPattern": "off"
+                    }
+                }
+            }
+        },
+        {
+            "includes": [
+                "src/cli/**/*.ts",
+                "src/db/migrations/**/*.ts",
+                "src/contexts/logger.context.ts",
+                "src/index-node.ts",
+                "src/shared/export/browser/**/*.ts",
+                "src/shared/export/exporters/**/*.ts",
+                "src/shared/export/adapters/BrowserAssetProvider.ts",
+                "src/shared/export/providers/DatabaseAssetProvider.ts",
+                "src/shared/export/providers/CombinedAssetProvider.ts"
+            ],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noConsole": "off"
                     }
                 }
             }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -396,6 +396,65 @@ configure({
 afterEach(() => resetDependencies());
 ```
 
+### 8.3 Context System
+
+The codebase uses a **Context per Domain** architecture for cross-cutting concerns:
+
+| Context | Purpose | Location |
+|---------|---------|----------|
+| **ConfigContext** | Centralized env configuration | `src/contexts/config.context.ts` |
+| **LoggerContext** | Structured logging abstraction | `src/contexts/logger.context.ts` |
+| **CollaborationContext** | WebSocket module dependencies | `src/websocket/collaboration.context.ts` |
+
+#### ConfigContext
+
+Provides validated, typed access to all environment variables:
+
+```typescript
+import { getConfig, createConfigContext } from '../contexts/config.context';
+
+const config = getConfig();
+config.port          // number
+config.db.dialect    // 'sqlite' | 'postgres' | 'mysql'
+config.redis.enabled // boolean
+
+// For testing with custom config
+const testConfig = createConfigContext({ APP_PORT: '3000' });
+```
+
+#### LoggerContext
+
+Structured logging replacing `console.*`:
+
+```typescript
+import { getLogger, silentLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'my-service' });
+logger.info('Operation completed', { duration: 45 });
+logger.error('Failed', error, { context: 'details' });
+
+// In tests: use silentLogger to suppress output
+```
+
+#### CollaborationContext
+
+Unified dependency injection for WebSocket modules:
+
+```typescript
+import {
+    createTestCollaborationContext,
+    configureAllModules,
+    resetAllModules,
+} from '../websocket/collaboration.context';
+
+// Configure all WebSocket modules at once
+const ctx = createTestCollaborationContext({ db: testDb });
+configureAllModules(ctx);
+
+// Reset after tests
+afterEach(() => resetAllModules());
+```
+
 ## 9. Configuration
 
 ### 9.1 Environment Variables
@@ -437,11 +496,14 @@ APP_AUTH_METHODS=password     # password,cas,openid,guest
 | `src/index.ts` | Elysia entry point |
 | `src/routes/` | REST API routes |
 | `src/services/` | Business logic |
+| `src/contexts/config.context.ts` | Centralized configuration |
+| `src/contexts/logger.context.ts` | Structured logging |
 | `src/db/client.ts` | Kysely instance |
 | `src/db/queries/` | Database queries |
 | `src/websocket/yjs-websocket.ts` | WebSocket handler |
 | `src/websocket/room-manager.ts` | Room lifecycle |
 | `src/websocket/asset-coordinator.ts` | P2P coordination |
+| `src/websocket/collaboration.context.ts` | WebSocket DI context |
 
 ### Frontend (public/app/)
 
@@ -489,7 +551,7 @@ DB_PATH=:memory: ELYSIA_FILES_DIR=/tmp/test bun test src/path/to/file.spec.ts
 Never use `mock.module()`. Use dependency injection:
 
 ```typescript
-// Configure mocks
+// Configure mocks for individual modules
 configure({
     db: testDb,
     queries: { findById: mockFindById }
@@ -497,6 +559,34 @@ configure({
 
 // Reset after test
 afterEach(() => resetDependencies());
+```
+
+### Testing with CollaborationContext
+
+For WebSocket/collaboration tests, use `CollaborationContext` to configure all modules at once:
+
+```typescript
+import {
+    createTestCollaborationContext,
+    configureAllModules,
+    resetAllModules,
+} from './collaboration.context';
+import { silentLogger } from '../contexts/logger.context';
+
+describe('WebSocketFeature', () => {
+    beforeEach(async () => {
+        const testDb = await createTestDb();
+        const ctx = createTestCollaborationContext({
+            db: testDb,
+            queries: { findProjectByUuid: mockFindProject },
+        });
+        configureAllModules(ctx);
+    });
+
+    afterEach(() => {
+        resetAllModules();
+    });
+});
 ```
 
 ## 12. Security

--- a/src/cli/commands/tmp-cleanup.spec.ts
+++ b/src/cli/commands/tmp-cleanup.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { execute, printHelp, runCli, type TmpCleanupDependencies } from './tmp-cleanup';
+import { resetConfigContext } from '../../contexts/config.context';
 
 describe('Tmp Cleanup Command', () => {
     const testDir = path.join(process.cwd(), 'test', 'temp', 'tmp-cleanup-test');
@@ -14,6 +15,7 @@ describe('Tmp Cleanup Command', () => {
         await fs.ensureDir(testDir);
         // Set files dir to test directory
         process.env.ELYSIA_FILES_DIR = testDir;
+        resetConfigContext(); // Reset to pick up new ELYSIA_FILES_DIR
         // Create tmp subdirectory
         await fs.ensureDir(path.join(testDir, 'tmp'));
     });
@@ -21,6 +23,7 @@ describe('Tmp Cleanup Command', () => {
     afterEach(async () => {
         await fs.remove(testDir);
         process.env = { ...originalEnv };
+        resetConfigContext(); // Reset to restore original environment
     });
 
     describe('execute', () => {

--- a/src/contexts/config.context.spec.ts
+++ b/src/contexts/config.context.spec.ts
@@ -1,0 +1,441 @@
+/**
+ * ConfigContext Tests
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { createConfigContext, getConfig, resetConfigContext, setConfigContext } from './config.context';
+
+describe('ConfigContext', () => {
+    beforeEach(() => {
+        resetConfigContext();
+    });
+
+    afterEach(() => {
+        resetConfigContext();
+    });
+
+    describe('createConfigContext', () => {
+        it('should create config with default values when env is empty', () => {
+            const config = createConfigContext({});
+
+            expect(config.env).toBe('prod');
+            expect(config.debug).toBe(false);
+            expect(config.onlineMode).toBe(true);
+            expect(config.port).toBe(8080);
+            expect(config.basePath).toBe('');
+        });
+
+        it('should parse APP_ENV correctly', () => {
+            const devConfig = createConfigContext({ APP_ENV: 'dev' });
+            expect(devConfig.env).toBe('dev');
+
+            const testConfig = createConfigContext({ APP_ENV: 'test' });
+            expect(testConfig.env).toBe('test');
+
+            const prodConfig = createConfigContext({ APP_ENV: 'prod' });
+            expect(prodConfig.env).toBe('prod');
+        });
+
+        it('should parse boolean values correctly', () => {
+            const trueConfig = createConfigContext({ APP_DEBUG: 'true' });
+            expect(trueConfig.debug).toBe(true);
+
+            const oneConfig = createConfigContext({ APP_DEBUG: '1' });
+            expect(oneConfig.debug).toBe(true);
+
+            const yesConfig = createConfigContext({ APP_DEBUG: 'yes' });
+            expect(yesConfig.debug).toBe(true);
+
+            const falseConfig = createConfigContext({ APP_DEBUG: 'false' });
+            expect(falseConfig.debug).toBe(false);
+
+            const zeroConfig = createConfigContext({ APP_DEBUG: '0' });
+            expect(zeroConfig.debug).toBe(false);
+        });
+
+        it('should parse port from multiple env variables', () => {
+            const appPortConfig = createConfigContext({ APP_PORT: '3000' });
+            expect(appPortConfig.port).toBe(3000);
+
+            const portConfig = createConfigContext({ PORT: '4000' });
+            expect(portConfig.port).toBe(4000);
+
+            const nestPortConfig = createConfigContext({ NEST_PORT: '5000' });
+            expect(nestPortConfig.port).toBe(5000);
+
+            // APP_PORT takes precedence
+            const bothConfig = createConfigContext({ APP_PORT: '3000', PORT: '4000' });
+            expect(bothConfig.port).toBe(3000);
+        });
+
+        it('should use custom cwd function for path resolution', () => {
+            const config = createConfigContext({}, () => '/custom/path');
+            expect(config.filesDir).toBe('/custom/path/data');
+            expect(config.publicDir).toBe('/custom/path/public');
+        });
+    });
+
+    describe('Database configuration', () => {
+        it('should default to SQLite dialect', () => {
+            const config = createConfigContext({});
+            expect(config.db.dialect).toBe('sqlite');
+            expect(config.db.path).toBe('data/exelearning.db');
+        });
+
+        it('should parse pdo_sqlite driver', () => {
+            const config = createConfigContext({ DB_DRIVER: 'pdo_sqlite' });
+            expect(config.db.dialect).toBe('sqlite');
+        });
+
+        it('should parse MySQL variants', () => {
+            const pdoMysql = createConfigContext({ DB_DRIVER: 'pdo_mysql' });
+            expect(pdoMysql.db.dialect).toBe('mysql');
+
+            const mysql = createConfigContext({ DB_DRIVER: 'mysql' });
+            expect(mysql.db.dialect).toBe('mysql');
+
+            const mysql2 = createConfigContext({ DB_DRIVER: 'mysql2' });
+            expect(mysql2.db.dialect).toBe('mysql');
+
+            const mariadb = createConfigContext({ DB_DRIVER: 'mariadb' });
+            expect(mariadb.db.dialect).toBe('mysql');
+        });
+
+        it('should parse PostgreSQL variants', () => {
+            const pdoPgsql = createConfigContext({ DB_DRIVER: 'pdo_pgsql' });
+            expect(pdoPgsql.db.dialect).toBe('postgres');
+
+            const pgsql = createConfigContext({ DB_DRIVER: 'pgsql' });
+            expect(pgsql.db.dialect).toBe('postgres');
+
+            const postgres = createConfigContext({ DB_DRIVER: 'postgres' });
+            expect(postgres.db.dialect).toBe('postgres');
+        });
+
+        it('should set correct default ports per dialect', () => {
+            const sqlite = createConfigContext({ DB_DRIVER: 'sqlite' });
+            expect(sqlite.db.port).toBe(0);
+
+            const mysql = createConfigContext({ DB_DRIVER: 'mysql' });
+            expect(mysql.db.port).toBe(3306);
+
+            const postgres = createConfigContext({ DB_DRIVER: 'postgres' });
+            expect(postgres.db.port).toBe(5432);
+        });
+
+        it('should set correct default charset per dialect', () => {
+            const mysql = createConfigContext({ DB_DRIVER: 'mysql' });
+            expect(mysql.db.charset).toBe('utf8mb4');
+
+            const postgres = createConfigContext({ DB_DRIVER: 'postgres' });
+            expect(postgres.db.charset).toBe('utf8');
+        });
+
+        it('should parse database connection settings', () => {
+            const config = createConfigContext({
+                DB_DRIVER: 'postgres',
+                DB_HOST: 'db.example.com',
+                DB_PORT: '5433',
+                DB_NAME: 'mydb',
+                DB_USER: 'myuser',
+                DB_PASSWORD: 'mypassword',
+                DB_POOL_MIN: '2',
+                DB_POOL_MAX: '20',
+            });
+
+            expect(config.db.host).toBe('db.example.com');
+            expect(config.db.port).toBe(5433);
+            expect(config.db.name).toBe('mydb');
+            expect(config.db.user).toBe('myuser');
+            expect(config.db.password).toBe('mypassword');
+            expect(config.db.poolMin).toBe(2);
+            expect(config.db.poolMax).toBe(20);
+        });
+    });
+
+    describe('Redis configuration', () => {
+        it('should be disabled by default', () => {
+            const config = createConfigContext({});
+            expect(config.redis.enabled).toBe(false);
+            expect(config.redis.host).toBe('');
+        });
+
+        it('should be enabled when REDIS_HOST is set', () => {
+            const config = createConfigContext({
+                REDIS_HOST: 'redis.example.com',
+            });
+            expect(config.redis.enabled).toBe(true);
+            expect(config.redis.host).toBe('redis.example.com');
+            expect(config.redis.port).toBe(6379);
+        });
+
+        it('should parse Redis password', () => {
+            const config = createConfigContext({
+                REDIS_HOST: 'localhost',
+                REDIS_PORT: '6380',
+                REDIS_PASSWORD: 'secret',
+            });
+            expect(config.redis.port).toBe(6380);
+            expect(config.redis.password).toBe('secret');
+        });
+    });
+
+    describe('Authentication configuration', () => {
+        it('should default to password auth', () => {
+            const config = createConfigContext({});
+            expect(config.auth.methods).toEqual(['password']);
+        });
+
+        it('should parse multiple auth methods', () => {
+            const config = createConfigContext({
+                APP_AUTH_METHODS: 'password,cas,openid,guest',
+            });
+            expect(config.auth.methods).toEqual(['password', 'cas', 'openid', 'guest']);
+        });
+
+        it('should filter invalid auth methods', () => {
+            const config = createConfigContext({
+                APP_AUTH_METHODS: 'password,invalid,cas,unknown',
+            });
+            expect(config.auth.methods).toEqual(['password', 'cas']);
+        });
+
+        it('should parse auth settings', () => {
+            const config = createConfigContext({
+                AUTH_CREATE_USERS: 'false',
+                AUTH_TEMP_EMAIL_DOMAIN: 'custom.domain',
+                API_JWT_SECRET: 'supersecret',
+                API_JWT_ISSUER: 'myissuer',
+                API_JWT_AUDIENCE: 'myaudience',
+            });
+
+            expect(config.auth.createUsers).toBe(false);
+            expect(config.auth.tempEmailDomain).toBe('custom.domain');
+            expect(config.auth.jwtSecret).toBe('supersecret');
+            expect(config.auth.jwtIssuer).toBe('myissuer');
+            expect(config.auth.jwtAudience).toBe('myaudience');
+        });
+    });
+
+    describe('CAS configuration', () => {
+        it('should parse CAS settings', () => {
+            const config = createConfigContext({
+                CAS_URL: 'https://cas.example.com',
+                CAS_VALIDATE_PATH: '/validate',
+                CAS_LOGIN_PATH: '/auth',
+                CAS_LOGOUT_PATH: '/exit',
+            });
+
+            expect(config.cas.url).toBe('https://cas.example.com');
+            expect(config.cas.validatePath).toBe('/validate');
+            expect(config.cas.loginPath).toBe('/auth');
+            expect(config.cas.logoutPath).toBe('/exit');
+        });
+    });
+
+    describe('OIDC configuration', () => {
+        it('should parse OIDC settings', () => {
+            const config = createConfigContext({
+                OIDC_ISSUER: 'https://oidc.example.com',
+                OIDC_AUTHORIZATION_ENDPOINT: 'https://oidc.example.com/auth',
+                OIDC_TOKEN_ENDPOINT: 'https://oidc.example.com/token',
+                OIDC_USERINFO_ENDPOINT: 'https://oidc.example.com/userinfo',
+                OIDC_SCOPE: 'openid profile email',
+                OIDC_CLIENT_ID: 'myclient',
+                OIDC_CLIENT_SECRET: 'myclientsecret',
+            });
+
+            expect(config.oidc.issuer).toBe('https://oidc.example.com');
+            expect(config.oidc.authorizationEndpoint).toBe('https://oidc.example.com/auth');
+            expect(config.oidc.tokenEndpoint).toBe('https://oidc.example.com/token');
+            expect(config.oidc.userinfoEndpoint).toBe('https://oidc.example.com/userinfo');
+            expect(config.oidc.scope).toBe('openid profile email');
+            expect(config.oidc.clientId).toBe('myclient');
+            expect(config.oidc.clientSecret).toBe('myclientsecret');
+        });
+    });
+
+    describe('Storage configuration', () => {
+        it('should use default storage values', () => {
+            const config = createConfigContext({});
+            expect(config.storage.maxDiskSpaceMb).toBe(1024);
+            expect(config.storage.defaultQuotaMb).toBe(4096);
+            expect(config.storage.countAutosaveSpace).toBe(true);
+            expect(config.storage.maxUploadSizeMb).toBe(1024);
+        });
+
+        it('should parse storage settings', () => {
+            const config = createConfigContext({
+                USER_STORAGE_MAX_DISK_SPACE: '2048',
+                DEFAULT_QUOTA: '8192',
+                COUNT_USER_AUTOSAVE_SPACE_ODE_FILES: 'false',
+                FILE_UPLOAD_MAX_SIZE: '512',
+            });
+
+            expect(config.storage.maxDiskSpaceMb).toBe(2048);
+            expect(config.storage.defaultQuotaMb).toBe(8192);
+            expect(config.storage.countAutosaveSpace).toBe(false);
+            expect(config.storage.maxUploadSizeMb).toBe(512);
+        });
+    });
+
+    describe('Autosave configuration', () => {
+        it('should use default autosave values', () => {
+            const config = createConfigContext({});
+            expect(config.autosave.enabled).toBe(true);
+            expect(config.autosave.intervalSeconds).toBe(600);
+            expect(config.autosave.maxFiles).toBe(10);
+        });
+
+        it('should parse autosave settings', () => {
+            const config = createConfigContext({
+                AUTOSAVE_ODE_FILES_FUNCTION: 'false',
+                PERMANENT_SAVE_AUTOSAVE_TIME_INTERVAL: '300',
+                PERMANENT_SAVE_AUTOSAVE_MAX_NUMBER_OF_FILES: '5',
+            });
+
+            expect(config.autosave.enabled).toBe(false);
+            expect(config.autosave.intervalSeconds).toBe(300);
+            expect(config.autosave.maxFiles).toBe(5);
+        });
+    });
+
+    describe('Cleanup configuration', () => {
+        it('should be disabled by default', () => {
+            const config = createConfigContext({});
+            expect(config.cleanup.enabled).toBe(false);
+            expect(config.cleanup.intervalHours).toBe(24);
+            expect(config.cleanup.unsavedAgeHours).toBe(24);
+            expect(config.cleanup.guestAgeDays).toBe(7);
+        });
+
+        it('should parse cleanup settings', () => {
+            const config = createConfigContext({
+                CLEANUP_ENABLED: 'true',
+                CLEANUP_INTERVAL_HOURS: '12',
+                CLEANUP_UNSAVED_AGE_HOURS: '48',
+                CLEANUP_GUEST_AGE_DAYS: '14',
+            });
+
+            expect(config.cleanup.enabled).toBe(true);
+            expect(config.cleanup.intervalHours).toBe(12);
+            expect(config.cleanup.unsavedAgeHours).toBe(48);
+            expect(config.cleanup.guestAgeDays).toBe(14);
+        });
+    });
+
+    describe('Feature configuration', () => {
+        it('should use default feature values', () => {
+            const config = createConfigContext({});
+            expect(config.features.onlineThemesInstall).toBe(false);
+            expect(config.features.onlineIdevicesInstall).toBe(false);
+            expect(config.features.versionControl).toBe(true);
+            expect(config.features.defaultProjectVisibility).toBe('private');
+            expect(config.features.collaborativeBlockLevel).toBe('idevice');
+            expect(config.features.recentFilesAmount).toBe(3);
+        });
+
+        it('should parse feature settings', () => {
+            const config = createConfigContext({
+                ONLINE_THEMES_INSTALL: '1',
+                ONLINE_IDEVICES_INSTALL: '1',
+                VERSION_CONTROL: 'false',
+                DEFAULT_PROJECT_VISIBILITY: 'public',
+                COLLABORATIVE_BLOCK_LEVEL: 'page',
+                USER_RECENT_ODE_FILES_AMOUNT: '5',
+            });
+
+            expect(config.features.onlineThemesInstall).toBe(true);
+            expect(config.features.onlineIdevicesInstall).toBe(true);
+            expect(config.features.versionControl).toBe(false);
+            expect(config.features.defaultProjectVisibility).toBe('public');
+            expect(config.features.collaborativeBlockLevel).toBe('page');
+            expect(config.features.recentFilesAmount).toBe(5);
+        });
+    });
+
+    describe('Test user configuration', () => {
+        it('should include test user in dev environment', () => {
+            const config = createConfigContext({
+                APP_ENV: 'dev',
+                TEST_USER_EMAIL: 'test@example.com',
+                TEST_USER_USERNAME: 'testuser',
+                TEST_USER_PASSWORD: 'testpass',
+            });
+
+            expect(config.testUser).toBeDefined();
+            expect(config.testUser?.email).toBe('test@example.com');
+            expect(config.testUser?.username).toBe('testuser');
+            expect(config.testUser?.password).toBe('testpass');
+        });
+
+        it('should include test user in test environment', () => {
+            const config = createConfigContext({ APP_ENV: 'test' });
+            expect(config.testUser).toBeDefined();
+        });
+
+        it('should not include test user in prod environment', () => {
+            const config = createConfigContext({ APP_ENV: 'prod' });
+            expect(config.testUser).toBeUndefined();
+        });
+    });
+
+    describe('Path configuration', () => {
+        it('should prefer ELYSIA_FILES_DIR over FILES_DIR', () => {
+            const config = createConfigContext({
+                ELYSIA_FILES_DIR: '/elysia/data',
+                FILES_DIR: '/files/data',
+            });
+            expect(config.filesDir).toBe('/elysia/data');
+        });
+
+        it('should use FILES_DIR when ELYSIA_FILES_DIR is not set', () => {
+            const config = createConfigContext({
+                FILES_DIR: '/files/data',
+            });
+            expect(config.filesDir).toBe('/files/data');
+        });
+    });
+
+    describe('Immutability', () => {
+        it('should return frozen config object', () => {
+            const config = createConfigContext({});
+            expect(Object.isFrozen(config)).toBe(true);
+        });
+
+        it('should have frozen sub-configurations', () => {
+            const config = createConfigContext({});
+            expect(Object.isFrozen(config.db)).toBe(true);
+            expect(Object.isFrozen(config.redis)).toBe(true);
+            expect(Object.isFrozen(config.auth)).toBe(true);
+            expect(Object.isFrozen(config.cas)).toBe(true);
+            expect(Object.isFrozen(config.oidc)).toBe(true);
+            expect(Object.isFrozen(config.storage)).toBe(true);
+            expect(Object.isFrozen(config.autosave)).toBe(true);
+            expect(Object.isFrozen(config.cleanup)).toBe(true);
+            expect(Object.isFrozen(config.features)).toBe(true);
+        });
+    });
+
+    describe('getConfig singleton', () => {
+        it('should return the same instance on multiple calls', () => {
+            const config1 = getConfig();
+            const config2 = getConfig();
+            expect(config1).toBe(config2);
+        });
+
+        it('should reset with resetConfigContext', () => {
+            const config1 = getConfig();
+            resetConfigContext();
+            const config2 = getConfig();
+            // They may be equal but should be different instances
+            expect(config1).not.toBe(config2);
+        });
+
+        it('should use custom config with setConfigContext', () => {
+            const customConfig = createConfigContext({ APP_PORT: '9999' });
+            setConfigContext(customConfig);
+            const config = getConfig();
+            expect(config.port).toBe(9999);
+        });
+    });
+});

--- a/src/contexts/config.context.ts
+++ b/src/contexts/config.context.ts
@@ -1,0 +1,413 @@
+/**
+ * ConfigContext - Centralized Configuration Management
+ *
+ * Replaces scattered process.env reads with a validated, typed configuration object.
+ * All configuration is read once at startup, validated, and frozen.
+ *
+ * Usage:
+ *   import { getConfig, createConfigContext } from './contexts/config.context';
+ *
+ *   // Production: use default singleton
+ *   const config = getConfig();
+ *
+ *   // Testing: create isolated instance
+ *   const testConfig = createConfigContext({ APP_PORT: '3000', ... });
+ */
+import { join } from 'path';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type DbDialect = 'sqlite' | 'postgres' | 'mysql';
+export type AuthMethod = 'none' | 'password' | 'cas' | 'openid' | 'guest';
+export type CollaborativeBlockLevel = 'page' | 'idevice';
+export type ProjectVisibility = 'private' | 'public';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Database configuration
+ */
+export interface DbConfig {
+    readonly dialect: DbDialect;
+    readonly path?: string;
+    readonly host: string;
+    readonly port: number;
+    readonly name: string;
+    readonly user: string;
+    readonly password: string;
+    readonly charset: string;
+    readonly poolMin: number;
+    readonly poolMax: number;
+}
+
+/**
+ * Redis configuration
+ */
+export interface RedisConfig {
+    readonly enabled: boolean;
+    readonly host: string;
+    readonly port: number;
+    readonly password: string;
+}
+
+/**
+ * Authentication configuration
+ */
+export interface AuthConfig {
+    readonly methods: AuthMethod[];
+    readonly createUsers: boolean;
+    readonly tempEmailDomain: string;
+    readonly jwtSecret: string;
+    readonly jwtIssuer: string;
+    readonly jwtAudience: string;
+}
+
+/**
+ * CAS configuration
+ */
+export interface CasConfig {
+    readonly url: string;
+    readonly validatePath: string;
+    readonly loginPath: string;
+    readonly logoutPath: string;
+}
+
+/**
+ * OpenID Connect configuration
+ */
+export interface OidcConfig {
+    readonly issuer: string;
+    readonly authorizationEndpoint: string;
+    readonly tokenEndpoint: string;
+    readonly userinfoEndpoint: string;
+    readonly scope: string;
+    readonly clientId: string;
+    readonly clientSecret: string;
+}
+
+/**
+ * Storage and quota configuration
+ */
+export interface StorageConfig {
+    readonly maxDiskSpaceMb: number;
+    readonly defaultQuotaMb: number;
+    readonly countAutosaveSpace: boolean;
+    readonly maxUploadSizeMb: number;
+}
+
+/**
+ * Autosave configuration
+ */
+export interface AutosaveConfig {
+    readonly enabled: boolean;
+    readonly intervalSeconds: number;
+    readonly maxFiles: number;
+}
+
+/**
+ * Cleanup configuration
+ */
+export interface CleanupConfig {
+    readonly enabled: boolean;
+    readonly intervalHours: number;
+    readonly unsavedAgeHours: number;
+    readonly guestAgeDays: number;
+}
+
+/**
+ * Feature flags
+ */
+export interface FeatureConfig {
+    readonly onlineThemesInstall: boolean;
+    readonly onlineIdevicesInstall: boolean;
+    readonly versionControl: boolean;
+    readonly defaultProjectVisibility: ProjectVisibility;
+    readonly collaborativeBlockLevel: CollaborativeBlockLevel;
+    readonly recentFilesAmount: number;
+}
+
+/**
+ * Complete application configuration
+ */
+export interface ConfigContext {
+    // Application core
+    readonly env: 'dev' | 'prod' | 'test';
+    readonly debug: boolean;
+    readonly secret: string;
+    readonly onlineMode: boolean;
+    readonly port: number;
+    readonly basePath: string;
+
+    // Paths
+    readonly filesDir: string;
+    readonly publicDir: string;
+    readonly cacheDir: string;
+    readonly logDir: string;
+
+    // Logging
+    readonly logLevel: LogLevel;
+
+    // Sub-configurations
+    readonly db: DbConfig;
+    readonly redis: RedisConfig;
+    readonly auth: AuthConfig;
+    readonly cas: CasConfig;
+    readonly oidc: OidcConfig;
+    readonly storage: StorageConfig;
+    readonly autosave: AutosaveConfig;
+    readonly cleanup: CleanupConfig;
+    readonly features: FeatureConfig;
+
+    // Test credentials (only populated in dev/test environments)
+    readonly testUser?: {
+        readonly email: string;
+        readonly username: string;
+        readonly password: string;
+    };
+}
+
+// ============================================================================
+// VALIDATION HELPERS
+// ============================================================================
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+    if (value === undefined || value === '') return defaultValue;
+    const lower = value.toLowerCase().trim();
+    return lower === 'true' || lower === '1' || lower === 'yes';
+}
+
+function parseIntValue(value: string | undefined, defaultValue: number): number {
+    if (value === undefined || value === '') return defaultValue;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+function parseString(value: string | undefined, defaultValue: string): string {
+    return value?.trim() || defaultValue;
+}
+
+function parseDbDialect(driver: string | undefined): DbDialect {
+    const d = (driver || 'pdo_sqlite').toLowerCase();
+    switch (d) {
+        case 'pdo_mysql':
+        case 'mysql':
+        case 'mysql2':
+        case 'mariadb':
+            return 'mysql';
+        case 'pdo_pgsql':
+        case 'pgsql':
+        case 'postgres':
+        case 'postgresql':
+            return 'postgres';
+        default:
+            return 'sqlite';
+    }
+}
+
+function parseAuthMethods(value: string | undefined): AuthMethod[] {
+    if (!value || value.trim() === '') return ['password'];
+    const methods = value.split(',').map(m => m.trim().toLowerCase() as AuthMethod);
+    const valid: AuthMethod[] = ['none', 'password', 'cas', 'openid', 'guest'];
+    return methods.filter(m => valid.includes(m));
+}
+
+function parseLogLevel(value: string | undefined): LogLevel {
+    const level = (value || 'info').toLowerCase() as LogLevel;
+    const valid: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+    return valid.includes(level) ? level : 'info';
+}
+
+function parseProjectVisibility(value: string | undefined): ProjectVisibility {
+    const v = (value || 'private').toLowerCase();
+    return v === 'public' ? 'public' : 'private';
+}
+
+function parseBlockLevel(value: string | undefined): CollaborativeBlockLevel {
+    const v = (value || 'idevice').toLowerCase();
+    return v === 'page' ? 'page' : 'idevice';
+}
+
+// ============================================================================
+// FACTORY FUNCTION
+// ============================================================================
+
+/**
+ * Create a ConfigContext from environment variables
+ *
+ * @param env - Environment variable source (defaults to process.env)
+ * @param cwd - Current working directory (defaults to process.cwd())
+ * @returns Frozen ConfigContext object
+ */
+export function createConfigContext(
+    env: Record<string, string | undefined> = process.env,
+    cwd: () => string = () => process.cwd(),
+): ConfigContext {
+    // Application core
+    const appEnv = parseString(env.APP_ENV, 'prod') as 'dev' | 'prod' | 'test';
+    const debug = parseBoolean(env.APP_DEBUG, false);
+    const secret = parseString(env.APP_SECRET, '');
+    const onlineMode = parseBoolean(env.APP_ONLINE_MODE, true);
+    const port = parseIntValue(env.APP_PORT || env.PORT || env.NEST_PORT, 8080);
+    const basePath = parseString(env.BASE_PATH, '');
+
+    // Paths
+    const filesDir = parseString(env.ELYSIA_FILES_DIR || env.FILES_DIR, join(cwd(), 'data'));
+    const publicDir = parseString(env.PUBLIC_DIR, join(cwd(), 'public'));
+    const cacheDir = parseString(env.CACHE_DIR, '');
+    const logDir = parseString(env.LOG_DIR, '');
+
+    // Logging
+    const logLevel = parseLogLevel(env.LOG_LEVEL);
+
+    // Database
+    const dbDialect = parseDbDialect(env.DB_DRIVER);
+    const db: DbConfig = Object.freeze({
+        dialect: dbDialect,
+        path: dbDialect === 'sqlite' ? parseString(env.DB_PATH, 'data/exelearning.db') : undefined,
+        host: parseString(env.DB_HOST, 'localhost'),
+        port: parseIntValue(env.DB_PORT, dbDialect === 'postgres' ? 5432 : dbDialect === 'mysql' ? 3306 : 0),
+        name: parseString(env.DB_NAME, 'exelearning'),
+        user: parseString(env.DB_USER, 'exelearning'),
+        password: parseString(env.DB_PASSWORD, ''),
+        charset: parseString(env.DB_CHARSET, dbDialect === 'mysql' ? 'utf8mb4' : 'utf8'),
+        poolMin: parseIntValue(env.DB_POOL_MIN, 0),
+        poolMax: parseIntValue(env.DB_POOL_MAX, 10),
+    });
+
+    // Redis
+    const redisHost = parseString(env.REDIS_HOST, '');
+    const redis: RedisConfig = Object.freeze({
+        enabled: redisHost.length > 0,
+        host: redisHost,
+        port: parseIntValue(env.REDIS_PORT, 6379),
+        password: parseString(env.REDIS_PASSWORD, ''),
+    });
+
+    // Authentication
+    const auth: AuthConfig = Object.freeze({
+        methods: parseAuthMethods(env.APP_AUTH_METHODS),
+        createUsers: parseBoolean(env.AUTH_CREATE_USERS, true),
+        tempEmailDomain: parseString(env.AUTH_TEMP_EMAIL_DOMAIN, 'domain.local'),
+        jwtSecret: parseString(env.API_JWT_SECRET, 'dev_secret_change_me'),
+        jwtIssuer: parseString(env.API_JWT_ISSUER, ''),
+        jwtAudience: parseString(env.API_JWT_AUDIENCE, ''),
+    });
+
+    // CAS
+    const cas: CasConfig = Object.freeze({
+        url: parseString(env.CAS_URL, ''),
+        validatePath: parseString(env.CAS_VALIDATE_PATH, '/p3/serviceValidate'),
+        loginPath: parseString(env.CAS_LOGIN_PATH, '/login'),
+        logoutPath: parseString(env.CAS_LOGOUT_PATH, '/logout'),
+    });
+
+    // OIDC
+    const oidc: OidcConfig = Object.freeze({
+        issuer: parseString(env.OIDC_ISSUER, ''),
+        authorizationEndpoint: parseString(env.OIDC_AUTHORIZATION_ENDPOINT, ''),
+        tokenEndpoint: parseString(env.OIDC_TOKEN_ENDPOINT, ''),
+        userinfoEndpoint: parseString(env.OIDC_USERINFO_ENDPOINT, ''),
+        scope: parseString(env.OIDC_SCOPE, 'openid email'),
+        clientId: parseString(env.OIDC_CLIENT_ID, ''),
+        clientSecret: parseString(env.OIDC_CLIENT_SECRET, ''),
+    });
+
+    // Storage
+    const storage: StorageConfig = Object.freeze({
+        maxDiskSpaceMb: parseIntValue(env.USER_STORAGE_MAX_DISK_SPACE, 1024),
+        defaultQuotaMb: parseIntValue(env.DEFAULT_QUOTA, 4096),
+        countAutosaveSpace: parseBoolean(env.COUNT_USER_AUTOSAVE_SPACE_ODE_FILES, true),
+        maxUploadSizeMb: parseIntValue(env.FILE_UPLOAD_MAX_SIZE, 1024),
+    });
+
+    // Autosave
+    const autosave: AutosaveConfig = Object.freeze({
+        enabled: parseBoolean(env.AUTOSAVE_ODE_FILES_FUNCTION, true),
+        intervalSeconds: parseIntValue(env.PERMANENT_SAVE_AUTOSAVE_TIME_INTERVAL, 600),
+        maxFiles: parseIntValue(env.PERMANENT_SAVE_AUTOSAVE_MAX_NUMBER_OF_FILES, 10),
+    });
+
+    // Cleanup
+    const cleanup: CleanupConfig = Object.freeze({
+        enabled: parseBoolean(env.CLEANUP_ENABLED, false),
+        intervalHours: parseIntValue(env.CLEANUP_INTERVAL_HOURS, 24),
+        unsavedAgeHours: parseIntValue(env.CLEANUP_UNSAVED_AGE_HOURS, 24),
+        guestAgeDays: parseIntValue(env.CLEANUP_GUEST_AGE_DAYS, 7),
+    });
+
+    // Features
+    const features: FeatureConfig = Object.freeze({
+        onlineThemesInstall: parseBoolean(env.ONLINE_THEMES_INSTALL, false),
+        onlineIdevicesInstall: parseBoolean(env.ONLINE_IDEVICES_INSTALL, false),
+        versionControl: parseBoolean(env.VERSION_CONTROL, true),
+        defaultProjectVisibility: parseProjectVisibility(env.DEFAULT_PROJECT_VISIBILITY),
+        collaborativeBlockLevel: parseBlockLevel(env.COLLABORATIVE_BLOCK_LEVEL),
+        recentFilesAmount: parseIntValue(env.USER_RECENT_ODE_FILES_AMOUNT, 3),
+    });
+
+    // Test user (only in non-prod)
+    const testUser =
+        appEnv !== 'prod'
+            ? Object.freeze({
+                  email: parseString(env.TEST_USER_EMAIL, 'user@exelearning.net'),
+                  username: parseString(env.TEST_USER_USERNAME, 'user'),
+                  password: parseString(env.TEST_USER_PASSWORD, '1234'),
+              })
+            : undefined;
+
+    return Object.freeze({
+        env: appEnv,
+        debug,
+        secret,
+        onlineMode,
+        port,
+        basePath,
+        filesDir,
+        publicDir,
+        cacheDir,
+        logDir,
+        logLevel,
+        db,
+        redis,
+        auth,
+        cas,
+        oidc,
+        storage,
+        autosave,
+        cleanup,
+        features,
+        testUser,
+    });
+}
+
+// ============================================================================
+// DEFAULT SINGLETON
+// ============================================================================
+
+let _config: ConfigContext | null = null;
+
+/**
+ * Get the default ConfigContext singleton
+ * Created lazily on first access
+ */
+export function getConfig(): ConfigContext {
+    if (!_config) {
+        _config = createConfigContext();
+    }
+    return _config;
+}
+
+/**
+ * Reset the default ConfigContext (for testing only)
+ */
+export function resetConfigContext(): void {
+    _config = null;
+}
+
+/**
+ * Set a custom ConfigContext as the default (for testing only)
+ */
+export function setConfigContext(config: ConfigContext): void {
+    _config = config;
+}

--- a/src/contexts/logger.context.spec.ts
+++ b/src/contexts/logger.context.spec.ts
@@ -1,0 +1,528 @@
+/**
+ * LoggerContext Tests
+ */
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import {
+    createLoggerContext,
+    getLogger,
+    resetLoggerContext,
+    setLoggerContext,
+    silentLogger,
+    CapturingLogger,
+} from './logger.context';
+import { createConfigContext, resetConfigContext } from './config.context';
+
+describe('LoggerContext', () => {
+    beforeEach(() => {
+        resetLoggerContext();
+        resetConfigContext();
+    });
+
+    afterEach(() => {
+        resetLoggerContext();
+        resetConfigContext();
+    });
+
+    describe('silentLogger', () => {
+        it('should have all logger methods', () => {
+            expect(typeof silentLogger.debug).toBe('function');
+            expect(typeof silentLogger.info).toBe('function');
+            expect(typeof silentLogger.warn).toBe('function');
+            expect(typeof silentLogger.error).toBe('function');
+            expect(typeof silentLogger.child).toBe('function');
+        });
+
+        it('should not throw when logging', () => {
+            expect(() => silentLogger.debug('test')).not.toThrow();
+            expect(() => silentLogger.info('test')).not.toThrow();
+            expect(() => silentLogger.warn('test')).not.toThrow();
+            expect(() => silentLogger.error('test')).not.toThrow();
+            expect(() => silentLogger.error('test', new Error('err'))).not.toThrow();
+        });
+
+        it('should return silentLogger from child()', () => {
+            const child = silentLogger.child({ component: 'test' });
+            expect(child).toBe(silentLogger);
+        });
+
+        it('should have error level', () => {
+            expect(silentLogger.level).toBe('error');
+        });
+    });
+
+    describe('CapturingLogger', () => {
+        let logger: CapturingLogger;
+
+        beforeEach(() => {
+            logger = new CapturingLogger();
+        });
+
+        it('should capture debug messages', () => {
+            logger.debug('debug message', { key: 'value' });
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].level).toBe('debug');
+            expect(logger.logs[0].message).toBe('debug message');
+            expect(logger.logs[0].context).toEqual({ key: 'value' });
+        });
+
+        it('should capture info messages', () => {
+            logger.info('info message');
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].level).toBe('info');
+            expect(logger.logs[0].message).toBe('info message');
+        });
+
+        it('should capture warn messages', () => {
+            logger.warn('warn message');
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].level).toBe('warn');
+        });
+
+        it('should capture error messages with error object', () => {
+            const error = new Error('test error');
+            logger.error('error message', error, { extra: 'data' });
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].level).toBe('error');
+            expect(logger.logs[0].error).toBe(error);
+            expect(logger.logs[0].context).toEqual({ extra: 'data' });
+        });
+
+        it('should capture error messages without error object', () => {
+            logger.error('error message');
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].error).toBeUndefined();
+        });
+
+        it('should include timestamp in captured logs', () => {
+            const before = new Date();
+            logger.info('test');
+            const after = new Date();
+
+            expect(logger.logs[0].timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime());
+            expect(logger.logs[0].timestamp.getTime()).toBeLessThanOrEqual(after.getTime());
+        });
+
+        it('should clear logs', () => {
+            logger.info('test1');
+            logger.info('test2');
+            expect(logger.logs).toHaveLength(2);
+
+            logger.clear();
+            expect(logger.logs).toHaveLength(0);
+        });
+
+        it('should find logs by predicate', () => {
+            logger.info('info message');
+            logger.warn('warn message');
+            logger.error('error message');
+
+            const warnings = logger.findLogs(log => log.level === 'warn');
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0].message).toBe('warn message');
+        });
+
+        it('should check for log existence with hasLog', () => {
+            logger.info('user logged in');
+            logger.error('failed to connect');
+
+            expect(logger.hasLog('info', 'logged in')).toBe(true);
+            expect(logger.hasLog('error', 'connect')).toBe(true);
+            expect(logger.hasLog('warn', 'anything')).toBe(false);
+        });
+
+        it('should support regex in hasLog', () => {
+            logger.info('User 123 logged in');
+
+            expect(logger.hasLog('info', /User \d+ logged/)).toBe(true);
+            expect(logger.hasLog('info', /Admin \d+/)).toBe(false);
+        });
+
+        it('should respect log level', () => {
+            const warnLogger = new CapturingLogger('warn');
+            warnLogger.debug('debug');
+            warnLogger.info('info');
+            warnLogger.warn('warn');
+            warnLogger.error('error');
+
+            expect(warnLogger.logs).toHaveLength(2);
+            expect(warnLogger.hasLog('warn', 'warn')).toBe(true);
+            expect(warnLogger.hasLog('error', 'error')).toBe(true);
+        });
+
+        it('should create child logger with merged context', () => {
+            const parent = new CapturingLogger('debug', { requestId: 'abc' });
+            const child = parent.child({ userId: 123 }) as CapturingLogger;
+
+            child.info('test');
+            expect(child.logs[0].context).toEqual({ requestId: 'abc', userId: 123 });
+        });
+    });
+
+    describe('createLoggerContext', () => {
+        it('should create legacy logger by default in non-prod', () => {
+            const config = createConfigContext({ APP_ENV: 'dev' });
+            const logger = createLoggerContext({}, config);
+            expect(logger.level).toBe('info');
+        });
+
+        it('should create structured logger in prod', () => {
+            const config = createConfigContext({ APP_ENV: 'prod' });
+            const logger = createLoggerContext({}, config);
+            expect(logger.level).toBe('info');
+        });
+
+        it('should use log level from config', () => {
+            const config = createConfigContext({ LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({}, config);
+            expect(logger.level).toBe('debug');
+        });
+
+        it('should allow overriding log level', () => {
+            const config = createConfigContext({ LOG_LEVEL: 'info' });
+            const logger = createLoggerContext({ level: 'warn' }, config);
+            expect(logger.level).toBe('warn');
+        });
+
+        it('should allow forcing structured mode', () => {
+            const config = createConfigContext({ APP_ENV: 'dev' });
+            const logger = createLoggerContext({ structured: true }, config);
+            expect(logger.level).toBe('info');
+        });
+
+        it('should support prefix option for legacy logger', () => {
+            const config = createConfigContext({ APP_ENV: 'dev' });
+            const logger = createLoggerContext({ prefix: 'MyComponent' }, config);
+            expect(logger.level).toBe('info');
+        });
+    });
+
+    describe('log level filtering', () => {
+        it('should filter debug when level is info', () => {
+            const logger = new CapturingLogger('info');
+            logger.debug('should not appear');
+            logger.info('should appear');
+
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].message).toBe('should appear');
+        });
+
+        it('should filter debug and info when level is warn', () => {
+            const logger = new CapturingLogger('warn');
+            logger.debug('debug');
+            logger.info('info');
+            logger.warn('warn');
+            logger.error('error');
+
+            expect(logger.logs).toHaveLength(2);
+            expect(logger.logs[0].message).toBe('warn');
+            expect(logger.logs[1].message).toBe('error');
+        });
+
+        it('should only show errors when level is error', () => {
+            const logger = new CapturingLogger('error');
+            logger.debug('debug');
+            logger.info('info');
+            logger.warn('warn');
+            logger.error('error');
+
+            expect(logger.logs).toHaveLength(1);
+            expect(logger.logs[0].message).toBe('error');
+        });
+
+        it('should show all when level is debug', () => {
+            const logger = new CapturingLogger('debug');
+            logger.debug('debug');
+            logger.info('info');
+            logger.warn('warn');
+            logger.error('error');
+
+            expect(logger.logs).toHaveLength(4);
+        });
+    });
+
+    describe('getLogger singleton', () => {
+        it('should return the same instance on multiple calls', () => {
+            const logger1 = getLogger();
+            const logger2 = getLogger();
+            expect(logger1).toBe(logger2);
+        });
+
+        it('should reset with resetLoggerContext', () => {
+            const logger1 = getLogger();
+            resetLoggerContext();
+            const logger2 = getLogger();
+            expect(logger1).not.toBe(logger2);
+        });
+
+        it('should use custom logger with setLoggerContext', () => {
+            const customLogger = new CapturingLogger();
+            setLoggerContext(customLogger);
+
+            const logger = getLogger();
+            expect(logger).toBe(customLogger);
+        });
+    });
+
+    describe('child loggers', () => {
+        it('should inherit parent log level', () => {
+            const parent = new CapturingLogger('warn');
+            const child = parent.child({ component: 'test' }) as CapturingLogger;
+
+            expect(child.level).toBe('warn');
+        });
+
+        it('should merge context from multiple levels', () => {
+            const root = new CapturingLogger('debug', { app: 'test' });
+            const request = root.child({ requestId: '123' }) as CapturingLogger;
+            const user = request.child({ userId: 456 }) as CapturingLogger;
+
+            user.info('action');
+
+            expect(user.logs[0].context).toEqual({
+                app: 'test',
+                requestId: '123',
+                userId: 456,
+            });
+        });
+    });
+
+    describe('StructuredLogger', () => {
+        let debugSpy: ReturnType<typeof spyOn>;
+        let infoSpy: ReturnType<typeof spyOn>;
+        let warnSpy: ReturnType<typeof spyOn>;
+        let errorSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            debugSpy = spyOn(console, 'debug').mockImplementation(() => {});
+            infoSpy = spyOn(console, 'info').mockImplementation(() => {});
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            debugSpy.mockRestore();
+            infoSpy.mockRestore();
+            warnSpy.mockRestore();
+            errorSpy.mockRestore();
+        });
+
+        it('should output JSON for debug messages', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+
+            logger.debug('debug message', { key: 'value' });
+
+            expect(debugSpy).toHaveBeenCalledTimes(1);
+            const output = debugSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.level).toBe('debug');
+            expect(parsed.message).toBe('debug message');
+            expect(parsed.key).toBe('value');
+            expect(parsed.timestamp).toBeDefined();
+        });
+
+        it('should output JSON for info messages', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+
+            logger.info('info message');
+
+            expect(infoSpy).toHaveBeenCalledTimes(1);
+            const output = infoSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.level).toBe('info');
+            expect(parsed.message).toBe('info message');
+        });
+
+        it('should output JSON for warn messages', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+
+            logger.warn('warn message', { warning: true });
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            const output = warnSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.level).toBe('warn');
+            expect(parsed.message).toBe('warn message');
+            expect(parsed.warning).toBe(true);
+        });
+
+        it('should output JSON for error messages with error object', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+            const error = new Error('test error');
+
+            logger.error('error message', error, { extra: 'data' });
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            const output = errorSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.level).toBe('error');
+            expect(parsed.message).toBe('error message');
+            expect(parsed.error.name).toBe('Error');
+            expect(parsed.error.message).toBe('test error');
+            expect(parsed.extra).toBe('data');
+        });
+
+        it('should output JSON for error messages without error object', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+
+            logger.error('error message', null, { extra: 'data' });
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            const output = errorSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.level).toBe('error');
+            expect(parsed.error).toBeUndefined();
+        });
+
+        it('should include base context in child logger output', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: true }, config);
+            const child = logger.child({ component: 'test-component' });
+
+            child.info('child message');
+
+            expect(infoSpy).toHaveBeenCalledTimes(1);
+            const output = infoSpy.mock.calls[0][0];
+            const parsed = JSON.parse(output);
+            expect(parsed.component).toBe('test-component');
+        });
+
+        it('should respect log level filtering', () => {
+            const config = createConfigContext({ APP_ENV: 'prod', LOG_LEVEL: 'warn' });
+            const logger = createLoggerContext({ structured: true }, config);
+
+            logger.debug('debug');
+            logger.info('info');
+            logger.warn('warn');
+            logger.error('error');
+
+            expect(debugSpy).not.toHaveBeenCalled();
+            expect(infoSpy).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('LegacyLogger', () => {
+        let debugSpy: ReturnType<typeof spyOn>;
+        let logSpy: ReturnType<typeof spyOn>;
+        let warnSpy: ReturnType<typeof spyOn>;
+        let errorSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            debugSpy = spyOn(console, 'debug').mockImplementation(() => {});
+            logSpy = spyOn(console, 'log').mockImplementation(() => {});
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            debugSpy.mockRestore();
+            logSpy.mockRestore();
+            warnSpy.mockRestore();
+            errorSpy.mockRestore();
+        });
+
+        it('should output legacy format for debug messages', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false, prefix: 'TestComponent' }, config);
+
+            logger.debug('debug message', { key: 'value' });
+
+            expect(debugSpy).toHaveBeenCalledTimes(1);
+            const output = debugSpy.mock.calls[0][0];
+            expect(output).toContain('[TestComponent]');
+            expect(output).toContain('debug message');
+            expect(output).toContain('"key":"value"');
+        });
+
+        it('should output legacy format for info messages', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false, prefix: 'TestComponent' }, config);
+
+            logger.info('info message');
+
+            expect(logSpy).toHaveBeenCalledTimes(1);
+            const output = logSpy.mock.calls[0][0];
+            expect(output).toContain('[TestComponent]');
+            expect(output).toContain('info message');
+        });
+
+        it('should output legacy format for warn messages', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false, prefix: 'TestComponent' }, config);
+
+            logger.warn('warn message');
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            const output = warnSpy.mock.calls[0][0];
+            expect(output).toContain('[TestComponent]');
+            expect(output).toContain('warn message');
+        });
+
+        it('should output legacy format for error messages with error object', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false, prefix: 'TestComponent' }, config);
+            const error = new Error('test error');
+
+            logger.error('error message', error, { extra: 'data' });
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy.mock.calls[0][0]).toContain('[TestComponent]');
+            expect(errorSpy.mock.calls[0][0]).toContain('error message');
+            expect(errorSpy.mock.calls[0][1]).toBe('test error');
+        });
+
+        it('should output legacy format for error messages without error object', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false, prefix: 'TestComponent' }, config);
+
+            logger.error('error message', null, { extra: 'data' });
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy.mock.calls[0][0]).toContain('error message');
+        });
+
+        it('should create child logger with component prefix', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false }, config);
+            const child = logger.child({ component: 'ChildComponent' });
+
+            child.info('child message');
+
+            expect(logSpy).toHaveBeenCalledTimes(1);
+            const output = logSpy.mock.calls[0][0];
+            expect(output).toContain('[ChildComponent]');
+        });
+
+        it('should output without prefix when none specified', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'debug' });
+            const logger = createLoggerContext({ structured: false }, config);
+
+            logger.info('message without prefix');
+
+            expect(logSpy).toHaveBeenCalledTimes(1);
+            const output = logSpy.mock.calls[0][0];
+            expect(output).toBe('message without prefix');
+        });
+
+        it('should respect log level filtering', () => {
+            const config = createConfigContext({ APP_ENV: 'dev', LOG_LEVEL: 'error' });
+            const logger = createLoggerContext({ structured: false }, config);
+
+            logger.debug('debug');
+            logger.info('info');
+            logger.warn('warn');
+            logger.error('error');
+
+            expect(debugSpy).not.toHaveBeenCalled();
+            expect(logSpy).not.toHaveBeenCalled();
+            expect(warnSpy).not.toHaveBeenCalled();
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/contexts/logger.context.ts
+++ b/src/contexts/logger.context.ts
@@ -1,0 +1,400 @@
+/**
+ * LoggerContext - Centralized Logging Abstraction
+ *
+ * Replaces direct console.* calls with a structured logging interface.
+ * Supports log levels, structured context, and test-friendly silent mode.
+ *
+ * Usage:
+ *   import { getLogger, createLoggerContext, silentLogger } from './contexts/logger.context';
+ *
+ *   // Production: use default singleton
+ *   const logger = getLogger();
+ *   logger.info('User logged in', { userId: 123 });
+ *
+ *   // Testing: use silent logger
+ *   const logger = silentLogger;
+ *
+ *   // Scoped logging:
+ *   const requestLogger = logger.child({ requestId: 'abc123' });
+ *   requestLogger.info('Processing request');  // includes requestId in output
+ */
+import { getConfig, type ConfigContext, type LogLevel } from './config.context';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Context data that can be attached to log messages
+ */
+export type LogContext = Record<string, unknown>;
+
+/**
+ * Logger interface with standard log levels and child logger support
+ */
+export interface LoggerContext {
+    /**
+     * Log a debug message (most verbose, typically disabled in production)
+     */
+    debug(message: string, context?: LogContext): void;
+
+    /**
+     * Log an informational message
+     */
+    info(message: string, context?: LogContext): void;
+
+    /**
+     * Log a warning message
+     */
+    warn(message: string, context?: LogContext): void;
+
+    /**
+     * Log an error message with optional error object
+     */
+    error(message: string, error?: Error | null, context?: LogContext): void;
+
+    /**
+     * Create a child logger with additional context
+     * Child loggers inherit parent context and merge with new context
+     */
+    child(context: LogContext): LoggerContext;
+
+    /**
+     * Get the current log level
+     */
+    readonly level: LogLevel;
+}
+
+// ============================================================================
+// LOG LEVEL UTILITIES
+// ============================================================================
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+    debug: 0,
+    info: 1,
+    warn: 2,
+    error: 3,
+};
+
+function shouldLog(currentLevel: LogLevel, messageLevel: LogLevel): boolean {
+    return LOG_LEVEL_PRIORITY[messageLevel] >= LOG_LEVEL_PRIORITY[currentLevel];
+}
+
+// ============================================================================
+// STRUCTURED LOGGER IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Structured JSON logger that outputs to console
+ */
+class StructuredLogger implements LoggerContext {
+    constructor(
+        public readonly level: LogLevel,
+        private readonly baseContext: LogContext = {},
+    ) {}
+
+    debug(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'debug')) {
+            this.log('debug', message, context);
+        }
+    }
+
+    info(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'info')) {
+            this.log('info', message, context);
+        }
+    }
+
+    warn(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'warn')) {
+            this.log('warn', message, context);
+        }
+    }
+
+    error(message: string, error?: Error | null, context?: LogContext): void {
+        if (shouldLog(this.level, 'error')) {
+            const errorContext: LogContext = { ...context };
+            if (error) {
+                errorContext.error = {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                };
+            }
+            this.log('error', message, errorContext);
+        }
+    }
+
+    child(context: LogContext): LoggerContext {
+        return new StructuredLogger(this.level, {
+            ...this.baseContext,
+            ...context,
+        });
+    }
+
+    private log(level: LogLevel, message: string, context?: LogContext): void {
+        const timestamp = new Date().toISOString();
+        const logEntry = {
+            timestamp,
+            level,
+            message,
+            ...this.baseContext,
+            ...context,
+        };
+
+        // Use appropriate console method based on level
+        switch (level) {
+            case 'debug':
+                console.debug(JSON.stringify(logEntry));
+                break;
+            case 'info':
+                console.info(JSON.stringify(logEntry));
+                break;
+            case 'warn':
+                console.warn(JSON.stringify(logEntry));
+                break;
+            case 'error':
+                console.error(JSON.stringify(logEntry));
+                break;
+        }
+    }
+}
+
+// ============================================================================
+// LEGACY LOGGER (Backward Compatible)
+// ============================================================================
+
+/**
+ * Legacy logger that outputs in the original console format
+ * Used for gradual migration - maintains existing log format
+ */
+class LegacyLogger implements LoggerContext {
+    constructor(
+        public readonly level: LogLevel,
+        private readonly prefix: string = '',
+    ) {}
+
+    debug(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'debug')) {
+            this.logLegacy('debug', message, context);
+        }
+    }
+
+    info(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'info')) {
+            this.logLegacy('info', message, context);
+        }
+    }
+
+    warn(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'warn')) {
+            this.logLegacy('warn', message, context);
+        }
+    }
+
+    error(message: string, error?: Error | null, context?: LogContext): void {
+        if (shouldLog(this.level, 'error')) {
+            const prefix = this.prefix ? `[${this.prefix}] ` : '';
+            if (error) {
+                console.error(`${prefix}${message}`, error.message, context || '');
+            } else {
+                console.error(`${prefix}${message}`, context || '');
+            }
+        }
+    }
+
+    child(context: LogContext): LoggerContext {
+        const component = context.component as string | undefined;
+        return new LegacyLogger(this.level, component || this.prefix);
+    }
+
+    private logLegacy(level: LogLevel, message: string, context?: LogContext): void {
+        const prefix = this.prefix ? `[${this.prefix}] ` : '';
+        const contextStr = context ? ` ${JSON.stringify(context)}` : '';
+
+        switch (level) {
+            case 'debug':
+                console.debug(`${prefix}${message}${contextStr}`);
+                break;
+            case 'info':
+                console.log(`${prefix}${message}${contextStr}`);
+                break;
+            case 'warn':
+                console.warn(`${prefix}${message}${contextStr}`);
+                break;
+            case 'error':
+                console.error(`${prefix}${message}${contextStr}`);
+                break;
+        }
+    }
+}
+
+// ============================================================================
+// SILENT LOGGER (for testing)
+// ============================================================================
+
+/**
+ * Silent logger that discards all log messages
+ * Use this in tests to prevent log pollution
+ */
+export const silentLogger: LoggerContext = {
+    level: 'error',
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => silentLogger,
+};
+
+// ============================================================================
+// CAPTURING LOGGER (for testing)
+// ============================================================================
+
+/**
+ * Log entry captured by CapturingLogger
+ */
+export interface CapturedLog {
+    level: LogLevel;
+    message: string;
+    error?: Error | null;
+    context?: LogContext;
+    timestamp: Date;
+}
+
+/**
+ * Logger that captures all log messages for testing assertions
+ */
+export class CapturingLogger implements LoggerContext {
+    public readonly logs: CapturedLog[] = [];
+
+    constructor(
+        public readonly level: LogLevel = 'debug',
+        private readonly baseContext: LogContext = {},
+    ) {}
+
+    debug(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'debug')) {
+            this.capture('debug', message, null, context);
+        }
+    }
+
+    info(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'info')) {
+            this.capture('info', message, null, context);
+        }
+    }
+
+    warn(message: string, context?: LogContext): void {
+        if (shouldLog(this.level, 'warn')) {
+            this.capture('warn', message, null, context);
+        }
+    }
+
+    error(message: string, error?: Error | null, context?: LogContext): void {
+        if (shouldLog(this.level, 'error')) {
+            this.capture('error', message, error, context);
+        }
+    }
+
+    child(context: LogContext): LoggerContext {
+        return new CapturingLogger(this.level, {
+            ...this.baseContext,
+            ...context,
+        });
+    }
+
+    private capture(level: LogLevel, message: string, error?: Error | null, context?: LogContext): void {
+        this.logs.push({
+            level,
+            message,
+            error,
+            context: { ...this.baseContext, ...context },
+            timestamp: new Date(),
+        });
+    }
+
+    /**
+     * Clear all captured logs
+     */
+    clear(): void {
+        this.logs.length = 0;
+    }
+
+    /**
+     * Find logs matching a predicate
+     */
+    findLogs(predicate: (log: CapturedLog) => boolean): CapturedLog[] {
+        return this.logs.filter(predicate);
+    }
+
+    /**
+     * Check if any log matches the given criteria
+     */
+    hasLog(level: LogLevel, messagePattern: string | RegExp): boolean {
+        return this.logs.some(log => {
+            if (log.level !== level) return false;
+            if (typeof messagePattern === 'string') {
+                return log.message.includes(messagePattern);
+            }
+            return messagePattern.test(log.message);
+        });
+    }
+}
+
+// ============================================================================
+// FACTORY FUNCTION
+// ============================================================================
+
+export interface LoggerOptions {
+    level?: LogLevel;
+    structured?: boolean;
+    prefix?: string;
+}
+
+/**
+ * Create a LoggerContext with the specified options
+ *
+ * @param options - Logger configuration
+ * @param config - Optional ConfigContext for default level
+ */
+export function createLoggerContext(options: LoggerOptions = {}, config?: ConfigContext): LoggerContext {
+    const cfg = config ?? getConfig();
+    const level = options.level ?? cfg.logLevel;
+    const structured = options.structured ?? cfg.env === 'prod';
+
+    if (structured) {
+        return new StructuredLogger(level);
+    }
+    return new LegacyLogger(level, options.prefix);
+}
+
+// ============================================================================
+// DEFAULT SINGLETON
+// ============================================================================
+
+let _logger: LoggerContext | null = null;
+
+/**
+ * Get the default LoggerContext singleton
+ * Created lazily on first access
+ */
+export function getLogger(): LoggerContext {
+    if (!_logger) {
+        _logger = createLoggerContext();
+    }
+    return _logger;
+}
+
+/**
+ * Reset the default LoggerContext (for testing only)
+ */
+export function resetLoggerContext(): void {
+    _logger = null;
+}
+
+/**
+ * Set a custom LoggerContext as the default (for testing only)
+ */
+export function setLoggerContext(logger: LoggerContext): void {
+    _logger = logger;
+}

--- a/src/db/client.spec.ts
+++ b/src/db/client.spec.ts
@@ -18,6 +18,7 @@ import {
     resetClientCacheForTesting,
     getDialect,
 } from './client';
+import { resetConfigContext } from '../contexts/config.context';
 
 describe('Kysely ORM Client', () => {
     describe('db instance', () => {
@@ -115,6 +116,7 @@ describe('Kysely ORM Client', () => {
                 // Set up postgres config with password
                 process.env.DB_DRIVER = 'pdo_pgsql';
                 process.env.DB_PASSWORD = 'secret123';
+                resetConfigContext(); // Reset ConfigContext cache to pick up new env
 
                 const info = getDbInfo();
 
@@ -124,6 +126,7 @@ describe('Kysely ORM Client', () => {
                 // Restore original env
                 process.env.DB_DRIVER = originalDriver;
                 process.env.DB_PASSWORD = originalPassword;
+                resetConfigContext(); // Reset ConfigContext cache to restore original
             }
         });
 
@@ -136,6 +139,7 @@ describe('Kysely ORM Client', () => {
                 // Set up postgres config without password
                 process.env.DB_DRIVER = 'pdo_pgsql';
                 process.env.DB_PASSWORD = '';
+                resetConfigContext(); // Reset ConfigContext cache to pick up new env
 
                 const info = getDbInfo();
 
@@ -145,6 +149,7 @@ describe('Kysely ORM Client', () => {
                 // Restore original env
                 process.env.DB_DRIVER = originalDriver;
                 process.env.DB_PASSWORD = originalPassword;
+                resetConfigContext(); // Reset ConfigContext cache to restore original
             }
         });
 

--- a/src/db/dialect.spec.ts
+++ b/src/db/dialect.spec.ts
@@ -13,6 +13,7 @@ import {
     type PostgresConfig,
     type MysqlConfig,
 } from './dialect';
+import { resetConfigContext } from '../contexts/config.context';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -21,6 +22,8 @@ describe('Kysely Dialect Factory', () => {
     const testDbDir = path.join(process.cwd(), 'test', 'temp', 'dialect-test');
 
     beforeEach(() => {
+        // Reset ConfigContext so each test gets fresh config from modified process.env
+        resetConfigContext();
         // Ensure test directory exists
         if (!fs.existsSync(testDbDir)) {
             fs.mkdirSync(testDbDir, { recursive: true });
@@ -30,6 +33,7 @@ describe('Kysely Dialect Factory', () => {
     afterEach(() => {
         process.env = { ...originalEnv };
         resetDependencies();
+        resetConfigContext(); // Reset ConfigContext singleton so next test gets fresh config
         // Clean up test directory
         if (fs.existsSync(testDbDir)) {
             fs.rmSync(testDbDir, { recursive: true, force: true });
@@ -182,10 +186,12 @@ describe('Kysely Dialect Factory', () => {
             expect(dialect).toBe('mysql');
         });
 
-        it('should be case insensitive', () => {
+        it('should be case insensitive for postgres', () => {
             process.env.DB_DRIVER = 'POSTGRES';
             expect(getDialectFromEnv()).toBe('postgres');
+        });
 
+        it('should be case insensitive for mysql', () => {
             process.env.DB_DRIVER = 'MySQL';
             expect(getDialectFromEnv()).toBe('mysql');
         });

--- a/src/db/dialect.ts
+++ b/src/db/dialect.ts
@@ -1,10 +1,14 @@
 /**
  * Kysely Dialect Factory
  * Supports SQLite, PostgreSQL, and MySQL using Bun's native drivers
+ *
+ * Now supports ConfigContext for centralized configuration.
+ * Falls back to process.env for backward compatibility.
  */
 import type { Dialect } from 'kysely';
 import { resolve, dirname } from 'path';
 import { mkdirSync, existsSync } from 'fs';
+import { getConfig, type ConfigContext } from '../contexts/config.context';
 
 // ============================================================================
 // RUNTIME DETECTION
@@ -115,58 +119,60 @@ function mapDriverToDialect(driver: string): DbDialect {
 }
 
 /**
- * Get database configuration from environment variables
+ * Get database configuration from ConfigContext or environment variables
+ *
+ * @param config - Optional ConfigContext. If not provided, uses getConfig() singleton.
  */
-export function getDbConfig(): DbConfig {
-    const driver = process.env.DB_DRIVER || 'pdo_sqlite';
-    const dialect = mapDriverToDialect(driver);
+export function getDbConfig(config?: ConfigContext): DbConfig {
+    // Use ConfigContext if available, otherwise fall back to singleton
+    const cfg = config ?? getConfig();
+    const dbConfig = cfg.db;
 
-    const poolMin = Number.parseInt(process.env.DB_POOL_MIN || '0', 10);
-    const poolMax = Number.parseInt(process.env.DB_POOL_MAX || '10', 10);
-
-    if (dialect === 'sqlite') {
+    if (dbConfig.dialect === 'sqlite') {
         return {
             dialect: 'sqlite',
-            sqlitePath: process.env.DB_PATH || 'data/exelearning.db',
-            poolMin,
-            poolMax,
+            sqlitePath: dbConfig.path || 'data/exelearning.db',
+            poolMin: dbConfig.poolMin,
+            poolMax: dbConfig.poolMax,
         };
     }
 
-    if (dialect === 'postgres') {
+    if (dbConfig.dialect === 'postgres') {
         return {
             dialect: 'postgres',
-            host: process.env.DB_HOST || 'localhost',
-            port: Number.parseInt(process.env.DB_PORT || '5432', 10),
-            database: process.env.DB_NAME || 'exelearning',
-            user: process.env.DB_USER || 'exelearning',
-            password: process.env.DB_PASSWORD || '',
-            charset: process.env.DB_CHARSET || 'utf8',
-            poolMin,
-            poolMax,
+            host: dbConfig.host,
+            port: dbConfig.port,
+            database: dbConfig.name,
+            user: dbConfig.user,
+            password: dbConfig.password,
+            charset: dbConfig.charset,
+            poolMin: dbConfig.poolMin,
+            poolMax: dbConfig.poolMax,
         };
     }
 
     // MySQL
     return {
         dialect: 'mysql',
-        host: process.env.DB_HOST || 'localhost',
-        port: Number.parseInt(process.env.DB_PORT || '3306', 10),
-        database: process.env.DB_NAME || 'exelearning',
-        user: process.env.DB_USER || 'exelearning',
-        password: process.env.DB_PASSWORD || '',
-        charset: process.env.DB_CHARSET || 'utf8mb4',
-        poolMin,
-        poolMax,
+        host: dbConfig.host,
+        port: dbConfig.port,
+        database: dbConfig.name,
+        user: dbConfig.user,
+        password: dbConfig.password,
+        charset: dbConfig.charset,
+        poolMin: dbConfig.poolMin,
+        poolMax: dbConfig.poolMax,
     };
 }
 
 /**
- * Get the dialect type from environment
+ * Get the dialect type from ConfigContext or environment
+ *
+ * @param config - Optional ConfigContext. If not provided, uses getConfig() singleton.
  */
-export function getDialectFromEnv(): DbDialect {
-    const driver = process.env.DB_DRIVER || 'pdo_sqlite';
-    return mapDriverToDialect(driver);
+export function getDialectFromEnv(config?: ConfigContext): DbDialect {
+    const cfg = config ?? getConfig();
+    return cfg.db.dialect;
 }
 
 // ============================================================================

--- a/src/db/helpers.spec.ts
+++ b/src/db/helpers.spec.ts
@@ -24,6 +24,7 @@ import {
     deleteByColumnAndReturn,
     deleteByIdAndReturn,
 } from './helpers';
+import { resetConfigContext } from '../contexts/config.context';
 
 describe('Database Helpers', () => {
     let db: Kysely<Database>;
@@ -45,10 +46,12 @@ describe('Database Helpers', () => {
         const originalDriver = process.env.DB_DRIVER;
         try {
             process.env.DB_DRIVER = driver;
+            resetConfigContext(); // Reset ConfigContext cache to pick up new DB_DRIVER
             resetDialectCache();
             return await fn();
         } finally {
             process.env.DB_DRIVER = originalDriver;
+            resetConfigContext(); // Reset ConfigContext cache to restore original
             resetDialectCache();
         }
     }
@@ -109,6 +112,7 @@ describe('Database Helpers', () => {
             const originalDriver = process.env.DB_DRIVER;
             try {
                 process.env.DB_DRIVER = 'mysql';
+                resetConfigContext(); // Reset ConfigContext cache to pick up new DB_DRIVER
                 resetDialectCache();
                 const input = new Uint8Array([9, 8, 7]);
                 const result = toBinaryData(input);
@@ -116,6 +120,7 @@ describe('Database Helpers', () => {
                 expect([...result]).toEqual([9, 8, 7]);
             } finally {
                 process.env.DB_DRIVER = originalDriver;
+                resetConfigContext(); // Reset ConfigContext cache to restore original
                 resetDialectCache();
             }
         });

--- a/src/db/helpers.ts
+++ b/src/db/helpers.ts
@@ -13,6 +13,9 @@ import type { Kysely, Insertable, Updateable, ColumnDefinitionBuilder, DataTypeE
 import { sql } from 'kysely';
 import type { Database } from './types';
 import { getDialectFromEnv, type DbDialect } from './dialect';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'db-helpers' });
 
 // Cache the dialect to avoid repeated environment lookups
 let cachedDialect: DbDialect | null = null;
@@ -66,7 +69,7 @@ export function fromBinaryData(data: unknown): Uint8Array {
     if (Buffer.isBuffer(data)) {
         return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
     }
-    console.warn(`[fromBinaryData] Unknown data type: ${typeof data}`);
+    logger.warn('Unknown data type in fromBinaryData', { dataType: typeof data });
     return new Uint8Array(0);
 }
 

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -4,6 +4,10 @@
  */
 import { Kysely, Migrator, sql, type Migration, type MigrationProvider } from 'kysely';
 import { tableExists as tableExistsHelper, getDialect } from '../helpers';
+import { getLogger } from '../../contexts/logger.context';
+
+// Create logger for migrations
+const logger = getLogger().child({ component: 'db/migrations' });
 
 // Import all migrations
 import * as migration000 from './000_legacy_symfony';
@@ -87,7 +91,7 @@ async function syncLegacyMigrations(db: Kysely<unknown>): Promise<void> {
     // 000_legacy_symfony will clean up old Symfony schema
     // 001_initial will create new tables (uses ifNotExists)
     if (usersTableExists && !projectsTableExists) {
-        console.log('[DB] Detected Symfony legacy database...');
+        logger.info('Detected Symfony legacy database');
 
         if (!migrationTableExists) {
             // Create migration tracking tables
@@ -129,7 +133,7 @@ async function syncLegacyMigrations(db: Kysely<unknown>): Promise<void> {
 
         // Let migrations run normally - 000_legacy_symfony will clean up Symfony,
         // 001_initial will create missing tables
-        console.log('[DB] Migration tracking created, will run schema updates');
+        logger.info('Migration tracking created, will run schema updates');
         return;
     }
 
@@ -147,7 +151,7 @@ async function syncLegacyMigrations(db: Kysely<unknown>): Promise<void> {
 async function areAllMigrationsExecuted(db: Kysely<unknown>): Promise<boolean> {
     const migrationTableExists = await tableExists(db, 'kysely_migration');
     const dialect = getDialect();
-    console.log('[Migration] Migration table exists:', migrationTableExists);
+    logger.debug('Migration table exists', { migrationTableExists });
     if (!migrationTableExists && dialect !== 'mysql') {
         return false; // No tracking table = need to run migrations
     }
@@ -162,18 +166,18 @@ async function areAllMigrationsExecuted(db: Kysely<unknown>): Promise<boolean> {
         const executedNames = new Set(result.rows.map(r => r.name));
         const allMigrationNames = Object.keys(migrations);
 
-        console.log('[Migration] Executed migrations:', [...executedNames]);
-        console.log('[Migration] Required migrations:', allMigrationNames);
+        logger.debug('Executed migrations', { executedMigrations: [...executedNames] });
+        logger.debug('Required migrations', { allMigrationNames });
 
         // Check if all migrations are executed
         const allDone = allMigrationNames.every(name => executedNames.has(name));
-        console.log('[Migration] All migrations done:', allDone);
+        logger.debug('All migrations done', { allDone });
         return allDone;
     } catch (err) {
         if (!migrationTableExists) {
             return false; // Table genuinely missing (or not visible) = need to run migrations
         }
-        console.log('[Migration] Error checking migrations:', err);
+        logger.warn('Error checking migrations', { error: err instanceof Error ? err.message : String(err) });
         return false; // Error = need to run migrations to be safe
     }
 }
@@ -188,10 +192,10 @@ async function cleanStaleLocks(db: Kysely<unknown>): Promise<void> {
         // Delete any existing lock rows - they're stale since we're just starting
         // We try unconditionally because tableExists() might fail for some databases
         await sql`DELETE FROM kysely_migration_lock WHERE id = 'migration_lock'`.execute(db);
-        console.log('[Migration] Cleaned stale locks');
+        logger.debug('Cleaned stale locks');
     } catch (err) {
         // Ignore errors - table might not exist yet or be empty
-        console.log('[Migration] No stale locks to clean (or table does not exist)');
+        logger.debug('No stale locks to clean (or table does not exist)');
     }
 }
 
@@ -212,7 +216,7 @@ export async function migrateToLatest(
     // If all migrations are already executed, skip the migrator entirely
     // This avoids Kysely's lock acquisition which can fail on MySQL with stale locks
     if (await areAllMigrationsExecuted(db)) {
-        console.log('No pending migrations');
+        logger.info('No pending migrations');
         return { success: true, executedMigrations: [] };
     }
 
@@ -225,14 +229,14 @@ export async function migrateToLatest(
     const executedMigrations = results?.filter(r => r.status === 'Success').map(r => r.migrationName) || [];
 
     if (error) {
-        console.error('Migration failed:', error);
+        logger.error('Migration failed', error);
         return { success: false, executedMigrations, error };
     }
 
     if (executedMigrations.length > 0) {
-        console.log('Migrations executed:', executedMigrations.join(', '));
+        logger.info('Migrations executed', { migrations: executedMigrations });
     } else {
-        console.log('No pending migrations');
+        logger.info('No pending migrations');
     }
 
     return { success: true, executedMigrations };
@@ -255,14 +259,14 @@ export async function migrateDown(
     const rolledBack = results?.find(r => r.status === 'Success')?.migrationName;
 
     if (error) {
-        console.error('Rollback failed:', error);
+        logger.error('Rollback failed', error);
         return { success: false, error };
     }
 
     if (rolledBack) {
-        console.log('Rolled back:', rolledBack);
+        logger.info('Rolled back migration', { migration: rolledBack });
     } else {
-        console.log('No migrations to rollback');
+        logger.info('No migrations to rollback');
     }
 
     return { success: true, rolledBack };

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { renderTemplate, setRenderLocale } from './services/template';
 import { getSettingNumber } from './services/app-settings';
 import { getBasePath } from './utils/basepath.util';
 import { HttpException, TranslatableException, getStatusText } from './exceptions';
+import { getLogger } from './contexts/logger.context';
 import { MIME_TYPES } from './utils/mime-types';
 import { isRedisEnabled, connectRedis, disconnectRedis } from './redis/client';
 import { initializeCrossInstanceHandler } from './websocket/room-manager';
@@ -55,6 +56,9 @@ import * as path from 'path';
 // APP_PORT is used by Electron, PORT is standard convention
 const PORT = parseInt(process.env.APP_PORT || process.env.PORT || '8080', 10);
 
+// Create logger for the application
+const logger = getLogger().child({ component: 'http' });
+
 const app = new Elysia()
     // === GLOBAL ERROR HANDLER ===
     .onError(({ code, error, request, set }) => {
@@ -69,12 +73,18 @@ const app = new Elysia()
         const url = new URL(request.url);
         const pathname = url.pathname;
 
-        // Log error (5xx = error, 4xx = warning)
-        const logLevel = statusCode >= 500 ? 'error' : 'warn';
-        console[logLevel](
-            `[${logLevel.toUpperCase()}] ${request.method} ${pathname} - ${statusCode}: ${error.message}`,
-        );
-        if (statusCode >= 500) console.error(error.stack);
+        // Log error using LoggerContext (5xx = error, 4xx = warning)
+        const logContext = {
+            method: request.method,
+            path: pathname,
+            statusCode,
+        };
+
+        if (statusCode >= 500) {
+            logger.error(`${request.method} ${pathname} - ${statusCode}: ${error.message}`, error, logContext);
+        } else {
+            logger.warn(`${request.method} ${pathname} - ${statusCode}: ${error.message}`, logContext);
+        }
 
         // Detect if API request
         const isApi =
@@ -117,7 +127,7 @@ const app = new Elysia()
             });
         } catch (renderErr) {
             // Fallback HTML if template fails
-            console.error('[Error] Template render failed:', renderErr);
+            logger.error('Template render failed', renderErr instanceof Error ? renderErr : null, { template });
             const basePath = getBasePath();
             return `<!DOCTYPE html>
 <html><head><title>Error ${statusCode}</title></head>
@@ -208,7 +218,7 @@ const app = new Elysia()
                         });
                     }
                 } catch (err) {
-                    console.error('[StaticFiles] Error serving file:', filePath, err);
+                    logger.error('Error serving file', err instanceof Error ? err : null, { filePath });
                 }
             }
             // File not found - let it fall through to 404
@@ -521,6 +531,11 @@ if (routePrefix) {
     );
 }
 
+// Create loggers for different components
+const themesLogger = getLogger().child({ component: 'themes' });
+const dbLogger = getLogger().child({ component: 'db' });
+const redisLogger = getLogger().child({ component: 'redis' });
+
 /**
  * Sync builtin themes from filesystem to database
  * Scans public/files/perm/themes/base/ and registers each theme in the DB
@@ -529,14 +544,14 @@ async function syncBuiltinThemes() {
     const baseThemesPath = path.join(process.cwd(), 'public', 'files', 'perm', 'themes', 'base');
 
     if (!fs.existsSync(baseThemesPath)) {
-        console.log('[Themes] Base themes directory not found, skipping sync');
+        themesLogger.info('Base themes directory not found, skipping sync');
         return;
     }
 
     const entries = fs.readdirSync(baseThemesPath, { withFileTypes: true });
     const themeDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
 
-    console.log(`[Themes] Syncing ${themeDirs.length} base themes...`);
+    themesLogger.info('Syncing base themes', { count: themeDirs.length });
 
     for (const dirName of themeDirs) {
         const configPath = path.join(baseThemesPath, dirName, 'config.xml');
@@ -581,27 +596,27 @@ async function syncBuiltinThemes() {
     // Remove themes that no longer exist in filesystem
     await removeOrphanedBaseThemes(db, themeDirs);
 
-    console.log(`[Themes] Base themes synced`);
+    themesLogger.info('Base themes synced');
 }
 
 // Bootstrap: run migrations, seed, and start server
 async function bootstrap() {
     // 1. Run migrations
-    console.log('[DB] Running migrations...');
+    dbLogger.info('Running migrations...');
     const migrationResult = await migrateToLatest(db);
     if (!migrationResult.success) {
-        console.error('[DB] Migration failed:', migrationResult.error);
+        dbLogger.error('Migration failed', migrationResult.error instanceof Error ? migrationResult.error : null);
         process.exit(1);
     }
 
     // 2. Initialize Redis for high availability (if configured)
     if (isRedisEnabled()) {
-        console.log('[Redis] REDIS_HOST is set, enabling multi-instance mode...');
+        redisLogger.info('REDIS_HOST is set, enabling multi-instance mode...');
         const connected = await connectRedis();
         if (connected) {
             initializeCrossInstanceHandler();
         } else {
-            console.warn('[Redis] Failed to connect, falling back to single-instance mode');
+            redisLogger.warn('Failed to connect, falling back to single-instance mode');
         }
     }
 
@@ -614,7 +629,7 @@ async function bootstrap() {
 
     const existingUser = await findUserByEmail(db, testEmail);
     if (!existingUser) {
-        console.log('[DB] Creating test user...');
+        dbLogger.info('Creating test user...');
         const hashedPassword = await Bun.password.hash(testPassword, { algorithm: 'bcrypt' });
         const defaultQuota = await getSettingNumber(
             db,
@@ -630,7 +645,7 @@ async function bootstrap() {
             quota_mb: defaultQuota,
             is_active: 1,
         });
-        console.log(`[DB] Test user created: ${testEmail}`);
+        dbLogger.info('Test user created', { email: testEmail });
     }
 
     // 6. Start server
@@ -640,23 +655,27 @@ async function bootstrap() {
     // 7. Start cleanup scheduler (for unsaved and guest projects)
     startCleanupScheduler(getCleanupConfigFromEnv());
 
-    console.log(`Elysia server running at http://localhost:${PORT}`);
-    console.log(`Pages: /login, /workarea`);
-    console.log(`Auth endpoints: /api/auth/login, /api/auth/logout, /api/session/check`);
-    console.log(`Project endpoints: /api/project/*, /api/export/*`);
-    console.log(`Filemanager endpoints: /filemanager/*`);
-    console.log(`WebSocket (Yjs): ws://localhost:${PORT}/yjs/project-<uuid>?token=<jwt>`);
-    console.log(`Static files: /public/*`);
+    logger.info('Elysia server started', {
+        port: PORT,
+        endpoints: {
+            pages: '/login, /workarea',
+            auth: '/api/auth/login, /api/auth/logout, /api/session/check',
+            project: '/api/project/*, /api/export/*',
+            filemanager: '/filemanager/*',
+            websocket: `ws://localhost:${PORT}/yjs/project-<uuid>?token=<jwt>`,
+            static: '/public/*',
+        },
+    });
 }
 
 bootstrap().catch(err => {
-    console.error('[FATAL] Bootstrap failed:', err);
+    logger.error('Bootstrap failed', err instanceof Error ? err : new Error(String(err)));
     process.exit(1);
 });
 
 // Graceful shutdown
 async function gracefulShutdown(signal: string) {
-    console.log(`${signal} received, shutting down...`);
+    logger.info('Shutting down', { signal });
     stopWebSocket();
     stopCleanupScheduler();
     await disconnectRedis();

--- a/src/redis/client.spec.ts
+++ b/src/redis/client.spec.ts
@@ -13,20 +13,24 @@ import {
     getRedisStatus,
     resetRedisState,
 } from './client';
+import { resetConfigContext } from '../contexts/config.context';
 
 describe('Redis Client', () => {
     const originalEnv = { ...process.env };
 
     beforeEach(() => {
-        resetRedisState();
-        // Clear Redis-related env vars
+        // Clear Redis-related env vars first
         delete process.env.REDIS_HOST;
         delete process.env.REDIS_PORT;
         delete process.env.REDIS_PASSWORD;
+        // Reset state AFTER clearing env so config reads fresh values
+        resetRedisState();
+        resetConfigContext();
     });
 
     afterEach(() => {
         resetRedisState();
+        resetConfigContext();
         // Restore original env
         process.env = { ...originalEnv };
     });
@@ -203,6 +207,7 @@ describe('Redis Client', () => {
             getRedisConfig();
 
             resetRedisState();
+            resetConfigContext(); // Also reset ConfigContext to clear cached config
 
             // After reset, getPublisher should create new instances
             process.env.REDIS_HOST = 'redis2';

--- a/src/redis/client.ts
+++ b/src/redis/client.ts
@@ -4,12 +4,20 @@
  * Lazy initialization pattern (like db/client.ts).
  * Uses separate clients for pub/sub (ioredis requirement).
  *
- * Configuration via environment variables:
+ * Now supports ConfigContext for centralized configuration.
+ * Falls back to getConfig() singleton for backward compatibility.
+ *
+ * Configuration via ConfigContext or environment variables:
  * - REDIS_HOST: Redis server hostname (empty = disabled)
  * - REDIS_PORT: Redis server port (default: 6379)
  * - REDIS_PASSWORD: Redis password (optional)
  */
 import Redis from 'ioredis';
+import { getConfig, type ConfigContext } from '../contexts/config.context';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for Redis module
+const logger = getLogger().child({ component: 'redis' });
 
 // ============================================================================
 // TYPES
@@ -35,27 +43,32 @@ let _connected = false;
 // ============================================================================
 
 /**
- * Check if Redis is enabled (REDIS_HOST is set)
+ * Check if Redis is enabled
+ *
+ * @param config - Optional ConfigContext. If not provided, uses getConfig() singleton.
  */
-export function isRedisEnabled(): boolean {
-    const host = process.env.REDIS_HOST?.trim();
-    return !!host && host.length > 0;
+export function isRedisEnabled(config?: ConfigContext): boolean {
+    const cfg = config ?? getConfig();
+    return cfg.redis.enabled;
 }
 
 /**
- * Get Redis configuration from environment
+ * Get Redis configuration from ConfigContext or environment
+ *
+ * @param config - Optional ConfigContext. If not provided, uses getConfig() singleton.
  */
-export function getRedisConfig(): RedisConfig | null {
+export function getRedisConfig(config?: ConfigContext): RedisConfig | null {
     if (_config) return _config;
 
-    if (!isRedisEnabled()) {
+    const cfg = config ?? getConfig();
+    if (!cfg.redis.enabled) {
         return null;
     }
 
     _config = {
-        host: process.env.REDIS_HOST!.trim(),
-        port: parseInt(process.env.REDIS_PORT || '6379', 10),
-        password: process.env.REDIS_PASSWORD?.trim() || undefined,
+        host: cfg.redis.host,
+        port: cfg.redis.port,
+        password: cfg.redis.password || undefined,
     };
 
     return _config;
@@ -69,17 +82,18 @@ export function getRedisConfig(): RedisConfig | null {
  * Create a Redis client with standard options
  */
 function createRedisClient(role: 'pub' | 'sub'): Redis | null {
-    const config = getRedisConfig();
-    if (!config) return null;
+    const redisConfig = getRedisConfig();
+    if (!redisConfig) return null;
 
+    const appConfig = getConfig();
     const client = new Redis({
-        host: config.host,
-        port: config.port,
-        password: config.password,
+        host: redisConfig.host,
+        port: redisConfig.port,
+        password: redisConfig.password,
         lazyConnect: true,
         retryStrategy: (times: number) => {
             if (times > 10) {
-                console.error(`[Redis-${role}] Max retries reached, giving up`);
+                logger.error('Max retries reached, giving up', null, { role });
                 return null; // Stop retrying
             }
             const delay = Math.min(times * 100, 3000);
@@ -87,27 +101,27 @@ function createRedisClient(role: 'pub' | 'sub'): Redis | null {
         },
         maxRetriesPerRequest: 3,
         enableReadyCheck: true,
-        showFriendlyErrorStack: process.env.APP_ENV !== 'prod',
+        showFriendlyErrorStack: appConfig.env !== 'prod',
     });
 
     client.on('error', err => {
-        console.error(`[Redis-${role}] Error:`, err.message);
+        logger.error('Connection error', err, { role });
     });
 
     client.on('connect', () => {
-        console.log(`[Redis-${role}] Connected to ${config.host}:${config.port}`);
+        logger.info('Connected', { role, host: redisConfig.host, port: redisConfig.port });
     });
 
     client.on('ready', () => {
-        console.log(`[Redis-${role}] Ready`);
+        logger.debug('Ready', { role });
     });
 
     client.on('reconnecting', () => {
-        console.log(`[Redis-${role}] Reconnecting...`);
+        logger.info('Reconnecting', { role });
     });
 
     client.on('close', () => {
-        console.log(`[Redis-${role}] Connection closed`);
+        logger.info('Connection closed', { role });
     });
 
     return client;
@@ -148,7 +162,7 @@ export function getSubscriber(): Redis | null {
  */
 export async function connectRedis(): Promise<boolean> {
     if (!isRedisEnabled()) {
-        console.log('[Redis] REDIS_HOST not set, running in single-instance mode');
+        logger.debug('REDIS_HOST not set, running in single-instance mode');
         return false;
     }
 
@@ -157,7 +171,7 @@ export async function connectRedis(): Promise<boolean> {
         const subscriber = getSubscriber();
 
         if (!publisher || !subscriber) {
-            console.error('[Redis] Failed to create clients');
+            logger.error('Failed to create clients');
             return false;
         }
 
@@ -165,11 +179,10 @@ export async function connectRedis(): Promise<boolean> {
         await Promise.all([publisher.connect(), subscriber.connect()]);
 
         _connected = true;
-        console.log('[Redis] Pub/sub clients connected successfully');
+        logger.info('Pub/sub clients connected successfully');
         return true;
     } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error('[Redis] Failed to connect:', message);
+        logger.error('Failed to connect', err instanceof Error ? err : new Error(String(err)));
         _connected = false;
         return false;
     }
@@ -199,7 +212,7 @@ export async function disconnectRedis(): Promise<void> {
 
     _connected = false;
     _config = null;
-    console.log('[Redis] Disconnected');
+    logger.debug('Disconnected');
 }
 
 /**

--- a/src/redis/pubsub-manager.spec.ts
+++ b/src/redis/pubsub-manager.spec.ts
@@ -15,6 +15,7 @@ import {
     getSubscribedChannels,
 } from './pubsub-manager';
 import { resetRedisState } from './client';
+import { resetConfigContext } from '../contexts/config.context';
 
 describe('PubSub Manager', () => {
     const originalEnv = { ...process.env };
@@ -26,6 +27,7 @@ describe('PubSub Manager', () => {
         delete process.env.REDIS_HOST;
         delete process.env.REDIS_PORT;
         delete process.env.REDIS_PASSWORD;
+        resetConfigContext(); // Reset to pick up env changes
     });
 
     afterEach(() => {
@@ -33,6 +35,7 @@ describe('PubSub Manager', () => {
         resetRedisState();
         // Restore original env
         process.env = { ...originalEnv };
+        resetConfigContext(); // Reset to restore original environment
     });
 
     describe('getInstanceId', () => {
@@ -79,6 +82,7 @@ describe('PubSub Manager', () => {
 
         test('returns enabled but not connected when configured', () => {
             process.env.REDIS_HOST = 'redis';
+            resetConfigContext(); // Reset to pick up new REDIS_HOST
             const stats = getPubSubStats();
 
             expect(stats.enabled).toBe(true);

--- a/src/redis/pubsub-manager.ts
+++ b/src/redis/pubsub-manager.ts
@@ -11,6 +11,9 @@
  */
 import { randomUUID } from 'crypto';
 import { getPublisher, getSubscriber, isRedisEnabled, isRedisConnected } from './client';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'pubsub-manager' });
 
 // ============================================================================
 // TYPES
@@ -127,7 +130,7 @@ function initializeListener(): void {
                 });
             }
         } catch (err) {
-            console.error('[PubSubManager] Failed to parse message:', err);
+            logger.error('Failed to parse message', err instanceof Error ? err : null);
         }
     });
 
@@ -193,7 +196,7 @@ export async function publish(docName: string, message: Buffer | string, meta?: 
     try {
         await publisher.publish(channel, JSON.stringify(crossMsg));
     } catch (err) {
-        console.error(`[PubSubManager] Failed to publish to ${channel}:`, err);
+        logger.error('Failed to publish', err instanceof Error ? err : null, { channel });
     }
 }
 
@@ -219,9 +222,9 @@ export async function subscribe(docName: string): Promise<void> {
     try {
         await subscriber.subscribe(channel);
         subscribedChannels.add(channel);
-        console.log(`[PubSubManager] Subscribed to ${channel}`);
+        logger.debug('Subscribed to channel', { channel });
     } catch (err) {
-        console.error(`[PubSubManager] Failed to subscribe to ${channel}:`, err);
+        logger.error('Failed to subscribe', err instanceof Error ? err : null, { channel });
     }
 }
 
@@ -247,9 +250,9 @@ export async function unsubscribe(docName: string): Promise<void> {
     try {
         await subscriber.unsubscribe(channel);
         subscribedChannels.delete(channel);
-        console.log(`[PubSubManager] Unsubscribed from ${channel}`);
+        logger.debug('Unsubscribed from channel', { channel });
     } catch (err) {
-        console.error(`[PubSubManager] Failed to unsubscribe from ${channel}:`, err);
+        logger.error('Failed to unsubscribe', err instanceof Error ? err : null, { channel });
     }
 }
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -20,6 +20,9 @@ import { isValidReturnUrl, getSafeRedirectUrl } from '../utils/redirect-validato
 import { getBasePath, prefixPath } from '../utils/basepath.util';
 import type { LoginRequest, GuestLoginRequest } from './types/request-payloads';
 import { getAuthMethods, getSettingString } from '../services/app-settings';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'auth-routes' });
 
 /**
  * Dependency types for auth routes
@@ -538,7 +541,7 @@ export function createAuthRoutes(deps: AuthDependencies = defaultDeps) {
                         ],
                     });
                 } catch (error) {
-                    console.error('CAS authentication error:', error);
+                    logger.error('CAS authentication error', error instanceof Error ? error : null);
                     set.status = 500;
                     return { error: 'Server Error', message: 'CAS authentication failed. Please try again later.' };
                 }
@@ -822,7 +825,7 @@ export function createAuthRoutes(deps: AuthDependencies = defaultDeps) {
                         ],
                     });
                 } catch (error) {
-                    console.error('OpenID authentication error:', error);
+                    logger.error('OpenID authentication error', error instanceof Error ? error : null);
                     set.status = 500;
                     return { error: 'Server Error', message: 'OpenID authentication failed. Please try again later.' };
                 }

--- a/src/routes/convert.ts
+++ b/src/routes/convert.ts
@@ -40,6 +40,9 @@ import {
     ElpxExporter,
     type ExportResult,
 } from '../shared/export';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'convert-routes' });
 
 // =============================================================================
 // Types and Interfaces
@@ -228,7 +231,7 @@ export function createConvertRoutes(deps: ConvertDependencies = defaultDeps) {
             return result;
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[Convert] Error during ${exportType} export:`, error);
+            logger.error('Export error', error instanceof Error ? error : null, { exportType });
             return { success: false, error: errorMessage };
         }
     }

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -51,6 +51,10 @@ import { db as defaultDb } from '../db/client';
 import { findProjectByUuid as findProjectByUuidDefault } from '../db/queries';
 import { DatabaseAssetProvider as DatabaseAssetProviderDefault } from '../shared/export/providers/DatabaseAssetProvider';
 import { CombinedAssetProvider as CombinedAssetProviderDefault } from '../shared/export/providers/CombinedAssetProvider';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for export routes
+const logger = getLogger().child({ component: 'routes/export' });
 
 // ============================================================================
 // Types and Interfaces for Dependency Injection
@@ -371,11 +375,12 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
 
             if (options.structure) {
                 // Yjs structure sent from client - convert to ParsedOdeStructure
-                console.log('[Export] Using Yjs structure from client');
-                console.log('[Export] Structure pages:', options.structure.pages?.length);
-                console.log('[Export] Structure meta theme:', options.structure.meta?.theme);
+                logger.debug('Using Yjs structure from client', {
+                    pageCount: options.structure.pages?.length,
+                    metaTheme: options.structure.meta?.theme,
+                });
                 const parsedStructure = convertYjsStructureToParsed(options.structure);
-                console.log('[Export] Parsed theme:', parsedStructure.meta?.theme);
+                logger.debug('Parsed structure theme', { theme: parsedStructure.meta?.theme });
                 document = new ElpDocumentAdapter(parsedStructure, tempDir);
             } else if (session.odeId) {
                 // Try to load Yjs document from database
@@ -387,10 +392,10 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
                             // Check if document has content
                             yjsDocWrapper = new ServerYjsDocumentWrapper(yjsDoc, session.odeId);
                             if (yjsDocWrapper.hasContent()) {
-                                console.log('[Export] Using Yjs document from database');
+                                logger.debug('Using Yjs document from database');
                                 document = new YjsDocumentAdapter(yjsDocWrapper);
                             } else {
-                                console.log('[Export] Yjs document empty, falling back to session structure');
+                                logger.debug('Yjs document empty, falling back to session structure');
                                 yjsDocWrapper.destroy();
                                 yjsDocWrapper = null;
                                 if (session.structure) {
@@ -400,20 +405,22 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
                                 }
                             }
                         } else if (session.structure) {
-                            console.log('[Export] No Yjs document in database, using session structure');
+                            logger.debug('No Yjs document in database, using session structure');
                             document = new ElpDocumentAdapter(session.structure, tempDir);
                         } else {
                             return { success: false, error: 'No project structure found' };
                         }
                     } else if (session.structure) {
-                        console.log('[Export] Project not found in database, using session structure');
+                        logger.debug('Project not found in database, using session structure');
                         document = new ElpDocumentAdapter(session.structure, tempDir);
                     } else {
                         return { success: false, error: 'No project structure found' };
                     }
                 } catch (yjsError) {
                     // Database/Yjs lookup failed - fall back to session structure
-                    console.warn('[Export] Yjs lookup failed, falling back to session structure:', yjsError);
+                    logger.warn('Yjs lookup failed, falling back to session structure', {
+                        error: yjsError instanceof Error ? yjsError.message : String(yjsError),
+                    });
                     if (session.structure) {
                         document = new ElpDocumentAdapter(session.structure, tempDir);
                     } else {
@@ -422,13 +429,13 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
                 }
             } else if (session.structure) {
                 // Session structure from when ELP was opened
-                console.log('[Export] Using session structure (no odeId)');
+                logger.debug('Using session structure (no odeId)');
                 document = new ElpDocumentAdapter(session.structure, tempDir);
             } else {
                 // Fallback: Try to parse content.xml directly (for CLI exports)
                 const contentXmlPath = path.join(tempDir, 'content.xml');
                 if (await fileExists(contentXmlPath)) {
-                    console.log('[Export] Fallback: parsing content.xml directly');
+                    logger.debug('Fallback: parsing content.xml directly');
                     document = await ElpDocumentAdapter.fromElpFile(tempDir);
                 } else {
                     return { success: false, error: 'No project structure found in session' };
@@ -436,7 +443,7 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
             }
 
             // Create providers using injected classes
-            console.log('[Export] Using publicDir:', publicDir);
+            logger.debug('Using publicDir', { publicDir });
             const resources: ResourceProvider = new FileSystemResourceProvider(publicDir);
             const zip: ZipProvider = new FflateZipProvider();
 
@@ -455,7 +462,10 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
                     }
                 } catch (error) {
                     // Database lookup failed - continue with filesystem only
-                    console.warn(`[Export] Could not lookup project ${session.odeId}:`, error);
+                    logger.warn('Could not lookup project', {
+                        odeId: session.odeId,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
             }
 
@@ -507,7 +517,7 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
             return { ...result, zipPath };
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[Export] Error during ${exportType} export:`, error);
+            logger.error('Error during export', error instanceof Error ? error : null, { exportType });
             return { success: false, error: errorMessage };
         } finally {
             // Cleanup Yjs document if we created one
@@ -640,7 +650,7 @@ export function createExportRoutes(deps: ExportDependencies = {}): Elysia {
 
                 // For Yjs-only sessions (yjs-*), create a virtual session if structure is provided
                 if (!session && options.structure) {
-                    console.log('[Export] Yjs-only session detected, using structure from request body');
+                    logger.debug('Yjs-only session detected, using structure from request body');
                     const projectTitle = options.structure.meta?.title || 'Untitled';
                     session = {
                         id: odeSessionId,

--- a/src/routes/games.ts
+++ b/src/routes/games.ts
@@ -7,6 +7,9 @@
  */
 import { Elysia, t } from 'elysia';
 import { getSession as getSessionDefault, type ProjectSession } from '../services/session-manager';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'games-routes' });
 
 // ============================================================================
 // DEPENDENCY INJECTION
@@ -383,7 +386,7 @@ export const gamesRoutes = new Elysia({ prefix: '/api/games' })
             if (!session) {
                 // Session not found - return empty data (not an error)
                 // This can happen if the session expired or was never created
-                console.log(`[Games] Session not found: ${odeSessionId}`);
+                logger.debug('Session not found', { odeSessionId });
                 return {
                     success: true,
                     data: [],
@@ -393,7 +396,7 @@ export const gamesRoutes = new Elysia({ prefix: '/api/games' })
             // Extract iDevices from session structure
             const data = extractIdevicesFromStructure(odeSessionId, session.structure);
 
-            console.log(`[Games] Returning ${data.length} items for session ${odeSessionId}`);
+            logger.debug('Returning items for session', { odeSessionId, count: data.length });
 
             return {
                 success: true,

--- a/src/routes/idevices.ts
+++ b/src/routes/idevices.ts
@@ -10,6 +10,9 @@ import { getFilesDir } from '../services/file-helper';
 import { getAppVersion } from '../utils/version';
 import { getBasePath } from '../utils/basepath.util';
 import type { IdeviceFileUploadRequest } from './types/request-payloads';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'idevices-routes' });
 
 /**
  * Response data for file upload
@@ -387,10 +390,12 @@ export const idevicesRoutes = new Elysia({ name: 'idevices-routes' })
     // POST /api/idevices/upload/file/resources - Upload file resource (base64)
     .post('/api/idevices/upload/file/resources', async ({ body, cookie, set, request }) => {
         // Debug: log what we're receiving
-        console.log('[idevices/upload] Content-Type:', request.headers.get('content-type'));
-        console.log('[idevices/upload] Body type:', typeof body);
         const bodyObj = body as Record<string, unknown> | null;
-        console.log('[idevices/upload] Body keys:', bodyObj ? Object.keys(bodyObj) : 'null');
+        logger.debug('Upload request received', {
+            contentType: request.headers.get('content-type'),
+            bodyType: typeof body,
+            bodyKeys: bodyObj ? Object.keys(bodyObj) : null,
+        });
 
         const data = body as IdeviceFileUploadRequest;
         const odeIdeviceId = data?.odeIdeviceId;
@@ -407,10 +412,10 @@ export const idevicesRoutes = new Elysia({ name: 'idevices-routes' })
         // Validate required parameters
         if (!odeIdeviceId || !base64String || !filename) {
             set.status = 400;
-            console.log('[idevices/upload] Missing params:', {
-                odeIdeviceId: !!odeIdeviceId,
-                file: !!base64String,
-                filename: !!filename,
+            logger.debug('Missing upload params', {
+                hasOdeIdeviceId: !!odeIdeviceId,
+                hasFile: !!base64String,
+                hasFilename: !!filename,
             });
             return {
                 code: 'error: invalid data',

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -52,6 +52,10 @@ import { detectLocaleFromHeader, trans, DEFAULT_LOCALE } from '../services/trans
 import { decodePlatformJWT } from '../utils/platform-jwt';
 import type { JwtPayload } from './types/request-payloads';
 import { getDefaultTheme as getDefaultThemeDefault } from '../db/queries/themes';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for pages routes
+const logger = getLogger().child({ component: 'routes/pages' });
 
 /**
  * Login page query parameters
@@ -426,16 +430,17 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     if (!existingProject) {
                         existingProject = await findProjectByPlatformId(db, odeId);
                         if (existingProject) {
-                            console.log(
-                                `[Pages] Platform integration: Found project by platform_id ${odeId} -> ${existingProject.uuid}`,
-                            );
+                            logger.debug('Platform integration: Found project by platform_id', {
+                                platformId: odeId,
+                                projectUuid: existingProject.uuid,
+                            });
                         }
                     }
 
                     if (existingProject) {
                         // Found existing project - use it
                         projectUuid = existingProject.uuid;
-                        console.log(`[Pages] Platform integration: Using existing project ${projectUuid}`);
+                        logger.debug('Platform integration: Using existing project', { projectUuid });
                     } else {
                         // odeId is not a valid project UUID or platform_id (new content from Moodle)
                         // Create a new project and redirect, preserving jwt_token
@@ -458,9 +463,10 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                                 userId: currentUser.id,
                             });
 
-                            console.log(
-                                `[Pages] Platform integration: Created new project ${newSessionId} for Moodle cmid ${odeId}`,
-                            );
+                            logger.info('Platform integration: Created new project', {
+                                projectUuid: newSessionId,
+                                moodleCmid: odeId,
+                            });
 
                             // Redirect with jwt_token preserved
                             const basePath = getBasePath();
@@ -470,7 +476,10 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             }
                             return Response.redirect(redirectUrl, 302);
                         } catch (error) {
-                            console.error('[Pages] Platform integration: Failed to create new project:', error);
+                            logger.error(
+                                'Platform integration: Failed to create new project',
+                                error instanceof Error ? error : null,
+                            );
                             // Continue - will fall through to normal flow
                         }
                     }
@@ -490,9 +499,11 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             // Project saved in DB - verify access via DB (owner or collaborator)
                             const accessCheck = await checkProjectAccess(db, project, currentUser.id);
                             if (!accessCheck.hasAccess) {
-                                console.log(
-                                    `[Pages] Access denied to project ${projectUuid} for user ${currentUser.id}: ${accessCheck.reason}`,
-                                );
+                                logger.debug('Access denied to project', {
+                                    projectUuid,
+                                    userId: currentUser.id,
+                                    reason: accessCheck.reason,
+                                });
                                 const html = renderTemplate('workarea/access-denied', {
                                     basePath,
                                     projectId: projectUuid,
@@ -506,9 +517,11 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             }
                         } else if (session.userId && session.userId !== currentUser.id) {
                             // Session in memory from ANOTHER user - deny access
-                            console.log(
-                                `[Pages] Access denied to in-memory session ${projectUuid}: created by user ${session.userId}, accessed by ${currentUser.id}`,
-                            );
+                            logger.debug('Access denied to in-memory session', {
+                                projectUuid,
+                                sessionUserId: session.userId,
+                                accessingUserId: currentUser.id,
+                            });
                             const html = renderTemplate('workarea/access-denied', {
                                 basePath,
                                 projectId: projectUuid,
@@ -527,9 +540,11 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             // Project exists in DB - verify access
                             const accessCheck = await checkProjectAccess(db, project, currentUser.id);
                             if (!accessCheck.hasAccess) {
-                                console.log(
-                                    `[Pages] Access denied to project ${projectUuid} for user ${currentUser.id}: ${accessCheck.reason}`,
-                                );
+                                logger.debug('Access denied to project', {
+                                    projectUuid,
+                                    userId: currentUser.id,
+                                    reason: accessCheck.reason,
+                                });
                                 const html = renderTemplate('workarea/access-denied', {
                                     basePath,
                                     projectId: projectUuid,
@@ -543,7 +558,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             }
                         } else {
                             // Project doesn't exist in DB nor in session - 404
-                            console.log(`[Pages] Project not found: ${projectUuid}`);
+                            logger.debug('Project not found', { projectUuid });
                             const html = renderTemplate('security/error', {
                                 basePath,
                                 error: 'Project Not Found',
@@ -583,7 +598,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             userId: currentUser.id,
                         });
 
-                        console.log(`[Pages] Created ephemeral session ${newSessionId} for offline mode`);
+                        logger.debug('Created ephemeral session for offline mode', { sessionId: newSessionId });
 
                         return Response.redirect(buildRedirectUrl(newSessionId), 302);
                     }
@@ -608,11 +623,11 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             userId: currentUser.id,
                         });
 
-                        console.log(`[Pages] Created new project ${newSessionId} for user ${currentUser.id}`);
+                        logger.info('Created new project', { projectUuid: newSessionId, userId: currentUser.id });
 
                         return Response.redirect(buildRedirectUrl(newSessionId), 302);
                     } catch (error) {
-                        console.error('[Pages] Failed to create new project:', error);
+                        logger.error('Failed to create new project', error instanceof Error ? error : null);
                         // Continue without project if creation fails
                     }
                 }
@@ -1056,7 +1071,9 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                         target[mapping.path[mapping.path.length - 1]] = parsedValue;
                     }
                 } catch (error) {
-                    console.warn('[Admin] Failed to load stored settings:', error);
+                    logger.warn('Failed to load stored settings', {
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
                 defaultQuota = parseNumber(adminSettings.storage.default_quota, defaultQuota);
 

--- a/src/routes/platform-integration.ts
+++ b/src/routes/platform-integration.ts
@@ -9,6 +9,9 @@ import { Elysia, t } from 'elysia';
 import { getBasePath } from '../utils/basepath.util';
 import { decodePlatformJWT, getPlatformIntegrationParams } from '../utils/platform-jwt';
 import { platformPetitionGet, platformPetitionSet } from '../services/platform-integration';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'platform-integration-routes' });
 
 /**
  * Platform integration routes
@@ -120,7 +123,7 @@ export const platformIntegrationRoutes = new Elysia({ name: 'platform-integratio
                 };
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
-                console.error('[PlatformIntegration] openPlatformElp error:', message);
+                logger.error('openPlatformElp error', error instanceof Error ? error : null, { message });
 
                 set.status = 500;
                 return {
@@ -181,7 +184,7 @@ export const platformIntegrationRoutes = new Elysia({ name: 'platform-integratio
                 };
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
-                console.error('[PlatformIntegration] set_platform_new_ode error:', message);
+                logger.error('set_platform_new_ode error', error instanceof Error ? error : null, { message });
 
                 set.status = 500;
                 // Return format expected by frontend

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -61,6 +61,10 @@ import type {
     StructureSaveRequest,
     ProjectMetadataRequest,
 } from './types/request-payloads';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for project routes
+const logger = getLogger().child({ component: 'routes/project' });
 
 // ============================================================================
 // Types and Interfaces for Dependency Injection
@@ -534,7 +538,7 @@ export function createProjectRoutes(deps: ProjectDependencies = defaultDependenc
                         theme: themeDirName,
                     });
                     await upsertSnapshot(db, projectRecord.id, initialYjsData, '1.0');
-                    console.log(`[Project] Created initial Yjs document for project ${projectRecord.uuid}`);
+                    logger.info('Created initial Yjs document', { projectUuid: projectRecord.uuid });
                 }
 
                 // Use project UUID as session ID
@@ -549,7 +553,7 @@ export function createProjectRoutes(deps: ProjectDependencies = defaultDependenc
                     userId,
                 });
 
-                console.log(`[Project] Created new project ${projectRecord.uuid} with title "${title}"`);
+                logger.info('Created new project', { projectUuid: projectRecord.uuid, title });
 
                 // Get global default theme (can be base or site)
                 let defaultTheme: { dirName: string; displayName: string; url: string; type: 'base' | 'site' } | null =
@@ -639,24 +643,24 @@ export function createProjectRoutes(deps: ProjectDependencies = defaultDependenc
                     const allowedBase = path.resolve(path.join(filesDir, 'tmp'));
 
                     if (!resolvedPath.startsWith(allowedBase)) {
-                        console.warn(`[Project] Cleanup blocked: path outside allowed directory: ${resolvedPath}`);
+                        logger.warn('Cleanup blocked: path outside allowed directory', { resolvedPath });
                         return { success: false, message: 'Invalid path' };
                     }
 
                     // Only delete .elp/.elpx files
                     if (!resolvedPath.endsWith('.elp') && !resolvedPath.endsWith('.elpx')) {
-                        console.warn(`[Project] Cleanup blocked: not an ELP file: ${resolvedPath}`);
+                        logger.warn('Cleanup blocked: not an ELP file', { resolvedPath });
                         return { success: false, message: 'Invalid file type' };
                     }
 
                     if (await fileExists(fullPath)) {
                         await fs.remove(fullPath);
-                        console.log(`[Project] Cleaned up import file: ${fullPath}`);
+                        logger.debug('Cleaned up import file', { fullPath });
                     }
 
                     return { success: true, message: 'File cleaned up' };
                 } catch (error: unknown) {
-                    console.warn(`[Project] Cleanup error:`, error);
+                    logger.warn('Cleanup error', { error: error instanceof Error ? error.message : String(error) });
                     const errorMessage = error instanceof Error ? error.message : String(error);
                     return { success: false, message: errorMessage };
                 }
@@ -1135,7 +1139,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                         saved_once: 0,
                     });
 
-                    console.log(`[Project] Created project ${uuid} for user ${currentUser.id} via sharing endpoint`);
+                    logger.info('Created project via sharing endpoint', { projectUuid: uuid, userId: currentUser.id });
                 }
 
                 const owner = await findUserById(db, project.owner_id);
@@ -1382,10 +1386,15 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                                         content_hash: asset.content_hash,
                                     });
                                 } else {
-                                    console.warn(`[Project Duplicate] Asset file not found: ${asset.storage_path}`);
+                                    logger.warn('Asset file not found during duplicate', {
+                                        storagePath: asset.storage_path,
+                                    });
                                 }
                             } catch (err) {
-                                console.warn(`[Project Duplicate] Failed to copy asset ${asset.id}:`, err);
+                                logger.warn('Failed to copy asset during duplicate', {
+                                    assetId: asset.id,
+                                    error: err instanceof Error ? err.message : String(err),
+                                });
                             }
                         }
                     }
@@ -1732,7 +1741,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
 
                 // Clean up session resources if needed
                 // In stateless mode, sessions are managed by IndexedDB on client
-                console.log(`[Project] Closing session: ${odeSessionId || 'unknown'}`);
+                logger.debug('Closing session', { odeSessionId: odeSessionId || 'unknown' });
 
                 return {
                     success: true,
@@ -1991,12 +2000,15 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const filesDir = getFilesDir();
 
                 // Debug: log received data
-                console.log(`[UsedFiles] Raw body keys:`, Object.keys(data));
-                console.log(`[UsedFiles] idevices type:`, typeof data.idevices, Array.isArray(data.idevices));
-                console.log(`[UsedFiles] Received ${idevices.length} idevices`);
-                console.log(`[UsedFiles] Received metadata for ${Object.keys(assetMetadata).length} assets`);
+                logger.debug('UsedFiles request received', {
+                    bodyKeys: Object.keys(data),
+                    idevicesType: typeof data.idevices,
+                    isArray: Array.isArray(data.idevices),
+                    ideviceCount: idevices.length,
+                    assetMetadataCount: Object.keys(assetMetadata).length,
+                });
                 if (idevices.length > 0) {
-                    console.log('[UsedFiles] First idevice HTML sample:', idevices[0].html?.substring(0, 500));
+                    logger.debug('First idevice HTML sample', { sample: idevices[0].html?.substring(0, 500) });
                 }
 
                 interface UsedFileInfo {
@@ -2044,7 +2056,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
 
                     // Debug: log found links
                     if (links.length > 0) {
-                        console.log('[UsedFiles] Found links:', links);
+                        logger.debug('Found links in idevice', { linkCount: links.length });
                     }
 
                     return links;
@@ -2178,7 +2190,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 // This endpoint acknowledges the request and returns a new UUID
                 const newNavStructureId = crypto.randomUUID();
 
-                console.log(`[Project] Clone nav-structure request: ${navStructureId} -> ${newNavStructureId}`);
+                logger.debug('Clone nav-structure request', { navStructureId, newNavStructureId });
 
                 return {
                     responseMessage: 'OK',
@@ -2201,7 +2213,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { odeSessionId, order: _order } = data;
 
                 // In stateless Yjs mode, reordering is handled client-side
-                console.log(`[Project] Reorder nav-structures request`);
+                logger.debug('Reorder nav-structures request');
 
                 return {
                     responseMessage: 'OK',
@@ -2217,7 +2229,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { odeSessionId, pageId, order: _order } = data;
 
                 // In stateless Yjs mode, reordering is handled client-side
-                console.log(`[Project] Reorder pag-structures request for page ${pageId}`);
+                logger.debug('Reorder pag-structures request', { pageId });
 
                 return {
                     responseMessage: 'OK',
@@ -2234,7 +2246,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { odeSessionId, blockId, order: _order } = data;
 
                 // In stateless Yjs mode, reordering is handled client-side
-                console.log(`[Project] Reorder idevices request for block ${blockId}`);
+                logger.debug('Reorder idevices request', { blockId });
 
                 return {
                     responseMessage: 'OK',
@@ -2254,7 +2266,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { id } = params;
 
                 // In stateless Yjs mode, deletion is handled client-side
-                console.log(`[Project] Delete nav-structure request: ${id}`);
+                logger.debug('Delete nav-structure request', { id });
 
                 return {
                     responseMessage: 'OK',
@@ -2269,7 +2281,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { id } = params;
 
                 // In stateless Yjs mode, deletion is handled client-side
-                console.log(`[Project] Delete pag-structure request: ${id}`);
+                logger.debug('Delete pag-structure request', { id });
 
                 return {
                     responseMessage: 'OK',
@@ -2284,7 +2296,7 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const { id } = params;
 
                 // In stateless Yjs mode, deletion is handled client-side
-                console.log(`[Project] Delete idevice request: ${id}`);
+                logger.debug('Delete idevice request', { id });
 
                 return {
                     responseMessage: 'OK',

--- a/src/routes/resources.ts
+++ b/src/routes/resources.ts
@@ -7,6 +7,9 @@ import { Elysia } from 'elysia';
 import * as fs from 'fs';
 import * as path from 'path';
 import { LEGACY_IDEVICE_MAPPING } from '../shared/export/constants';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'resources-routes' });
 
 // Base paths for resources
 const THEMES_BASE_PATH = 'public/files/perm/themes/base';
@@ -108,7 +111,7 @@ function scanDirectory(dirPath: string, basePath: string = ''): string[] {
             }
         }
     } catch (e) {
-        console.warn(`[Resources] Error scanning directory ${dirPath}:`, e);
+        logger.warn('Error scanning directory', { dirPath, error: e instanceof Error ? e.message : String(e) });
     }
 
     return files;

--- a/src/routes/themes.ts
+++ b/src/routes/themes.ts
@@ -12,6 +12,9 @@ import { db } from '../db/client';
 import { getEnabledSiteThemes, getDefaultTheme, getBaseThemes } from '../db/queries/themes';
 import type { Theme } from '../db/types';
 import { validateThemeZip, extractTheme, slugify, BASE_THEME_NAMES } from '../services/admin-upload-validator';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'themes-routes' });
 
 // Base path for themes
 const THEMES_BASE_PATH = 'public/files/perm/themes/base';
@@ -373,7 +376,9 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
             siteThemes = siteThemesDb.map(siteThemeToConfig);
         } catch (error) {
             // Silently ignore if themes table doesn't exist yet (migration pending)
-            console.warn('[themes] Could not load site themes:', error instanceof Error ? error.message : error);
+            logger.warn('Could not load site themes', {
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
 
         try {
@@ -381,7 +386,9 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
             baseThemesFromDb = await getBaseThemes(db);
         } catch (error) {
             // Silently ignore if themes table doesn't exist yet (migration pending)
-            console.warn('[themes] Could not load theme settings:', error instanceof Error ? error.message : error);
+            logger.warn('Could not load theme settings', {
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
 
         // Create a map of disabled base themes (is_enabled=0)
@@ -603,7 +610,7 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
                     },
                 };
             } catch (error) {
-                console.error('[themes] Theme import error:', error);
+                logger.error('Theme import error', error instanceof Error ? error : null);
                 set.status = 500;
                 const message = error instanceof Error ? error.message : 'Unknown error';
                 return { responseMessage: 'ERROR', error: message };
@@ -768,7 +775,7 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
                     theme: themeConfig,
                 };
             } catch (error) {
-                console.error('[Themes] Upload error:', error);
+                logger.error('Theme upload error', error instanceof Error ? error : null);
                 set.status = 500;
                 return {
                     responseMessage: 'ERROR',
@@ -840,7 +847,7 @@ export const themesRoutes = new Elysia({ name: 'themes-routes' })
                 deleted: { name: themeId },
             };
         } catch (error) {
-            console.error('[Themes] Delete error:', error);
+            logger.error('Theme delete error', error instanceof Error ? error : null);
             set.status = 500;
             return {
                 responseMessage: 'ERROR',

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -16,6 +16,9 @@ import {
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
 import type { JwtPayload, UserPreferencesRequest } from './types/request-payloads';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'user-routes' });
 
 /**
  * Preference value wrapper type expected by frontend
@@ -123,7 +126,7 @@ export function createUserRoutes(deps: UserDependencies = defaultDependencies) {
         try {
             await queries.setPreference(database, userId, key, stringValue);
         } catch (error) {
-            console.error('[User] Failed to save preference:', error);
+            logger.error('Failed to save preference', error instanceof Error ? error : null);
         }
     }
 
@@ -223,7 +226,7 @@ export function createUserRoutes(deps: UserDependencies = defaultDependencies) {
 
                     return { responseMessage: 'OK' };
                 } catch (error) {
-                    console.error('[User] Failed to save preferences:', error);
+                    logger.error('Failed to save preferences', error instanceof Error ? error : null);
                     set.status = 500;
                     return { error: 'Internal Error', message: 'Failed to save preferences' };
                 }
@@ -248,7 +251,7 @@ export function createUserRoutes(deps: UserDependencies = defaultDependencies) {
 
                     return { responseMessage: 'OK' };
                 } catch (error) {
-                    console.error('[User] Failed to save preferences:', error);
+                    logger.error('Failed to save preferences', error instanceof Error ? error : null);
                     set.status = 500;
                     return { error: 'Internal Error', message: 'Failed to save preferences' };
                 }
@@ -269,7 +272,7 @@ export function createUserRoutes(deps: UserDependencies = defaultDependencies) {
                     await saveUserPreference(userId, 'lopdAcceptedAt', new Date().toISOString());
                     return { success: true, message: 'LOPD accepted' };
                 } catch (error) {
-                    console.error('[User] Failed to save LOPD acceptance:', error);
+                    logger.error('Failed to save LOPD acceptance', error instanceof Error ? error : null);
                     set.status = 500;
                     return { error: 'Internal Error', message: 'Failed to save LOPD acceptance' };
                 }

--- a/src/routes/yjs.ts
+++ b/src/routes/yjs.ts
@@ -15,6 +15,9 @@ import { fromBinaryData } from '../db/helpers';
 import { db } from '../db/client';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'yjs-routes' });
 
 /**
  * Query dependencies for Yjs routes
@@ -62,7 +65,7 @@ export function createYjsRoutes(deps: YjsDependencies = defaultDependencies) {
             .get('/uuid/:uuid/yjs-document', async ({ params }) => {
                 const project = await queries.findProjectByUuid(database, params.uuid);
                 if (!project) {
-                    console.log(`[Yjs GET] Project not found: ${params.uuid}`);
+                    logger.debug('Project not found', { uuid: params.uuid });
                     return new Response(JSON.stringify({ error: 'Not Found', message: 'Project not found' }), {
                         status: 404,
                         headers: { 'Content-Type': 'application/json' },
@@ -71,7 +74,7 @@ export function createYjsRoutes(deps: YjsDependencies = defaultDependencies) {
 
                 const snapshot = await queries.findSnapshotByProjectId(database, project.id);
                 if (!snapshot) {
-                    console.log(`[Yjs GET] No snapshot for project ${project.id} (uuid: ${params.uuid})`);
+                    logger.debug('No snapshot for project', { projectId: project.id, uuid: params.uuid });
                     return new Response(JSON.stringify({ error: 'Not Found', message: 'No document saved' }), {
                         status: 404,
                         headers: { 'Content-Type': 'application/json' },

--- a/src/services/asset-priority-queue.ts
+++ b/src/services/asset-priority-queue.ts
@@ -11,6 +11,9 @@
  *   25  - LOW: Background prefetch
  *   0   - IDLE: Normal upload during save
  */
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'priority-queue' });
 
 export const PRIORITY = {
     CRITICAL: 100,
@@ -115,10 +118,12 @@ class ServerPriorityQueue {
             this.sortQueue(projectId);
         }
 
-        console.log(
-            `[PriorityQueue] Registered: ${assetId.substring(0, 8)}... ` +
-                `project=${projectId.substring(0, 8)}... priority=${priority} reason=${item.reason}`,
-        );
+        logger.debug('Registered priority item', {
+            assetId: assetId.substring(0, 8),
+            projectId: projectId.substring(0, 8),
+            priority,
+            reason: item.reason,
+        });
     }
 
     /**
@@ -212,10 +217,11 @@ class ServerPriorityQueue {
 
         slots.push(slot);
 
-        console.log(
-            `[PriorityQueue] Active slot: ${slot.assetId.substring(0, 8)}... ` +
-                `client=${slot.clientId.substring(0, 8)}... priority=${slot.priority}`,
-        );
+        logger.debug('Active slot', {
+            assetId: slot.assetId.substring(0, 8),
+            clientId: slot.clientId.substring(0, 8),
+            priority: slot.priority,
+        });
     }
 
     /**
@@ -231,7 +237,7 @@ class ServerPriorityQueue {
         const idx = slots.findIndex(s => s.assetId === assetId);
         if (idx >= 0) {
             const [slot] = slots.splice(idx, 1);
-            console.log(`[PriorityQueue] Released slot: ${assetId.substring(0, 8)}...`);
+            logger.debug('Released slot', { assetId: assetId.substring(0, 8) });
             return slot;
         }
         return undefined;
@@ -377,7 +383,7 @@ class ServerPriorityQueue {
     clearProject(projectId: string): void {
         this.queues.delete(projectId);
         this.activeSlots.delete(projectId);
-        console.log(`[PriorityQueue] Cleared project: ${projectId.substring(0, 8)}...`);
+        logger.debug('Cleared project', { projectId: projectId.substring(0, 8) });
     }
 
     /**
@@ -441,10 +447,10 @@ class ServerPriorityQueue {
             const staleSlots = slots.filter(s => now - s.startTime > maxAge);
 
             for (const slot of staleSlots) {
-                console.log(
-                    `[PriorityQueue] Cleaning stale slot: ${slot.assetId.substring(0, 8)}... ` +
-                        `age=${Math.round((now - slot.startTime) / 1000)}s`,
-                );
+                logger.debug('Cleaning stale slot', {
+                    assetId: slot.assetId.substring(0, 8),
+                    ageSeconds: Math.round((now - slot.startTime) / 1000),
+                });
                 this.releaseSlot(projectId, slot.assetId);
             }
         }

--- a/src/services/cleanup-scheduler.ts
+++ b/src/services/cleanup-scheduler.ts
@@ -18,6 +18,10 @@ import { getFilesDir, remove, fileExists } from './file-helper';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
 import * as path from 'path';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for cleanup scheduler
+const logger = getLogger().child({ component: 'cleanup-scheduler' });
 
 /**
  * Configuration for the cleanup scheduler
@@ -153,13 +157,13 @@ export async function runCleanup(
     config: CleanupSchedulerConfig = state.config,
 ): Promise<CleanupResult> {
     if (state.isRunning) {
-        console.log('[CleanupScheduler] Cleanup already in progress, skipping');
+        logger.debug('Cleanup already in progress, skipping');
         return { success: true, unsavedDeleted: 0, guestDeleted: 0, diskCleaned: 0, errors: [] };
     }
 
     state.isRunning = true;
     const startTime = Date.now();
-    console.log('[CleanupScheduler] Starting cleanup...');
+    logger.info('Starting cleanup');
 
     const result: CleanupResult = {
         success: true,
@@ -181,9 +185,10 @@ export async function runCleanup(
         const unsavedIds = new Set(unsavedProjects.map(p => p.id));
         const uniqueGuestProjects = guestProjects.filter(p => !unsavedIds.has(p.id));
 
-        console.log(
-            `[CleanupScheduler] Found ${unsavedProjects.length} unsaved and ${uniqueGuestProjects.length} guest projects to delete`,
-        );
+        logger.info('Found projects to delete', {
+            unsavedCount: unsavedProjects.length,
+            guestCount: uniqueGuestProjects.length,
+        });
 
         // Delete unsaved projects
         for (const project of unsavedProjects) {
@@ -227,17 +232,18 @@ export async function runCleanup(
 
         state.lastRun = new Date();
         const elapsed = Date.now() - startTime;
-        console.log(
-            `[CleanupScheduler] Cleanup completed in ${elapsed}ms: ` +
-                `${result.unsavedDeleted} unsaved, ${result.guestDeleted} guest deleted, ` +
-                `${result.diskCleaned} asset dirs cleaned` +
-                (result.errors.length ? `, ${result.errors.length} errors` : ''),
-        );
+        logger.info('Cleanup completed', {
+            elapsedMs: elapsed,
+            unsavedDeleted: result.unsavedDeleted,
+            guestDeleted: result.guestDeleted,
+            diskCleaned: result.diskCleaned,
+            errorCount: result.errors.length,
+        });
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         result.success = false;
         result.errors.push(`Cleanup failed: ${message}`);
-        console.error('[CleanupScheduler] Cleanup failed:', err);
+        logger.error('Cleanup failed', err instanceof Error ? err : null);
     } finally {
         state.isRunning = false;
     }
@@ -259,30 +265,31 @@ export function startScheduler(
     state.deps = { ...defaultDeps, ...deps };
 
     if (!state.config.enabled) {
-        console.log('[CleanupScheduler] Scheduler is disabled');
+        logger.info('Scheduler is disabled');
         return;
     }
 
     const timers = state.deps.timers || { setInterval, clearInterval };
 
-    console.log(
-        `[CleanupScheduler] Starting scheduler with interval ${state.config.intervalMs}ms ` +
-            `(unsaved: ${state.config.unsavedAgeHours}h, guest: ${state.config.guestAgeDays}d)`,
-    );
+    logger.info('Starting scheduler', {
+        intervalMs: state.config.intervalMs,
+        unsavedAgeHours: state.config.unsavedAgeHours,
+        guestAgeDays: state.config.guestAgeDays,
+    });
 
     // Run immediately on startup
     runCleanup(state.deps, state.config).catch(err => {
-        console.error('[CleanupScheduler] Initial cleanup failed:', err);
+        logger.error('Initial cleanup failed', err instanceof Error ? err : null);
     });
 
     // Schedule periodic runs
     state.timer = timers.setInterval(() => {
         runCleanup(state.deps, state.config).catch(err => {
-            console.error('[CleanupScheduler] Scheduled cleanup failed:', err);
+            logger.error('Scheduled cleanup failed', err instanceof Error ? err : null);
         });
     }, state.config.intervalMs);
 
-    console.log('[CleanupScheduler] Scheduler started');
+    logger.info('Scheduler started');
 }
 
 /**
@@ -293,7 +300,7 @@ export function stopScheduler(): void {
         const timers = state.deps.timers || { setInterval, clearInterval };
         timers.clearInterval(state.timer);
         state.timer = null;
-        console.log('[CleanupScheduler] Scheduler stopped');
+        logger.info('Scheduler stopped');
     }
 }
 

--- a/src/services/export/html5-export.ts
+++ b/src/services/export/html5-export.ts
@@ -17,8 +17,9 @@ import * as previewModule from './preview';
 import * as htmlGeneratorModule from './html-generator';
 import { ExportResult, ExportFormat, Html5ExportOptions } from './interfaces';
 import { ParsedOdeStructure, NormalizedPage } from '../xml/interfaces';
+import { getLogger } from '../../contexts/logger.context';
 
-const DEBUG = process.env.APP_DEBUG === '1';
+const logger = getLogger().child({ component: 'html5-export' });
 
 // ============================================================================
 // Types and Interfaces
@@ -150,7 +151,7 @@ export function createHtml5ExportService(deps: Html5ExportDeps = {}): Html5Expor
         const themeSourceDir = path.join(getCwd(), 'public', 'files', 'perm', 'themes', 'base', themeName);
         const themeDestDir = path.join(exportDir, 'theme');
 
-        if (DEBUG) console.log(`[Html5Export] Copying theme "${themeName}" from ${themeSourceDir}`);
+        logger.debug('Copying theme', { themeName, themeSourceDir });
 
         await fs.ensureDir(themeDestDir);
 
@@ -176,9 +177,9 @@ export function createHtml5ExportService(deps: Html5ExportDeps = {}): Html5Expor
                 }
             }
 
-            if (DEBUG) console.log(`[Html5Export] Theme "${themeName}" copied successfully`);
+            logger.debug('Theme copied successfully', { themeName });
         } else {
-            console.warn(`[Html5Export] Theme not found: ${themeSourceDir}, using fallback styles`);
+            logger.warn('Theme not found, using fallback styles', { themeSourceDir });
         }
     }
 
@@ -239,11 +240,10 @@ body { font-family: sans-serif; margin: 0; padding: 0; }
     async function exportToHtml5(odeSessionId: string, options: Html5ExportOptions = {}): Promise<ExportResult> {
         try {
             const isPreviewMode = options.preview === true;
-            if (DEBUG) {
-                console.log(
-                    `[Html5Export] Exporting session ${odeSessionId} to HTML5 (${isPreviewMode ? 'preview' : 'download'} mode)`,
-                );
-            }
+            logger.debug('Exporting session to HTML5', {
+                odeSessionId,
+                mode: isPreviewMode ? 'preview' : 'download',
+            });
 
             // Get session
             const session = getSession(odeSessionId);
@@ -258,11 +258,11 @@ body { font-family: sans-serif; margin: 0; padding: 0; }
                 // Preview mode: use session temp directory with random subdirectory
                 const tempPath = options.tempPath || preview.generateRandomTempPath();
                 exportDir = getPreviewExportPath(odeSessionId, tempPath);
-                if (DEBUG) console.log(`[Html5Export] Preview export directory: ${exportDir}`);
+                logger.debug('Preview export directory', { exportDir });
             } else {
                 // Download mode: use temp path for ZIP creation
                 exportDir = getTempPath(`html5-export-${odeSessionId}`);
-                if (DEBUG) console.log(`[Html5Export] Download export directory: ${exportDir}`);
+                logger.debug('Download export directory', { exportDir });
             }
 
             await fs.ensureDir(exportDir);
@@ -280,7 +280,7 @@ body { font-family: sans-serif; margin: 0; padding: 0; }
 
                     const previewUrl = preview.buildPreviewUrl(odeSessionId, options.tempPath || '', 'index.html');
 
-                    console.log(`[Html5Export] Successfully generated preview at ${previewUrl}`);
+                    logger.info('Successfully generated preview', { previewUrl });
 
                     return {
                         filePath: exportDir,
@@ -300,7 +300,7 @@ body { font-family: sans-serif; margin: 0; padding: 0; }
                     // Get file size
                     const stats = await fs.stat(zipPath);
 
-                    console.log(`[Html5Export] Successfully exported HTML5 to ${zipPath}`);
+                    logger.info('Successfully exported HTML5', { zipPath, fileSize: stats.size });
 
                     return {
                         filePath: zipPath,
@@ -317,8 +317,7 @@ body { font-family: sans-serif; margin: 0; padding: 0; }
                 }
             }
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[Html5Export] Failed to export HTML5: ${errorMessage}`);
+            logger.error('Failed to export HTML5', error instanceof Error ? error : null, { odeSessionId });
             throw error;
         }
     }

--- a/src/services/export/preview.ts
+++ b/src/services/export/preview.ts
@@ -6,8 +6,9 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
 import * as mime from 'mime-types';
+import { getLogger } from '../../contexts/logger.context';
 
-const DEBUG = process.env.APP_DEBUG === '1';
+const logger = getLogger().child({ component: 'preview' });
 
 /**
  * Generate random temp path for preview isolation
@@ -34,13 +35,13 @@ export function buildPreviewUrl(sessionId: string, tempPath: string, filePath: s
         const month = sessionId.substring(4, 6);
         const day = sessionId.substring(6, 8);
         const urlPath = `/files/tmp/${year}/${month}/${day}/${sessionId}/export/${tempPath}${filePath}`;
-        if (DEBUG) console.log(`[Preview] Built date-based preview URL: ${urlPath}`);
+        logger.debug('Built date-based preview URL', { urlPath });
         return urlPath;
     }
 
     // Fallback URL for non-date session IDs
     const urlPath = `/files/tmp/${sessionId}/export/${tempPath}${filePath}`;
-    if (DEBUG) console.log(`[Preview] Built fallback preview URL: ${urlPath}`);
+    logger.debug('Built fallback preview URL', { urlPath });
     return urlPath;
 }
 
@@ -94,19 +95,19 @@ export function getMimeType(filePath: string): string {
 export function validateUrlParams(year: string, month: string, day: string): boolean {
     // Validate year (4 digits)
     if (!/^\d{4}$/.test(year)) {
-        if (DEBUG) console.warn(`[Preview] Invalid year format: ${year}`);
+        logger.debug('Invalid year format', { year });
         return false;
     }
 
     // Validate month (2 digits)
     if (!/^\d{2}$/.test(month)) {
-        if (DEBUG) console.warn(`[Preview] Invalid month format: ${month}`);
+        logger.debug('Invalid month format', { month });
         return false;
     }
 
     // Validate day (2 digits)
     if (!/^\d{2}$/.test(day)) {
-        if (DEBUG) console.warn(`[Preview] Invalid day format: ${day}`);
+        logger.debug('Invalid day format', { day });
         return false;
     }
 
@@ -158,6 +159,6 @@ export function extractSessionPathComponents(sessionPath: string): SessionPathCo
         }
     }
 
-    console.error(`[Preview] Invalid session path format: ${sessionPath}`);
+    logger.error('Invalid session path format', null, { sessionPath });
     return null;
 }

--- a/src/services/file-helper.ts
+++ b/src/services/file-helper.ts
@@ -2,10 +2,15 @@
  * File Helper Service for Elysia
  * Provides file system path utilities and directory management
  *
- * Uses Dependency Injection pattern for testability
+ * Uses Dependency Injection pattern for testability.
+ * Now supports ConfigContext for centralized configuration.
  */
 import * as fsExtra from 'fs-extra';
 import * as pathModule from 'path';
+import { getConfig, type ConfigContext } from '../contexts/config.context';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'file-helper' });
 
 // Re-export utilities from the shared utils
 export {
@@ -33,6 +38,7 @@ export interface FileHelperDeps {
     path?: typeof pathModule;
     getEnv?: (key: string) => string | undefined;
     getCwd?: () => string;
+    config?: ConfigContext;
 }
 
 /**
@@ -72,15 +78,29 @@ export interface FileHelper {
 
 /**
  * Create a FileHelper instance with injected dependencies
+ *
+ * @param deps - Optional dependencies. If config is provided, uses it for paths.
+ *               Falls back to getConfig() singleton when neither config nor getEnv is provided.
  */
 export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
     const fs = deps.fs ?? fsExtra;
     const path = deps.path ?? pathModule;
+
+    // If custom getEnv/getCwd provided, use those (backward compatibility for tests)
+    // Otherwise, use ConfigContext
+    const hasCustomEnv = deps.getEnv !== undefined || deps.getCwd !== undefined;
+
     const getEnv = deps.getEnv ?? ((key: string) => process.env[key]);
     const getCwd = deps.getCwd ?? (() => process.cwd());
 
+    // Get ConfigContext (either provided or singleton)
+    const getConfigContext = (): ConfigContext => deps.config ?? getConfig();
+
     // Internal helper for public directory
     const getPublicDir = (): string => {
+        if (!hasCustomEnv) {
+            return getConfigContext().publicDir;
+        }
         return getEnv('PUBLIC_DIR') || path.join(getCwd(), 'public');
     };
 
@@ -89,6 +109,12 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
     // ========================================================================
 
     const getFilesDir = (): string => {
+        // Use ConfigContext when no custom env functions are provided
+        if (!hasCustomEnv) {
+            return getConfigContext().filesDir;
+        }
+
+        // Legacy behavior: check individual env vars (for backward compatibility)
         // ELYSIA_FILES_DIR takes priority (used by tests)
         const elysiaFilesDir = getEnv('ELYSIA_FILES_DIR');
         if (elysiaFilesDir) {
@@ -114,7 +140,7 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
         const sessionPath = getOdeSessionPath(odeSessionId, filesDir);
 
         if (!sessionPath) {
-            console.warn(`Invalid session ID format: ${odeSessionId}. Using fallback directory structure.`);
+            logger.warn('Invalid session ID format, using fallback directory structure', { odeSessionId });
             return path.join(filesDir, 'tmp', odeSessionId);
         }
 
@@ -131,7 +157,7 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
         const filesDir = getFilesDir();
 
         if (!dateComponents) {
-            console.warn(`Invalid session ID format: ${odeSessionId}. Using fallback directory structure.`);
+            logger.warn('Invalid session ID format, using fallback directory structure', { odeSessionId });
             return path.join(filesDir, 'dist', odeSessionId);
         }
 

--- a/src/services/idevice-config.ts
+++ b/src/services/idevice-config.ts
@@ -6,6 +6,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { XMLParser } from 'fast-xml-parser';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'idevice-config' });
 
 export interface IdeviceConfigCache {
     cssClass: string;
@@ -50,7 +53,7 @@ export function loadIdeviceConfigs(customBasePath?: string): void {
     configCache = new Map();
 
     if (!fs.existsSync(basePath)) {
-        console.warn(`[IdeviceConfig] iDevices path not found: ${basePath}`);
+        logger.warn('iDevices path not found', { basePath });
         return;
     }
 
@@ -89,11 +92,14 @@ export function loadIdeviceConfigs(customBasePath?: string): void {
             configCache.set(entry.name, config);
             configCache.set(entry.name.toLowerCase(), config);
         } catch (err) {
-            console.warn(`[IdeviceConfig] Failed to parse ${configPath}:`, err);
+            logger.warn('Failed to parse iDevice config', {
+                configPath,
+                error: err instanceof Error ? err.message : String(err),
+            });
         }
     }
 
-    console.log(`[IdeviceConfig] Loaded ${configCache.size} iDevice configs`);
+    logger.info('Loaded iDevice configs', { count: configCache.size });
 }
 
 /**

--- a/src/services/platform-integration.ts
+++ b/src/services/platform-integration.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
+import { getLogger } from '../contexts/logger.context';
 
 // Centralized export system
 import {
@@ -32,6 +33,8 @@ import {
     Html5Exporter,
     type ExportResult,
 } from '../shared/export';
+
+const logger = getLogger().child({ component: 'platform-integration' });
 
 /**
  * Response from platform when fetching an ELP file
@@ -149,7 +152,7 @@ export async function platformPetitionGet(payload: PlatformJWTPayload, jwtToken:
         return content;
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.error('[PlatformIntegration] Error fetching ELP from platform:', message);
+        logger.error('Error fetching ELP from platform', error instanceof Error ? error : null, { message });
         throw new Error(`Failed to fetch ELP from platform: ${message}`);
     }
 }
@@ -321,7 +324,7 @@ export async function platformPetitionSet(
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.error('[PlatformIntegration] Error uploading to platform:', message);
+        logger.error('Error uploading to platform', error instanceof Error ? error : null, { message });
         return {
             success: false,
             error: `Failed to upload to platform: ${message}`,

--- a/src/services/translation.ts
+++ b/src/services/translation.ts
@@ -7,8 +7,9 @@
 import { XMLParser } from 'fast-xml-parser';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getLogger } from '../contexts/logger.context';
 
-const DEBUG = process.env.APP_DEBUG === '1';
+const logger = getLogger().child({ component: 'translation' });
 
 /**
  * Interface translations - locales with XLF files
@@ -212,7 +213,7 @@ function getTranslationsDir(): string {
 export function loadAllTranslations(): void {
     const translationsDir = getTranslationsDir();
 
-    if (DEBUG) console.log(`[Translation] Loading translations from: ${translationsDir}`);
+    logger.debug('Loading translations', { translationsDir });
 
     for (const locale of Object.keys(LOCALES)) {
         const filePath = path.join(translationsDir, `messages.${locale}.xlf`);
@@ -222,19 +223,21 @@ export function loadAllTranslations(): void {
                 const content = fs.readFileSync(filePath, 'utf-8');
                 const result = parseXlfContent(content);
                 catalogues.set(locale, result.translations);
-                if (DEBUG)
-                    console.log(`[Translation] Loaded ${result.translations.size} translations for locale: ${locale}`);
+                logger.debug('Loaded translations for locale', {
+                    locale,
+                    count: result.translations.size,
+                });
             } else {
-                if (DEBUG) console.log(`[Translation] Translation file not found: ${filePath}`);
+                logger.debug('Translation file not found', { filePath });
                 catalogues.set(locale, new Map());
             }
         } catch (error) {
-            console.error(`[Translation] Error loading translations for ${locale}:`, error);
+            logger.error('Error loading translations', error instanceof Error ? error : null, { locale });
             catalogues.set(locale, new Map());
         }
     }
 
-    console.log(`[Translation] Loaded ${catalogues.size} locales`);
+    logger.info('Loaded translation locales', { count: catalogues.size });
 }
 
 /**

--- a/src/services/xml/legacy-xml-parser.ts
+++ b/src/services/xml/legacy-xml-parser.ts
@@ -11,8 +11,9 @@ import {
     RealOdeNavStructure,
 } from './interfaces';
 import { generateId } from '../../utils/id-generator.util';
+import { getLogger } from '../../contexts/logger.context';
 
-const DEBUG = process.env.APP_DEBUG === '1';
+const logger = getLogger().child({ component: 'legacy-xml-parser' });
 
 // State for current parsing session
 let _xmlContent = '';
@@ -28,7 +29,7 @@ export function parse(
     rawXmlContent?: string,
     currentSessionId?: string,
 ): ParsedOdeStructure {
-    if (DEBUG) console.log('[LegacyParser] Parsing legacy instance format');
+    logger.debug('Parsing legacy instance format');
 
     _xmlContent = rawXmlContent || '';
     _sessionId = currentSessionId || '';
@@ -40,7 +41,7 @@ export function parse(
 
     // Find all nodes
     const allNodes = findAllNodes(parsed.instance);
-    if (DEBUG) console.log(`[LegacyParser] Found ${allNodes.length} legacy nodes`);
+    logger.debug('Found legacy nodes', { count: allNodes.length });
 
     // Extract metadata
     const meta = extractMetadata(parsed.instance);
@@ -67,7 +68,7 @@ export function parse(
 
     const navigation = { page: pages };
 
-    if (DEBUG) console.log(`[LegacyParser] Collected ${srcRoutes.length} resource paths`);
+    logger.debug('Collected resource paths', { count: srcRoutes.length });
 
     return {
         meta,
@@ -374,7 +375,7 @@ function buildPageHierarchy(nodes: LegacyInstanceNode[]): NormalizedPage[] {
     // This is INTENTIONAL behavior for legacy imports. See doc/conventions.md.
     const { shouldFlatten, rootRef } = shouldFlattenRootChildren();
     if (shouldFlatten && rootRef) {
-        if (DEBUG) console.log('[LegacyParser] Applying root node flattening convention for v2.x import');
+        logger.debug('Applying root node flattening convention for v2.x import');
         return flattenRootChildren(pages, rootRef);
     }
 
@@ -680,7 +681,7 @@ function mapIdeviceType(className: string): string {
     // Check if this is a text-based iDevice that should convert to 'text'
     for (const textType of textBasedIdevices) {
         if (className.includes(textType)) {
-            if (DEBUG) console.log(`[LegacyParser] Converting ${textType} to 'text' for editability`);
+            logger.debug('Converting text-based iDevice to text for editability', { textType });
             return 'text';
         }
     }
@@ -717,7 +718,7 @@ function mapIdeviceType(className: string): string {
     // Check for interactive iDevice mappings
     for (const [legacyType, modernType] of Object.entries(interactiveTypeMap)) {
         if (className.includes(legacyType)) {
-            if (DEBUG) console.log(`[LegacyParser] Mapping ${legacyType} to '${modernType}'`);
+            logger.debug('Mapping legacy iDevice to modern type', { legacyType, modernType });
             return modernType;
         }
     }
@@ -726,7 +727,7 @@ function mapIdeviceType(className: string): string {
     // JsIdevice is the modern JSON-based iDevice system. The actual type
     // is stored within the iDevice's JSON properties.
     if (className.includes('JsIdevice')) {
-        if (DEBUG) console.log(`[LegacyParser] Detected JsIdevice (modern format)`);
+        logger.debug('Detected JsIdevice (modern format)');
         // Return 'js' to indicate this needs special handling to extract the actual type
         return 'js';
     }
@@ -738,7 +739,7 @@ function mapIdeviceType(className: string): string {
     const match = className.match(/(\w+)Idevice/);
     const extractedType = match ? match[1].toLowerCase() : 'unknown';
 
-    if (DEBUG) console.log(`[LegacyParser] Unknown iDevice '${extractedType}' → converting to 'text' for editability`);
+    logger.debug('Unknown iDevice, converting to text for editability', { extractedType });
 
     // Convert unknown types to 'text' to ensure editability
     return 'text';

--- a/src/services/xml/xml-builder.ts
+++ b/src/services/xml/xml-builder.ts
@@ -6,6 +6,9 @@ import { XMLBuilder } from 'fast-xml-parser';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { OdeXmlDocument, OdeXmlMeta, OdeXmlNavigation, NormalizedPage, ParsedOdeStructure } from './interfaces';
+import { getLogger } from '../../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'xml-builder' });
 
 export interface XmlBuildOptions {
     format?: boolean;
@@ -32,7 +35,7 @@ const DEBUG = process.env.APP_DEBUG === '1';
  * Build ODE XML from parsed structure
  */
 export function buildFromStructure(structure: ParsedOdeStructure): string {
-    if (DEBUG) console.log('[XmlBuilder] Building XML from structure');
+    logger.debug('Building XML from structure');
 
     // Build navigation tree from flat pages array
     const navigation = buildNavigationFromPages(structure.pages);
@@ -51,7 +54,7 @@ export function buildFromStructure(structure: ParsedOdeStructure): string {
     // Add XML declaration
     const xmlWithDeclaration = `<?xml version="1.0" encoding="UTF-8"?>\n${xml}`;
 
-    console.log('[XmlBuilder] Successfully built XML document');
+    logger.debug('Successfully built XML document');
     return xmlWithDeclaration;
 }
 
@@ -124,7 +127,7 @@ function buildPageTree(page: NormalizedPage, allPages: NormalizedPage[]): XmlPag
  * Write XML to file
  */
 export async function writeToFile(structure: ParsedOdeStructure, outputPath: string): Promise<string> {
-    if (DEBUG) console.log(`[XmlBuilder] Writing XML to file: ${outputPath}`);
+    logger.debug('Writing XML to file', { outputPath });
 
     const xml = buildFromStructure(structure);
 
@@ -135,7 +138,7 @@ export async function writeToFile(structure: ParsedOdeStructure, outputPath: str
     // Write file
     await fs.writeFile(outputPath, xml, 'utf-8');
 
-    console.log(`[XmlBuilder] Successfully wrote XML to ${outputPath}`);
+    logger.debug('Successfully wrote XML', { outputPath });
     return outputPath;
 }
 

--- a/src/services/xml/xml-parser.ts
+++ b/src/services/xml/xml-parser.ts
@@ -4,6 +4,7 @@
  */
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import * as fs from 'fs-extra';
+import { getLogger } from '../../contexts/logger.context';
 import {
     OdeXmlDocument,
     OdeXmlMeta,
@@ -43,13 +44,15 @@ const parser = new XMLParser({
     allowBooleanAttributes: true,
 });
 
+// Create logger for XML parser
+const logger = getLogger().child({ component: 'xml-parser' });
 const DEBUG = process.env.APP_DEBUG === '1';
 
 /**
  * Parse ODE XML from file
  */
 export async function parseFromFile(xmlPath: string, sessionId?: string): Promise<ParsedOdeStructure> {
-    if (DEBUG) console.log(`[XmlParser] Parsing XML file: ${xmlPath}`);
+    if (DEBUG) logger.debug('Parsing XML file', { xmlPath });
 
     if (!(await fs.pathExists(xmlPath))) {
         throw new Error(`XML file not found: ${xmlPath}`);
@@ -73,15 +76,17 @@ export interface ParseOptions {
  * Parse ODE XML from string
  */
 export function parseFromString(xmlContent: string, sessionId?: string, options?: ParseOptions): ParsedOdeStructure {
-    if (DEBUG) console.log('[XmlParser] Parsing XML from string');
+    if (DEBUG) logger.debug('Parsing XML from string');
 
     const parsed = parser.parse(xmlContent);
 
     if (DEBUG) {
-        console.log(`[XmlParser] Parsed object keys: ${JSON.stringify(Object.keys(parsed))}`);
-        console.log(
-            `[XmlParser] Has ode: ${!!parsed.ode}, Has exe_document: ${!!parsed.exe_document}, Has instance: ${!!parsed.instance}`,
-        );
+        logger.debug('Parsed object', {
+            keys: Object.keys(parsed),
+            hasOde: !!parsed.ode,
+            hasExeDocument: !!parsed.exe_document,
+            hasInstance: !!parsed.instance,
+        });
     }
 
     // Validate ODE XML structure (for real ODE format)
@@ -89,32 +94,32 @@ export function parseFromString(xmlContent: string, sessionId?: string, options?
         const validation = validateOdeXml(parsed);
         if (!validation.valid) {
             const errorMsg = formatValidationErrors(validation);
-            console.error(`[XmlParser] XML validation failed:\n${errorMsg}`);
+            logger.error('XML validation failed', null, { errors: errorMsg });
             throw new Error(`Invalid ODE XML structure:\n${errorMsg}`);
         }
         if (validation.warnings.length > 0 && options?.strictValidation) {
             const errorMsg = formatValidationErrors(validation);
-            console.warn(`[XmlParser] XML validation warnings:\n${errorMsg}`);
+            logger.warn('XML validation warnings (strict mode)', { warnings: errorMsg });
             throw new Error(`ODE XML has validation warnings:\n${errorMsg}`);
         }
         if (validation.warnings.length > 0 && DEBUG) {
-            console.warn(`[XmlParser] XML validation warnings:\n${formatValidationErrors(validation)}`);
+            logger.warn('XML validation warnings', { warnings: formatValidationErrors(validation) });
         }
     }
 
     // Check format and parse accordingly
     if (parsed.ode) {
-        if (DEBUG) console.log('[XmlParser] Detected real ODE XML format');
+        if (DEBUG) logger.debug('Detected real ODE XML format');
         return parseRealOdeFormat(parsed as RealOdeXmlDocument);
     }
 
     if (parsed.exe_document) {
-        if (DEBUG) console.log('[XmlParser] Detected exe_document XML format');
+        if (DEBUG) logger.debug('Detected exe_document XML format');
         return parseExeDocumentFormat(parsed as OdeXmlDocument);
     }
 
     if (parsed.instance) {
-        if (DEBUG) console.log('[XmlParser] Detected legacy instance XML format');
+        if (DEBUG) logger.debug('Detected legacy instance XML format');
         return legacyParser.parse(parsed as LegacyInstanceXmlDocument, xmlContent, sessionId);
     }
 
@@ -141,7 +146,7 @@ function parseExeDocumentFormat(parsed: OdeXmlDocument): ParsedOdeStructure {
     const meta = extractMetadata(parsed.exe_document.meta || {});
     const pages = normalizePagesFromNavigation(parsed.exe_document.navigation);
 
-    console.log(`[XmlParser] Parsed ${pages.length} pages from exe_document XML`);
+    logger.info('Parsed exe_document XML', { pageCount: pages.length });
 
     const raw: RealOdeXmlDocument = { ode: {} };
 
@@ -172,7 +177,7 @@ function parseRealOdeFormat(parsed: RealOdeXmlDocument): ParsedOdeStructure {
 
     const pages = normalizePagesFromOdeNavStructures(parsed.ode.odeNavStructures?.odeNavStructure || []);
 
-    console.log(`[XmlParser] Parsed ${pages.length} pages from real ODE XML`);
+    logger.info('Parsed real ODE XML', { pageCount: pages.length });
 
     const navigation: OdeXmlNavigation = { page: [] };
 

--- a/src/utils/platform-jwt.ts
+++ b/src/utils/platform-jwt.ts
@@ -8,6 +8,9 @@
  * - Platform JWT: signed with APP_SECRET or PROVIDER_TOKENS[i], payload {userid, cmid, returnurl, pkgtype}
  */
 import { jwtVerify } from 'jose';
+import { getLogger } from '../contexts/logger.context';
+
+const logger = getLogger().child({ component: 'platform-jwt' });
 
 /**
  * Payload structure for platform JWT tokens
@@ -157,7 +160,7 @@ export async function decodePlatformJWT(token: string, providerId?: string): Pro
         const secret = getProviderSecret(providerId);
 
         if (!secret) {
-            console.error('[PlatformJWT] No secret available for JWT verification');
+            logger.error('No secret available for JWT verification', null);
             return null;
         }
 
@@ -172,14 +175,13 @@ export async function decodePlatformJWT(token: string, providerId?: string): Pro
 
         // Validate required fields
         if (!platformPayload.returnurl) {
-            console.error('[PlatformJWT] Missing required field: returnurl');
+            logger.error('Missing required field: returnurl', null);
             return null;
         }
 
         return platformPayload;
     } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error('[PlatformJWT] JWT decode error:', message);
+        logger.error('JWT decode error', error instanceof Error ? error : null);
         return null;
     }
 }
@@ -231,13 +233,13 @@ export async function getPlatformIntegrationParams(
     // Extract and validate provider
     const providerId = extractProviderId(payload);
     if (providerId && !isValidProvider(providerId)) {
-        console.warn(`[PlatformJWT] Invalid provider ID in JWT: ${providerId}`);
+        logger.warn('Invalid provider ID in JWT', { providerId });
         return null;
     }
 
     // Validate return URL against allowed providers
     if (!isAllowedProviderUrl(payload.returnurl)) {
-        console.warn(`[PlatformJWT] Return URL not in allowed providers: ${payload.returnurl}`);
+        logger.warn('Return URL not in allowed providers', { returnurl: payload.returnurl });
         return null;
     }
 

--- a/src/websocket/access-notifier.ts
+++ b/src/websocket/access-notifier.ts
@@ -8,8 +8,12 @@
  */
 import type { ServerWebSocket } from 'bun';
 import * as roomManagerDefault from './room-manager';
+import { getLogger } from '../contexts/logger.context';
 
 const DEBUG = process.env.APP_DEBUG === '1';
+
+// Create logger for access notifier
+const logger = getLogger().child({ component: 'access-notifier' });
 
 /**
  * Asset message prefix byte (0xFF)
@@ -133,7 +137,7 @@ function sendAndClose(ws: ServerWebSocket<unknown>, message: Uint8Array, reason:
         }, 100);
     } catch (err) {
         if (DEBUG) {
-            console.error('[AccessNotifier] Error sending message:', err);
+            logger.error('Error sending message', err instanceof Error ? err : null);
         }
         // Try to close anyway
         try {
@@ -161,7 +165,7 @@ export function notifyVisibilityChanged(projectUuid: string, ownerId: number, co
 
     if (connectedUserIds.length === 0) {
         if (DEBUG) {
-            console.log(`[AccessNotifier] No users connected to project ${projectUuid}`);
+            logger.debug('No users connected to project', { projectUuid });
         }
         return 0;
     }
@@ -174,7 +178,7 @@ export function notifyVisibilityChanged(projectUuid: string, ownerId: number, co
 
     if (usersToKick.length === 0) {
         if (DEBUG) {
-            console.log(`[AccessNotifier] All connected users are authorized for project ${projectUuid}`);
+            logger.debug('All connected users are authorized', { projectUuid });
         }
         return 0;
     }
@@ -193,16 +197,16 @@ export function notifyVisibilityChanged(projectUuid: string, ownerId: number, co
         }
 
         if (DEBUG) {
-            console.log(
-                `[AccessNotifier] Kicked user ${userId} from project ${projectUuid} (${connections.length} connections)`,
-            );
+            logger.debug('Kicked user from project', { userId, projectUuid, connections: connections.length });
         }
     }
 
     if (DEBUG) {
-        console.log(
-            `[AccessNotifier] Visibility change: kicked ${usersToKick.length} users (${kickedCount} connections) from project ${projectUuid}`,
-        );
+        logger.info('Visibility change: kicked users', {
+            projectUuid,
+            usersKicked: usersToKick.length,
+            connectionsKicked: kickedCount,
+        });
     }
 
     return usersToKick.length;
@@ -223,7 +227,7 @@ export function notifyCollaboratorRemoved(projectUuid: string, removedUserId: nu
 
     if (connections.length === 0) {
         if (DEBUG) {
-            console.log(`[AccessNotifier] User ${removedUserId} not connected to project ${projectUuid}`);
+            logger.debug('User not connected to project', { userId: removedUserId, projectUuid });
         }
         return 0;
     }
@@ -238,9 +242,11 @@ export function notifyCollaboratorRemoved(projectUuid: string, removedUserId: nu
     }
 
     if (DEBUG) {
-        console.log(
-            `[AccessNotifier] Collaborator removed: kicked user ${removedUserId} from project ${projectUuid} (${connections.length} connections)`,
-        );
+        logger.info('Collaborator removed: kicked user', {
+            userId: removedUserId,
+            projectUuid,
+            connections: connections.length,
+        });
     }
 
     return connections.length;

--- a/src/websocket/asset-coordinator.ts
+++ b/src/websocket/asset-coordinator.ts
@@ -17,6 +17,7 @@
 import { WebSocket as WsWebSocket } from 'ws';
 import { randomUUID } from 'crypto';
 import type { Kysely } from 'kysely';
+import { getLogger } from '../contexts/logger.context';
 import {
     AssetMessage,
     AssetMessageType,
@@ -46,6 +47,9 @@ import {
 } from '../services/asset-priority-queue';
 
 const DEBUG = process.env.APP_DEBUG === '1';
+
+// Create logger for asset coordinator
+const logger = getLogger().child({ component: 'asset-coordinator' });
 
 /**
  * Asset message prefix byte (0xFF)
@@ -147,7 +151,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
     function sendToClient(projectUuid: string, clientId: string, message: AssetMessage): void {
         const socket = getClientSocket(projectUuid, clientId);
         if (!socket) {
-            console.warn(`[AssetCoordinator] Cannot send to ${clientId}: socket not found`);
+            logger.warn('Cannot send to client: socket not found', { clientId });
             return;
         }
 
@@ -155,8 +159,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             const binaryMessage = encodeAssetMessage(message);
             socket.send(binaryMessage);
         } catch (err: unknown) {
-            const errMessage = err instanceof Error ? err.message : String(err);
-            console.error(`[AssetCoordinator] Failed to send to ${clientId}:`, errMessage);
+            logger.error('Failed to send to client', err instanceof Error ? err : null, { clientId });
         }
     }
 
@@ -172,8 +175,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             try {
                 socket.send(binaryMessage);
             } catch (err: unknown) {
-                const errMessage = err instanceof Error ? err.message : String(err);
-                console.error(`[AssetCoordinator] Failed to broadcast to ${cId}:`, errMessage);
+                logger.error('Failed to broadcast to client', err instanceof Error ? err : null, { clientId: cId });
             }
         });
     }
@@ -191,8 +193,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                 try {
                     socket.send(binaryMessage);
                 } catch (err: unknown) {
-                    const errMessage = err instanceof Error ? err.message : String(err);
-                    console.error(`[AssetCoordinator] Failed to broadcast to ${cId}:`, errMessage);
+                    logger.error('Failed to broadcast to client', err instanceof Error ? err : null, { clientId: cId });
                 }
             }
         });
@@ -225,7 +226,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         const peersWithAsset = projectAssets?.get(assetId);
 
         if (!peersWithAsset || peersWithAsset.size === 0) {
-            console.error(`[AssetCoordinator] No peer has asset ${assetId}`);
+            logger.error('No peer has asset', null, { assetId });
             return;
         }
 
@@ -239,12 +240,12 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         }
 
         if (!peerClientId) {
-            console.warn(`[AssetCoordinator] Only requester ${requestedBy} has asset ${assetId}`);
+            logger.warn('Only requester has asset', { requestedBy, assetId });
             return;
         }
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Requesting ${peerClientId} to upload asset ${assetId}`);
+            logger.debug('Requesting peer to upload asset', { peerClientId, assetId });
         }
 
         const requestId = generateId();
@@ -272,7 +273,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             if (!pending || pending.length === 0) continue;
 
             if (DEBUG) {
-                console.log(`[AssetCoordinator] Asset ${assetId} available, fulfilling ${pending.length} requests`);
+                logger.debug('Asset available, fulfilling requests', { assetId, requestCount: pending.length });
             }
 
             // Get highest priority request
@@ -299,9 +300,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
 
         if (!peersWithAsset || peersWithAsset.size === 0) {
             if (DEBUG) {
-                console.log(
-                    `[AssetCoordinator] No peer has asset ${assetId.substring(0, 8)}... (priority=${priority})`,
-                );
+                logger.debug('No peer has asset', { assetId: assetId.substring(0, 8), priority });
             }
 
             // Add to pending requests
@@ -328,16 +327,17 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
 
         if (!peerClientId) {
             if (DEBUG) {
-                console.warn(`[AssetCoordinator] Only requester has asset ${assetId.substring(0, 8)}...`);
+                logger.warn('Only requester has asset', { assetId: assetId.substring(0, 8) });
             }
             return;
         }
 
         if (DEBUG) {
-            console.log(
-                `[AssetCoordinator] Requesting ${peerClientId.substring(0, 8)}... to upload ` +
-                    `asset ${assetId.substring(0, 8)}... with priority=${priority}`,
-            );
+            logger.debug('Requesting peer to upload asset with priority', {
+                peerClientId: peerClientId.substring(0, 8),
+                assetId: assetId.substring(0, 8),
+                priority,
+            });
         }
 
         const requestId = generateId();
@@ -381,16 +381,19 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: AwarenessUpdateData | undefined,
     ): Promise<void> {
         if (!data || !Array.isArray(data.availableAssets)) {
-            console.warn(`[AssetCoordinator] Invalid awareness update from ${clientId}`);
+            logger.warn('Invalid awareness update', { clientId });
             return;
         }
 
         const { availableAssets, totalAssets = availableAssets.length } = data;
 
         if (DEBUG) {
-            console.log(
-                `[AssetCoordinator] Client ${clientId} has ${availableAssets.length}/${totalAssets} assets for project ${projectUuid}`,
-            );
+            logger.debug('Client has assets', {
+                clientId,
+                availableCount: availableAssets.length,
+                totalAssets,
+                projectUuid,
+            });
         }
 
         // Initialize project tracking if needed
@@ -421,14 +424,14 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: AssetRequestData | undefined,
     ): Promise<void> {
         if (!data || !data.assetId) {
-            console.warn(`[AssetCoordinator] Invalid asset request from ${clientId}`);
+            logger.warn('Invalid asset request', { clientId });
             return;
         }
 
         const { assetId, priority = 'low', reason = 'render' } = data;
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Client ${clientId} requested asset ${assetId} (${priority}, ${reason})`);
+            logger.debug('Client requested asset', { clientId, assetId, priority, reason });
         }
 
         // 1. Check if asset exists in database
@@ -444,7 +447,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             if (asset) {
                 // Asset exists in DB, send URL immediately
                 if (DEBUG) {
-                    console.log(`[AssetCoordinator] Asset ${assetId} found in database`);
+                    logger.debug('Asset found in database', { assetId });
                 }
 
                 sendToClient(projectUuid, clientId, {
@@ -462,8 +465,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                 return;
             }
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[AssetCoordinator] Error checking database for asset ${assetId}:`, errorMessage);
+            logger.error('Error checking database for asset', error instanceof Error ? error : null, { assetId });
         }
 
         // 2. Check if any peer has it
@@ -472,7 +474,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
 
         if (!peersWithAsset || peersWithAsset.size === 0) {
             // No one has it yet
-            console.warn(`[AssetCoordinator] Asset ${assetId} not found in DB and no peer has it`);
+            logger.warn('Asset not found in DB and no peer has it', { assetId });
 
             // Add to pending queue
             const key = `${projectUuid}:${assetId}`;
@@ -502,19 +504,19 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: AssetUploadedData | undefined,
     ): Promise<void> {
         if (!data || !data.assetId) {
-            console.warn(`[AssetCoordinator] Invalid asset uploaded from ${clientId}`);
+            logger.warn('Invalid asset uploaded', { clientId });
             return;
         }
 
         const { assetId, requestedBy, success = false, size, error } = data;
 
         if (!success) {
-            console.error(`[AssetCoordinator] Client ${clientId} failed to upload ${assetId}: ${error}`);
+            logger.error('Client failed to upload asset', null, { clientId, assetId, error });
             return;
         }
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Client ${clientId} uploaded asset ${assetId} (${size} bytes)`);
+            logger.debug('Client uploaded asset', { clientId, assetId, size });
         }
 
         // Notify the specific requester
@@ -548,14 +550,17 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: PrefetchProgressData | undefined,
     ): void {
         if (!data || typeof data.total !== 'number') {
-            console.warn(`[AssetCoordinator] Invalid prefetch progress from ${clientId}`);
+            logger.warn('Invalid prefetch progress', { clientId });
             return;
         }
 
         if (DEBUG) {
-            console.log(
-                `[AssetCoordinator] Client ${clientId} prefetch: ${data.completed}/${data.total} (${data.failed} failed)`,
-            );
+            logger.debug('Client prefetch progress', {
+                clientId,
+                completed: data.completed,
+                total: data.total,
+                failed: data.failed,
+            });
         }
     }
 
@@ -568,23 +573,23 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: BulkUploadProgressData | undefined,
     ): Promise<void> {
         if (!data || !data.status) {
-            console.warn(`[AssetCoordinator] Invalid bulk upload progress from ${clientId}`);
+            logger.warn('Invalid bulk upload progress', { clientId });
             return;
         }
 
         const { status, total, completed = 0, failed = 0, failedAssets } = data;
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Bulk upload ${status}: ${completed}/${total}, ${failed} failed`);
+            logger.debug('Bulk upload progress', { status, completed, total, failed });
         }
 
         if (status === 'completed') {
-            console.log(`[AssetCoordinator] Bulk upload by ${clientId}: ${completed} assets available`);
+            logger.info('Bulk upload completed', { clientId, assetsAvailable: completed });
 
             if (failedAssets && failedAssets.length > 0) {
-                console.warn(
-                    `[AssetCoordinator] Failed: ${failedAssets.map(a => a.assetId.substring(0, 8)).join(', ')}`,
-                );
+                logger.warn('Bulk upload had failures', {
+                    failedAssetIds: failedAssets.map(a => a.assetId.substring(0, 8)),
+                });
             }
 
             // Notify other clients using binary encoding with 0xFF prefix
@@ -606,8 +611,9 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                         try {
                             socket.send(binaryMessage);
                         } catch (err: unknown) {
-                            const errMessage = err instanceof Error ? err.message : String(err);
-                            console.error(`[AssetCoordinator] Failed to notify ${otherClientId}:`, errMessage);
+                            logger.error('Failed to notify client', err instanceof Error ? err : null, {
+                                clientId: otherClientId,
+                            });
                         }
                     }
                 });
@@ -624,17 +630,19 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         data: PriorityUpdateData | undefined,
     ): Promise<void> {
         if (!data || !data.assetId) {
-            console.warn(`[AssetCoordinator] Invalid priority update from ${clientId}`);
+            logger.warn('Invalid priority update', { clientId });
             return;
         }
 
         const { assetId, priority, reason, pageId } = data;
 
         if (DEBUG) {
-            console.log(
-                `[AssetCoordinator] Priority update: ${assetId.substring(0, 8)}... ` +
-                    `priority=${priority} reason=${reason} from=${clientId.substring(0, 8)}...`,
-            );
+            logger.debug('Priority update', {
+                assetId: assetId.substring(0, 8),
+                priority,
+                reason,
+                clientId: clientId.substring(0, 8),
+            });
         }
 
         // Register in server priority queue
@@ -670,8 +678,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                 }
             }
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[AssetCoordinator] Error checking asset ${assetId}:`, errorMessage);
+            logger.error('Error checking asset', error instanceof Error ? error : null, { assetId });
         }
 
         // Check if we should preempt any current uploads
@@ -680,10 +687,10 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             const { targetSlot, preemptingItem } = preemptResult;
 
             if (DEBUG) {
-                console.log(
-                    `[AssetCoordinator] Preempting upload ${targetSlot.assetId.substring(0, 8)}... ` +
-                        `for higher priority ${preemptingItem?.assetId.substring(0, 8)}...`,
-                );
+                logger.debug('Preempting upload for higher priority', {
+                    preemptedAssetId: targetSlot.assetId.substring(0, 8),
+                    preemptingAssetId: preemptingItem?.assetId.substring(0, 8),
+                });
             }
 
             // Send preempt message to the uploading client
@@ -733,10 +740,11 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         const { targetPageId, assetIds } = data;
 
         if (DEBUG) {
-            console.log(
-                `[AssetCoordinator] Navigation hint: page=${targetPageId.substring(0, 8)}... ` +
-                    `assets=${assetIds.length} from=${clientId.substring(0, 8)}...`,
-            );
+            logger.debug('Navigation hint', {
+                targetPageId: targetPageId.substring(0, 8),
+                assetCount: assetIds.length,
+                clientId: clientId.substring(0, 8),
+            });
         }
 
         // Boost priority for all navigation assets
@@ -766,19 +774,18 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                 }
             }
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[AssetCoordinator] Error checking navigation assets:`, errorMessage);
+            logger.error('Error checking navigation assets', error instanceof Error ? error : null);
         }
 
         if (missingAssets.length === 0) {
             if (DEBUG) {
-                console.log(`[AssetCoordinator] All navigation assets already available`);
+                logger.debug('All navigation assets already available');
             }
             return;
         }
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] ${missingAssets.length} navigation assets need fetching`);
+            logger.debug('Navigation assets need fetching', { count: missingAssets.length });
         }
 
         // Request upload from peers for missing assets
@@ -801,7 +808,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         clientSockets.get(projectUuid)!.set(clientId, socket);
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Registered client ${clientId} for project ${projectUuid}`);
+            logger.debug('Registered client', { clientId, projectUuid });
         }
     }
 
@@ -823,7 +830,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         }
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Unregistered client ${clientId} from project ${projectUuid}`);
+            logger.debug('Unregistered client', { clientId, projectUuid });
         }
     }
 
@@ -847,7 +854,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         priorityQueue.clearProject(projectUuid);
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Cleaned up project ${projectUuid}`);
+            logger.debug('Cleaned up project', { projectUuid });
         }
     }
 
@@ -888,11 +895,10 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
                     break;
 
                 default:
-                    console.warn(`[AssetCoordinator] Unknown message type: ${type}`);
+                    logger.warn('Unknown message type', { type });
             }
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(`[AssetCoordinator] Error handling message type ${type}:`, errorMessage);
+            logger.error('Error handling message', error instanceof Error ? error : null, { type });
         }
     }
 
@@ -901,12 +907,12 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
      */
     async function onCollaborationDetected(projectUuid: string): Promise<void> {
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Collaboration detected for project ${projectUuid}`);
+            logger.debug('Collaboration detected', { projectUuid });
         }
 
         const projectAssets = assetAvailability.get(projectUuid);
         if (!projectAssets) {
-            console.warn(`[AssetCoordinator] No asset awareness for project ${projectUuid}`);
+            logger.warn('No asset awareness for project', { projectUuid });
             return;
         }
 
@@ -934,7 +940,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         });
 
         if (!referenceClientId) {
-            console.warn('[AssetCoordinator] No reference client found');
+            logger.warn('No reference client found');
             return;
         }
 
@@ -942,7 +948,7 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
         const referenceAssetIds = Array.from(referenceAssets);
 
         if (DEBUG) {
-            console.log(`[AssetCoordinator] Reference client ${referenceClientId} has ${referenceAssets.size} assets`);
+            logger.debug('Reference client identified', { referenceClientId, assetCount: referenceAssets.size });
         }
 
         // Request reference client to upload ALL assets
@@ -965,12 +971,12 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             const missingAssets = Array.from(referenceAssets).filter(assetId => !assetsSet.has(assetId));
 
             if (missingAssets.length === 0) {
-                if (DEBUG) console.log(`[AssetCoordinator] Client ${cId} has all assets`);
+                if (DEBUG) logger.debug('Client has all assets', { clientId: cId });
                 return;
             }
 
             if (DEBUG) {
-                console.log(`[AssetCoordinator] Client ${cId} missing ${missingAssets.length} assets`);
+                logger.debug('Client missing assets', { clientId: cId, missingCount: missingAssets.length });
             }
 
             sendToClient(projectUuid, cId, {

--- a/src/websocket/collaboration.context.spec.ts
+++ b/src/websocket/collaboration.context.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * Tests for CollaborationContext
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+    createCollaborationContext,
+    createTestCollaborationContext,
+    createMockPubSub,
+    createMockPriorityQueue,
+    configureAllModules,
+    resetAllModules,
+    getCollaborationContext,
+    resetCollaborationContext,
+} from './collaboration.context';
+import { silentLogger, CapturingLogger } from '../contexts/logger.context';
+import { createTestDb, destroyTestDb } from '../../test/helpers/test-db';
+import type { Kysely } from 'kysely';
+import type { Database } from '../db/types';
+
+describe('CollaborationContext', () => {
+    describe('createCollaborationContext', () => {
+        it('should create context with default values', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.db).toBeDefined();
+            expect(ctx.logger).toBeDefined();
+            expect(ctx.queries).toBeDefined();
+            expect(ctx.yjsQueries).toBeDefined();
+            expect(ctx.auth).toBeDefined();
+            expect(ctx.sessionManager).toBeDefined();
+            expect(ctx.priorityQueue).toBeDefined();
+            expect(ctx.pubSub).toBeDefined();
+        });
+
+        it('should create frozen/immutable context', () => {
+            const ctx = createCollaborationContext();
+
+            expect(Object.isFrozen(ctx)).toBe(true);
+        });
+
+        it('should allow overriding db', async () => {
+            const testDb = await createTestDb();
+            try {
+                const ctx = createCollaborationContext({ db: testDb });
+
+                expect(ctx.db).toBe(testDb);
+            } finally {
+                await destroyTestDb(testDb);
+            }
+        });
+
+        it('should allow overriding logger', () => {
+            const ctx = createCollaborationContext({ logger: silentLogger });
+
+            expect(ctx.logger).toBe(silentLogger);
+        });
+
+        it('should allow partial query overrides', () => {
+            const mockFindProject = async () => undefined;
+            const ctx = createCollaborationContext({
+                queries: { findProjectByUuid: mockFindProject },
+            });
+
+            expect(ctx.queries.findProjectByUuid).toBe(mockFindProject);
+            // Other queries should still have defaults
+            expect(ctx.queries.checkProjectAccess).toBeDefined();
+            expect(ctx.queries.markProjectAsSaved).toBeDefined();
+        });
+
+        it('should allow partial Yjs query overrides', () => {
+            const mockSaveFullState = async () => {};
+            const ctx = createCollaborationContext({
+                yjsQueries: { saveFullState: mockSaveFullState },
+            });
+
+            expect(ctx.yjsQueries.saveFullState).toBe(mockSaveFullState);
+            // Other queries should still have defaults
+            expect(ctx.yjsQueries.loadDocumentState).toBeDefined();
+        });
+
+        it('should allow cleanupDelayOverride', () => {
+            const ctx = createCollaborationContext({ cleanupDelayOverride: 100 });
+
+            expect(ctx.cleanupDelayOverride).toBe(100);
+        });
+
+        it('should allow partial pubSub overrides', () => {
+            const mockIsPubSubEnabled = () => true;
+            const ctx = createCollaborationContext({
+                pubSub: { isPubSubEnabled: mockIsPubSubEnabled },
+            });
+
+            expect(ctx.pubSub.isPubSubEnabled).toBe(mockIsPubSubEnabled);
+            // Other pubSub methods should still have defaults
+            expect(ctx.pubSub.publish).toBeDefined();
+        });
+    });
+
+    describe('createTestCollaborationContext', () => {
+        it('should create context with silent logger', () => {
+            const ctx = createTestCollaborationContext();
+
+            expect(ctx.logger).toBe(silentLogger);
+        });
+
+        it('should set cleanupDelayOverride to 0', () => {
+            const ctx = createTestCollaborationContext();
+
+            expect(ctx.cleanupDelayOverride).toBe(0);
+        });
+
+        it('should allow additional overrides', async () => {
+            const testDb = await createTestDb();
+            try {
+                const ctx = createTestCollaborationContext({ db: testDb });
+
+                expect(ctx.db).toBe(testDb);
+                expect(ctx.logger).toBe(silentLogger);
+                expect(ctx.cleanupDelayOverride).toBe(0);
+            } finally {
+                await destroyTestDb(testDb);
+            }
+        });
+    });
+
+    describe('createMockPubSub', () => {
+        it('should create mock pub/sub service', () => {
+            const mockPubSub = createMockPubSub();
+
+            expect(mockPubSub.isPubSubEnabled()).toBe(false);
+            expect(typeof mockPubSub.publish).toBe('function');
+            expect(typeof mockPubSub.subscribe).toBe('function');
+            expect(typeof mockPubSub.unsubscribe).toBe('function');
+            expect(typeof mockPubSub.setMessageHandler).toBe('function');
+        });
+
+        it('should have no-op implementations', async () => {
+            const mockPubSub = createMockPubSub();
+
+            // These should not throw
+            await mockPubSub.publish('test', Buffer.from('test'));
+            await mockPubSub.subscribe('test');
+            await mockPubSub.unsubscribe('test');
+            mockPubSub.setMessageHandler(() => {});
+        });
+    });
+
+    describe('createMockPriorityQueue', () => {
+        it('should create mock priority queue service', () => {
+            const mockQueue = createMockPriorityQueue();
+
+            expect(typeof mockQueue.registerRequest).toBe('function');
+            expect(typeof mockQueue.registerActiveSlot).toBe('function');
+            expect(typeof mockQueue.releaseSlot).toBe('function');
+            expect(typeof mockQueue.clearProject).toBe('function');
+            expect(typeof mockQueue.shouldPreempt).toBe('function');
+            expect(typeof mockQueue.getStats).toBe('function');
+            expect(typeof mockQueue.peekNextUpload).toBe('function');
+        });
+
+        it('should return safe defaults', () => {
+            const mockQueue = createMockPriorityQueue();
+
+            expect(mockQueue.shouldPreempt('test')).toEqual({
+                shouldPreempt: false,
+                reason: 'mock',
+            });
+            expect(mockQueue.getStats('test')).toEqual({
+                pending: [],
+                active: [],
+                pendingCount: 0,
+                activeCount: 0,
+            });
+            expect(mockQueue.peekNextUpload('test')).toBeNull();
+        });
+
+        it('should have no-op implementations for mutations', () => {
+            const mockQueue = createMockPriorityQueue();
+
+            // These should not throw
+            mockQueue.registerRequest({
+                assetId: 'test',
+                clientId: 'client',
+                projectId: 'project',
+                priority: 1,
+                reason: 'test',
+            });
+            mockQueue.registerActiveSlot({
+                assetId: 'test',
+                clientId: 'client',
+                projectId: 'project',
+                priority: 1,
+            });
+            mockQueue.releaseSlot('project', 'test');
+            mockQueue.clearProject('project');
+        });
+    });
+
+    describe('configureAllModules / resetAllModules', () => {
+        afterEach(() => {
+            resetAllModules();
+        });
+
+        it('should configure all modules without error', () => {
+            const ctx = createTestCollaborationContext();
+
+            // Should not throw
+            expect(() => configureAllModules(ctx)).not.toThrow();
+        });
+
+        it('should reset all modules without error', () => {
+            const ctx = createTestCollaborationContext();
+            configureAllModules(ctx);
+
+            // Should not throw
+            expect(() => resetAllModules()).not.toThrow();
+        });
+    });
+
+    describe('getCollaborationContext / resetCollaborationContext', () => {
+        afterEach(() => {
+            resetCollaborationContext();
+        });
+
+        it('should return singleton context', () => {
+            const ctx1 = getCollaborationContext();
+            const ctx2 = getCollaborationContext();
+
+            expect(ctx1).toBe(ctx2);
+        });
+
+        it('should create new context after reset', () => {
+            const ctx1 = getCollaborationContext();
+            resetCollaborationContext();
+            const ctx2 = getCollaborationContext();
+
+            expect(ctx1).not.toBe(ctx2);
+        });
+    });
+
+    describe('Query interface completeness', () => {
+        it('should have all common queries', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.queries.findProjectByUuid).toBeDefined();
+            expect(ctx.queries.checkProjectAccess).toBeDefined();
+            expect(ctx.queries.markProjectAsSaved).toBeDefined();
+            expect(ctx.queries.findAssetByClientId).toBeDefined();
+        });
+
+        it('should have all Yjs persistence queries', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.yjsQueries.saveFullState).toBeDefined();
+            expect(ctx.yjsQueries.loadDocumentState).toBeDefined();
+            expect(ctx.yjsQueries.findUpdatesByProjectId).toBeDefined();
+            expect(ctx.yjsQueries.findUpdatesSince).toBeDefined();
+            expect(ctx.yjsQueries.deleteAllUpdates).toBeDefined();
+            expect(ctx.yjsQueries.deleteUpdatesBefore).toBeDefined();
+            expect(ctx.yjsQueries.countUpdates).toBeDefined();
+            expect(ctx.yjsQueries.getLatestVersion).toBeDefined();
+            expect(ctx.yjsQueries.getAllUpdateBuffers).toBeDefined();
+            expect(ctx.yjsQueries.documentExists).toBeDefined();
+            expect(ctx.yjsQueries.saveIncrementalUpdate).toBeDefined();
+            expect(ctx.yjsQueries.loadDocumentWithUpdates).toBeDefined();
+            expect(ctx.yjsQueries.upsertSnapshot).toBeDefined();
+            expect(ctx.yjsQueries.deleteUpdatesUpToVersion).toBeDefined();
+            expect(ctx.yjsQueries.findSnapshotByProjectId).toBeDefined();
+        });
+    });
+
+    describe('Service interface completeness', () => {
+        it('should have auth service', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.auth.verifyToken).toBeDefined();
+        });
+
+        it('should have session manager service', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.sessionManager.getSession).toBeDefined();
+        });
+
+        it('should have priority queue service', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.priorityQueue.registerRequest).toBeDefined();
+            expect(ctx.priorityQueue.registerActiveSlot).toBeDefined();
+            expect(ctx.priorityQueue.releaseSlot).toBeDefined();
+            expect(ctx.priorityQueue.clearProject).toBeDefined();
+            expect(ctx.priorityQueue.shouldPreempt).toBeDefined();
+            expect(ctx.priorityQueue.getStats).toBeDefined();
+            expect(ctx.priorityQueue.peekNextUpload).toBeDefined();
+        });
+
+        it('should have pub/sub service', () => {
+            const ctx = createCollaborationContext();
+
+            expect(ctx.pubSub.publish).toBeDefined();
+            expect(ctx.pubSub.subscribe).toBeDefined();
+            expect(ctx.pubSub.unsubscribe).toBeDefined();
+            expect(ctx.pubSub.isPubSubEnabled).toBeDefined();
+            expect(ctx.pubSub.setMessageHandler).toBeDefined();
+        });
+    });
+
+    describe('Integration with test database', () => {
+        let testDb: Kysely<Database>;
+
+        beforeEach(async () => {
+            testDb = await createTestDb();
+        });
+
+        afterEach(async () => {
+            resetAllModules();
+            await destroyTestDb(testDb);
+        });
+
+        it('should work with real test database', async () => {
+            const ctx = createTestCollaborationContext({ db: testDb });
+
+            expect(ctx.db).toBe(testDb);
+
+            // Configure modules with the test context
+            configureAllModules(ctx);
+
+            // Modules should now use the test database
+            // (actual functionality tested in individual module tests)
+        });
+
+        it('should allow using CapturingLogger for assertions', () => {
+            const capturingLogger = new CapturingLogger();
+            const ctx = createCollaborationContext({ logger: capturingLogger });
+
+            expect(ctx.logger).toBe(capturingLogger);
+
+            // Can use capturing logger to verify log calls
+            capturingLogger.info('test message', { key: 'value' });
+            expect(capturingLogger.logs).toHaveLength(1);
+            expect(capturingLogger.logs[0]).toMatchObject({
+                level: 'info',
+                message: 'test message',
+            });
+        });
+    });
+});

--- a/src/websocket/collaboration.context.ts
+++ b/src/websocket/collaboration.context.ts
@@ -1,0 +1,452 @@
+/**
+ * Collaboration Context for WebSocket Subsystem
+ *
+ * Provides a unified dependency container for all WebSocket-related modules:
+ * - room-manager.ts
+ * - asset-coordinator.ts
+ * - yjs-persistence.ts
+ * - yjs-websocket.ts
+ *
+ * Benefits:
+ * - Single point of configuration for testing
+ * - Shared dependencies (db, logger, queries) in one place
+ * - Easier reasoning about module interactions
+ * - Simplified mock setup for tests
+ *
+ * Usage:
+ * ```typescript
+ * // Production: modules use defaults
+ * import * as roomManager from './room-manager';
+ *
+ * // Testing: configure all modules at once
+ * import { createCollaborationContext, configureAllModules } from './collaboration.context';
+ *
+ * const ctx = createCollaborationContext({
+ *     db: testDb,
+ *     logger: silentLogger,
+ *     queries: { findProjectByUuid: mockFindProject },
+ * });
+ * configureAllModules(ctx);
+ * ```
+ */
+import type { Kysely } from 'kysely';
+import type { Database, Project, Asset } from '../db/types';
+import type { LoggerContext } from '../contexts/logger.context';
+import { getLogger, silentLogger } from '../contexts/logger.context';
+import { db as defaultDb } from '../db/client';
+
+// Import default query implementations
+import {
+    findProjectByUuid as defaultFindProjectByUuid,
+    checkProjectAccess as defaultCheckProjectAccess,
+    markProjectAsSaved as defaultMarkProjectAsSaved,
+    findAssetByClientId as defaultFindAssetByClientId,
+} from '../db/queries';
+
+// Import Yjs persistence queries
+import {
+    saveFullState as defaultSaveFullState,
+    loadDocumentState as defaultLoadDocumentState,
+    findUpdatesByProjectId as defaultFindUpdatesByProjectId,
+    findUpdatesSince as defaultFindUpdatesSince,
+    deleteAllUpdates as defaultDeleteAllUpdates,
+    deleteUpdatesBefore as defaultDeleteUpdatesBefore,
+    countUpdates as defaultCountUpdates,
+    getLatestVersion as defaultGetLatestVersion,
+    getAllUpdateBuffers as defaultGetAllUpdateBuffers,
+    documentExists as defaultDocumentExists,
+    saveIncrementalUpdate as defaultSaveIncrementalUpdate,
+    loadDocumentWithUpdates as defaultLoadDocumentWithUpdates,
+    upsertSnapshot as defaultUpsertSnapshot,
+    deleteUpdatesUpToVersion as defaultDeleteUpdatesUpToVersion,
+    findSnapshotByProjectId as defaultFindSnapshotByProjectId,
+} from '../db/queries';
+
+// Import service dependencies
+import { verifyToken as defaultVerifyToken } from '../routes/auth';
+import { getSession as defaultGetSession } from '../services/session-manager';
+import {
+    serverPriorityQueue as defaultPriorityQueue,
+    type PriorityQueueRequest,
+    type ActiveSlot,
+    type PreemptResult,
+    type QueueStats,
+} from '../services/asset-priority-queue';
+import * as defaultPubSub from '../redis/pubsub-manager';
+
+// ============================================================================
+// QUERY INTERFACES
+// ============================================================================
+
+/**
+ * Common queries shared across modules
+ */
+export interface CommonQueries {
+    findProjectByUuid: (db: Kysely<Database>, uuid: string) => Promise<Project | undefined>;
+    checkProjectAccess: (db: Kysely<Database>, projectId: number, userId: number) => Promise<boolean>;
+    markProjectAsSaved: (db: Kysely<Database>, projectId: number) => Promise<void>;
+    findAssetByClientId: (db: Kysely<Database>, clientId: string, projectId: number) => Promise<Asset | undefined>;
+}
+
+/**
+ * Yjs persistence queries
+ */
+export interface YjsPersistenceQueries {
+    saveFullState: typeof defaultSaveFullState;
+    loadDocumentState: typeof defaultLoadDocumentState;
+    findUpdatesByProjectId: typeof defaultFindUpdatesByProjectId;
+    findUpdatesSince: typeof defaultFindUpdatesSince;
+    deleteAllUpdates: typeof defaultDeleteAllUpdates;
+    deleteUpdatesBefore: typeof defaultDeleteUpdatesBefore;
+    countUpdates: typeof defaultCountUpdates;
+    getLatestVersion: typeof defaultGetLatestVersion;
+    getAllUpdateBuffers: typeof defaultGetAllUpdateBuffers;
+    documentExists: typeof defaultDocumentExists;
+    saveIncrementalUpdate: typeof defaultSaveIncrementalUpdate;
+    loadDocumentWithUpdates: typeof defaultLoadDocumentWithUpdates;
+    upsertSnapshot: typeof defaultUpsertSnapshot;
+    deleteUpdatesUpToVersion: typeof defaultDeleteUpdatesUpToVersion;
+    findSnapshotByProjectId: typeof defaultFindSnapshotByProjectId;
+}
+
+// ============================================================================
+// SERVICE INTERFACES
+// ============================================================================
+
+/**
+ * Auth service interface
+ */
+export interface AuthService {
+    verifyToken: typeof defaultVerifyToken;
+}
+
+/**
+ * Session manager interface
+ */
+export interface SessionManagerService {
+    getSession: typeof defaultGetSession;
+}
+
+/**
+ * Priority queue interface
+ */
+export interface PriorityQueueService {
+    registerRequest: (request: PriorityQueueRequest) => void;
+    registerActiveSlot: (slot: ActiveSlot) => void;
+    releaseSlot: (projectId: string, assetId: string) => void;
+    clearProject: (projectId: string) => void;
+    shouldPreempt: (projectId: string) => PreemptResult;
+    getStats: (projectId: string) => QueueStats;
+    peekNextUpload: (projectId: string) => PriorityQueueRequest | null;
+}
+
+/**
+ * Pub/sub manager interface
+ */
+export interface PubSubService {
+    publish: typeof defaultPubSub.publish;
+    subscribe: typeof defaultPubSub.subscribe;
+    unsubscribe: typeof defaultPubSub.unsubscribe;
+    isPubSubEnabled: typeof defaultPubSub.isPubSubEnabled;
+    setMessageHandler: typeof defaultPubSub.setMessageHandler;
+}
+
+// ============================================================================
+// COLLABORATION CONTEXT
+// ============================================================================
+
+/**
+ * Full collaboration context with all dependencies
+ */
+export interface CollaborationContext {
+    // Core infrastructure
+    readonly db: Kysely<Database>;
+    readonly logger: LoggerContext;
+
+    // Queries
+    readonly queries: CommonQueries;
+    readonly yjsQueries: YjsPersistenceQueries;
+
+    // Services
+    readonly auth: AuthService;
+    readonly sessionManager: SessionManagerService;
+    readonly priorityQueue: PriorityQueueService;
+    readonly pubSub: PubSubService;
+
+    // Configuration overrides (for testing)
+    readonly cleanupDelayOverride?: number;
+}
+
+/**
+ * Options for creating a collaboration context
+ */
+export interface CollaborationContextOptions {
+    db?: Kysely<Database>;
+    logger?: LoggerContext;
+    queries?: Partial<CommonQueries>;
+    yjsQueries?: Partial<YjsPersistenceQueries>;
+    auth?: Partial<AuthService>;
+    sessionManager?: Partial<SessionManagerService>;
+    priorityQueue?: Partial<PriorityQueueService>;
+    pubSub?: Partial<PubSubService>;
+    cleanupDelayOverride?: number;
+}
+
+// ============================================================================
+// DEFAULT VALUES
+// ============================================================================
+
+const defaultCommonQueries: CommonQueries = {
+    findProjectByUuid: defaultFindProjectByUuid,
+    checkProjectAccess: defaultCheckProjectAccess,
+    markProjectAsSaved: defaultMarkProjectAsSaved,
+    findAssetByClientId: defaultFindAssetByClientId,
+};
+
+const defaultYjsQueries: YjsPersistenceQueries = {
+    saveFullState: defaultSaveFullState,
+    loadDocumentState: defaultLoadDocumentState,
+    findUpdatesByProjectId: defaultFindUpdatesByProjectId,
+    findUpdatesSince: defaultFindUpdatesSince,
+    deleteAllUpdates: defaultDeleteAllUpdates,
+    deleteUpdatesBefore: defaultDeleteUpdatesBefore,
+    countUpdates: defaultCountUpdates,
+    getLatestVersion: defaultGetLatestVersion,
+    getAllUpdateBuffers: defaultGetAllUpdateBuffers,
+    documentExists: defaultDocumentExists,
+    saveIncrementalUpdate: defaultSaveIncrementalUpdate,
+    loadDocumentWithUpdates: defaultLoadDocumentWithUpdates,
+    upsertSnapshot: defaultUpsertSnapshot,
+    deleteUpdatesUpToVersion: defaultDeleteUpdatesUpToVersion,
+    findSnapshotByProjectId: defaultFindSnapshotByProjectId,
+};
+
+const defaultAuthService: AuthService = {
+    verifyToken: defaultVerifyToken,
+};
+
+const defaultSessionManagerService: SessionManagerService = {
+    getSession: defaultGetSession,
+};
+
+const defaultPriorityQueueService: PriorityQueueService = {
+    registerRequest: defaultPriorityQueue.registerRequest,
+    registerActiveSlot: defaultPriorityQueue.registerActiveSlot,
+    releaseSlot: defaultPriorityQueue.releaseSlot,
+    clearProject: defaultPriorityQueue.clearProject,
+    shouldPreempt: defaultPriorityQueue.shouldPreempt,
+    getStats: defaultPriorityQueue.getStats,
+    peekNextUpload: defaultPriorityQueue.peekNextUpload,
+};
+
+const defaultPubSubService: PubSubService = {
+    publish: defaultPubSub.publish,
+    subscribe: defaultPubSub.subscribe,
+    unsubscribe: defaultPubSub.unsubscribe,
+    isPubSubEnabled: defaultPubSub.isPubSubEnabled,
+    setMessageHandler: defaultPubSub.setMessageHandler,
+};
+
+// ============================================================================
+// FACTORY FUNCTION
+// ============================================================================
+
+/**
+ * Create a collaboration context with optional overrides
+ *
+ * @param options - Optional overrides for dependencies
+ * @returns Frozen collaboration context
+ *
+ * @example
+ * ```typescript
+ * // Production: use defaults
+ * const ctx = createCollaborationContext();
+ *
+ * // Testing: override specific dependencies
+ * const ctx = createCollaborationContext({
+ *     db: testDb,
+ *     logger: silentLogger,
+ *     queries: { findProjectByUuid: mockFindProject },
+ *     cleanupDelayOverride: 0, // Immediate cleanup in tests
+ * });
+ * ```
+ */
+export function createCollaborationContext(options: CollaborationContextOptions = {}): CollaborationContext {
+    const context: CollaborationContext = {
+        db: options.db ?? defaultDb,
+        logger: options.logger ?? getLogger(),
+
+        queries: {
+            ...defaultCommonQueries,
+            ...options.queries,
+        },
+
+        yjsQueries: {
+            ...defaultYjsQueries,
+            ...options.yjsQueries,
+        },
+
+        auth: {
+            ...defaultAuthService,
+            ...options.auth,
+        },
+
+        sessionManager: {
+            ...defaultSessionManagerService,
+            ...options.sessionManager,
+        },
+
+        priorityQueue: {
+            ...defaultPriorityQueueService,
+            ...options.priorityQueue,
+        },
+
+        pubSub: {
+            ...defaultPubSubService,
+            ...options.pubSub,
+        },
+
+        cleanupDelayOverride: options.cleanupDelayOverride,
+    };
+
+    return Object.freeze(context);
+}
+
+// ============================================================================
+// TEST UTILITIES
+// ============================================================================
+
+/**
+ * Create a collaboration context with silent logger and common test defaults
+ *
+ * @param options - Additional overrides
+ * @returns Test-friendly collaboration context
+ */
+export function createTestCollaborationContext(options: CollaborationContextOptions = {}): CollaborationContext {
+    return createCollaborationContext({
+        logger: silentLogger,
+        cleanupDelayOverride: 0, // Immediate cleanup in tests
+        ...options,
+    });
+}
+
+/**
+ * Create mock pub/sub service that does nothing
+ * Useful for tests that don't need Redis functionality
+ */
+export function createMockPubSub(): PubSubService {
+    return {
+        publish: async () => {},
+        subscribe: async () => {},
+        unsubscribe: async () => {},
+        isPubSubEnabled: () => false,
+        setMessageHandler: () => {},
+    };
+}
+
+/**
+ * Create mock priority queue service
+ * Useful for tests that don't need actual priority queue
+ */
+export function createMockPriorityQueue(): PriorityQueueService {
+    return {
+        registerRequest: () => {},
+        registerActiveSlot: () => {},
+        releaseSlot: () => {},
+        clearProject: () => {},
+        shouldPreempt: () => ({ shouldPreempt: false, reason: 'mock' }),
+        getStats: () => ({
+            pending: [],
+            active: [],
+            pendingCount: 0,
+            activeCount: 0,
+        }),
+        peekNextUpload: () => null,
+    };
+}
+
+// ============================================================================
+// MODULE CONFIGURATION HELPERS
+// ============================================================================
+
+// Import configure functions (avoid circular deps by importing types only at top)
+import { configure as configureRoomManager, resetDependencies as resetRoomManager } from './room-manager';
+import { configure as configureYjsPersistence, resetDependencies as resetYjsPersistence } from './yjs-persistence';
+import { configure as configureYjsWebSocket, resetDependencies as resetYjsWebSocket } from './yjs-websocket';
+
+/**
+ * Configure all WebSocket modules with a collaboration context
+ *
+ * @param ctx - The collaboration context to use
+ *
+ * @example
+ * ```typescript
+ * const ctx = createTestCollaborationContext({ db: testDb });
+ * configureAllModules(ctx);
+ *
+ * // Now all modules use the test context
+ * // Run your tests...
+ *
+ * // Clean up
+ * resetAllModules();
+ * ```
+ */
+export function configureAllModules(ctx: CollaborationContext): void {
+    // Configure room manager
+    configureRoomManager({
+        pubSub: ctx.pubSub,
+        cleanupDelayOverride: ctx.cleanupDelayOverride,
+    });
+
+    // Configure Yjs persistence
+    configureYjsPersistence({
+        db: ctx.db,
+        queries: ctx.yjsQueries,
+    });
+
+    // Configure Yjs WebSocket
+    configureYjsWebSocket({
+        db: ctx.db,
+        queries: {
+            findProjectByUuid: ctx.queries.findProjectByUuid,
+            checkProjectAccess: ctx.queries.checkProjectAccess,
+            markProjectAsSaved: ctx.queries.markProjectAsSaved,
+        },
+        sessionManager: ctx.sessionManager,
+        auth: ctx.auth,
+    });
+}
+
+/**
+ * Reset all WebSocket modules to default dependencies
+ * Call this in afterEach() to prevent test pollution
+ */
+export function resetAllModules(): void {
+    resetRoomManager();
+    resetYjsPersistence();
+    resetYjsWebSocket();
+}
+
+// ============================================================================
+// DEFAULT CONTEXT SINGLETON
+// ============================================================================
+
+let _defaultContext: CollaborationContext | null = null;
+
+/**
+ * Get the default collaboration context (singleton)
+ * Creates one on first access with production defaults
+ */
+export function getCollaborationContext(): CollaborationContext {
+    if (!_defaultContext) {
+        _defaultContext = createCollaborationContext();
+    }
+    return _defaultContext;
+}
+
+/**
+ * Reset the default context (for testing)
+ */
+export function resetCollaborationContext(): void {
+    _defaultContext = null;
+}

--- a/src/websocket/heartbeat.ts
+++ b/src/websocket/heartbeat.ts
@@ -9,6 +9,10 @@
  */
 import type { ServerWebSocket } from 'bun';
 import { getConfig, isDebugEnabled } from './config';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for heartbeat module
+const logger = getLogger().child({ component: 'heartbeat' });
 
 /**
  * WebSocket data interface (must match yjs-websocket.ts)
@@ -64,7 +68,7 @@ export function startHeartbeat(clientId: string, ws: ServerWebSocket<WsData>): v
         const timeSinceLastPong = Date.now() - state.lastPong;
         if (timeSinceLastPong > config.pingInterval + config.pongTimeout) {
             if (isDebugEnabled()) {
-                console.log(`[Heartbeat] Client ${clientId} timed out (${timeSinceLastPong}ms since last pong)`);
+                logger.debug('Client timed out', { clientId, timeSinceLastPong });
             }
             ws.close(4008, 'Heartbeat timeout');
             stopHeartbeat(clientId);
@@ -75,11 +79,11 @@ export function startHeartbeat(clientId: string, ws: ServerWebSocket<WsData>): v
         try {
             ws.ping();
             if (isDebugEnabled()) {
-                console.log(`[Heartbeat] Sent ping to ${clientId}`);
+                logger.debug('Sent ping', { clientId });
             }
         } catch (err) {
             if (isDebugEnabled()) {
-                console.error(`[Heartbeat] Failed to send ping to ${clientId}:`, err);
+                logger.error('Failed to send ping', err instanceof Error ? err : null, { clientId });
             }
             // Connection likely closed, cleanup will happen via close handler
         }
@@ -93,7 +97,7 @@ export function startHeartbeat(clientId: string, ws: ServerWebSocket<WsData>): v
     });
 
     if (isDebugEnabled()) {
-        console.log(`[Heartbeat] Started for ${clientId} (interval: ${config.pingInterval}ms)`);
+        logger.debug('Started', { clientId, interval: config.pingInterval });
     }
 }
 
@@ -108,7 +112,7 @@ export function onPong(clientId: string): void {
     if (state) {
         state.lastPong = Date.now();
         if (isDebugEnabled()) {
-            console.log(`[Heartbeat] Received pong from ${clientId}`);
+            logger.debug('Received pong', { clientId });
         }
     }
 }
@@ -130,7 +134,7 @@ export function stopHeartbeat(clientId: string): void {
         heartbeats.delete(clientId);
 
         if (isDebugEnabled()) {
-            console.log(`[Heartbeat] Stopped for ${clientId}`);
+            logger.debug('Stopped', { clientId });
         }
     }
 }
@@ -153,6 +157,6 @@ export function stopAllHeartbeats(): void {
         stopHeartbeat(clientId);
     }
     if (isDebugEnabled()) {
-        console.log('[Heartbeat] Stopped all heartbeats');
+        logger.debug('Stopped all heartbeats');
     }
 }

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -11,6 +11,20 @@ export * as yjsWebSocket from './yjs-websocket';
 export * as yjsPersistence from './yjs-persistence';
 export * as assetCoordinator from './asset-coordinator';
 
+// Context
+export {
+    createCollaborationContext,
+    createTestCollaborationContext,
+    createMockPubSub,
+    createMockPriorityQueue,
+    configureAllModules,
+    resetAllModules,
+    getCollaborationContext,
+    resetCollaborationContext,
+    type CollaborationContext,
+    type CollaborationContextOptions,
+} from './collaboration.context';
+
 // Convenience re-exports
 export {
     createWebSocketRoutes,

--- a/src/websocket/message-parser.ts
+++ b/src/websocket/message-parser.ts
@@ -9,6 +9,10 @@
  */
 import type { AssetMessage, AssetMessageType } from './types';
 import { DEBUG } from './config';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for message parser
+const logger = getLogger().child({ component: 'message-parser' });
 
 /**
  * All valid asset message types
@@ -84,7 +88,7 @@ function parseJsonString(message: string): ParsedMessage {
 
         // Valid JSON but not an asset message
         if (DEBUG) {
-            console.log(`[MessageParser] Unknown JSON message type: ${parsed.type}`);
+            logger.debug('Unknown JSON message type', { type: parsed.type });
         }
         return { kind: 'unknown', raw: message };
     } catch {
@@ -126,13 +130,13 @@ function parseBuffer(message: Buffer): ParsedMessage {
 
             // Valid JSON but not asset message - treat as unknown
             if (DEBUG) {
-                console.log(`[MessageParser] Unknown JSON message type in 0xFF message: ${parsed.type}`);
+                logger.debug('Unknown JSON message type in 0xFF message', { type: parsed.type });
             }
             return { kind: 'unknown', raw: message };
         } catch {
             // Not valid JSON after 0xFF prefix - treat as unknown
             if (DEBUG) {
-                console.log('[MessageParser] Invalid JSON after 0xFF prefix');
+                logger.debug('Invalid JSON after 0xFF prefix');
             }
             return { kind: 'unknown', raw: message };
         }
@@ -153,7 +157,7 @@ function parseBuffer(message: Buffer): ParsedMessage {
             }
 
             if (DEBUG) {
-                console.log(`[MessageParser] Unknown JSON message type in buffer: ${parsed.type}`);
+                logger.debug('Unknown JSON message type in buffer', { type: parsed.type });
             }
             return { kind: 'unknown', raw: message };
         } catch {

--- a/src/websocket/room-manager.ts
+++ b/src/websocket/room-manager.ts
@@ -12,6 +12,10 @@ import type { ServerWebSocket } from 'bun';
 import { getConfig, DEBUG } from './config';
 import * as assetCoordinatorDefault from './asset-coordinator';
 import * as pubSubDefault from '../redis/pubsub-manager';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for room manager
+const logger = getLogger().child({ component: 'room-manager' });
 
 // ============================================================================
 // DEPENDENCY INJECTION INTERFACES
@@ -141,7 +145,7 @@ export function getOrCreateRoom(docName: string, projectUuid?: string): Room {
         rooms.set(docName, room);
 
         if (DEBUG) {
-            console.log(`[RoomManager] Created room: ${docName} (project: ${uuid})`);
+            logger.debug('Created room', { docName, projectUuid: uuid });
         }
     } else {
         // Cancel any pending cleanup since room is being accessed
@@ -172,12 +176,12 @@ export function addConnection(docName: string, ws: ServerWebSocket<WsData>, proj
     // Subscribe to Redis channel when first client joins
     if (wasEmpty && deps.pubSub.isPubSubEnabled()) {
         deps.pubSub.subscribe(docName).catch(err => {
-            console.error(`[RoomManager] Failed to subscribe to Redis channel ${docName}:`, err);
+            logger.error('Failed to subscribe to Redis channel', err instanceof Error ? err : null, { docName });
         });
     }
 
     if (DEBUG) {
-        console.log(`[RoomManager] Added connection to ${docName} (${room.conns.size} total)`);
+        logger.debug('Added connection', { docName, total: room.conns.size });
     }
 
     return room;
@@ -194,7 +198,7 @@ export function removeConnection(docName: string, ws: ServerWebSocket<WsData>): 
     room.conns.delete(ws);
 
     if (DEBUG) {
-        console.log(`[RoomManager] Removed connection from ${docName} (${room.conns.size} remaining)`);
+        logger.debug('Removed connection', { docName, remaining: room.conns.size });
     }
 
     // Schedule cleanup if empty
@@ -225,14 +229,14 @@ export function scheduleCleanup(docName: string): void {
     const cleanupDelay = deps.cleanupDelayOverride ?? config.cleanupDelay;
 
     if (DEBUG) {
-        console.log(`[RoomManager] Scheduled cleanup for ${docName} in ${cleanupDelay}ms`);
+        logger.debug('Scheduled cleanup', { docName, cleanupDelay });
     }
 
     setTimeout(() => {
         // Check if cleanup was aborted (client reconnected)
         if (controller.signal.aborted) {
             if (DEBUG) {
-                console.log(`[RoomManager] Cleanup cancelled for ${docName} (client reconnected)`);
+                logger.debug('Cleanup cancelled (client reconnected)', { docName });
             }
             return;
         }
@@ -247,7 +251,7 @@ export function scheduleCleanup(docName: string): void {
         rooms.delete(docName);
 
         if (DEBUG) {
-            console.log(`[RoomManager] Cleaned up room ${docName}`);
+            logger.debug('Cleaned up room', { docName });
         }
 
         // Unsubscribe from Redis channel
@@ -275,7 +279,7 @@ export function cancelCleanup(docName: string): void {
         room.cleanupController = undefined;
 
         if (DEBUG) {
-            console.log(`[RoomManager] Cancelled pending cleanup for ${docName}`);
+            logger.debug('Cancelled pending cleanup', { docName });
         }
     }
 }
@@ -294,7 +298,7 @@ export function relayMessage(sender: ServerWebSocket<WsData>, docName: string, m
                 conn.send(message);
             } catch (err) {
                 if (DEBUG) {
-                    console.error(`[RoomManager] Error relaying message:`, err);
+                    logger.error('Error relaying message', err instanceof Error ? err : null, { docName });
                 }
             }
         }
@@ -315,7 +319,7 @@ export function broadcastToRoom(docName: string, message: Buffer | string): void
                 conn.send(message);
             } catch (err) {
                 if (DEBUG) {
-                    console.error(`[RoomManager] Error broadcasting:`, err);
+                    logger.error('Error broadcasting', err instanceof Error ? err : null, { docName });
                 }
             }
         }
@@ -418,7 +422,7 @@ export function closeAllRooms(): void {
     rooms.clear();
 
     if (DEBUG) {
-        console.log('[RoomManager] Closed all rooms');
+        logger.debug('Closed all rooms');
     }
 }
 
@@ -460,9 +464,9 @@ export function initializeCrossInstanceHandler(): void {
         broadcastToRoom(docName, message);
 
         if (DEBUG) {
-            console.log(`[RoomManager] Received cross-instance message for ${docName} (isAsset: ${meta.isAsset})`);
+            logger.debug('Received cross-instance message', { docName, isAsset: meta.isAsset });
         }
     });
 
-    console.log('[RoomManager] Cross-instance handler initialized');
+    logger.info('Cross-instance handler initialized');
 }

--- a/src/websocket/yjs-persistence.ts
+++ b/src/websocket/yjs-persistence.ts
@@ -38,6 +38,10 @@ import { db as defaultDb } from '../db/client';
 import { getConfig, DEBUG } from './config';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/schema';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for Yjs persistence
+const logger = getLogger().child({ component: 'yjs-persistence' });
 
 // ============================================================================
 // DEPENDENCY INJECTION INTERFACES
@@ -143,11 +147,10 @@ export async function saveFullState(projectId: number, state: Uint8Array, client
         await deps.queries.saveFullState(deps.db, projectId, buffer, clientId);
 
         if (DEBUG) {
-            console.log(`[YjsPersistence] Saved full state for project ${projectId} (${buffer.length} bytes)`);
+            logger.debug('Saved full state', { projectId, bytes: buffer.length });
         }
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to save for project ${projectId}:`, errorMessage);
+        logger.error('Failed to save', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -174,15 +177,14 @@ export async function loadDocument(projectId: number): Promise<Uint8Array | null
         const state = await deps.queries.loadDocumentState(deps.db, projectId);
 
         if (!state) {
-            if (DEBUG) console.log(`[YjsPersistence] No document found for project ${projectId}`);
+            if (DEBUG) logger.debug('No document found', { projectId });
             return null;
         }
 
-        if (DEBUG) console.log(`[YjsPersistence] Loaded project ${projectId}: ${state.length} bytes`);
+        if (DEBUG) logger.debug('Loaded project', { projectId, bytes: state.length });
         return state;
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to load project ${projectId}:`, errorMessage);
+        logger.error('Failed to load project', error instanceof Error ? error : null, { projectId });
         return null;
     }
 }
@@ -199,15 +201,12 @@ export async function loadUpdatesSince(projectId: number, sinceVersion: string =
         const updates = await deps.queries.findUpdatesSince(deps.db, projectId, sinceVersion);
 
         if (DEBUG) {
-            console.log(
-                `[YjsPersistence] Loaded ${updates.length} updates for project ${projectId} since v${sinceVersion}`,
-            );
+            logger.debug('Loaded updates', { projectId, count: updates.length, sinceVersion });
         }
 
         return updates.map(update => new Uint8Array(update.update_data));
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to load updates for project ${projectId}:`, errorMessage);
+        logger.error('Failed to load updates', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -239,7 +238,7 @@ export async function reconstructDocument(projectId: number): Promise<Y.Doc> {
 
     if (state) {
         Y.applyUpdate(ydoc, state);
-        if (DEBUG) console.log(`[YjsPersistence] Reconstructed Y.Doc for project ${projectId}`);
+        if (DEBUG) logger.debug('Reconstructed Y.Doc', { projectId });
     }
 
     return ydoc;
@@ -255,11 +254,10 @@ export async function deleteAllUpdates(projectId: number): Promise<number> {
     try {
         await deps.queries.deleteAllUpdates(deps.db, projectId);
         const deletedCount = 1; // Kysely doesn't return changes count easily
-        if (DEBUG) console.log(`[YjsPersistence] Deleted updates for project ${projectId}`);
+        if (DEBUG) logger.debug('Deleted updates', { projectId });
         return deletedCount;
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to delete for project ${projectId}:`, errorMessage);
+        logger.error('Failed to delete updates', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -283,13 +281,12 @@ export async function pruneUpdatesBefore(projectId: number, beforeVersion: strin
         await deps.queries.deleteUpdatesBefore(deps.db, projectId, beforeVersion);
 
         if (DEBUG) {
-            console.log(`[YjsPersistence] Pruned updates for project ${projectId} before v${beforeVersion}`);
+            logger.debug('Pruned updates', { projectId, beforeVersion });
         }
 
         return 1; // Kysely doesn't return changes count easily
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to prune for project ${projectId}:`, errorMessage);
+        logger.error('Failed to prune', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -302,7 +299,7 @@ export async function saveFullStateByUuid(projectUuid: string, state: Uint8Array
     const project = await deps.queries.findProjectByUuid(deps.db, projectUuid);
 
     if (!project) {
-        console.error(`[YjsPersistence] Project not found: ${projectUuid}`);
+        logger.warn('Project not found', { projectUuid });
         return false;
     }
 
@@ -324,7 +321,7 @@ export async function loadDocumentByUuid(projectUuid: string): Promise<Uint8Arra
     const project = await deps.queries.findProjectByUuid(deps.db, projectUuid);
 
     if (!project) {
-        console.error(`[YjsPersistence] Project not found: ${projectUuid}`);
+        logger.warn('Project not found', { projectUuid });
         return null;
     }
 
@@ -380,17 +377,18 @@ export async function saveIncrementalUpdate(
         );
 
         if (DEBUG) {
-            console.log(
-                `[YjsPersistence] Saved incremental update for project ${projectId} ` +
-                    `(${update.length} bytes, ${result.stats.count} total updates)`,
-            );
+            logger.debug('Saved incremental update', {
+                projectId,
+                bytes: update.length,
+                totalUpdates: result.stats.count,
+            });
         }
 
         // If compaction is needed, do it now
         if (result.compacted) {
             await compactToSnapshot(projectId);
             if (DEBUG) {
-                console.log(`[YjsPersistence] Compacted project ${projectId} to snapshot`);
+                logger.debug('Compacted to snapshot', { projectId });
             }
         }
 
@@ -400,8 +398,7 @@ export async function saveIncrementalUpdate(
             bytesStored: update.length,
         };
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to save incremental update for project ${projectId}:`, errorMessage);
+        logger.error('Failed to save incremental update', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -417,7 +414,7 @@ export async function saveIncrementalUpdateByUuid(
     const project = await deps.queries.findProjectByUuid(deps.db, projectUuid);
 
     if (!project) {
-        console.error(`[YjsPersistence] Project not found: ${projectUuid}`);
+        logger.warn('Project not found', { projectUuid });
         return null;
     }
 
@@ -444,7 +441,7 @@ export async function compactToSnapshot(projectId: number): Promise<void> {
         const { snapshot, updates } = await deps.queries.loadDocumentWithUpdates(deps.db, projectId);
 
         if (updates.length === 0 && !snapshot) {
-            if (DEBUG) console.log(`[YjsPersistence] Nothing to compact for project ${projectId}`);
+            if (DEBUG) logger.debug('Nothing to compact', { projectId });
             return;
         }
 
@@ -478,14 +475,14 @@ export async function compactToSnapshot(projectId: number): Promise<void> {
         doc.destroy();
 
         if (DEBUG) {
-            console.log(
-                `[YjsPersistence] Compacted ${updates.length} updates into snapshot ` +
-                    `for project ${projectId} (${fullState.length} bytes)`,
-            );
+            logger.debug('Compacted updates into snapshot', {
+                projectId,
+                updatesCount: updates.length,
+                bytes: fullState.length,
+            });
         }
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to compact project ${projectId}:`, errorMessage);
+        logger.error('Failed to compact', error instanceof Error ? error : null, { projectId });
         throw error;
     }
 }
@@ -503,17 +500,14 @@ export async function loadDocumentEfficient(projectId: number): Promise<Uint8Arr
 
         // No data at all
         if (!snapshot && updates.length === 0) {
-            if (DEBUG) console.log(`[YjsPersistence] No document found for project ${projectId}`);
+            if (DEBUG) logger.debug('No document found', { projectId });
             return null;
         }
 
         // Only snapshot, no updates - return directly
         if (snapshot && updates.length === 0) {
             if (DEBUG) {
-                console.log(
-                    `[YjsPersistence] Loaded project ${projectId} from snapshot ` +
-                        `(${snapshot.snapshot_data.length} bytes)`,
-                );
+                logger.debug('Loaded from snapshot', { projectId, bytes: snapshot.snapshot_data.length });
             }
             return new Uint8Array(snapshot.snapshot_data);
         }
@@ -533,16 +527,16 @@ export async function loadDocumentEfficient(projectId: number): Promise<Uint8Arr
         doc.destroy();
 
         if (DEBUG) {
-            console.log(
-                `[YjsPersistence] Loaded project ${projectId}: merged snapshot + ${updates.length} updates ` +
-                    `(${state.length} bytes)`,
-            );
+            logger.debug('Loaded merged snapshot + updates', {
+                projectId,
+                updatesCount: updates.length,
+                bytes: state.length,
+            });
         }
 
         return state;
     } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[YjsPersistence] Failed to load project ${projectId}:`, errorMessage);
+        logger.error('Failed to load project', error instanceof Error ? error : null, { projectId });
         return null;
     }
 }
@@ -554,7 +548,7 @@ export async function loadDocumentEfficientByUuid(projectUuid: string): Promise<
     const project = await deps.queries.findProjectByUuid(deps.db, projectUuid);
 
     if (!project) {
-        console.error(`[YjsPersistence] Project not found: ${projectUuid}`);
+        logger.warn('Project not found', { projectUuid });
         return null;
     }
 

--- a/src/websocket/yjs-websocket.ts
+++ b/src/websocket/yjs-websocket.ts
@@ -43,6 +43,10 @@ import { DEBUG } from './config';
 import { startHeartbeat, stopHeartbeat, onPong, stopAllHeartbeats, getHeartbeatStats } from './heartbeat';
 import * as roomManager from './room-manager';
 import { parseMessage } from './message-parser';
+import { getLogger } from '../contexts/logger.context';
+
+// Create logger for WebSocket module
+const logger = getLogger().child({ component: 'yjs-websocket' });
 
 // ============================================================================
 // DEPENDENCY INJECTION INTERFACES
@@ -201,7 +205,7 @@ export async function checkWebSocketProjectAccess(
     const session = deps.sessionManager.getSession(projectUuid);
     if (session) {
         // Session exists in memory - allow access
-        if (DEBUG) console.log(`[YjsWebSocket] Access granted via in-memory session: ${projectUuid}`);
+        if (DEBUG) logger.debug('Access granted via in-memory session', { projectUuid });
         return { hasAccess: true };
     }
 
@@ -210,8 +214,7 @@ export async function checkWebSocketProjectAccess(
 
     if (!project) {
         // Neither in session nor in database - deny access
-        if (DEBUG)
-            console.log(`[YjsWebSocket] Project ${projectUuid} not found in session or database, denying access`);
+        if (DEBUG) logger.debug('Project not found in session or database, denying access', { projectUuid });
         return { hasAccess: false, reason: 'Project not found' };
     }
 
@@ -231,7 +234,7 @@ export async function handleWebSocketOpen(
     // Extract project UUID from document name
     const projectUuid = roomManager.extractProjectUuid(docName);
     if (!projectUuid) {
-        console.error(`[YjsWebSocket] Invalid document name format: ${docName}`);
+        logger.warn('Invalid document name format', { docName });
         return {
             success: false,
             error: { code: 4000, reason: 'Invalid document name format. Expected: project-<uuid>' },
@@ -240,20 +243,20 @@ export async function handleWebSocketOpen(
 
     // Validate JWT token
     if (!token) {
-        console.error('[YjsWebSocket] Token required');
+        logger.warn('Token required');
         return { success: false, error: { code: 4001, reason: 'Token required' } };
     }
 
     const user = await deps.auth.verifyToken(token);
     if (!user) {
-        console.error('[YjsWebSocket] Invalid token');
+        logger.warn('Invalid token');
         return { success: false, error: { code: 4001, reason: 'Invalid token' } };
     }
 
     // Check project access
     const access = await checkWebSocketProjectAccess(projectUuid, user.sub);
     if (!access.hasAccess) {
-        console.error(`[YjsWebSocket] Access denied: ${access.reason}`);
+        logger.warn('Access denied', { projectUuid, reason: access.reason });
         return { success: false, error: { code: 4003, reason: access.reason || 'Access denied' } };
     }
 
@@ -285,11 +288,11 @@ export async function handleWebSocketOpen(
     deps.assetCoordinator.registerClient(projectUuid, clientId, ws as unknown as WsWebSocket);
 
     const clientCount = room.conns.size;
-    console.log(`[YjsWebSocket] Client ${clientId} (user ${userId}) connected to ${docName} (${clientCount} total)`);
+    logger.info('Client connected', { clientId, userId, docName, clientCount });
 
     // Detect collaboration and trigger asset prefetch
     if (clientCount > 1) {
-        console.log(`[YjsWebSocket] Collaboration detected in ${projectUuid}`);
+        logger.info('Collaboration detected', { projectUuid });
 
         // Auto-save unsaved projects when collaboration starts
         // This ensures documents aren't lost when multiple users work together
@@ -297,9 +300,7 @@ export async function handleWebSocketOpen(
             try {
                 const project = await deps.queries.findProjectByUuid(deps.db, projectUuid);
                 if (project && !project.saved_once) {
-                    console.log(
-                        `[YjsWebSocket] Project ${projectUuid} not saved yet, requesting sync from first client`,
-                    );
+                    logger.info('Project not saved yet, requesting sync from first client', { projectUuid });
 
                     // Find the first (oldest) client in the room to request state
                     const firstClient = Array.from(room.conns)[0];
@@ -311,16 +312,16 @@ export async function handleWebSocketOpen(
                             projectUuid,
                         });
                         firstClient.send(syncRequestMsg);
-                        console.log(`[YjsWebSocket] Sent request-sync-state to first client for ${projectUuid}`);
+                        logger.debug('Sent request-sync-state to first client', { projectUuid });
                     }
                 }
             } catch (err) {
-                console.error('[YjsWebSocket] Error checking project save status:', err);
+                logger.error('Error checking project save status', err instanceof Error ? err : null, { projectUuid });
             }
         })();
 
         deps.assetCoordinator.onCollaborationDetected(projectUuid).catch(err => {
-            console.error('[YjsWebSocket] Error in collaboration detection:', err);
+            logger.error('Error in collaboration detection', err instanceof Error ? err : null, { projectUuid });
         });
     }
 
@@ -352,7 +353,9 @@ export function handleWebSocketMessage(ws: ServerWebSocket<WsData>, data: WsData
         case 'asset':
             // Handle asset coordination message
             deps.assetCoordinator.handleMessage(data.projectUuid, data.clientId, parsed.message).catch(err => {
-                console.error('[YjsWebSocket] Error handling asset message:', err);
+                logger.error('Error handling asset message', err instanceof Error ? err : null, {
+                    clientId: data.clientId,
+                });
             });
 
             // Relay asset message to other instances via Redis
@@ -386,7 +389,7 @@ export function handleWebSocketMessage(ws: ServerWebSocket<WsData>, data: WsData
         case 'unknown':
             // Unknown message type - log and ignore
             if (DEBUG) {
-                console.log(`[YjsWebSocket] Unknown message type from ${data.clientId}`);
+                logger.debug('Unknown message type', { clientId: data.clientId });
             }
             break;
     }
@@ -414,9 +417,7 @@ export function handleWebSocketClose(ws: ServerWebSocket<WsData>, data: WsData |
 
     if (DEBUG) {
         const room = docName !== 'unknown' ? roomManager.getRoom(docName) : null;
-        console.log(
-            `[YjsWebSocket] Client ${clientId} disconnected from ${docName} ` + `(${room?.conns.size ?? 0} remaining)`,
-        );
+        logger.debug('Client disconnected', { clientId, docName, remaining: room?.conns.size ?? 0 });
     }
 
     // Unregister from asset coordinator
@@ -465,22 +466,24 @@ export function createWebSocketRoutes() {
  */
 export function initialize(_httpServer?: unknown): void {
     if (initialized) {
-        console.warn('[YjsWebSocket] Already initialized');
+        logger.warn('Already initialized');
         return;
     }
 
     initialized = true;
     const port = parseInt(process.env.ELYSIA_PORT || process.env.PORT || '3002', 10);
-    console.log(`[YjsWebSocket] WebSocket routes ready on port ${port}`);
-    console.log(`[YjsWebSocket] Connect to: ws://localhost:${port}/yjs/project-<uuid>?token=<jwt>`);
-    console.log('[YjsWebSocket] Mode: stateless-relay with heartbeat');
+    logger.info('WebSocket routes ready', {
+        port,
+        endpoint: `ws://localhost:${port}/yjs/project-<uuid>?token=<jwt>`,
+        mode: 'stateless-relay with heartbeat',
+    });
 }
 
 /**
  * Stop the WebSocket server
  */
 export function stop(): void {
-    console.log('[YjsWebSocket] Stopping server...');
+    logger.info('Stopping server');
 
     // Stop all heartbeats
     stopAllHeartbeats();
@@ -492,7 +495,7 @@ export function stop(): void {
     clientMetaMap.clear();
     initialized = false;
 
-    console.log('[YjsWebSocket] Server stopped');
+    logger.info('Server stopped');
 }
 
 /**


### PR DESCRIPTION
This pull request introduces an explicit **Context per Domain** dependency injection approach to improve maintainability, testability, and architectural clarity.

Until now, several cross-cutting concerns (configuration, logging, collaboration/WebSocket setup) were handled through implicit imports or ad-hoc initialization. This made dependencies harder to track, increased coupling between modules, and complicated test setup.

The new approach makes dependencies explicit at the domain level and standardizes how they are created and consumed.

---

### Main changes

**Context system**

* Introduced domain-scoped contexts:

  * `ConfigContext` for environment and configuration handling
  * `LoggerContext` for structured logging
  * `CollaborationContext` for WebSocket and collaboration modules
* Centralized dependency setup for collaboration features.
* Contexts are passed explicitly and avoid global or implicit state.

**Testing**

* Updated CLI and WebSocket tests to use context reset and configuration helpers.
* Ensured environment changes and shared dependencies are isolated between tests.

**Logging and linting**

* Updated `biome.json` to discourage direct `console.*` usage in server code.
* Enforced the use of `LoggerContext` for structured logging.
* Explicit exceptions added for CLI tools, migrations, browser code, and tests.

**Documentation**

* Updated `CLAUDE.md` and `doc/architecture.md` to document:

  * The new context structure
  * Recommended usage patterns
  * Testing guidelines

---

### Rationale

This change aims to:

* Make dependencies explicit and easier to reason about.
* Reduce hidden coupling between modules.
* Simplify test setup without relying on global mocks.
* Establish a clear and consistent foundation for future refactoring.

The implementation is incremental and scoped. It does not introduce a global “god context” and avoids framework-level dependency injection mechanisms.