### PR TITLE
Fix refresh yjs when opening project

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOpenUserOdeFiles.js
@@ -1431,6 +1431,12 @@ export default class modalOpenUserOdeFiles extends Modal {
 
                     try {
                         Logger.log('[OpenFile] Static mode - importing file:', odeFileName);
+
+                        // Clear assets from previous project before importing new one
+                        if (yjsBridge.clearAssetsForNewProject) {
+                            await yjsBridge.clearAssetsForNewProject();
+                        }
+
                         await yjsBridge.importFromElpx(odeFile, {
                             onProgress: (progress) => importProgress.update(progress)
                         });

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -2993,6 +2993,42 @@ class YjsProjectBridge {
 
     Logger.log('[YjsProjectBridge] Disconnected');
   }
+
+  /**
+   * Clear all assets for importing a new project (static mode)
+   * This clears asset caches and Yjs assets map without disconnecting the bridge
+   * Used when opening a new project file on top of an existing one in static mode
+   */
+  async clearAssetsForNewProject() {
+    Logger.log('[YjsProjectBridge] Clearing assets for new project...');
+
+    // Clear AssetManager caches (memory + Cache API)
+    if (this.assetManager) {
+      // Revoke blob URLs and clear memory caches
+      for (const blobURL of this.assetManager.blobURLCache.values()) {
+        URL.revokeObjectURL(blobURL);
+      }
+      this.assetManager.blobURLCache.clear();
+      this.assetManager.reverseBlobCache.clear();
+      this.assetManager.blobCache.clear();
+
+      // Clear Cache API storage
+      await this.assetManager.clearCache();
+
+      Logger.log('[YjsProjectBridge] AssetManager caches cleared');
+    }
+
+    // Clear Yjs assets Y.Map (metadata storage)
+    const assetsMap = this.documentManager?.ydoc?.getMap('assets');
+    if (assetsMap && assetsMap.size > 0) {
+      this.documentManager.ydoc.transact(() => {
+        assetsMap.clear();
+      });
+      Logger.log('[YjsProjectBridge] Yjs assets map cleared');
+    }
+
+    Logger.log('[YjsProjectBridge] Assets cleared for new project');
+  }
 }
 
 // Export for use

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -5196,4 +5196,111 @@ describe('YjsProjectBridge', () => {
       expect(bridge.documentManager.markDirty).toHaveBeenCalled();
     });
   });
+
+  describe('clearAssetsForNewProject', () => {
+    let mockYdoc;
+    let mockAssetsMap;
+    let mockAssetsData;
+
+    beforeEach(() => {
+      // Create a mock Y.Map-like object for assets
+      mockAssetsData = new Map();
+      mockAssetsMap = {
+        get size() {
+          return mockAssetsData.size;
+        },
+        set: (key, value) => mockAssetsData.set(key, value),
+        get: (key) => mockAssetsData.get(key),
+        clear: mock(() => mockAssetsData.clear()),
+      };
+
+      mockYdoc = {
+        getMap: mock((name) => {
+          if (name === 'assets') return mockAssetsMap;
+          return new Map();
+        }),
+        transact: mock((fn) => fn()),
+      };
+
+      bridge.documentManager = {
+        ydoc: mockYdoc,
+      };
+
+      bridge.assetManager = {
+        blobCache: new Map(),
+        blobURLCache: new Map(),
+        reverseBlobCache: new Map(),
+        clearCache: mock(async () => {}),
+      };
+    });
+
+    it('clears AssetManager memory caches', async () => {
+      // Setup: add some assets to caches
+      bridge.assetManager.blobCache.set('test-id', new Blob(['test']));
+      bridge.assetManager.blobURLCache.set('test-id', 'blob:http://test/123');
+      bridge.assetManager.reverseBlobCache.set('blob:http://test/123', 'test-id');
+
+      await bridge.clearAssetsForNewProject();
+
+      expect(bridge.assetManager.blobCache.size).toBe(0);
+      expect(bridge.assetManager.blobURLCache.size).toBe(0);
+      expect(bridge.assetManager.reverseBlobCache.size).toBe(0);
+    });
+
+    it('revokes blob URLs when clearing caches', async () => {
+      const mockRevokeObjectURL = mock(() => {});
+      global.URL = { revokeObjectURL: mockRevokeObjectURL };
+
+      bridge.assetManager.blobURLCache.set('test-id-1', 'blob:http://test/123');
+      bridge.assetManager.blobURLCache.set('test-id-2', 'blob:http://test/456');
+
+      await bridge.clearAssetsForNewProject();
+
+      expect(mockRevokeObjectURL).toHaveBeenCalledTimes(2);
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:http://test/123');
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:http://test/456');
+    });
+
+    it('clears Yjs assets map when it has entries', async () => {
+      // Setup: add asset metadata to Yjs
+      mockAssetsData.set('test-asset', { id: 'test-asset', filename: 'test.jpg' });
+
+      await bridge.clearAssetsForNewProject();
+
+      expect(mockYdoc.transact).toHaveBeenCalled();
+      expect(mockAssetsMap.clear).toHaveBeenCalled();
+    });
+
+    it('does not call transact when assets map is empty', async () => {
+      // Assets map is already empty
+
+      await bridge.clearAssetsForNewProject();
+
+      expect(mockYdoc.transact).not.toHaveBeenCalled();
+    });
+
+    it('calls clearCache on AssetManager', async () => {
+      await bridge.clearAssetsForNewProject();
+
+      expect(bridge.assetManager.clearCache).toHaveBeenCalled();
+    });
+
+    it('handles missing assetManager gracefully', async () => {
+      bridge.assetManager = null;
+
+      await expect(bridge.clearAssetsForNewProject()).resolves.not.toThrow();
+    });
+
+    it('handles missing documentManager gracefully', async () => {
+      bridge.documentManager = null;
+
+      await expect(bridge.clearAssetsForNewProject()).resolves.not.toThrow();
+    });
+
+    it('handles missing ydoc gracefully', async () => {
+      bridge.documentManager = {};
+
+      await expect(bridge.clearAssetsForNewProject()).resolves.not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
<p>When opening a new ELP file on top of an existing project in static mode, the asset cleanup was incomplete compared to online mode:</p>

Mode | Flow | Cleanup
-- | -- | --
Online | reinitializeWithProject() → yjsBridge.disconnect() → new bridge | Full cleanup (AssetManager.cleanup() called)
Static | yjsBridge.importFromElpx() → refreshAfterDirectImport() | Navigation cleared only, assets persist


<p>The problem occurs because:</p>
<ol>
<li><code>importFromElpx()</code> with <code>clearExisting=true</code> clears the navigation Y.Array and updates metadata, but does <strong>not</strong> clear the assets Y.Map or AssetManager caches</li>
<li>Static mode uses the same <code>projectId</code> throughout the session (generated once on page load), so the Cache API cache name (<code>exe-assets-{projectId}</code>) remains the same</li>
<li>Old assets persist in memory caches (<code>blobCache</code>, <code>blobURLCache</code>, <code>reverseBlobCache</code>) and Cache API storage</li>
</ol>
<h2>Solution</h2>
<p>Added a new <code>clearAssetsForNewProject()</code> method to <code>YjsProjectBridge.js</code> that clears:</p>
<ul>
<li>AssetManager memory caches (with proper blob URL revocation)</li>
<li>Cache API storage</li>
<li>Yjs assets Y.Map metadata</li>
</ul>
<p>This method is called before <code>importFromElpx()</code> in the static mode path, mirroring the cleanup that happens in online mode when the bridge is disconnected and recreated.</p></body></html>