### PR TITLE
Hotfix/fix firefox e2e test 2

### DIFF
--- a/test/e2e/playwright/helpers/workarea-helpers.ts
+++ b/test/e2e/playwright/helpers/workarea-helpers.ts
@@ -360,14 +360,33 @@ export async function navigateToIdevicePage(page: Page, ideviceId: string, idevi
         try {
             await navItem.waitFor({ state: 'attached', timeout: 5000 });
             await navItem.scrollIntoViewIfNeeded();
+
+            // Capture current page heading before clicking (to detect content change)
+            const currentHeading = await page.evaluate(() => {
+                const heading = document.querySelector('#node-content h1');
+                return heading?.textContent || '';
+            });
+
             await navItem.click({ force: true });
 
-            // Wait for content area to update (deterministic wait, not fixed timeout)
+            // Wait for content area to update by detecting heading change or iDevice presence
             await page.waitForFunction(
-                () => {
+                ({ prevHeading, targetId, targetType }) => {
+                    // Check if the target iDevice is now visible
+                    const targetEl = document.getElementById(targetId);
+                    if (targetEl?.classList.contains(targetType)) {
+                        return true;
+                    }
+
+                    // Check if the heading changed (indicating page navigation completed)
                     const nodeContent = document.querySelector('#node-content');
-                    return nodeContent && nodeContent.children.length > 0;
+                    if (!nodeContent || nodeContent.children.length === 0) {
+                        return false;
+                    }
+                    const newHeading = nodeContent.querySelector('h1')?.textContent || '';
+                    return newHeading !== prevHeading;
                 },
+                { prevHeading: currentHeading, targetId: ideviceId, targetType: ideviceType },
                 { timeout: 5000 },
             );
 


### PR DESCRIPTION
This pull request improves the reliability and speed of the `navigateToIdevicePage` helper used in Playwright end-to-end tests. The changes focus on making navigation and page content detection more robust, particularly when clicking through navigation elements to find a specific iDevice.

**Navigation and DOM interaction improvements:**

* Added waits to ensure navigation elements are attached before interacting, reducing flakiness when the DOM is still loading.
* Re-queries navigation elements on each iteration to get fresh references, accounting for possible DOM changes during navigation.
* Uses page heading detection and iDevice presence checks to more reliably determine when navigation has completed, instead of relying solely on timeouts.
* Reduces unnecessary waiting by decreasing the buffer timeout after finding the iDevice, speeding up tests.
* Adds error handling to continue navigation attempts even if a navigation click or wait fails, improving test resilience.