### PR TITLE
Fix preview in new window stopping after ~1 minute (Service Worker content loss)

### DIFF
--- a/public/app/workarea/interface/elements/previewPanel.js
+++ b/public/app/workarea/interface/elements/previewPanel.js
@@ -43,6 +43,11 @@ export default class PreviewPanelManager {
         // Blob URL navigation state
         this._blobUrlFiles = null;
         this._blobUrlCurrentPage = null;
+
+        // Popup window tracking
+        this._popupWindow = null;
+        this._popupMonitorTimer = null;
+        this._recoveryChannel = null;
     }
 
     /**
@@ -53,6 +58,8 @@ export default class PreviewPanelManager {
         this.subscribeToChanges();
         this.resetToDefaultState();
         this._setupVisibilityHandler();
+        this._setupBroadcastChannelListener();
+        this._setupServiceWorkerListener();
         Logger.log('[PreviewPanel] Initialized');
     }
 
@@ -65,6 +72,10 @@ export default class PreviewPanelManager {
         this.isOpen = false;
         this.panel?.classList.remove('active');
         this.overlay?.classList.remove('active');
+
+        // Clean up popup tracking
+        this._popupWindow = null;
+        this._clearPopupMonitor();
 
         const workarea = document.getElementById('workarea');
         workarea?.setAttribute('data-preview-pinned', 'false');
@@ -91,11 +102,94 @@ export default class PreviewPanelManager {
     }
 
     /**
-     * Check if preview is currently visible (open or pinned)
+     * Setup BroadcastChannel listener for popup recovery.
+     * The popup's PREVIEW_REFRESH_SCRIPT relays CONTENT_NEEDED from the SW
+     * as PREVIEW_CONTENT_LOST via BroadcastChannel. This listener picks it up
+     * and triggers a content refresh so the popup can recover.
+     */
+    _setupBroadcastChannelListener() {
+        if (typeof BroadcastChannel === 'undefined') return;
+
+        this._recoveryChannel = new BroadcastChannel('exe-preview-recovery');
+        this._recoveryChannel.onmessage = (event) => {
+            if (event.data?.type === 'PREVIEW_CONTENT_LOST') {
+                Logger.log('[PreviewPanel] Popup reported content lost, refreshing SW content...');
+                this.refreshWithServiceWorker().catch((err) => {
+                    Logger.error('[PreviewPanel] Failed to recover popup content:', err);
+                });
+            }
+        };
+        Logger.log('[PreviewPanel] BroadcastChannel listener installed');
+    }
+
+    /**
+     * Listen for CONTENT_NEEDED messages directly from the Service Worker.
+     * SW client.postMessage() arrives on navigator.serviceWorker, NOT window.
+     * This ensures the main window can respond to SW recovery requests
+     * even when no preview iframe or popup has the relay script loaded.
+     */
+    _setupServiceWorkerListener() {
+        if (typeof navigator === 'undefined' || !navigator.serviceWorker?.addEventListener) return;
+
+        this._swMessageHandler = (event) => {
+            if (event.data?.type === 'CONTENT_NEEDED' && this._isPreviewVisible()) {
+                Logger.log('[PreviewPanel] SW requested content refresh (direct):', event.data.reason);
+                // Debounce to avoid multiple refreshes
+                if (this._swContentNeededTimer) {
+                    clearTimeout(this._swContentNeededTimer);
+                }
+                this._swContentNeededTimer = setTimeout(() => {
+                    this._swContentNeededTimer = null;
+                    this.refreshWithServiceWorker().catch((err) => {
+                        Logger.error('[PreviewPanel] Failed to resend content to SW:', err);
+                    });
+                }, 100);
+            }
+        };
+
+        navigator.serviceWorker.addEventListener('message', this._swMessageHandler);
+        Logger.log('[PreviewPanel] Service Worker message listener installed');
+    }
+
+    /**
+     * Start polling to detect when popup window closes.
+     * When closed, clean up the reference and stop polling.
+     */
+    _setupPopupMonitor() {
+        this._clearPopupMonitor();
+        this._popupMonitorTimer = setInterval(() => {
+            if (!this._isPopupOpen()) {
+                Logger.log('[PreviewPanel] Popup window closed');
+                this._popupWindow = null;
+                this._clearPopupMonitor();
+            }
+        }, 2000);
+    }
+
+    /**
+     * Clear popup monitor interval
+     */
+    _clearPopupMonitor() {
+        if (this._popupMonitorTimer) {
+            clearInterval(this._popupMonitorTimer);
+            this._popupMonitorTimer = null;
+        }
+    }
+
+    /**
+     * Check if preview is currently visible (open, pinned, or popup open)
      * @returns {boolean}
      */
     _isPreviewVisible() {
-        return this.isOpen || this.isPinned;
+        return this.isOpen || this.isPinned || this._isPopupOpen();
+    }
+
+    /**
+     * Check if a popup preview window is currently open
+     * @returns {boolean}
+     */
+    _isPopupOpen() {
+        return this._popupWindow != null && !this._popupWindow.closed;
     }
 
     /**
@@ -1210,6 +1304,8 @@ export default class PreviewPanelManager {
             const newTab = window.open(viewerUrl, '_blank');
 
             if (newTab) {
+                this._popupWindow = newTab;
+                this._setupPopupMonitor();
                 Logger.log('[PreviewPanel] Preview opened in new tab');
             } else {
                 Logger.warn('[PreviewPanel] Popup blocked - trying fallback');
@@ -1378,6 +1474,26 @@ export default class PreviewPanelManager {
         if (this._contentNeededRefreshTimer) {
             clearTimeout(this._contentNeededRefreshTimer);
             this._contentNeededRefreshTimer = null;
+        }
+
+        // Clean up popup tracking
+        this._popupWindow = null;
+        this._clearPopupMonitor();
+
+        // Close recovery BroadcastChannel
+        if (this._recoveryChannel) {
+            this._recoveryChannel.close();
+            this._recoveryChannel = null;
+        }
+
+        // Remove SW message listener
+        if (this._swMessageHandler) {
+            navigator.serviceWorker?.removeEventListener('message', this._swMessageHandler);
+            this._swMessageHandler = null;
+        }
+        if (this._swContentNeededTimer) {
+            clearTimeout(this._swContentNeededTimer);
+            this._swContentNeededTimer = null;
         }
 
         // Revoke blob URLs

--- a/public/app/workarea/interface/elements/previewPanel.test.js
+++ b/public/app/workarea/interface/elements/previewPanel.test.js
@@ -148,6 +148,8 @@ describe('PreviewPanelManager', () => {
       const subscribeSpy = vi.spyOn(manager, 'subscribeToChanges');
       const resetSpy = vi.spyOn(manager, 'resetToDefaultState').mockImplementation(() => {});
       const visibilitySpy = vi.spyOn(manager, '_setupVisibilityHandler').mockImplementation(() => {});
+      const broadcastSpy = vi.spyOn(manager, '_setupBroadcastChannelListener').mockImplementation(() => {});
+      const swListenerSpy = vi.spyOn(manager, '_setupServiceWorkerListener').mockImplementation(() => {});
 
       manager.init();
 
@@ -155,6 +157,8 @@ describe('PreviewPanelManager', () => {
       expect(subscribeSpy).toHaveBeenCalled();
       expect(resetSpy).toHaveBeenCalled();
       expect(visibilitySpy).toHaveBeenCalled();
+      expect(broadcastSpy).toHaveBeenCalled();
+      expect(swListenerSpy).toHaveBeenCalled();
     });
   });
 
@@ -181,11 +185,45 @@ describe('PreviewPanelManager', () => {
         expect(manager._isPreviewVisible()).toBe(true);
       });
 
-      it('should return false when neither open nor pinned', () => {
+      it('should return true when popup is open', () => {
         manager.isOpen = false;
         manager.isPinned = false;
+        manager._popupWindow = { closed: false };
+
+        expect(manager._isPreviewVisible()).toBe(true);
+      });
+
+      it('should return false when popup is closed', () => {
+        manager.isOpen = false;
+        manager.isPinned = false;
+        manager._popupWindow = { closed: true };
 
         expect(manager._isPreviewVisible()).toBe(false);
+      });
+
+      it('should return false when neither open, pinned, nor popup', () => {
+        manager.isOpen = false;
+        manager.isPinned = false;
+        manager._popupWindow = null;
+
+        expect(manager._isPreviewVisible()).toBe(false);
+      });
+    });
+
+    describe('_isPopupOpen', () => {
+      it('should return true when popup exists and is not closed', () => {
+        manager._popupWindow = { closed: false };
+        expect(manager._isPopupOpen()).toBe(true);
+      });
+
+      it('should return false when popup is null', () => {
+        manager._popupWindow = null;
+        expect(manager._isPopupOpen()).toBe(false);
+      });
+
+      it('should return false when popup is closed', () => {
+        manager._popupWindow = { closed: true };
+        expect(manager._isPopupOpen()).toBe(false);
       });
     });
 
@@ -382,6 +420,204 @@ describe('PreviewPanelManager', () => {
         vi.useRealTimers();
       });
     });
+
+    describe('CONTENT_NEEDED with popup open', () => {
+      it('should refresh when CONTENT_NEEDED received and popup is open', async () => {
+        vi.useFakeTimers();
+        manager.bindEvents();
+        manager.isOpen = false;
+        manager.isPinned = false;
+        manager._popupWindow = { closed: false };
+        const refreshSpy = vi.spyOn(manager, 'refresh').mockResolvedValue();
+
+        const event = new MessageEvent('message', {
+          data: { type: 'CONTENT_NEEDED', reason: 'SW restarted' },
+        });
+        window.dispatchEvent(event);
+
+        vi.advanceTimersByTime(150);
+
+        expect(refreshSpy).toHaveBeenCalled();
+        vi.useRealTimers();
+      });
+    });
+
+    describe('BroadcastChannel recovery', () => {
+      it('should setup BroadcastChannel listener on init', () => {
+        const originalBC = globalThis.BroadcastChannel;
+        let capturedChannel = null;
+        globalThis.BroadcastChannel = class {
+          constructor(name) { this.name = name; capturedChannel = this; }
+          close() {}
+        };
+
+        manager._setupBroadcastChannelListener();
+
+        expect(capturedChannel).not.toBeNull();
+        expect(capturedChannel.name).toBe('exe-preview-recovery');
+        expect(manager._recoveryChannel).toBe(capturedChannel);
+
+        globalThis.BroadcastChannel = originalBC;
+      });
+
+      it('should call refreshWithServiceWorker when PREVIEW_CONTENT_LOST received', async () => {
+        const swRefreshSpy = vi.spyOn(manager, 'refreshWithServiceWorker').mockResolvedValue();
+
+        const originalBC = globalThis.BroadcastChannel;
+        let onMessageHandler = null;
+        globalThis.BroadcastChannel = class {
+          constructor() {}
+          set onmessage(handler) { onMessageHandler = handler; }
+          get onmessage() { return onMessageHandler; }
+          close() {}
+        };
+
+        manager._setupBroadcastChannelListener();
+
+        // Simulate receiving PREVIEW_CONTENT_LOST
+        onMessageHandler({ data: { type: 'PREVIEW_CONTENT_LOST' } });
+
+        // Wait for async call
+        await vi.waitFor(() => {
+          expect(swRefreshSpy).toHaveBeenCalled();
+        });
+
+        globalThis.BroadcastChannel = originalBC;
+      });
+
+      it('should not crash if BroadcastChannel is unavailable', () => {
+        const originalBC = globalThis.BroadcastChannel;
+        delete globalThis.BroadcastChannel;
+
+        expect(() => manager._setupBroadcastChannelListener()).not.toThrow();
+        expect(manager._recoveryChannel).toBeNull();
+
+        globalThis.BroadcastChannel = originalBC;
+      });
+    });
+
+    describe('SW message listener', () => {
+      it('should setup navigator.serviceWorker message listener', () => {
+        const addEventSpy = vi.fn();
+        const originalSW = navigator.serviceWorker;
+        Object.defineProperty(navigator, 'serviceWorker', {
+          value: { addEventListener: addEventSpy, removeEventListener: vi.fn() },
+          configurable: true,
+        });
+
+        manager._setupServiceWorkerListener();
+
+        expect(addEventSpy).toHaveBeenCalledWith('message', expect.any(Function));
+        expect(manager._swMessageHandler).toBeDefined();
+
+        Object.defineProperty(navigator, 'serviceWorker', { value: originalSW, configurable: true });
+      });
+
+      it('should call refreshWithServiceWorker when CONTENT_NEEDED received and popup open', async () => {
+        vi.useFakeTimers();
+        const swRefreshSpy = vi.spyOn(manager, 'refreshWithServiceWorker').mockResolvedValue();
+        manager._popupWindow = { closed: false };
+
+        let capturedHandler;
+        const originalSW = navigator.serviceWorker;
+        Object.defineProperty(navigator, 'serviceWorker', {
+          value: {
+            addEventListener: (type, handler) => { capturedHandler = handler; },
+            removeEventListener: vi.fn(),
+          },
+          configurable: true,
+        });
+
+        manager._setupServiceWorkerListener();
+
+        // Simulate SW CONTENT_NEEDED
+        capturedHandler({ data: { type: 'CONTENT_NEEDED', reason: 'SW restarted' } });
+        vi.advanceTimersByTime(150);
+
+        expect(swRefreshSpy).toHaveBeenCalled();
+
+        Object.defineProperty(navigator, 'serviceWorker', { value: originalSW, configurable: true });
+        vi.useRealTimers();
+      });
+
+      it('should not refresh when preview is not visible', async () => {
+        vi.useFakeTimers();
+        const swRefreshSpy = vi.spyOn(manager, 'refreshWithServiceWorker').mockResolvedValue();
+        manager.isOpen = false;
+        manager.isPinned = false;
+        manager._popupWindow = null;
+
+        let capturedHandler;
+        const originalSW = navigator.serviceWorker;
+        Object.defineProperty(navigator, 'serviceWorker', {
+          value: {
+            addEventListener: (type, handler) => { capturedHandler = handler; },
+            removeEventListener: vi.fn(),
+          },
+          configurable: true,
+        });
+
+        manager._setupServiceWorkerListener();
+        capturedHandler({ data: { type: 'CONTENT_NEEDED', reason: 'SW restarted' } });
+        vi.advanceTimersByTime(150);
+
+        expect(swRefreshSpy).not.toHaveBeenCalled();
+
+        Object.defineProperty(navigator, 'serviceWorker', { value: originalSW, configurable: true });
+        vi.useRealTimers();
+      });
+    });
+
+    describe('popup monitor', () => {
+      it('should start monitoring on _setupPopupMonitor', () => {
+        vi.useFakeTimers();
+        manager._popupWindow = { closed: false };
+
+        manager._setupPopupMonitor();
+
+        expect(manager._popupMonitorTimer).not.toBeNull();
+        vi.useRealTimers();
+      });
+
+      it('should clear popup reference when popup closes', () => {
+        vi.useFakeTimers();
+        const popup = { closed: false };
+        manager._popupWindow = popup;
+
+        manager._setupPopupMonitor();
+
+        // Simulate popup closing
+        popup.closed = true;
+        vi.advanceTimersByTime(2500);
+
+        expect(manager._popupWindow).toBeNull();
+        expect(manager._popupMonitorTimer).toBeNull();
+        vi.useRealTimers();
+      });
+
+      it('should not clear popup reference while popup is open', () => {
+        vi.useFakeTimers();
+        manager._popupWindow = { closed: false };
+
+        manager._setupPopupMonitor();
+
+        vi.advanceTimersByTime(2500);
+
+        expect(manager._popupWindow).not.toBeNull();
+        vi.useRealTimers();
+      });
+
+      it('should clear monitor on _clearPopupMonitor', () => {
+        vi.useFakeTimers();
+        manager._popupWindow = { closed: false };
+        manager._setupPopupMonitor();
+
+        manager._clearPopupMonitor();
+
+        expect(manager._popupMonitorTimer).toBeNull();
+        vi.useRealTimers();
+      });
+    });
   });
 
   describe('open/close', () => {
@@ -481,6 +717,38 @@ describe('PreviewPanelManager', () => {
         expect.stringContaining('/viewer/index.html'),
         '_blank'
       );
+    });
+
+    it('should store popup window reference and start monitor', async () => {
+      manager.isServiceWorkerPreviewAvailable = vi.fn().mockReturnValue(true);
+      manager.refreshWithServiceWorker = vi.fn().mockResolvedValue();
+
+      const mockPopup = { closed: false };
+      global.open = vi.fn(() => mockPopup);
+      const monitorSpy = vi.spyOn(manager, '_setupPopupMonitor').mockImplementation(() => {});
+
+      await manager.extractToNewTab();
+
+      expect(manager._popupWindow).toBe(mockPopup);
+      expect(monitorSpy).toHaveBeenCalled();
+    });
+
+    it('should not store popup reference when popup is blocked', async () => {
+      manager.isServiceWorkerPreviewAvailable = vi.fn().mockReturnValue(true);
+      manager.refreshWithServiceWorker = vi.fn().mockResolvedValue();
+      global.open = vi.fn(() => null);
+
+      const mockClick = vi.fn();
+      vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') {
+          return { click: mockClick, href: '', target: '' };
+        }
+        return document.createElement(tag);
+      });
+
+      await manager.extractToNewTab();
+
+      expect(manager._popupWindow).toBeNull();
     });
 
     it('should fallback to link click if popup is blocked', async () => {
@@ -713,6 +981,36 @@ describe('PreviewPanelManager', () => {
       expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('blob:pdf-2');
       expect(manager._pdfEmbedBlobUrls).toBeNull();
     });
+
+    it('should clean up popup tracking, recovery channel, and SW listener', () => {
+      vi.useFakeTimers();
+      manager._popupWindow = { closed: false };
+      manager._setupPopupMonitor();
+
+      const closeSpy = vi.fn();
+      manager._recoveryChannel = { close: closeSpy };
+
+      const removeEventSpy = vi.fn();
+      const handler = vi.fn();
+      manager._swMessageHandler = handler;
+      const originalSW = navigator.serviceWorker;
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { removeEventListener: removeEventSpy },
+        configurable: true,
+      });
+
+      manager.destroy();
+
+      expect(manager._popupWindow).toBeNull();
+      expect(manager._popupMonitorTimer).toBeNull();
+      expect(closeSpy).toHaveBeenCalled();
+      expect(manager._recoveryChannel).toBeNull();
+      expect(removeEventSpy).toHaveBeenCalledWith('message', handler);
+      expect(manager._swMessageHandler).toBeNull();
+
+      Object.defineProperty(navigator, 'serviceWorker', { value: originalSW, configurable: true });
+      vi.useRealTimers();
+    });
   });
 
   // NOTE: Tests for blobToDataUrl and processUserThemeCssUrls have been removed
@@ -733,6 +1031,18 @@ describe('PreviewPanelManager', () => {
       expect(mockElements.previewsidenav.classList.contains('active')).toBe(false);
       expect(mockElements['preview-sidenav-overlay'].classList.contains('active')).toBe(false);
       expect(mockElements.workarea.getAttribute('data-preview-pinned')).toBe('false');
+    });
+
+    it('should clear popup tracking state', () => {
+      vi.useFakeTimers();
+      manager._popupWindow = { closed: false };
+      manager._setupPopupMonitor();
+
+      manager.resetToDefaultState();
+
+      expect(manager._popupWindow).toBeNull();
+      expect(manager._popupMonitorTimer).toBeNull();
+      vi.useRealTimers();
     });
   });
 

--- a/public/preview-sw.js
+++ b/public/preview-sw.js
@@ -125,7 +125,9 @@ const EXTERNAL_LINK_HANDLER_SCRIPT = `
 `;
 
 /**
- * Script to handle preview refresh notifications from SW
+ * Script to handle preview refresh notifications from SW.
+ * Also handles CONTENT_NEEDED: when the SW loses content, this relays
+ * the event to the main window via BroadcastChannel so it can regenerate.
  */
 const PREVIEW_REFRESH_SCRIPT = `
 <script data-injected-by="eXeLearning-Preview">
@@ -143,8 +145,59 @@ const PREVIEW_REFRESH_SCRIPT = `
                     window.location.reload();
                 }
             }
+            if (event.data && event.data.type === 'CONTENT_NEEDED') {
+                // SW lost its content — relay to main window via BroadcastChannel
+                try {
+                    var ch = new BroadcastChannel('exe-preview-recovery');
+                    ch.postMessage({ type: 'PREVIEW_CONTENT_LOST' });
+                    ch.close();
+                } catch (e) { /* BroadcastChannel not supported */ }
+            }
         });
     }
+})();
+</script>
+`;
+
+/**
+ * Script to keep the Service Worker alive by periodically pinging it.
+ * Only pings when the viewer page is visible. Stops when hidden.
+ * Cleans up on beforeunload.
+ */
+const KEEPALIVE_SCRIPT = `
+<script data-injected-by="eXeLearning-Preview">
+(function() {
+    var timer = null;
+    var INTERVAL = 20000; // 20 seconds
+
+    function ping() {
+        if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage({ type: 'GET_STATUS' });
+        }
+    }
+
+    function start() {
+        if (!timer) {
+            timer = setInterval(ping, INTERVAL);
+            ping(); // immediate first ping
+        }
+    }
+
+    function stop() {
+        if (timer) {
+            clearInterval(timer);
+            timer = null;
+        }
+    }
+
+    // Start only when visible
+    if (!document.hidden) start();
+
+    document.addEventListener('visibilitychange', function() {
+        if (document.hidden) { stop(); } else { start(); }
+    });
+
+    window.addEventListener('beforeunload', stop);
 })();
 </script>
 `;
@@ -417,6 +470,7 @@ function injectScripts(body, options = { openExternalLinksInNewWindow: true }) {
             scriptsToInject += EXTERNAL_LINK_HANDLER_SCRIPT;
         }
         scriptsToInject += PREVIEW_REFRESH_SCRIPT;
+        scriptsToInject += KEEPALIVE_SCRIPT;
         scriptsToInject += PDF_EMBED_HANDLER_SCRIPT;
 
         // Find insertion point (before </body> or </html>)
@@ -457,6 +511,16 @@ function createNotReadyResponse() {
             '<body style="font-family: system-ui; padding: 2rem; text-align: center;">' +
             '<h2>Preview not available</h2>' +
             '<p>Please open the preview panel to load content.</p>' +
+            '<script>' +
+            // Ask the main window to resend content via BroadcastChannel
+            'try{var ch=new BroadcastChannel("exe-preview-recovery");' +
+            'ch.postMessage({type:"PREVIEW_CONTENT_LOST"});ch.close();}catch(e){}' +
+            // Auto-reload when SW gets content back (CONTENT_UPDATED)
+            'if(navigator.serviceWorker){' +
+            'navigator.serviceWorker.addEventListener("message",function(e){' +
+            'if(e.data&&e.data.type==="CONTENT_UPDATED"){window.location.reload();}' +
+            '});}' +
+            '</script>' +
             '</body></html>',
         {
             status: 503,
@@ -622,6 +686,7 @@ if (typeof module !== 'undefined' && module.exports) {
         MIME_TYPES,
         EXTERNAL_LINK_HANDLER_SCRIPT,
         PREVIEW_REFRESH_SCRIPT,
+        KEEPALIVE_SCRIPT,
         PDF_EMBED_HANDLER_SCRIPT,
         getMimeType,
         extractFilePath,
@@ -718,6 +783,18 @@ if (typeof self !== 'undefined' && typeof self.addEventListener === 'function') 
                         fileCount: contentFiles.size,
                     });
                 }
+
+                // Broadcast CONTENT_UPDATED to all clients (needed for popup recovery)
+                // When content is restored after SW termination, other clients (e.g. popup
+                // windows showing the 503 page) need to know content is available again.
+                self.clients.matchAll().then(clients => {
+                    clients.forEach(client => {
+                        client.postMessage({
+                            type: 'CONTENT_UPDATED',
+                            updatedPaths: Object.keys(data.files),
+                        });
+                    });
+                });
                 break;
 
             case 'UPDATE_FILES':

--- a/public/preview-sw.test.js
+++ b/public/preview-sw.test.js
@@ -10,6 +10,7 @@ import {
     MIME_TYPES,
     EXTERNAL_LINK_HANDLER_SCRIPT,
     PREVIEW_REFRESH_SCRIPT,
+    KEEPALIVE_SCRIPT,
     PDF_EMBED_HANDLER_SCRIPT,
     getMimeType,
     extractFilePath,
@@ -69,6 +70,25 @@ describe('Preview Service Worker', () => {
             expect(PREVIEW_REFRESH_SCRIPT).toContain('data-injected-by="eXeLearning-Preview"');
             expect(PREVIEW_REFRESH_SCRIPT).toContain('CONTENT_UPDATED');
             expect(PREVIEW_REFRESH_SCRIPT).toContain('window.location.reload()');
+        });
+
+        it('should have PREVIEW_REFRESH_SCRIPT handle CONTENT_NEEDED via BroadcastChannel', () => {
+            expect(PREVIEW_REFRESH_SCRIPT).toContain('CONTENT_NEEDED');
+            expect(PREVIEW_REFRESH_SCRIPT).toContain('exe-preview-recovery');
+            expect(PREVIEW_REFRESH_SCRIPT).toContain('PREVIEW_CONTENT_LOST');
+            expect(PREVIEW_REFRESH_SCRIPT).toContain('BroadcastChannel');
+        });
+
+        it('should have KEEPALIVE_SCRIPT defined', () => {
+            expect(KEEPALIVE_SCRIPT).toContain('data-injected-by="eXeLearning-Preview"');
+            expect(KEEPALIVE_SCRIPT).toContain('GET_STATUS');
+            expect(KEEPALIVE_SCRIPT).toContain('setInterval');
+            expect(KEEPALIVE_SCRIPT).toContain('visibilitychange');
+            expect(KEEPALIVE_SCRIPT).toContain('beforeunload');
+        });
+
+        it('should have KEEPALIVE_SCRIPT use 20 second interval', () => {
+            expect(KEEPALIVE_SCRIPT).toContain('20000');
         });
 
         it('should have PDF_EMBED_HANDLER_SCRIPT defined', () => {
@@ -330,6 +350,25 @@ describe('Preview Service Worker', () => {
             expect(resultHtml).toContain('window.location.reload()');
         });
 
+        it('should always include keepalive script', () => {
+            const html = '<!DOCTYPE html><html><body></body></html>';
+            const body = new TextEncoder().encode(html);
+            const result = injectScripts(body);
+            const resultHtml = new TextDecoder().decode(result);
+
+            expect(resultHtml).toContain('GET_STATUS');
+            expect(resultHtml).toContain('setInterval');
+        });
+
+        it('should include keepalive script even when external links disabled', () => {
+            const html = '<!DOCTYPE html><html><body></body></html>';
+            const body = new TextEncoder().encode(html);
+            const result = injectScripts(body, { openExternalLinksInNewWindow: false });
+            const resultHtml = new TextDecoder().decode(result);
+
+            expect(resultHtml).toContain('GET_STATUS');
+        });
+
         it('should always include PDF embed handler script', () => {
             const html = '<!DOCTYPE html><html><body></body></html>';
             const body = new TextEncoder().encode(html);
@@ -375,6 +414,20 @@ describe('Preview Service Worker', () => {
             const text = await response.text();
             expect(text).toContain('Preview not available');
             expect(text).toContain('open the preview panel');
+        });
+
+        it('should include recovery script that sends PREVIEW_CONTENT_LOST via BroadcastChannel', async () => {
+            const response = createNotReadyResponse();
+            const text = await response.text();
+            expect(text).toContain('exe-preview-recovery');
+            expect(text).toContain('PREVIEW_CONTENT_LOST');
+        });
+
+        it('should include CONTENT_UPDATED listener for auto-reload', async () => {
+            const response = createNotReadyResponse();
+            const text = await response.text();
+            expect(text).toContain('CONTENT_UPDATED');
+            expect(text).toContain('window.location.reload()');
         });
     });
 


### PR DESCRIPTION
### Description

When the preview is opened in a **new window**, navigation initially works but stops responding after about one minute. Attempting to move to another page shows the *“Preview not available”* error.

This happens because some browsers terminate the **Service Worker** when the preview window is idle for a short time (energy-saving behaviour). When that happens, the Service Worker loses the preview content stored in memory, so navigation requests fail.

This PR extends the recovery mechanism introduced in **#1044** (which handled the same problem when switching browser tabs) to also support the **preview opened in a new window**.

### Solution

The fix introduces a recovery flow between the preview window, the main editor window, and the Service Worker:

* **Service Worker (`preview-sw.js`)**

  * Broadcast `CONTENT_UPDATED` to all clients after `SET_CONTENT`, so popup windows know when content is restored.
  * Inject a keepalive script that periodically pings the SW to reduce the chance of termination.
  * Extend the injected preview scripts to relay `CONTENT_NEEDED` events via `BroadcastChannel`.
  * Improve the fallback *503 preview page* so it can request content regeneration and automatically reload once content is restored.

* **Preview panel (`previewPanel.js`)**

  * Track the popup preview window.
  * Listen for recovery messages via `BroadcastChannel`.
  * Listen directly to Service Worker messages (`navigator.serviceWorker`).
  * Automatically resend preview content when the SW reports that content is missing.
  * Monitor popup lifecycle and clean up listeners.

### Result

If the Service Worker is terminated while the preview window is open:

1. The preview shows the temporary *Preview not available* page.
2. The popup signals the main window that content was lost.
3. The main window regenerates and sends the preview content again.
4. The Service Worker restores the files and notifies all clients.
5. The popup reloads automatically and navigation continues working.

### Related work

This issue is closely related to **#1044**, which already fixed the same root cause when switching browser tabs.

The same mechanism appears to be used in **exeviewer**, so it would be good to review that code path as well.

@ignaciogros could you please also check whether a similar fix should be applied in **exeviewer**?
