### PR TITLE
Unify edit title string

### DIFF
--- a/scripts/static-bundle/static-index.html
+++ b/scripts/static-bundle/static-index.html
@@ -186,7 +186,7 @@
                 <div id="exe-title" class="title-not-editing">
                     <h2 class="exe-title content" id="change_title">...</h2>
                     <button class="btn button-square button-tertiary tertiary-green title-menu-button exe-app-tooltip"
-                            data-bs-toggle="tooltip" data-bs-placement="bottom" title="Change title" data-i18n-title="Change title" aria-label="Change title" data-i18n-aria-label="Change title">
+                            data-bs-toggle="tooltip" data-bs-placement="bottom" title="Edit title" data-i18n-title="Edit title" aria-label="Edit title" data-i18n-aria-label="Edit title">
                         <span class="exe-icon small-icon edit-icon-green"></span>
                     </button>
                 </div>

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -791,7 +791,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     user_menu: trans('User menu', {}, locale),
                     users_online: trans('Users online', {}, locale),
                     exit: trans('Exit', {}, locale),
-                    change_title: trans('Change title', {}, locale),
+                    change_title: trans('Edit title', {}, locale),
                     move_up: trans('Move up', {}, locale),
                     move_down: trans('Move down', {}, locale),
                     move_left: trans('Move left (up in hierarchy)', {}, locale),

--- a/views/workarea/workarea.njk
+++ b/views/workarea/workarea.njk
@@ -82,7 +82,7 @@
             <div class="content-info">
                 <div id="exe-title" class="title-not-editing">
                     <h2 class="exe-title content" id="change_title">...</h2>
-                    <button class="btn button-square button-tertiary tertiary-green title-menu-button exe-app-tooltip" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ t.change_title or 'Change title' }}" aria-label="{{ t.change_title or 'Change title' }}">
+                    <button class="btn button-square button-tertiary tertiary-green title-menu-button exe-app-tooltip" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ t.change_title or 'Edit title' }}" aria-label="{{ t.change_title or 'Edit title' }}">
                         <span class="exe-icon small-icon edit-icon-green"></span>
                     </button>
                 </div>


### PR DESCRIPTION
This pull request updates the wording of the "Change title" button throughout the app to "Edit title" for improved clarity and consistency. The change affects the button label, tooltip, and translation key in both the UI and code.

UI and translation updates:

* Updated the button tooltip and aria-label from "Change title" to "Edit title" in `static-index.html` and `workarea.njk` to reflect the new wording. 
* Changed the translation key value from "Change title" to "Edit title" in the `createPagesRoutes` function in `pages.ts`.