### PR TITLE
Fix e2e tests for impersonate on matrix db

### DIFF
--- a/doc/deploy/.env.e2e
+++ b/doc/deploy/.env.e2e
@@ -3,3 +3,5 @@
 # default settings without modifying the base docker-compose files.
 ONLINE_THEMES_INSTALL=1
 APP_PORT=8080
+ADMIN_EMAIL=admin@exelearning.test
+ADMIN_PASSWORD=AdminPass123!

--- a/doc/deploy/docker-compose.mariadb.yml
+++ b/doc/deploy/docker-compose.mariadb.yml
@@ -38,7 +38,7 @@ services:
       
       # Admin user (created/updated when ADMIN_PASSWORD is set)
       ADMIN_EMAIL: "${ADMIN_EMAIL}"
-      # ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
 
       API_JWT_SECRET: "${API_JWT_SECRET:-ChangeThisToASecretForMariaDBDeployment}"
     depends_on:

--- a/doc/deploy/docker-compose.postgres.yml
+++ b/doc/deploy/docker-compose.postgres.yml
@@ -38,7 +38,7 @@ services:
       
       # Admin user (created/updated when ADMIN_PASSWORD is set)
       ADMIN_EMAIL: "${ADMIN_EMAIL}"
-      # ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
 
       API_JWT_SECRET: "${API_JWT_SECRET:-ChangeThisToASecretForPostgresDeployment}"
     depends_on:

--- a/doc/deploy/docker-compose.sqlite.yml
+++ b/doc/deploy/docker-compose.sqlite.yml
@@ -35,7 +35,7 @@ services:
       
       # Admin user (created/updated when ADMIN_PASSWORD is set)
       ADMIN_EMAIL: "${ADMIN_EMAIL}"
-      # ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
 
       API_JWT_SECRET: "${API_JWT_SECRET:-ChangeThisToASecretForSQLiteDeployment}"
 


### PR DESCRIPTION
This pull request fix a regression on matrix DB e2e test and improves the deployment configuration by enabling the setup of an admin user for all supported database environments. The changes ensure that the admin email and password can be set via environment variables, making deployments more consistent and secure.

Admin user configuration enhancements:

* Added `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables to the `.env.e2e` file to allow easy configuration of admin credentials during deployments.
* Updated `docker-compose.mariadb.yml`, `docker-compose.postgres.yml`, and `docker-compose.sqlite.yml` to enable passing `ADMIN_PASSWORD` to the application service, ensuring the admin user can be created or updated automatically in all database setups. [[1]](diffhunk://#diff-c8d277a61177476358d1ef5f5d7eba7236f9dd7420628e7616051a5e822002faL41-R41) [[2]](diffhunk://#diff-8334465f06bcc588ea0aa3d6d3a3a3bb6132f80c17c0db54757411d7fd625075L41-R41) [[3]](diffhunk://#diff-704a8bd6e9ba0bbe711c9d23dc827bb89a8dce2b09eefd76694ca64a91c486fcL38-R38)