### PR TITLE
Fix: Checkbox properties not checked on static project load

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalProperties.js
+++ b/public/app/workarea/modals/modals/pages/modalProperties.js
@@ -18,6 +18,10 @@ export default class ModalProperties extends Modal {
         this.propertiesLockRefreshInterval = null;
     }
 
+    isCheckedValue(value) {
+        return value === true || value === 'true';
+    }
+
     /**
      *
      * @param {*} data
@@ -632,7 +636,7 @@ export default class ModalProperties extends Modal {
                 input.setAttribute('property', name);
                 input.setAttribute('data-type', 'checkbox');
                 input.classList.add('property-value', 'toggle-input');
-                input.checked = property.value == 'true' ? true : false;
+                input.checked = this.isCheckedValue(property.value);
 
                 const visual = document.createElement('span');
                 visual.classList.add('toggle-visual');

--- a/public/app/workarea/modals/modals/pages/modalProperties.test.js
+++ b/public/app/workarea/modals/modals/pages/modalProperties.test.js
@@ -149,6 +149,18 @@ describe('ModalProperties', () => {
       expect(el.querySelector('input').checked).toBe(true);
     });
 
+    it('should create checkbox (toggle) from boolean true value', () => {
+      const prop = { type: 'checkbox', value: true };
+      const el = modal.makeRowValueElement('id', 'name', prop);
+      expect(el.querySelector('input').checked).toBe(true);
+    });
+
+    it('should create checkbox (toggle) from boolean false value', () => {
+      const prop = { type: 'checkbox', value: false };
+      const el = modal.makeRowValueElement('id', 'name', prop);
+      expect(el.querySelector('input').checked).toBe(false);
+    });
+
     it('should create select with options', () => {
         const prop = { 
             type: 'select', 

--- a/public/app/workarea/project/projectManager.js
+++ b/public/app/workarea/project/projectManager.js
@@ -347,6 +347,17 @@ export default class projectManager {
         // Select first page and load its content
         await this.initialiceProject();
 
+        // Re-sync project properties form after refresh.
+        // During static imports, metadata can be cleared/reloaded in quick succession,
+        // leaving stale checkbox/select states in the existing form.
+        if (this.properties) {
+            this.properties.loadPropertiesFromYjs();
+            this.properties.formProperties?.reloadValues?.();
+        }
+        if (this._yjsBridge?.forceAllFormInputsSync) {
+            this._yjsBridge.forceAllFormInputsSync();
+        }
+
         // Show workarea
         this.showScreen();
         // Signal that the document is fully loaded and ready for interaction

--- a/public/app/workarea/project/projectManager.test.js
+++ b/public/app/workarea/project/projectManager.test.js
@@ -2907,7 +2907,11 @@ describe('ProjectManager', () => {
             };
             projectManager.properties = {
                 loadPropertiesFromYjs: vi.fn(),
+                formProperties: {
+                    reloadValues: vi.fn(),
+                },
             };
+            projectManager._yjsBridge = null;
             projectManager.initialiceProject = vi.fn().mockResolvedValue();
             projectManager.showScreen = vi.fn();
             mockApp.interface.odeTitleElement = { setTitle: vi.fn() };
@@ -2937,6 +2941,23 @@ describe('ProjectManager', () => {
 
             expect(projectManager.initialiceProject).toHaveBeenCalled();
             expect(projectManager.showScreen).toHaveBeenCalled();
+        });
+
+        it('reloads properties form values after refresh', async () => {
+            await projectManager.refreshAfterDirectImport();
+
+            expect(projectManager.properties.loadPropertiesFromYjs).toHaveBeenCalledTimes(2);
+            expect(projectManager.properties.formProperties.reloadValues).toHaveBeenCalled();
+        });
+
+        it('forces Yjs form input sync when bridge is available', async () => {
+            projectManager._yjsBridge = {
+                forceAllFormInputsSync: vi.fn(),
+            };
+
+            await projectManager.refreshAfterDirectImport();
+
+            expect(projectManager._yjsBridge.forceAllFormInputsSync).toHaveBeenCalled();
         });
 
         it('reinitializes theme binding when themes manager exists', async () => {

--- a/public/app/workarea/project/properties/formProperties.js
+++ b/public/app/workarea/project/properties/formProperties.js
@@ -16,6 +16,10 @@ export default class FormProperties {
         this.yjsBinding = null;
     }
 
+    isCheckedValue(value) {
+        return value === true || value === 'true';
+    }
+
     show() {
         this.combineMetadataProperties();
         const formElement = this.makeBodyElement(this.metadataProperties);
@@ -569,7 +573,7 @@ export default class FormProperties {
                 break;
             case 'checkbox':
                 valueElement = document.createElement('input');
-                valueElement.checked = property.value == 'true' ? true : false;
+                valueElement.checked = this.isCheckedValue(property.value);
                 valueElement.classList.add('toggle-input');
                 break;
             case 'date':
@@ -969,7 +973,7 @@ export default class FormProperties {
             if (!element) continue;
             switch (property.type) {
                 case 'checkbox':
-                    element.checked = property.value == 'true' ? true : false;
+                    element.checked = this.isCheckedValue(property.value);
                     break;
                 case 'select': {
                     const select = element.querySelector(

--- a/public/app/workarea/project/properties/formProperties.test.js
+++ b/public/app/workarea/project/properties/formProperties.test.js
@@ -501,9 +501,36 @@ describe('FormProperties', () => {
             expect(element.classList.contains('toggle-input')).toBe(true);
         });
 
+        it('should create checkbox input element from boolean true value', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const property = { type: 'checkbox', value: true, id: 'testId' };
+
+            const element = formProperties.makeRowValueElement(
+                'test-id',
+                'testName',
+                property
+            );
+
+            expect(element.tagName).toBe('INPUT');
+            expect(element.checked).toBe(true);
+        });
+
         it('should create checkbox as unchecked for false value', () => {
             const formProperties = new FormProperties(mockProperties);
             const property = { type: 'checkbox', value: 'false', id: 'testId' };
+
+            const element = formProperties.makeRowValueElement(
+                'test-id',
+                'testName',
+                property
+            );
+
+            expect(element.checked).toBe(false);
+        });
+
+        it('should create checkbox as unchecked for boolean false value', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const property = { type: 'checkbox', value: false, id: 'testId' };
 
             const element = formProperties.makeRowValueElement(
                 'test-id',
@@ -979,6 +1006,31 @@ describe('FormProperties', () => {
                     testCheckbox: {
                         type: 'checkbox',
                         value: 'true',
+                        alwaysVisible: true,
+                    },
+                },
+                cataloguing: {},
+                project: mockProject,
+            };
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.setAttribute('property', 'testCheckbox');
+            mockNodeContent.querySelector = vi.fn(() => checkbox);
+
+            formProperties.reloadValues();
+
+            expect(checkbox.checked).toBe(true);
+        });
+
+        it('should reload checkbox boolean values to checked', () => {
+            const formProperties = new FormProperties(mockProperties);
+            formProperties.nodeContent = mockNodeContent;
+            formProperties.properties = {
+                properties: {
+                    testCheckbox: {
+                        type: 'checkbox',
+                        value: true,
                         alwaysVisible: true,
                     },
                 },

--- a/public/app/workarea/project/properties/projectProperties.js
+++ b/public/app/workarea/project/properties/projectProperties.js
@@ -62,6 +62,9 @@ export default class ProjectProperties {
      * Show modal properties
      */
     showModalProperties() {
+        // Ensure modal opens with the latest values from Yjs metadata
+        this.loadPropertiesFromYjs();
+
         eXeLearning.app.modals.properties.show({
             node: this,
             title: _('Project properties'),
@@ -93,7 +96,11 @@ export default class ProjectProperties {
                 const metadataKey = this.mapPropertyToMetadataKey(key);
                 const value = metadata.get(metadataKey);
                 if (value !== undefined) {
-                    this.properties[key].value = value;
+                    if (property.type === 'checkbox' && typeof value === 'boolean') {
+                        this.properties[key].value = value ? 'true' : 'false';
+                    } else {
+                        this.properties[key].value = value;
+                    }
                 }
             }
 

--- a/public/app/workarea/project/properties/projectProperties.test.js
+++ b/public/app/workarea/project/properties/projectProperties.test.js
@@ -307,6 +307,14 @@ describe('ProjectProperties', () => {
             const callArgs = window.eXeLearning.app.modals.properties.show.mock.calls[0][0];
             expect(callArgs.fullScreen).toBe(true);
         });
+
+        it('should refresh properties from Yjs before opening modal', () => {
+            const loadSpy = vi.spyOn(projectProperties, 'loadPropertiesFromYjs');
+
+            projectProperties.showModalProperties();
+
+            expect(loadSpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('loadPropertiesFromYjs', () => {
@@ -443,6 +451,17 @@ describe('ProjectProperties', () => {
             projectProperties.loadPropertiesFromYjs();
 
             expect(mockDocumentManager.getMetadata).toHaveBeenCalledTimes(1);
+        });
+
+        it('should normalize checkbox metadata booleans to string values', () => {
+            projectProperties.properties = {
+                pp_addSearchBox: { title: 'Search', value: 'false', type: 'checkbox' },
+            };
+            mockMetadataMap.set('addSearchBox', true);
+
+            projectProperties.loadPropertiesFromYjs();
+
+            expect(projectProperties.properties.pp_addSearchBox.value).toBe('true');
         });
     });
 

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -1584,6 +1584,8 @@ class YjsProjectBridge {
       'pp_addPagination': 'addPagination',
       'pp_addSearchBox': 'addSearchBox',
       'pp_addAccessibilityToolbar': 'addAccessibilityToolbar',
+      'pp_addMathJax': 'addMathJax',
+      'pp_globalFont': 'globalFont',
       'pp_extraHeadContent': 'extraHeadContent',
       'exportSource': 'exportSource',
       'footer': 'footer',

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -3250,6 +3250,42 @@ describe('YjsProjectBridge', () => {
       expect(mockInput.value).toBe('New Title');
     });
 
+    it('updates addMathJax and globalFont inputs using mapped metadata keys', () => {
+      const mockCheckbox = {
+        getAttribute: (attr) => {
+          if (attr === 'property') return 'pp_addMathJax';
+          if (attr === 'data-type') return 'checkbox';
+          return null;
+        },
+        type: 'checkbox',
+        checked: false,
+      };
+      const mockSelect = {
+        getAttribute: (attr) => {
+          if (attr === 'property') return 'pp_globalFont';
+          if (attr === 'data-type') return 'select';
+          return null;
+        },
+        type: 'select-one',
+        value: '',
+      };
+      global.document.querySelectorAll = mock(() => [mockCheckbox, mockSelect]);
+
+      const mockMetadata = {
+        get: (key) => {
+          if (key === 'addMathJax') return true;
+          if (key === 'globalFont') return 'default';
+          return undefined;
+        },
+      };
+      bridge.documentManager.getMetadata = () => mockMetadata;
+
+      bridge.forceAllFormInputsSync();
+
+      expect(mockCheckbox.checked).toBe(true);
+      expect(mockSelect.value).toBe('default');
+    });
+
     it('clears stale text inputs when metadata key is missing', () => {
       const mockInput = {
         getAttribute: (attr) => {


### PR DESCRIPTION
**Problem**

When opening an `.elpx` project in static mode, checkbox properties in the Project Properties modal (such as "Add MathJax", "Add Search Box", "Add Accessibility Toolbar", etc.) were not being checked even when the values were stored as `true` in the Yjs metadata. This regression only affected the static build, not the online version.

The root cause was a type mismatch: Yjs metadata stores checkbox values as boolean `true`/`false`, but the form rendering code only compared against the string `'true'`, so `true === 'true'` always returned `false`, leaving all checkboxes unchecked after a project load.

**Steps to reproduce**

1. Use the static build of eXeLearning.
2. Open one of the attached `.elpx` files.
3. Open Project Properties.
4. Observe that options like "Add MathJax" or "Add Search Box" are unchecked despite being enabled in the file.

**Fix**

- Added a shared `isCheckedValue(value)` helper in `ModalProperties` and `FormProperties` that accepts both `true` (boolean) and `'true'` (string).
- Updated all checkbox rendering and reload paths to use this helper instead of the loose `== 'true'` comparison.
- Added `pp_addMathJax` and `pp_globalFont` to the Yjs property key map in `YjsProjectBridge`, which were missing and caused those fields to never sync.
- Added a re-sync step in `refreshAfterDirectImport` that calls `loadPropertiesFromYjs` and `reloadValues` after a static import, ensuring the form reflects the correct state after metadata is fully loaded.
- Added `loadPropertiesFromYjs` call before opening the modal in `showModalProperties`, so the modal always opens with fresh values from Yjs.
- Added normalization in `loadPropertiesFromYjs` to convert boolean checkbox metadata back to the string format `'true'`/`'false'` expected internally, keeping the rest of the codebase consistent.

**Tests**

New unit tests cover:
- Checkbox rendering with boolean `true` and `false` values.
- `reloadValues` correctly updating checkboxes from boolean metadata.
- `forceAllFormInputsSync` syncing `addMathJax` and `globalFont` inputs.
- `loadPropertiesFromYjs` normalizing boolean metadata to string values.
- `showModalProperties` calling `loadPropertiesFromYjs` before opening.
- `refreshAfterDirectImport` triggering form reload and Yjs bridge sync.

**Test files**
[exeflux2.elpx.zip](https://github.com/user-attachments/files/25467168/exeflux2.elpx.zip)
[testflux.elpx.zip](https://github.com/user-attachments/files/25467169/testflux.elpx.zip)

