### PR TITLE
Hide position column

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.js
@@ -29,7 +29,6 @@ export default class ModalOdeUsedFiles extends Modal {
             _('Page name'),
             _('Block name'),
             _('iDevice'),
-            _('Position'),
         ];
         for (let thCount = 0; thCount < thTitles.length; thCount++) {
             let th = document.createElement('th');
@@ -141,7 +140,6 @@ export default class ModalOdeUsedFiles extends Modal {
                 files[odeComponentLinkKey]['pageNamesUsedFiles'],
                 files[odeComponentLinkKey]['blockNamesUsedFiles'],
                 files[odeComponentLinkKey]['typeComponentSyncUsedFiles'],
-                files[odeComponentLinkKey]['orderComponentSyncUsedFiles'],
             ];
             let tr = document.createElement('tr');
             for (let tdCount = 0; tdCount < tdContent.length; tdCount++) {

--- a/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
+++ b/public/app/workarea/modals/modals/pages/modalOdeUsedFiles.test.js
@@ -231,11 +231,11 @@ describe('ModalOdeUsedFiles', () => {
   });
 
   describe('makeTheadElements', () => {
-    it('should create thead with 7 columns', () => {
+    it('should create thead with 6 columns', () => {
       const thead = modal.makeTheadElements();
       expect(thead.tagName).toBe('THEAD');
       const headers = thead.querySelectorAll('th');
-      expect(headers.length).toBe(7);
+      expect(headers.length).toBe(6);
     });
 
     it('should have correct column titles', () => {
@@ -247,7 +247,6 @@ describe('ModalOdeUsedFiles', () => {
       expect(headers[3].textContent).toBe('Page name');
       expect(headers[4].textContent).toBe('Block name');
       expect(headers[5].textContent).toBe('iDevice');
-      expect(headers[6].textContent).toBe('Position');
     });
   });
 
@@ -314,7 +313,7 @@ describe('ModalOdeUsedFiles', () => {
       expect(tbody.querySelectorAll('tr').length).toBe(3);
     });
 
-    it('should populate all 7 columns correctly', () => {
+    it('should populate all 6 columns correctly', () => {
       const data = {
         usedFiles: [
           {
@@ -330,14 +329,13 @@ describe('ModalOdeUsedFiles', () => {
       };
       const tbody = modal.makeTbodyElements(data);
       const cells = tbody.querySelectorAll('td');
-      expect(cells.length).toBe(7);
+      expect(cells.length).toBe(6);
       expect(cells[0].textContent).toBe('test.png');
       // cells[1] is the path link
       expect(cells[2].textContent).toBe('50KB');
       expect(cells[3].textContent).toBe('TestPage');
       expect(cells[4].textContent).toBe('TestBlock');
       expect(cells[5].textContent).toBe('ImageTest');
-      expect(cells[6].textContent).toBe('42');
     });
 
     it('should make path column clickable for server paths', () => {


### PR DESCRIPTION
This pull request updates the `ModalOdeUsedFiles` modal and its associated tests to remove the "Position" column from the displayed table. The changes ensure that both the UI and tests are consistent with the new 6-column structure.

**UI Changes:**
- Removed the "Position" column from the table header and row data in `ModalOdeUsedFiles`.

**Test Updates:**
- Updated tests to expect 6 columns instead of 7, including adjusting column count assertions and removing checks for the "Position" column.