### PR TITLE
fix: prevent data loss by warning user that language changes require a reload

### DIFF
--- a/public/app/workarea/user/preferences/userPreferences.js
+++ b/public/app/workarea/user/preferences/userPreferences.js
@@ -11,7 +11,8 @@ export default class UserPreferences {
         type: 'text',
         hide: true,
     };
-
+    userLang='';
+    
     /**
      * Load user preferences
      *
@@ -140,6 +141,7 @@ export default class UserPreferences {
                 this.manager.reloadVersionControl(this.preferences.versionControl.value);
             }
             if (this.preferences.locale) {
+				this.userLang=this.preferences.locale.value;
                 this.manager.reloadLang(this.preferences.locale.value);
             }
         } catch (error) {
@@ -185,11 +187,16 @@ export default class UserPreferences {
             this.manager.reloadVersionControl(preferences.versionControl);
         // Update interface lang
         if (preferences.locale) await this.manager.reloadLang(preferences.locale);
-
+		// Change license ????
+		
         // Reloading of the page so that it takes a possible change of language in the user preferences
-        if (params['locale'] !== undefined) {
-            window.onbeforeunload = null;
-            window.location.reload();
+        if (this.userLang!= params['locale']){
+            if (isStaticMode) {				
+			    eXe.app.alert('Language changes will take effect after restarting or creating a new project.');
+			}else{
+                window.onbeforeunload = null;
+                window.location.reload();
+	        }
         }
     }
 }

--- a/public/app/workarea/user/preferences/userPreferences.test.js
+++ b/public/app/workarea/user/preferences/userPreferences.test.js
@@ -22,6 +22,7 @@ describe('UserPreferences', () => {
     globalThis.eXeLearning = {
       app: {
         capabilities: { storage: { remote: true } }, // Server mode
+        alert: vi.fn(), 
         api: {
           parameters: {
             userPreferencesConfig: {
@@ -64,6 +65,7 @@ describe('UserPreferences', () => {
     };
 
     userPreferences = new UserPreferences(mockManager);
+    userPreferences.userLang = 'en'; 
   });
 
   afterEach(() => {
@@ -186,14 +188,34 @@ describe('UserPreferences', () => {
 
   describe('apiSaveProperties (static mode)', () => {
     beforeEach(() => {
-      // Set up static mode
       globalThis.eXeLearning.app.capabilities = { storage: { remote: false } };
+    });
+
+    it('should show alert and NOT reload when language changes in static mode', async () => {
+      userPreferences.preferences = {
+        locale: { value: 'en' }
+      };
+
+      const originalLocation = window.location;
+      delete window.location;
+      window.location = { reload: vi.fn() };
+
+      await userPreferences.apiSaveProperties({
+        locale: 'fr' 
+      });
+
+
+      expect(globalThis.eXeLearning.app.alert).toHaveBeenCalled();
+      
+
+      expect(window.location.reload).not.toHaveBeenCalled();
+
+      window.location = originalLocation;
     });
 
     it('should save preferences to localStorage in static mode', async () => {
       userPreferences.preferences = {
-        advancedMode: { value: 'false' },
-        versionControl: { value: 'true' }
+        advancedMode: { value: 'false' }
       };
 
       await userPreferences.apiSaveProperties({
@@ -204,19 +226,6 @@ describe('UserPreferences', () => {
         'exe_user_preferences',
         expect.any(String)
       );
-      expect(globalThis.eXeLearning.app.api.putSaveUserPreferences).not.toHaveBeenCalled();
-    });
-
-    it('should not call server API in static mode', async () => {
-      userPreferences.preferences = {
-        advancedMode: { value: 'false' }
-      };
-
-      await userPreferences.apiSaveProperties({
-        advancedMode: 'true'
-      });
-
-      expect(globalThis.eXeLearning.app.api.putSaveUserPreferences).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Simple solution to prevent window.location.reload() in static mode.
Adds a warning: "Language changes will take effect after restarting or creating a new project."

Note: This does not resolve the default license change issue.