### PR TITLE
Fix constrain violation on theme update

### DIFF
--- a/src/db/queries/themes.spec.ts
+++ b/src/db/queries/themes.spec.ts
@@ -604,6 +604,29 @@ describe('Theme Queries', () => {
             expect(updated?.display_name).toBe('Updated Toggle Theme');
         });
 
+        test('should update existing non-builtin theme with same dir_name', async () => {
+            // Create a site theme (is_builtin=0) with a dir_name
+            await createTheme(db, {
+                dir_name: 'conflict-theme',
+                display_name: 'Site Version',
+                is_builtin: 0,
+                is_enabled: 0,
+            });
+
+            // Upsert a base theme with the same dir_name — should update, not fail
+            await upsertBaseTheme(db, {
+                dir_name: 'conflict-theme',
+                display_name: 'Base Version',
+                version: '1.0.0',
+            });
+
+            const theme = await findThemeByDirName(db, 'conflict-theme');
+            expect(theme).toBeDefined();
+            expect(theme?.display_name).toBe('Base Version');
+            expect(theme?.is_builtin).toBe(1);
+            expect(theme?.version).toBe('1.0.0');
+        });
+
         test('should handle null optional fields', async () => {
             await upsertBaseTheme(db, {
                 dir_name: 'minimal-theme',

--- a/src/db/queries/themes.ts
+++ b/src/db/queries/themes.ts
@@ -324,43 +324,35 @@ export async function upsertBaseTheme(
         license?: string | null;
     },
 ): Promise<void> {
-    const existing = await findBaseThemeByDirName(db, data.dir_name);
-
-    if (existing) {
-        // Update metadata but preserve is_enabled setting
-        await db
-            .updateTable('themes')
-            .set({
-                display_name: data.display_name,
-                description: data.description ?? null,
-                version: data.version ?? null,
-                author: data.author ?? null,
-                license: data.license ?? null,
-                updated_at: now(),
-            })
-            .where('id', '=', existing.id)
-            .execute();
-    } else {
-        // Insert new builtin theme
-        await db
-            .insertInto('themes')
-            .values({
-                dir_name: data.dir_name,
+    await db
+        .insertInto('themes')
+        .values({
+            dir_name: data.dir_name,
+            display_name: data.display_name,
+            description: data.description ?? null,
+            version: data.version ?? null,
+            author: data.author ?? null,
+            license: data.license ?? null,
+            is_builtin: 1,
+            is_enabled: 1,
+            is_default: 0,
+            sort_order: 0,
+            storage_path: null,
+            created_at: now(),
+            updated_at: now(),
+        })
+        .onConflict(oc =>
+            oc.column('dir_name').doUpdateSet({
                 display_name: data.display_name,
                 description: data.description ?? null,
                 version: data.version ?? null,
                 author: data.author ?? null,
                 license: data.license ?? null,
                 is_builtin: 1,
-                is_enabled: 1, // Enabled by default
-                is_default: 0,
-                sort_order: 0,
-                storage_path: null, // Builtin themes use filesystem
-                created_at: now(),
                 updated_at: now(),
-            })
-            .execute();
-    }
+            }),
+        )
+        .execute();
 }
 
 /**


### PR DESCRIPTION
This PR fixes a unique constraint error in PostgreSQL when syncing builtin themes.

The previous implementation of `upsertBaseTheme()` used a non-atomic check-then-insert flow. That caused two failure scenarios:

1. If a theme already existed with the same `dir_name` but `is_builtin = 0`, `findBaseThemeByDirName()` did not find it because it only searched builtin themes, and the subsequent `INSERT` failed with `themes_dir_name_key`.
2. Two concurrent processes could both miss the existing row and try to insert the same `dir_name`, causing a race condition.

### Fix

`upsertBaseTheme()` now uses Kysely’s `onConflict(...).doUpdateSet()` on `dir_name`, making the operation atomic.

On conflict, it updates theme metadata and sets `is_builtin = 1`, while preserving fields such as:

* `is_enabled`
* `is_default`
* `sort_order`

### Tests

Added coverage for the case where a non-builtin theme already exists with the same `dir_name`, ensuring the operation updates the row instead of failing.
