### PR TITLE
generate .env if not exists in up-local and run-app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ bundle: deps
 # APP_ENV=dev (default): Elysia with hot-reload + SCSS watcher
 # APP_ENV=prod: Pre-compiled Elysia, no watchers
 .PHONY: up-local
-up-local: check-bun deps css bundle
+up-local: check-bun check-env deps css bundle
 ifeq ($(APP_ENV),prod)
 	@echo "Starting local (prod mode)..."
 	@$(MAKE) bundle
@@ -158,7 +158,7 @@ endif
 
 # Start full app: Static files + Electron (no server needed)
 .PHONY: run-app
-run-app: check-bun deps css bundle
+run-app: check-bun check-env deps css bundle
 	@echo "Building static files..."
 	@bun scripts/build-static-bundle.ts
 	@echo "Copying static files to app/..."


### PR DESCRIPTION
This pull request makes small improvements to the local development and app build process in the `Makefile` by ensuring that the environment is checked before running key commands.

* Build process reliability:
  * Added the `check-env` prerequisite to both the `up-local` and `run-app` targets in the `Makefile` to verify environment setup before executing dependencies and bundling steps. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L149-R149) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L161-R161)