### PR TITLE
1329 generate static preview for external prs

### DIFF
--- a/.github/workflows/external-pr-preview.yml
+++ b/.github/workflows/external-pr-preview.yml
@@ -1,3 +1,16 @@
+# =============================================================================
+# Deploy External PR Preview
+# =============================================================================
+# Deploys a static preview of pull requests from external contributors (forks)
+# to GitHub Pages under /pr-preview/pr-{number}/.
+#
+# Previews are automatically cleaned up when the PR is closed or merged.
+#
+# ⚠️  SECURITY NOTE: This workflow uses `pull_request_target`, which means it
+# requires maintainer approval before running. Since it builds and deploys code
+# from external forks, maintainers MUST carefully review the PR changes before
+# approving the workflow run to prevent malicious code execution.
+# =============================================================================
 name: Deploy external PR Preview
 
 on:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically deploy static previews of pull requests from external contributors (forks) to GitHub Pages. This enables maintainers and contributors to easily view and test changes from forked repositories before merging, with built-in cleanup and security considerations.

**New workflow for external PR previews:**

* Added `.github/workflows/external-pr-preview.yml` to deploy static previews of external PRs (forks) to GitHub Pages under `/pr-preview/pr-{number}/`, with automatic cleanup when PRs are closed or merged. The workflow uses `pull_request_target` for security and requires maintainer approval before running.
* The workflow includes steps for checking out the PR safely, setting up Bun, installing dependencies, generating a version string, building the static distribution, deploying the preview, and posting the preview URL to the PR summary.