### PR TITLE
Fixed homebrew push on release

### DIFF
--- a/.github/workflows/docs-and-repos.yml
+++ b/.github/workflows/docs-and-repos.yml
@@ -416,13 +416,22 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@main
 
       - name: Bump Homebrew cask PR
+        # Publishes to homebrew/cask via brew bump-cask-pr.
+        # Pre-releases (tags containing -beta or -rc) update the exelearning@beta cask;
+        # stable releases update the main exelearning cask.
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
-          # TODO: Remove @beta on 3.0.0 release!
-          brew bump-cask-pr exelearning@beta \
+
+          if [[ "$VERSION" == *-beta* || "$VERSION" == *-rc* ]]; then
+            CASK="exelearning@beta"
+          else
+            CASK="exelearning"
+          fi
+
+          brew bump-cask-pr "$CASK" \
             --version "$VERSION" \
             --no-audit \
             --no-browse


### PR DESCRIPTION
 Problem: macauley/action-homebrew-bump-cask@v1 calls brew ruby main.rb which loads Homebrew internals. Recent Homebrew dropped rubocop-ast from the portable Ruby, breaking the action at load time. The
  action is unmaintained.

  Fix: Two steps instead of one action:

  1. Homebrew/actions/setup-homebrew@main — the official action that exists .
  2. brew bump-cask-pr CLI — the official Homebrew command that does the same thing the broken action was doing: finds the cask, downloads the new DMG from the release URL
  (eXeLearning-{version}-universal.dmg), computes its SHA256, and opens a PR against homebrew-cask.

  Key details:
  - VERSION="${VERSION#v}" strips the leading v from the tag (e.g. v4.0.0-beta1 → 4.0.0-beta1)
  - HOMEBREW_GITHUB_API_TOKEN is the correct env var for brew bump-cask-pr to authenticate and create the PR
  - --no-audit skips the cask audit (same as the old action did)
  - --no-browse prevents it from opening a browser tab (CI environment)