### PR TITLE
Fix: Admin panel project counts excluding unsaved projects (#1207)

### DIFF
--- a/src/db/queries/admin.spec.ts
+++ b/src/db/queries/admin.spec.ts
@@ -732,7 +732,7 @@ describe('Admin Queries', () => {
             const userId = await seedTestUser(db, { email: 'owner@test.com', user_id: 'owner' });
             await seedTestProject(db, userId, { title: 'Active Project' });
 
-            // Create archived project
+            // Create archived but saved project
             const now = Date.now();
             await db
                 .insertInto('projects')
@@ -742,7 +742,7 @@ describe('Admin Queries', () => {
                     owner_id: userId,
                     status: 'archived',
                     visibility: 'private',
-                    saved_once: 0,
+                    saved_once: 1,
                     created_at: now,
                     updated_at: now,
                 })
@@ -752,6 +752,49 @@ describe('Admin Queries', () => {
 
             expect(stats.totalProjects).toBe(2);
             expect(stats.activeProjects).toBe(1);
+        });
+
+        it('should exclude unsaved projects from counts', async () => {
+            const userId = await seedTestUser(db, { email: 'owner@test.com', user_id: 'owner' });
+
+            // Create saved projects (should be counted)
+            await seedTestProject(db, userId, { title: 'Saved Active', uuid: 'saved-1' });
+            await seedTestProject(db, userId, { title: 'Saved Active 2', uuid: 'saved-2' });
+
+            // Create unsaved projects (should NOT be counted)
+            const now = Date.now();
+            await db
+                .insertInto('projects')
+                .values({
+                    uuid: 'unsaved-1',
+                    title: 'Unsaved Project 1',
+                    owner_id: userId,
+                    status: 'active',
+                    visibility: 'private',
+                    saved_once: 0,
+                    created_at: now,
+                    updated_at: now,
+                })
+                .execute();
+            await db
+                .insertInto('projects')
+                .values({
+                    uuid: 'unsaved-2',
+                    title: 'Unsaved Project 2',
+                    owner_id: userId,
+                    status: 'active',
+                    visibility: 'private',
+                    saved_once: 0,
+                    created_at: now,
+                    updated_at: now,
+                })
+                .execute();
+
+            const stats = await getSystemStats(db);
+
+            // Only saved projects should be counted
+            expect(stats.totalProjects).toBe(2);
+            expect(stats.activeProjects).toBe(2);
         });
 
         it('should return consistent numbers', async () => {

--- a/src/db/queries/admin.ts
+++ b/src/db/queries/admin.ts
@@ -273,6 +273,7 @@ export async function getSystemStats(db: Kysely<Database>): Promise<{
         db
             .selectFrom('projects')
             .select([sql<number>`count(id)`.as('total')])
+            .where('saved_once', '=', 1)
             .executeTakeFirst(),
     ]);
 
@@ -281,6 +282,7 @@ export async function getSystemStats(db: Kysely<Database>): Promise<{
         .selectFrom('projects')
         .select(sql<number>`count(id)`.as('count'))
         .where('status', '=', 'active')
+        .where('saved_once', '=', 1)
         .executeTakeFirst();
 
     return {


### PR DESCRIPTION
The admin panel stats were counting all project rows in the database, including unsaved ones (`saved_once = 0`). Every time a user navigates to `/workarea` without a `?project=` parameter, a new project row is created with `saved_once = 0`. This caused the "Total Projects" and "Active Projects" counts to inflate each time the user switched between the editor and the admin panel.

The project table listing already filtered by `saved_once = 1` (via `findProjectsPaginated`), but `getSystemStats()` did not apply the same filter.

**Changes:**

- Added `.where('saved_once', '=', 1)` to both the total projects and active projects queries in `getSystemStats()` (`src/db/queries/admin.ts`)
- Fixed the existing "should count active projects" test where the archived project incorrectly had `saved_once: 0` (`src/db/queries/admin.spec.ts`)
- Added a new test "should exclude unsaved projects from counts" that creates a mix of saved and unsaved projects and verifies only saved ones are counted

All 6362 tests pass, no lint issues.