### PR TITLE
Avoid tagging pre-releasees as latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=tikismaker,enable=${{ github.ref == 'refs/heads/tikismaker' }}
 


### PR DESCRIPTION
This pull request introduces a small but important change to the Docker image tagging logic in the CI workflow. The update restricts the application of the `latest` tag to only those tags that do not contain a hyphen (`-`), which helps prevent pre-release or non-standard tags from being labeled as `latest`.

* CI workflow (`.github/workflows/ci.yml`): Updated the condition for applying the `latest` Docker image tag so that it is only enabled for tag names without a hyphen.