### PR TITLE
fix: prevent duplicate feedback buttons when importing legacy ELP files

### DIFF
--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -595,7 +595,8 @@ export class ElpxImporter {
         let htmlView = legacyIdevice.htmlView || '';
 
         // If there's feedback content, append feedback button and content
-        if (legacyIdevice.feedbackHtml) {
+        // BUT only if the HTML doesn't already have feedback embedded (prevents duplication)
+        if (legacyIdevice.feedbackHtml && !this.htmlHasFeedback(htmlView)) {
             const buttonText = legacyIdevice.feedbackButton || 'Show Feedback';
             htmlView += `<div class="iDevice_buttons feedback-button js-required">`;
             htmlView += `<input type="button" class="feedbacktooglebutton" value="${this.escapeHtmlAttr(buttonText)}" `;
@@ -696,6 +697,27 @@ export class ElpxImporter {
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&#39;');
+    }
+
+    /**
+     * Check if HTML content already contains feedback button elements
+     * This prevents duplicate feedback when the handler already embedded feedback in htmlView
+     *
+     * @param html - HTML content to check
+     * @returns true if feedback button already exists
+     */
+    private htmlHasFeedback(html: string): boolean {
+        if (!html) return false;
+        // Check for various feedback button patterns used in legacy exports
+        // - feedbacktooglebutton: standard class name (note the typo in original)
+        // - feedbackbutton: alternative class name used in some versions
+        // - iDevice_buttons feedback-button: container class pattern
+        return (
+            html.includes('feedbacktooglebutton') ||
+            html.includes('feedbackbutton') ||
+            html.includes('iDevice_buttons feedback-button') ||
+            html.includes('class="feedback-button')
+        );
     }
 
     /**

--- a/src/shared/import/legacy-handlers/FreeTextHandler.ts
+++ b/src/shared/import/legacy-handlers/FreeTextHandler.ts
@@ -82,7 +82,17 @@ export class FreeTextHandler extends BaseLegacyHandler {
             }
         }
 
-        // Check for feedback and wrap in exe-text-activity if present
+        // Check if content already has feedback buttons embedded (legacy ELPs may have them in HTML)
+        // This prevents duplicate feedback buttons when importing
+        if (this.hasFeedbackButton(content)) {
+            // Content already has feedback, wrap in exe-text-activity if not already wrapped
+            if (!content.includes('exe-text-activity')) {
+                return `<div class="exe-text-activity">${content}</div>`;
+            }
+            return content;
+        }
+
+        // Check for feedback in XML and add if present
         const feedback = this.extractFeedback(dict, context);
         if (feedback.content) {
             let html = content;
@@ -97,21 +107,77 @@ export class FreeTextHandler extends BaseLegacyHandler {
     }
 
     /**
-     * Escape HTML attribute special characters
+     * Check if HTML content already contains feedback button elements
+     * Legacy ELPs may have feedback buttons embedded in content_w_resourcePaths
+     *
+     * @param html - HTML content to check
+     * @returns true if feedback button already exists
      */
-    private escapeHtmlAttr(str: string): string {
-        if (!str) return '';
-        return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    private hasFeedbackButton(html: string): boolean {
+        if (!html) return false;
+        // Check for various feedback button patterns used in legacy exports
+        // - feedbacktooglebutton: standard class name (note the typo in original)
+        // - feedbackbutton: alternative class name used in some versions
+        // - iDevice_buttons feedback-button: container class pattern
+        return (
+            html.includes('feedbacktooglebutton') ||
+            html.includes('feedbackbutton') ||
+            html.includes('iDevice_buttons feedback-button') ||
+            html.includes('class="feedback-button')
+        );
+    }
+
+    /**
+     * Extract the main content HTML from the dictionary (used to check for embedded feedback)
+     */
+    private extractMainContent(dict: Element): string {
+        // Strategy 1: Look for activityTextArea (main content)
+        const activityTextArea = this.findDictInstance(dict, 'activityTextArea');
+        if (activityTextArea) {
+            return this.extractTextAreaFieldContent(activityTextArea);
+        }
+
+        // Strategy 2: Look for "content" key
+        const contentTextArea = this.findDictInstance(dict, 'content');
+        if (contentTextArea) {
+            return this.extractTextAreaFieldContent(contentTextArea);
+        }
+
+        // Strategy 3: Look for "fields" list (JsIdevice format)
+        const fieldsContent = this.extractFieldsContent(dict);
+        if (fieldsContent) {
+            return fieldsContent;
+        }
+
+        // Strategy 4: Any TextAreaField in the dictionary
+        const instances = this.getDirectChildrenByTagName(dict, 'instance');
+        for (const inst of instances) {
+            const className = inst.getAttribute('class') || '';
+            if (className.includes('TextAreaField')) {
+                const content = this.extractTextAreaFieldContent(inst);
+                if (content) return content;
+            }
+        }
+
+        return '';
     }
 
     /**
      * Extract feedback content (for Reflection iDevices and GenericIdevice with FeedbackField)
+     * Returns empty if the main content HTML already has feedback embedded (prevents duplication)
      *
      * @param dict - Dictionary element
      * @param context - Context with language info
      */
     extractFeedback(dict: Element, context?: IdeviceHandlerContext): FeedbackResult {
         if (!dict) return { content: '', buttonCaption: '' };
+
+        // If the main content HTML already has feedback embedded, don't extract separate feedback
+        // This prevents duplication when legacy ELPs have feedback in both places
+        const mainContent = this.extractMainContent(dict);
+        if (this.hasFeedbackButton(mainContent)) {
+            return { content: '', buttonCaption: '' };
+        }
 
         // Use project language for default caption (not UI locale)
         const defaultCaption = this.getLocalizedFeedbackText(context?.language);
@@ -211,8 +277,16 @@ export class FreeTextHandler extends BaseLegacyHandler {
 
     /**
      * Extract properties for text iDevice
+     * Returns empty if the main content HTML already has feedback embedded (prevents duplication)
      */
     extractProperties(dict: Element, _ideviceId?: string): Record<string, unknown> {
+        // If the main content HTML already has feedback embedded, don't return feedback properties
+        // This prevents duplication when legacy ELPs have feedback in both places
+        const mainContent = this.extractMainContent(dict);
+        if (this.hasFeedbackButton(mainContent)) {
+            return {};
+        }
+
         const feedback = this.extractFeedback(dict);
         if (feedback.content) {
             return {

--- a/src/shared/import/legacy-handlers/handlers.spec.ts
+++ b/src/shared/import/legacy-handlers/handlers.spec.ts
@@ -290,6 +290,92 @@ describe('FreeTextHandler', () => {
             expect(result).toContain('feedbacktooglebutton');
             expect(result).toContain('Feedback content');
         });
+
+        it('should NOT add duplicate feedback when content already has feedbacktooglebutton', () => {
+            const contentWithFeedback = `<p>Main content</p>
+                <div class="iDevice_buttons feedback-button js-required">
+                    <input type="button" class="feedbacktooglebutton" value="Existing Feedback" />
+                </div>
+                <div class="feedback js-feedback js-hidden">Existing feedback content</div>`;
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="activityTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="${contentWithFeedback.replace(/"/g, '&quot;')}"/>
+                        </dictionary>
+                    </instance>
+                    <string role="key" value="answerTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="XML Feedback that should be ignored"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const result = handler.extractHtmlView(dict, { language: 'en' });
+            // Should contain existing feedback, not duplicate
+            expect(result).toContain('Existing Feedback');
+            expect(result).toContain('Existing feedback content');
+            // Should NOT contain the XML feedback
+            expect(result).not.toContain('XML Feedback that should be ignored');
+            // Should only have ONE feedback button
+            const feedbackButtonCount = (result.match(/feedbacktooglebutton/g) || []).length;
+            expect(feedbackButtonCount).toBe(1);
+        });
+
+        it('should NOT add duplicate feedback when content has feedbackbutton class', () => {
+            const contentWithFeedback = `<p>Content</p>
+                <div class="iDevice_buttons feedback-button js-required">
+                    <input type="button" class="feedbackbutton" value="Info" />
+                </div>
+                <div class="feedback js-feedback js-hidden">Info content</div>`;
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="activityTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="${contentWithFeedback.replace(/"/g, '&quot;')}"/>
+                        </dictionary>
+                    </instance>
+                    <string role="key" value="answerTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="Should be ignored"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const result = handler.extractHtmlView(dict, { language: 'en' });
+            expect(result).toContain('Info content');
+            expect(result).not.toContain('Should be ignored');
+        });
+
+        it('should wrap content with existing feedback in exe-text-activity if not already wrapped', () => {
+            const contentWithFeedback = `<p>Content</p>
+                <div class="iDevice_buttons feedback-button js-required">
+                    <input type="button" class="feedbacktooglebutton" value="Show" />
+                </div>
+                <div class="feedback js-feedback js-hidden">Feedback</div>`;
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="activityTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="${contentWithFeedback.replace(/"/g, '&quot;')}"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const result = handler.extractHtmlView(dict, { language: 'en' });
+            expect(result).toContain('exe-text-activity');
+            expect(result).toContain('Feedback');
+        });
     });
 
     describe('extractFeedback', () => {
@@ -371,6 +457,36 @@ describe('FreeTextHandler', () => {
             const result = handler.extractFeedback(dict, { language: 'es' });
             expect(result.buttonCaption).toBe('Mostrar retroalimentación');
         });
+
+        it('should return empty when content HTML already has feedback embedded', () => {
+            const contentWithFeedback = `<p>Main content</p>
+                <div class="iDevice_buttons feedback-button js-required">
+                    <input type="button" class="feedbacktooglebutton" value="Existing Feedback" />
+                </div>
+                <div class="feedback js-feedback js-hidden">Existing feedback content</div>`;
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="activityTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="${contentWithFeedback.replace(/"/g, '&quot;')}"/>
+                        </dictionary>
+                    </instance>
+                    <string role="key" value="answerTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="XML Feedback that should be ignored"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const result = handler.extractFeedback(dict, { language: 'en' });
+            // Should return empty because content already has feedback
+            expect(result.content).toBe('');
+            expect(result.buttonCaption).toBe('');
+        });
     });
 
     describe('extractProperties', () => {
@@ -396,6 +512,37 @@ describe('FreeTextHandler', () => {
             const props = handler.extractProperties(dict);
             expect(props.textFeedbackTextarea).toBe('Feedback text');
             expect(props.textFeedbackInput).toBe('Show');
+        });
+
+        it('should return empty when content HTML already has feedback embedded', () => {
+            const contentWithFeedback = `<p>Content</p>
+                <div class="iDevice_buttons feedback-button js-required">
+                    <input type="button" class="feedbackbutton" value="Info" />
+                </div>
+                <div class="feedback js-feedback js-hidden">Info content</div>`;
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="activityTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="${contentWithFeedback.replace(/"/g, '&quot;')}"/>
+                        </dictionary>
+                    </instance>
+                    <string role="key" value="answerTextArea"/>
+                    <instance class="TextAreaField">
+                        <dictionary>
+                            <string role="key" value="content"/>
+                            <unicode value="Should be ignored"/>
+                            <string role="key" value="buttonCaption"/>
+                            <string value="Show"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const props = handler.extractProperties(dict);
+            // Should return empty because content already has feedback
+            expect(props).toEqual({});
         });
     });
 });


### PR DESCRIPTION
This PR fixes issue #1199, where feedback buttons were duplicated when importing ELP files from older versions of eXeLearning.

This file contains different types of text iDevices, with and without feedback, for testing.

[todos_idevices_text_2.9.zip](https://github.com/user-attachments/files/25078862/todos_idevices_text_2.9.zip)

