### PR TITLE
Fix Project Properties field labels not translating to user's preferred language

### DIFF
--- a/public/app/rest/apiCallManager.js
+++ b/public/app/rest/apiCallManager.js
@@ -101,7 +101,9 @@ export default class ApiCallManager {
      *
      */
     async loadApiParameters() {
-        this.parameters = await this.getApiParameters();
+        // Get locale from config (set by server from user preference)
+        const locale = this.app?.eXeLearning?.config?.locale;
+        this.parameters = await this.getApiParameters(locale);
         for (var [key, data] of Object.entries(this.parameters.routes)) {
             this.endpoints[key] = {};
             this.endpoints[key].path = this.apiUrlBase + data.path;
@@ -118,14 +120,17 @@ export default class ApiCallManager {
      *
      * @returns {Promise<{routes: Object, userPreferencesConfig?: Object, odeProjectSyncPropertiesConfig?: Object}>}
      */
-    async getApiParameters() {
+    async getApiParameters(locale) {
         // Check static mode - return bundled data
         if (this._isStaticMode()) {
             return this._getStaticData('parameters') || { routes: {} };
         }
 
-        // Server mode - fetch from API
+        // Server mode - fetch from API with locale
         let url = this.apiUrlParameters;
+        if (locale) {
+            url += `?locale=${encodeURIComponent(locale)}`;
+        }
         return await this.func.get(url);
     }
 

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -703,10 +703,11 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
 
     // GET /api/parameter-management/parameters/data/list - Get ALL parameters (expected by frontend)
     // Applies translations based on Accept-Language header
-    .get('/api/parameter-management/parameters/data/list', async ({ request }) => {
-        // Detect locale from Accept-Language header
+    .get('/api/parameter-management/parameters/data/list', async ({ request, query }) => {
+        // Prioritize locale query param (from user preference), then Accept-Language header
+        const localeParam = (query as { locale?: string })?.locale;
         const acceptLanguage = request.headers.get('accept-language');
-        const locale = detectLocaleFromHeader(acceptLanguage);
+        const locale = localeParam || detectLocaleFromHeader(acceptLanguage);
         const canInstallThemes = await getSettingBoolean(
             defaultDb,
             'ONLINE_THEMES_INSTALL',


### PR DESCRIPTION
When users changed the UI language in User Preferences, the Project Properties form showed 
inconsistent translations: tab names were translated but field labels remained in the 
default language.

This issue only affected the online version. In desktop/static mode, the parameters are 
bundled with the application and already use the correct locale.

The problem occurred because the parameters API endpoint used the browser's Accept-Language 
header instead of the user's saved locale preference.

This PR:
- Adds a `locale` query parameter to the parameters API endpoint
- Passes the user's locale preference from `eXeLearning.config.locale` when fetching parameters
- The backend now prioritizes the query parameter over the Accept-Language header

After this change, all field labels in Project Properties (Title, Subtitle, Language, etc.) 
display in the user's chosen language.