### PR TITLE
Improve image optimizer avoiding optimize already optimized images

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalImageOptimizer.js
+++ b/public/app/workarea/modals/modals/pages/modalImageOptimizer.js
@@ -50,6 +50,9 @@ const STATUS_BADGE_CONFIG = {
     [STATUS.FAILED]: (error) => `<span class="badge bg-danger" title="${error || _('Error')}">${_('Failed')}</span>`,
 };
 
+const ALREADY_OPTIMIZED_MIN_SAVINGS_PERCENT = 1;
+const STATUS_ALREADY_OPTIMIZED = 'already_optimized';
+
 /**
  * ModalImageOptimizer
  *
@@ -498,6 +501,7 @@ export default class ModalImageOptimizer extends Modal {
     updateImageRow(assetId, data) {
         const row = this.rowElements.get(assetId);
         if (!row) return;
+        const isAlreadyOptimized = this.isAlreadyOptimized(data);
 
         // Update estimated size
         if (data.estimatedSize !== null && data.estimatedSize !== undefined) {
@@ -538,8 +542,11 @@ export default class ModalImageOptimizer extends Modal {
         // Update status
         const statusCell = row.querySelector('.image-optimizer-status');
         if (statusCell) {
-            statusCell.innerHTML = this.getStatusBadge(data.status, data.error);
+            const status = isAlreadyOptimized ? STATUS_ALREADY_OPTIMIZED : data.status;
+            statusCell.innerHTML = this.getStatusBadge(status, data.error);
         }
+
+        this.setAssetSelectable(assetId, !isAlreadyOptimized);
 
         // Highlight row when optimizing starts
         if (data.status === STATUS.OPTIMIZING && this.viewState === 'progress') {
@@ -562,8 +569,51 @@ export default class ModalImageOptimizer extends Modal {
      * @returns {string}
      */
     getStatusBadge(status, error = null) {
+        if (status === STATUS_ALREADY_OPTIMIZED) {
+            return `<span class="badge bg-secondary">${_('Already optimized')}</span>`;
+        }
         const badgeGenerator = STATUS_BADGE_CONFIG[status];
         return badgeGenerator ? badgeGenerator(error) : '';
+    }
+
+    isAlreadyOptimized(data) {
+        const originalSize = data.originalSize || 0;
+        const finalSize = data.optimizedSize || data.estimatedSize;
+        if (!originalSize || finalSize === null || finalSize === undefined) {
+            return false;
+        }
+
+        const savedBytes = originalSize - finalSize;
+        if (savedBytes <= 0) {
+            return true;
+        }
+
+        const savedPercent = (savedBytes / originalSize) * 100;
+        return savedPercent < ALREADY_OPTIMIZED_MIN_SAVINGS_PERCENT;
+    }
+
+    setAssetSelectable(assetId, selectable) {
+        const row = this.rowElements.get(assetId);
+        if (!row) return;
+
+        row.dataset.selectable = selectable ? 'true' : 'false';
+        const checkbox = row.querySelector('.image-optimizer-row-checkbox');
+        if (!checkbox) return;
+
+        if (!selectable) {
+            checkbox.checked = false;
+            this.selectedAssets.delete(assetId);
+        }
+
+        const canInteract = this.viewState === 'normal';
+        checkbox.disabled = !selectable || !canInteract;
+        this.updateSelectionState();
+    }
+
+    isAssetSelectable(assetId) {
+        const row = this.rowElements.get(assetId);
+        if (!row) return true;
+        return row.dataset.selectable !== 'false';
     }
 
     /**
@@ -584,6 +634,13 @@ export default class ModalImageOptimizer extends Modal {
      * @param {boolean} checked - Whether checked
      */
     onRowCheckboxChange(assetId, checked) {
+        if (!this.isAssetSelectable(assetId)) {
+            this.setRowCheckboxState(assetId, false);
+            this.selectedAssets.delete(assetId);
+            this.updateSelectionState();
+            return;
+        }
+
         if (checked) {
             this.selectedAssets.add(assetId);
         } else {
@@ -606,6 +663,9 @@ export default class ModalImageOptimizer extends Modal {
      */
     selectAll() {
         for (const assetId of this.optimizerManager.queue.keys()) {
+            if (!this.isAssetSelectable(assetId)) {
+                continue;
+            }
             this.selectedAssets.add(assetId);
             this.setRowCheckboxState(assetId, true);
         }
@@ -641,8 +701,20 @@ export default class ModalImageOptimizer extends Modal {
      */
     updateToggleAllState() {
         if (!this.toggleAllCheckbox) return;
-        const total = this.optimizerManager.queue.size;
-        const selected = this.selectedAssets.size;
+        const queueKeys = this.optimizerManager?.queue?.keys?.();
+        const assetIds = queueKeys ? Array.from(queueKeys) : Array.from(this.rowElements.keys());
+
+        let total = 0;
+        let selected = 0;
+        for (const assetId of assetIds) {
+            if (!this.isAssetSelectable(assetId)) {
+                continue;
+            }
+            total++;
+            if (this.selectedAssets.has(assetId)) {
+                selected++;
+            }
+        }
         this.toggleAllCheckbox.checked = total > 0 && selected === total;
         this.toggleAllCheckbox.indeterminate = selected > 0 && selected < total;
     }
@@ -652,7 +724,9 @@ export default class ModalImageOptimizer extends Modal {
      */
     updateButtons() {
         const hasSelection = this.selectedAssets.size > 0;
-        const isProcessing = this.optimizerManager?.isInProgress();
+        const isProcessing = typeof this.optimizerManager?.isInProgress === 'function'
+            ? this.optimizerManager.isInProgress()
+            : false;
 
         // Optimize only enabled if at least one selected item is READY (estimated)
         let hasReadyItems = false;
@@ -776,10 +850,10 @@ export default class ModalImageOptimizer extends Modal {
      * @param {boolean} interactive - Whether rows should be interactive
      */
     setRowsInteractive(interactive) {
-        for (const row of this.rowElements.values()) {
+        for (const [assetId, row] of this.rowElements.entries()) {
             const checkbox = row.querySelector('.image-optimizer-row-checkbox');
             if (checkbox) {
-                checkbox.disabled = !interactive;
+                checkbox.disabled = !interactive || !this.isAssetSelectable(assetId);
             }
         }
         if (this.toggleAllCheckbox) {

--- a/public/app/workarea/modals/modals/pages/modalImageOptimizer.js
+++ b/public/app/workarea/modals/modals/pages/modalImageOptimizer.js
@@ -502,10 +502,11 @@ export default class ModalImageOptimizer extends Modal {
         const row = this.rowElements.get(assetId);
         if (!row) return;
         const isAlreadyOptimized = this.isAlreadyOptimized(data);
+        const estimatedCell = row.querySelector('.image-optimizer-estimated-size');
+        const savingsCell = row.querySelector('.image-optimizer-savings');
 
         // Update estimated size
         if (data.estimatedSize !== null && data.estimatedSize !== undefined) {
-            const estimatedCell = row.querySelector('.image-optimizer-estimated-size');
             if (estimatedCell) {
                 estimatedCell.textContent = this.formatSize(data.estimatedSize);
                 estimatedCell.classList.remove('text-muted');
@@ -514,7 +515,6 @@ export default class ModalImageOptimizer extends Modal {
 
         // Update optimized size (after optimization)
         if (data.optimizedSize !== null && data.optimizedSize !== undefined) {
-            const estimatedCell = row.querySelector('.image-optimizer-estimated-size');
             if (estimatedCell) {
                 estimatedCell.textContent = this.formatSize(data.optimizedSize);
                 estimatedCell.classList.add('fw-bold');
@@ -522,7 +522,6 @@ export default class ModalImageOptimizer extends Modal {
         }
 
         // Update savings
-        const savingsCell = row.querySelector('.image-optimizer-savings');
         if (savingsCell) {
             const originalSize = data.originalSize || 0;
             const finalSize = data.optimizedSize || data.estimatedSize;
@@ -536,6 +535,17 @@ export default class ModalImageOptimizer extends Modal {
                 } else {
                     savingsCell.textContent = '0%';
                 }
+            }
+        }
+
+        if (isAlreadyOptimized) {
+            if (estimatedCell) {
+                estimatedCell.textContent = _('N/A');
+                estimatedCell.classList.add('text-muted');
+                estimatedCell.classList.remove('fw-bold');
+            }
+            if (savingsCell) {
+                savingsCell.textContent = _('N/A');
             }
         }
 

--- a/public/app/workarea/modals/modals/pages/modalImageOptimizer.test.js
+++ b/public/app/workarea/modals/modals/pages/modalImageOptimizer.test.js
@@ -573,7 +573,7 @@ describe('ModalImageOptimizer', () => {
             expect(savingsCell.innerHTML).toContain('25.0%');
         });
 
-        it('should update savings with negative value (size increased)', () => {
+        it('should show N/A savings when size would increase (already optimized)', () => {
             modal.updateImageRow('asset-1', {
                 originalSize: 1000,
                 estimatedSize: 1200,
@@ -581,7 +581,7 @@ describe('ModalImageOptimizer', () => {
             });
 
             const savingsCell = row.querySelector('.image-optimizer-savings');
-            expect(savingsCell.innerHTML).toContain('text-warning');
+            expect(savingsCell.textContent).toBe('N/A');
         });
 
         it('should update status badge', () => {
@@ -601,8 +601,12 @@ describe('ModalImageOptimizer', () => {
             });
 
             const statusCell = row.querySelector('.image-optimizer-status');
+            const estimatedCell = row.querySelector('.image-optimizer-estimated-size');
+            const savingsCell = row.querySelector('.image-optimizer-savings');
             const checkbox = row.querySelector('.image-optimizer-row-checkbox');
             expect(statusCell.innerHTML).toContain('Already optimized');
+            expect(estimatedCell.textContent).toBe('N/A');
+            expect(savingsCell.textContent).toBe('N/A');
             expect(checkbox.disabled).toBe(true);
             expect(checkbox.checked).toBe(false);
             expect(modal.selectedAssets.has('asset-1')).toBe(false);

--- a/public/app/workarea/modals/modals/pages/modalImageOptimizer.test.js
+++ b/public/app/workarea/modals/modals/pages/modalImageOptimizer.test.js
@@ -391,6 +391,34 @@ describe('ModalImageOptimizer', () => {
             const badge = modal.getStatusBadge('unknown');
             expect(badge).toBe('');
         });
+
+        it('should return badge for already optimized status', () => {
+            const badge = modal.getStatusBadge('already_optimized');
+            expect(badge).toContain('Already optimized');
+        });
+    });
+
+    describe('isAlreadyOptimized', () => {
+        it('should be true when estimated size is larger than original', () => {
+            expect(modal.isAlreadyOptimized({
+                originalSize: 1000,
+                estimatedSize: 1200,
+            })).toBe(true);
+        });
+
+        it('should be true when savings percent is below minimum threshold', () => {
+            expect(modal.isAlreadyOptimized({
+                originalSize: 1000,
+                estimatedSize: 995, // 0.5%
+            })).toBe(true);
+        });
+
+        it('should be false when savings percent is at or above minimum threshold', () => {
+            expect(modal.isAlreadyOptimized({
+                originalSize: 1000,
+                estimatedSize: 990, // 1.0%
+            })).toBe(false);
+        });
     });
 
     describe('buildImageRow', () => {
@@ -563,6 +591,23 @@ describe('ModalImageOptimizer', () => {
             expect(statusCell.innerHTML).toContain('Ready');
         });
 
+        it('should mark row as already optimized and disable selection', () => {
+            modal.selectedAssets.add('asset-1');
+
+            modal.updateImageRow('asset-1', {
+                status: STATUS.READY,
+                originalSize: 1000,
+                estimatedSize: 1002,
+            });
+
+            const statusCell = row.querySelector('.image-optimizer-status');
+            const checkbox = row.querySelector('.image-optimizer-row-checkbox');
+            expect(statusCell.innerHTML).toContain('Already optimized');
+            expect(checkbox.disabled).toBe(true);
+            expect(checkbox.checked).toBe(false);
+            expect(modal.selectedAssets.has('asset-1')).toBe(false);
+        });
+
         it('should not throw for unknown asset', () => {
             expect(() => {
                 modal.updateImageRow('unknown-asset', { status: STATUS.READY });
@@ -605,6 +650,19 @@ describe('ModalImageOptimizer', () => {
             modal.onRowCheckboxChange('asset-1', false);
 
             expect(modal.selectedAssets.has('asset-1')).toBe(false);
+        });
+
+        it('should keep asset unselected when row is not selectable', () => {
+            const blob = new Blob(['test'], { type: 'image/png' });
+            const row = modal.buildImageRow({ id: 'asset-1', filename: 'test.png', mime: 'image/png' }, blob, false);
+            row.dataset.selectable = 'false';
+            modal.rowElements.set('asset-1', row);
+
+            modal.onRowCheckboxChange('asset-1', true);
+
+            expect(modal.selectedAssets.has('asset-1')).toBe(false);
+            const checkbox = row.querySelector('.image-optimizer-row-checkbox');
+            expect(checkbox.checked).toBe(false);
         });
     });
 
@@ -662,6 +720,18 @@ describe('ModalImageOptimizer', () => {
                 const checkbox = row.querySelector('.image-optimizer-row-checkbox');
                 expect(checkbox.checked).toBe(false);
             }
+        });
+
+        it('should skip non-selectable assets when selecting all', () => {
+            const row1 = modal.rowElements.get('asset-1');
+            row1.dataset.selectable = 'false';
+            const checkbox1 = row1.querySelector('.image-optimizer-row-checkbox');
+
+            modal.selectAll();
+
+            expect(modal.selectedAssets.has('asset-1')).toBe(false);
+            expect(checkbox1.checked).toBe(false);
+            expect(modal.selectedAssets.has('asset-2')).toBe(true);
         });
     });
 


### PR DESCRIPTION
This pull request enhances the image optimizer modal by improving how images that are already optimized are handled. It introduces logic to automatically detect images that cannot be further optimized, updates their status display, and prevents users from selecting them for optimization. The changes also include comprehensive tests to ensure this new behavior works as expected.

**Image Optimization Logic Improvements:**

* Added logic to detect when an image is already optimized (savings below 1% or no reduction possible), and introduced a new status (`already_optimized`) for such cases. These images now display an "Already optimized" badge and are automatically made unselectable in the UI. 
* Updated selection logic throughout the modal to prevent already optimized assets from being (de)selected, including in bulk actions like "Select All", and ensured the UI reflects their unselectable state. 

**Testing Enhancements:**

* Added and updated unit tests to verify detection of already optimized images, correct badge rendering, and that non-selectable assets are properly excluded from selection actions and UI state.