### PR TITLE
Improve the pipelines canceling the running ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - tikismaker
       - 'release/*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/e2e-db-matrix.yml
+++ b/.github/workflows/e2e-db-matrix.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,10 @@ on:
       - tikismaker
       - 'release/*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This pull request introduces workflow improvements to our GitHub Actions configuration. The main change is the addition of concurrency controls to our CI and E2E workflows, which helps prevent duplicate or overlapping workflow runs for the same branch or pull request. This ensures that only the latest workflow run is active, reducing wasted resources and potential confusion.

**Workflow enhancements:**

* Added `concurrency` groups to `.github/workflows/ci.yml`, `.github/workflows/e2e.yml`, and `.github/workflows/e2e-db-matrix.yml` to cancel in-progress runs for the same workflow and ref, ensuring only the latest run continues. 

**File organization:**

* Renamed `.github/workflows/deploy.yml` to `.github/workflows/e2e-db-matrix.yml` for improved clarity and consistency.