### PR TITLE
Temporarily hide the "Pin preview" button in static version until styles are fully implemented

### DIFF
--- a/scripts/static-bundle/static-index.html
+++ b/scripts/static-bundle/static-index.html
@@ -248,7 +248,8 @@
                     <button id="preview-extract-button" class="btn button-square button-tertiary" title="Open in new tab" data-i18n-title="Open in new tab">
                         <span class="small-icon external-link-icon"></span>
                     </button>
-                    <button id="preview-pin-button" class="btn button-square button-tertiary" title="Pin preview" data-i18n-title="Pin preview">
+                    <!-- TEMPORARILY DISABLED: Pin preview functionality is disabled until styles are fully implemented -->
+                    <button id="preview-pin-button" class="btn button-square button-tertiary d-none" title="Pin preview" data-i18n-title="Pin preview">
                         <span class="small-icon pin-icon"></span>
                     </button>
                     <button id="preview-refresh-button" class="btn button-square button-tertiary" title="Refresh preview" data-i18n-title="Refresh preview">


### PR DESCRIPTION
This PR adds `d-none` to the `preview-pin-button` in `static-index.html` to hide it until its visual styles are complete.

**Note:**  @ignaciogros  I'd suggest we reconsider this change. Users who pin the preview already expect the layout to shift — they're choosing to do it because it fits their workflow (wide screens, etc.). Hiding a simple, potentially useful feature to polish styles feels inconsistent when we have similar rough edges elsewhere (e.g. mobile preview doesn't render well and that button is still visible).

My suggestion: ship it visible, let real usage guide us. If nobody uses it, we remove it. If people use it and the styles need work, we fix them. If we hide it now and add it to the backlog, it will likely stay there given our current priorities.

Launch → gather feedback → decide seems like a better approach than hiding it preemptively.