### PR TITLE
Skip MathJax loading for pre-rendered LaTeX content

### DIFF
--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -203,6 +203,21 @@ var $exe = {
             $("body").addClass("exe-auto-math"); // Always load it
             var math = $(".exe-math");
             var mathjax = false;
+
+            // Check if content is pre-rendered (SVG+MathML)
+            // Pre-rendered LaTeX uses class "exe-math-rendered"
+            // If ALL LaTeX is pre-rendered and no explicit exe-math-engine elements exist,
+            // no need for MathJax library (similar pattern to Mermaid pre-rendering)
+            var hasPreRendered = $(".exe-math-rendered").length > 0;
+            var hasExplicitEngine = $(".exe-math-engine").length > 0;
+
+            if (hasPreRendered && !hasExplicitEngine) {
+                // Content was pre-rendered to SVG+MathML, no need for MathJax library
+                // Still create links for code/image access if needed
+                $exe.math.createLinks(math);
+                return;
+            }
+
             if (math.length > 0 || $("body").hasClass("exe-auto-math")) {
                 if ($("body").hasClass("exe-auto-math")) {
                     var hasLatex = /(?:\\\(|\\\[|\\begin\{.*?})/.test($('body').html());

--- a/public/app/common/common.test.js
+++ b/public/app/common/common.test.js
@@ -724,6 +724,93 @@ describe('common.js $exe helpers', () => {
       const code = document.querySelector('.exe-math-code').innerHTML;
       expect(code).toContain('\\[');
     });
+
+    it('init skips MathJax loading when only pre-rendered elements exist', () => {
+      // Pre-rendered LaTeX content (produced by LatexPreRenderer)
+      document.body.innerHTML = `
+        <span class="exe-math-rendered" data-latex="\\frac{1}{2}">
+          <svg><text>1/2</text></svg>
+        </span>
+      `;
+      const loadMathJaxSpy = vi.spyOn(global.$exe.math, 'loadMathJax');
+      const createLinksSpy = vi.spyOn(global.$exe.math, 'createLinks');
+
+      global.$exe.math.init();
+
+      // MathJax should NOT be loaded
+      expect(loadMathJaxSpy).not.toHaveBeenCalled();
+      // createLinks should still be called
+      expect(createLinksSpy).toHaveBeenCalled();
+
+      loadMathJaxSpy.mockRestore();
+      createLinksSpy.mockRestore();
+    });
+
+    it('init loads MathJax when exe-math-engine elements exist alongside pre-rendered', () => {
+      // Both pre-rendered and explicit engine elements
+      document.body.innerHTML = `
+        <span class="exe-math-rendered" data-latex="\\frac{1}{2}">
+          <svg><text>1/2</text></svg>
+        </span>
+        <div class="exe-math exe-math-engine"><div class="exe-math-code">x^2</div></div>
+      `;
+      // Mock MathJax to avoid errors when callback is invoked
+      global.MathJax = {
+        typesetPromise: vi.fn().mockReturnValue(Promise.resolve()),
+      };
+      const loadMathJaxSpy = vi.spyOn(global.$exe.math, 'loadMathJax').mockImplementation((cb) => {
+        if (cb) cb();
+      });
+
+      global.$exe.math.init();
+
+      // MathJax SHOULD be loaded because exe-math-engine exists
+      expect(loadMathJaxSpy).toHaveBeenCalled();
+
+      loadMathJaxSpy.mockRestore();
+      delete global.MathJax;
+    });
+
+    it('init does not skip MathJax when no pre-rendered elements but LaTeX in body', () => {
+      // Raw LaTeX without pre-rendering
+      document.body.innerHTML = '<p>\\(x^2\\)</p>';
+      // Mock MathJax to avoid errors when callback is invoked
+      global.MathJax = {
+        typesetPromise: vi.fn().mockReturnValue(Promise.resolve()),
+      };
+      const loadMathJaxSpy = vi.spyOn(global.$exe.math, 'loadMathJax').mockImplementation((cb) => {
+        if (cb) cb();
+      });
+
+      global.$exe.math.init();
+
+      // MathJax SHOULD be loaded for raw LaTeX
+      expect(loadMathJaxSpy).toHaveBeenCalled();
+
+      loadMathJaxSpy.mockRestore();
+      delete global.MathJax;
+    });
+
+    it('init returns early for pre-rendered content without loading MathJax', () => {
+      // Verify that the regex in $('body').html() is not falsely triggered by data-latex attributes
+      document.body.innerHTML = `
+        <span class="exe-math-rendered" data-latex="\\(x^2\\)">
+          <svg><text>x²</text></svg>
+        </span>
+        <span class="exe-math-rendered" data-latex="\\[\\frac{a}{b}\\]">
+          <svg><text>a/b</text></svg>
+        </span>
+      `;
+      const loadMathJaxSpy = vi.spyOn(global.$exe.math, 'loadMathJax');
+
+      global.$exe.math.init();
+
+      // MathJax should NOT be loaded even though data-latex contains LaTeX patterns
+      // The fix detects pre-rendered elements and skips the regex check on HTML
+      expect(loadMathJaxSpy).not.toHaveBeenCalled();
+
+      loadMathJaxSpy.mockRestore();
+    });
   });
 });
 


### PR DESCRIPTION
Similar to #1077 (Mermaid cleanup), this fixes an issue where `common.js` attempts to load MathJax even when LaTeX content is already pre-rendered to SVG+MathML.

### Problem
When previewing content with pre-rendered LaTeX (default mode), the browser shows:
```
GET http://localhost:8085/viewer/libs/exe_math/tex-mml-svg.js net::ERR_ABORTED 404 (Not Found)
```

The `init()` function was detecting LaTeX patterns in the HTML body (including `data-latex` attributes from pre-rendered elements) and trying to load MathJax unnecessarily.

### Solution
Check for `exe-math-rendered` elements before attempting to load MathJax. If all LaTeX is pre-rendered and no explicit `exe-math-engine` elements exist, skip MathJax loading entirely.

### Testing

**Pre-render mode (default):**
1. Add LaTeX content to a page
2. Click Preview
3. Check browser console: no 404 error for `tex-mml-svg.js`
4. LaTeX displays correctly as static SVG

**Include MathJax mode:**
1. Enable "Include MathJax library" in project properties
2. Add LaTeX content and Preview
3. MathJax library loads correctly
4. Right-click context menu appears on LaTeX formulas