### PR TITLE
Fix #962 - Carousel FX: The "Next" link skipped one slide.

### DIFF
--- a/public/app/common/exe_effects/exe_effects.js
+++ b/public/app/common/exe_effects/exe_effects.js
@@ -600,10 +600,7 @@ $exeFX = {
         prevA.className = "fx-disabled-link";
         // Next
         nextLi.removeClass("fx-disabled");
-        nextA.onclick = function () {
-          $exeFX.carousel.show(gID, gID + "-1", 1);
-          return false;
-        }
+        nextA.className = "exeFXSlideLink" + gID + "_" + gID + "-1_1";
       } else {
         // Prev
         prevLi.removeClass("fx-disabled");


### PR DESCRIPTION
How to test this:

- Add a carousel.
- Click Next a couple of times.
- Then go back to the first position and click on Next again.

It should go to the right slide.