### PR TITLE
Fix. 1251 Interactive video editor not working

### DIFF
--- a/public/files/perm/idevices/base/interactive-video/edition/editor/index.html
+++ b/public/files/perm/idevices/base/interactive-video/edition/editor/index.html
@@ -83,12 +83,12 @@
             adminStyle.rel = 'stylesheet';
             adminStyle.href = window.__LOCAL_RESOURCE_PREFIX__ + 'css/admin.css';
             document.head.appendChild(adminStyle);
-
-            // Load langs script (local resource)
-            var langsScript = document.createElement('script');
-            langsScript.src = window.__LOCAL_RESOURCE_PREFIX__ + 'langs/all.js';
-            document.head.appendChild(langsScript);
         })();
+    </script>
+
+    <!-- Load langs script synchronously (required before admin.js) -->
+    <script>
+        document.write('<script src="' + window.__LOCAL_RESOURCE_PREFIX__ + 'langs/all.js"><\/script>');
     </script>
 
     <!-- Load external scripts after path computation -->


### PR DESCRIPTION
The change was made to prevent scripts from loading in the wrong order in the editor’s index.html

Previously, in the editor’s index.html, langs/all.js was loaded asynchronously and admin.js executed immediately. Since admin.js uses $i18n, it sometimes ran before $i18n was available, causing the $i18n is not defined error—especially on slow connections or without cache.