### PR TITLE
Allow view public projects

### DIFF
--- a/src/routes/admin.spec.ts
+++ b/src/routes/admin.spec.ts
@@ -1715,4 +1715,66 @@ describe('Admin Routes', () => {
             expect(response.status).toBe(404);
         });
     });
+
+    describe('GET /api/admin/projects/:id/download', () => {
+        it('should return 400 for invalid project id', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(createAdminRoutes(createMockDeps()));
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/projects/invalid/download', {
+                    method: 'GET',
+                    headers: { Authorization: `Bearer ${token}` },
+                }),
+            );
+
+            expect(response.status).toBe(400);
+            const body = await response.json();
+            expect(body.error).toBe('BAD_REQUEST');
+        });
+
+        it('should return 404 for non-existent project', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        findProjectById: async () => undefined,
+                    }),
+                ),
+            );
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/projects/999/download', {
+                    method: 'GET',
+                    headers: { Authorization: `Bearer ${token}` },
+                }),
+            );
+
+            expect(response.status).toBe(404);
+            const body = await response.json();
+            expect(body.error).toBe('NOT_FOUND');
+        });
+
+        it('should return 403 for private project', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        findProjectById: async () => mockProject({ id: 1, visibility: 'private' }),
+                    }),
+                ),
+            );
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/projects/1/download', {
+                    method: 'GET',
+                    headers: { Authorization: `Bearer ${token}` },
+                }),
+            );
+
+            expect(response.status).toBe(403);
+            const body = await response.json();
+            expect(body.error).toBe('FORBIDDEN');
+        });
+    });
 });

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -39,6 +39,18 @@ import { getUserStorageUsage as getUserStorageUsageDefault } from '../db/queries
 import { requireAdmin, hasRole, ROLES, PROTECTED_ROLE } from '../utils/guards';
 import { getSystemInfo } from '../services/system-info';
 import { createFileHelper, type FileHelper } from '../services/file-helper';
+import * as pathModule from 'path';
+import {
+    ElpxExporter,
+    FileSystemResourceProvider,
+    FileSystemAssetProvider,
+    DatabaseAssetProvider,
+    CombinedAssetProvider,
+    FflateZipProvider,
+    YjsDocumentAdapter,
+    ServerYjsDocumentWrapper,
+} from '../shared/export';
+import { reconstructDocument } from '../websocket/yjs-persistence';
 
 type AppSettingsTable = {
     key: string;
@@ -661,6 +673,57 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
 
                 await queries.hardDeleteProject(db, parsed.id);
                 return { success: true };
+            })
+
+            // GET /api/admin/projects/:id/download - Download project as .elpx (public projects only)
+            .get('/api/admin/projects/:id/download', async ({ params, set }) => {
+                const parsed = parseAndValidateId(params.id, set);
+                if ('error' in parsed) return parsed;
+
+                const project = await queries.findProjectById(db, parsed.id);
+                if (!project) {
+                    set.status = 404;
+                    return { error: 'NOT_FOUND', message: 'Project not found' };
+                }
+
+                if (project.visibility !== 'public') {
+                    set.status = 403;
+                    return { error: 'FORBIDDEN', message: 'Only public projects can be downloaded' };
+                }
+
+                const yjsDoc = await reconstructDocument(project.id);
+                const publicDir = pathModule.resolve(__dirname, '../../public');
+                const assetsDir = fileHelper!.getProjectAssetsDir(project.uuid);
+
+                const wrapper = new ServerYjsDocumentWrapper(yjsDoc, project.uuid);
+                const document = new YjsDocumentAdapter(wrapper);
+                const resources = new FileSystemResourceProvider(publicDir);
+                const zip = new FflateZipProvider();
+                const fsAssets = new FileSystemAssetProvider(assetsDir);
+                const dbAssets = new DatabaseAssetProvider(db, project.id, assetsDir);
+                const assets = new CombinedAssetProvider([dbAssets, fsAssets]);
+
+                const exporter = new ElpxExporter(document, resources, assets, zip);
+                const result = await exporter.export();
+
+                wrapper.destroy();
+
+                if (!result.success || !result.data) {
+                    set.status = 500;
+                    return { error: 'EXPORT_FAILED', message: result.error || 'Export failed' };
+                }
+
+                const slug = (project.title || 'untitled')
+                    .toLowerCase()
+                    .replace(/[^a-z0-9]+/g, '-')
+                    .replace(/^-|-$/g, '')
+                    .substring(0, 50);
+                const safeFilename = `project-${project.id}-${slug}.elpx`;
+
+                set.headers['content-type'] = 'application/zip';
+                set.headers['content-disposition'] = `attachment; filename="${safeFilename}"`;
+                set.headers['content-length'] = result.data.length.toString();
+                return result.data;
             })
 
             // DELETE /api/admin/users/:id - Delete user

--- a/views/admin/index.njk
+++ b/views/admin/index.njk
@@ -2395,19 +2395,28 @@
                     const createdAt = project.created_at ? new Date(project.created_at).toLocaleDateString() : '-';
                     const isChecked = selectedProjectIds.has(project.id) ? 'checked' : '';
 
+                    const isPublic = project.visibility === 'public';
                     const tr = document.createElement('tr');
                     tr.dataset.projectId = project.id;
                     tr.innerHTML = `
                         <td>
                             <input type="checkbox" class="bulk-checkbox project-checkbox" data-project-id="${project.id}" ${isChecked}>
                         </td>
-                        <td style="font-weight: 600; color: var(--admin-text-muted);">#${project.id}</td>
+                        <td style="font-weight: 600; color: var(--admin-text-muted);" title="${project.uuid}">#${project.id}</td>
                         <td>${project.title || '-'}</td>
                         <td>${ownerLabel}</td>
                         <td><span class="badge-role ${statusClass}">${project.status}</span></td>
                         <td><span class="badge-role ${visibilityClass}">${project.visibility}</span></td>
                         <td>${createdAt}</td>
                         <td>
+                            ${isPublic ? `
+                            <a class="btn-admin-outline" href="/workarea?project=${project.uuid}" target="_blank" title="{{ t.view_project or 'View Project' }}">
+                                <span class="mi mi-sm">open_in_new</span>
+                            </a>
+                            <button class="btn-admin-outline" onclick="downloadProjectElpx(${project.id}, '${(project.title || '').replace(/'/g, "\\'")}')" title="{{ t.download_elpx or 'Download .elpx' }}">
+                                <span class="mi mi-sm">download</span>
+                            </button>
+                            ` : ''}
                             <button class="btn-admin-outline" onclick="updateProjectStatus(${project.id}, '${nextStatus}')" title="${toggleLabel}">
                                 <span class="mi mi-sm">${toggleIcon}</span>
                             </button>
@@ -2717,6 +2726,26 @@
             } catch (err) {
                 console.error('Failed to delete project:', err);
                 alert(err.message || 'Failed to delete project');
+            }
+        }
+
+        async function downloadProjectElpx(projectId, projectTitle) {
+            try {
+                const res = await fetch(`${API_BASE}/projects/${projectId}/download`, { credentials: 'include' });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}));
+                    alert(err.message || T.error_downloading || 'Download failed');
+                    return;
+                }
+                const blob = await res.blob();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = res.headers.get('content-disposition')?.match(/filename="([^"]+)"/)?.[1] || `project-${projectId}.elpx`;
+                a.click();
+                URL.revokeObjectURL(url);
+            } catch (err) {
+                console.error('Download failed:', err);
             }
         }
 


### PR DESCRIPTION
This pull request introduces a new feature allowing admins to download public projects as `.elpx` files from the admin interface. The changes include backend route implementation, UI updates for download actions, and comprehensive tests to ensure correct behavior for various project states.

**Feature: Project Download as `.elpx`**

_Backend Implementation:_
* Added a new route `GET /api/admin/projects/:id/download` in `createAdminRoutes` to export public projects as `.elpx` files, including validation for project existence and visibility, and proper error handling.
* Imported necessary modules for export functionality, such as `ElpxExporter`, asset providers, and document adapters, in `src/routes/admin.ts`.

_Frontend & UI:_
* Updated `views/admin/index.njk` to show a download button for public projects, allowing admins to download the `.elpx` file directly from the project list.
* Added the `downloadProjectElpx` JavaScript function to handle the download action, including error handling and file naming logic.

_Test Coverage:_
* Added tests in `src/routes/admin.spec.ts` for the new download route, covering invalid project IDs, non-existent projects, and private projects to ensure correct HTTP status and error messages.