### PR TITLE
This PR fixes a File Manager preview issue seen in WAF-protected environments.

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalFileManager.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.js
@@ -116,6 +116,19 @@ export default class ModalFilemanager extends Modal {
         this.previewAudio = this.modalElement.querySelector('.media-library-preview-audio');
         this.previewFile = this.modalElement.querySelector('.media-library-preview-file');
         this.previewPdf = this.modalElement.querySelector('.media-library-preview-pdf');
+        if (!this.previewPdf) {
+            const previewContainer = this.modalElement.querySelector('.media-library-preview');
+            if (previewContainer) {
+                const pdfIframe = document.createElement('iframe');
+                pdfIframe.className = 'media-library-preview-pdf';
+                pdfIframe.style.display = 'none';
+                pdfIframe.style.width = '100%';
+                pdfIframe.style.height = '250px';
+                pdfIframe.style.border = '1px solid #ccc';
+                previewContainer.insertBefore(pdfIframe, this.previewFile || null);
+                this.previewPdf = pdfIframe;
+            }
+        }
 
         // Folder navigation elements
         this.breadcrumbs = this.modalElement.querySelector('.media-library-breadcrumbs');

--- a/views/workarea/modals/pages/filemanager.njk
+++ b/views/workarea/modals/pages/filemanager.njk
@@ -111,7 +111,6 @@
                                 <img src="" alt="" class="media-library-preview-img">
                                 <video src="" class="media-library-preview-video" controls style="display:none;"></video>
                                 <audio src="" class="media-library-preview-audio" controls style="display:none;"></audio>
-                                <iframe src="" class="media-library-preview-pdf" style="display:none; width:100%; height:250px; border:1px solid #ccc;"></iframe>
                                 <div class="media-library-preview-file" style="display:none;">
                                     <span class="exe-icon file-icon">description</span>
                                 </div>


### PR DESCRIPTION
Root cause: 

the modal template included a static <iframe src=""> for PDF preview. Using an
iframe with an empty src is not a good practice, and some WAFs treat this pattern as
suspicious/malicious, rewriting or corrupting the HTML response. In our case, that broke the
preview DOM and affected the sidebar rendering.

What changed:

- Removed the static PDF preview iframe from the server-rendered template.
- Created the PDF preview iframe dynamically in JavaScript during modal initialization.

Result:

- Prevents WAF HTML corruption in the preview block.
- Keeps PDF preview functionality intact.
- No regressions in other media previews (image/video/audio).
