### PR TITLE
Show 'untitled' in resource report when untitled box

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
@@ -149,8 +149,15 @@ export default class ModalOdeUsedFiles extends Modal {
                 // Column 1 (index 1) is the path - make it clickable
                 if (tdCount === 1) {
                     td.appendChild(this.createPathLink(tdContent[tdCount]));
-                } else if (tdCount === 4 && !tdContent[tdCount]) {
-                    // Column 4 is block name - show italic placeholder when empty
+                } else if (
+                    tdCount === 4
+                    && (
+                        !tdContent[tdCount]
+                        || tdContent[tdCount] === '-'
+                        || String(tdContent[tdCount]).trim() === ''
+                    )
+                ) {
+                    // Column 4 is block name - show italic placeholder when missing
                     let em = document.createElement('em');
                     em.textContent = _('Untitled');
                     td.appendChild(em);

--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
@@ -149,6 +149,11 @@ export default class ModalOdeUsedFiles extends Modal {
                 // Column 1 (index 1) is the path - make it clickable
                 if (tdCount === 1) {
                     td.appendChild(this.createPathLink(tdContent[tdCount]));
+                } else if (tdCount === 4 && !tdContent[tdCount]) {
+                    // Column 4 is block name - show italic placeholder when empty
+                    let em = document.createElement('em');
+                    em.textContent = _('Untitled');
+                    td.appendChild(em);
                 } else {
                     td.textContent = tdContent[tdCount];
                 }

--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
@@ -424,6 +424,27 @@ describe('ModalOdeUsedFiles', () => {
       expect(em.textContent).toBe('Untitled');
     });
 
+    it('should show italic "Untitled" placeholder for dash block name', () => {
+      const data = {
+        usedFiles: [
+          {
+            usedFiles: 'image.png',
+            usedFilesPath: '/api/assets/image.png',
+            usedFilesSize: '100KB',
+            pageNamesUsedFiles: 'Home',
+            blockNamesUsedFiles: '-',
+            typeComponentSyncUsedFiles: 'Image',
+            orderComponentSyncUsedFiles: 1
+          }
+        ]
+      };
+      const tbody = modal.makeTbodyElements(data);
+      const blockNameCell = tbody.querySelectorAll('td')[4];
+      const em = blockNameCell.querySelector('em');
+      expect(em).not.toBeNull();
+      expect(em.textContent).toBe('Untitled');
+    });
+
     it('should show normal text when block name is provided', () => {
       const data = {
         usedFiles: [

--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
@@ -402,6 +402,47 @@ describe('ModalOdeUsedFiles', () => {
       expect(span).not.toBeNull();
       expect(span.textContent).toBe('relative/path/image.png');
     });
+
+    it('should show italic "Untitled" placeholder for empty block name', () => {
+      const data = {
+        usedFiles: [
+          {
+            usedFiles: 'image.png',
+            usedFilesPath: '/api/assets/image.png',
+            usedFilesSize: '100KB',
+            pageNamesUsedFiles: 'Home',
+            blockNamesUsedFiles: '',
+            typeComponentSyncUsedFiles: 'Image',
+            orderComponentSyncUsedFiles: 1
+          }
+        ]
+      };
+      const tbody = modal.makeTbodyElements(data);
+      const blockNameCell = tbody.querySelectorAll('td')[4];
+      const em = blockNameCell.querySelector('em');
+      expect(em).not.toBeNull();
+      expect(em.textContent).toBe('Untitled');
+    });
+
+    it('should show normal text when block name is provided', () => {
+      const data = {
+        usedFiles: [
+          {
+            usedFiles: 'image.png',
+            usedFilesPath: '/api/assets/image.png',
+            usedFilesSize: '100KB',
+            pageNamesUsedFiles: 'Home',
+            blockNamesUsedFiles: 'My Block',
+            typeComponentSyncUsedFiles: 'Image',
+            orderComponentSyncUsedFiles: 1
+          }
+        ]
+      };
+      const tbody = modal.makeTbodyElements(data);
+      const blockNameCell = tbody.querySelectorAll('td')[4];
+      expect(blockNameCell.querySelector('em')).toBeNull();
+      expect(blockNameCell.textContent).toBe('My Block');
+    });
   });
 
   describe('makeOdeListElements', () => {


### PR DESCRIPTION
This pull request improves the display of the block name column in the `ModalOdeUsedFiles` modal by adding a user-friendly placeholder when the block name is missing, and adds corresponding tests to ensure this behavior.

**User interface improvements:**
* When the block name is empty in the used files table, an italicized "Untitled" placeholder is shown instead of leaving the cell blank. (`public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js`)

**Test coverage:**
* Added tests to verify that the "Untitled" placeholder appears when the block name is empty, and that the normal text is shown when a block name is provided. (`public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js`)