### PR TITLE
Fix typoo for build pacakge on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start:local": "cross-env FILES_DIR=data/ DB_PATH=data/exelearning.db PORT=8080 APP_ONLINE_MODE=1 bun run start:dev",
     "dev": "concurrently --names 'ELYSIA,SCSS' --prefix-colors 'blue,magenta' 'bun run start:dev' 'bun run sass:watch'",
     "dev:local": "concurrently --names 'ELYSIA,SCSS' --prefix-colors 'blue,magenta' 'bun run start:local' 'bun run sass:watch'",
-    "build": "bun build src/index.ts --outdir dist --target bun --external kysely --external kysely/* && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external kysely --external kysely/*",
+    "build": "bun build src/index.ts --outdir dist --target bun --external kysely --external 'kysely/*' && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external kysely --external 'kysely/*'",
     "build:standalone": "bun scripts/build-standalone.js",
     "build:all": "bun run build && bun run css:node && bun run bundle:resources && bun run bundle:app && bun run bundle:importers && bun run bundle:exporters",
     "build:static": "bun run build:all && bun scripts/build-static-bundle.ts",


### PR DESCRIPTION
This pull request makes a minor adjustment to the build script in the `package.json` file to improve compatibility with Bun's handling of external dependencies.

* Build script update: Changed the syntax for the `--external` flag to use quotes around `'kysely/*'` in the `build` script, ensuring Bun correctly recognizes the external module pattern.