### PR TITLE
[experiment] Add regeneration tool

### DIFF
--- a/public/app/workarea/menus/navbar/items/navbarHelp.js
+++ b/public/app/workarea/menus/navbar/items/navbarHelp.js
@@ -27,6 +27,9 @@ export default class NavbarFile {
         this.aboutButton = this.menu.navbar.querySelector(
             '#navbar-button-about-exe'
         );
+        this.regenerateProjectButton = this.menu.navbar.querySelector(
+            '#navbar-button-regenerate-project'
+        );
     }
 
     /**
@@ -42,6 +45,7 @@ export default class NavbarFile {
         this.setExeWebEvent();
         this.setReportBugEvent();
         this.setAboutExeEvent();
+        this.setRegenerateProjectEvent();
     }
 
     /**************************************************************************************
@@ -135,6 +139,19 @@ export default class NavbarFile {
         });
     }
 
+    /**
+     * Regenerate project
+     * Help -> Regenerate project...
+     *
+     */
+    setRegenerateProjectEvent() {
+        if (this.regenerateProjectButton) {
+            this.regenerateProjectButton.addEventListener('click', () => {
+                this.regenerateProjectEvent();
+            });
+        }
+    }
+
     /**************************************************************************************
      * EVENTS
      **************************************************************************************/
@@ -204,5 +221,13 @@ export default class NavbarFile {
      */
     aboutExeEvent() {
         eXeLearning.app.modals.about.show();
+    }
+
+    /**
+     * Show Regenerate project modal
+     *
+     */
+    regenerateProjectEvent() {
+        eXeLearning.app.modals.regenerateproject.show();
     }
 }

--- a/public/app/workarea/menus/navbar/items/navbarHelp.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarHelp.test.js
@@ -26,6 +26,9 @@ describe('NavbarHelp', () => {
           about: {
             show: vi.fn(),
           },
+          regenerateproject: {
+            show: vi.fn(),
+          },
         },
       },
     };
@@ -40,6 +43,7 @@ describe('NavbarHelp', () => {
       exeWeb: { addEventListener: vi.fn() },
       reportBug: { addEventListener: vi.fn() },
       about: { addEventListener: vi.fn() },
+      regenerateProject: { addEventListener: vi.fn() },
     };
 
     // Mock navbar element with querySelector
@@ -54,6 +58,7 @@ describe('NavbarHelp', () => {
         if (selector === '#navbar-button-exe-web') return mockButtons.exeWeb;
         if (selector === '#navbar-button-report-bug') return mockButtons.reportBug;
         if (selector === '#navbar-button-about-exe') return mockButtons.about;
+        if (selector === '#navbar-button-regenerate-project') return mockButtons.regenerateProject;
         return null;
       }),
     };
@@ -111,6 +116,10 @@ describe('NavbarHelp', () => {
       expect(mockNavbar.querySelector).toHaveBeenCalledWith('#navbar-button-about-exe');
     });
 
+    it('should query regenerate project button', () => {
+      expect(mockNavbar.querySelector).toHaveBeenCalledWith('#navbar-button-regenerate-project');
+    });
+
     it('should store button references', () => {
       expect(navbarHelp.assistantButton).toBe(mockButtons.assistant);
       expect(navbarHelp.tutorialButton).toBe(mockButtons.tutorial);
@@ -120,6 +129,7 @@ describe('NavbarHelp', () => {
       expect(navbarHelp.exeWebButton).toBe(mockButtons.exeWeb);
       expect(navbarHelp.reportBugButton).toBe(mockButtons.reportBug);
       expect(navbarHelp.aboutButton).toBe(mockButtons.about);
+      expect(navbarHelp.regenerateProjectButton).toBe(mockButtons.regenerateProject);
     });
   });
 
@@ -134,6 +144,7 @@ describe('NavbarHelp', () => {
         exeWeb: vi.spyOn(navbarHelp, 'setExeWebEvent'),
         reportBug: vi.spyOn(navbarHelp, 'setReportBugEvent'),
         about: vi.spyOn(navbarHelp, 'setAboutExeEvent'),
+        regenerateProject: vi.spyOn(navbarHelp, 'setRegenerateProjectEvent'),
       };
 
       navbarHelp.setEvents();
@@ -388,6 +399,32 @@ describe('NavbarHelp', () => {
     });
   });
 
+  describe('setRegenerateProjectEvent', () => {
+    it('should add click event listener to regenerate project button', () => {
+      navbarHelp.setRegenerateProjectEvent();
+
+      expect(mockButtons.regenerateProject.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('should call regenerateProjectEvent when button is clicked', () => {
+      const spy = vi.spyOn(navbarHelp, 'regenerateProjectEvent');
+      navbarHelp.setRegenerateProjectEvent();
+
+      const clickHandler = mockButtons.regenerateProject.addEventListener.mock.calls[0][1];
+      clickHandler();
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('regenerateProjectEvent', () => {
+    it('should show regenerate project modal', () => {
+      navbarHelp.regenerateProjectEvent();
+
+      expect(window.eXeLearning.app.modals.regenerateproject.show).toHaveBeenCalled();
+    });
+  });
+
   describe('integration', () => {
     it('should setup all event listeners on setEvents call', () => {
       navbarHelp.setEvents();
@@ -400,6 +437,7 @@ describe('NavbarHelp', () => {
       expect(mockButtons.exeWeb.addEventListener).toHaveBeenCalled();
       expect(mockButtons.reportBug.addEventListener).toHaveBeenCalled();
       expect(mockButtons.about.addEventListener).toHaveBeenCalled();
+      expect(mockButtons.regenerateProject.addEventListener).toHaveBeenCalled();
     });
 
     it('should show modals when respective buttons clicked', () => {

--- a/public/app/workarea/modals/modals/pages/modalRegenerateProject.js
+++ b/public/app/workarea/modals/modals/pages/modalRegenerateProject.js
@@ -1,0 +1,159 @@
+import Modal from '../modal.js';
+import { scanBrokenAssetReferences, regenerate } from '../../../utils/RegenerateProjectService.js';
+
+/**
+ * Modal for regenerating a project as a clean .elpx file
+ */
+export default class ModalRegenerateProject extends Modal {
+    constructor(manager) {
+        const id = 'modalRegenerateProject';
+        super(manager, id, undefined, false);
+        this.confirmButton = this.modalElement.querySelector('button.btn.btn-primary');
+    }
+
+    /**
+     * Build the modal body HTML
+     * @returns {string}
+     */
+    buildBodyHtml() {
+        return `
+            <div class="regenerate-project-content">
+                <p>${_('Export a clean copy of this project as a new .elpx file. The original project will not be modified.')}</p>
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="regenerate-flatten-resources">
+                    <label class="form-check-label" for="regenerate-flatten-resources">
+                        ${_('Flatten resources')}
+                    </label>
+                    <small class="form-text text-muted d-block">${_('Remove subfolders from asset paths, placing all files at root level.')}</small>
+                    <small class="form-text text-warning d-block">${_('Warning: if files in different folders share the same name, they will be renamed, which may break embedded resources. Use with caution.')}</small>
+                </div>
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" id="regenerate-check-broken">
+                    <label class="form-check-label" for="regenerate-check-broken">
+                        ${_('Check for broken references')}
+                    </label>
+                    <small class="form-text text-muted d-block">${_('Scan content for asset references that no longer exist.')}</small>
+                </div>
+                <div id="regenerate-warnings" class="d-none mb-3"></div>
+                <div id="regenerate-progress" class="d-none">
+                    <div class="d-flex align-items-center">
+                        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                        <span>${_('Generating file...')}</span>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     * Show the modal
+     */
+    show() {
+        this.titleDefault = _('Regenerate project');
+        const time = this.manager.closeModals() ? 500 : 50;
+
+        setTimeout(() => {
+            this.setTitle(this.titleDefault);
+            this.setBody(this.buildBodyHtml());
+
+            if (this.confirmButton) {
+                this.confirmButton.disabled = false;
+                this.confirmButton.textContent = _('Regenerate');
+            }
+
+            this.setConfirmExec(() => this.onConfirm());
+
+            this.modal.show();
+        }, time);
+    }
+
+    /**
+     * Handle confirm button click
+     */
+    async onConfirm() {
+        this.preventCloseModal = true;
+
+        const flattenResources = this.modalElement.querySelector('#regenerate-flatten-resources')?.checked || false;
+        const checkBroken = this.modalElement.querySelector('#regenerate-check-broken')?.checked || false;
+
+        const warningsArea = this.modalElement.querySelector('#regenerate-warnings');
+        const progressArea = this.modalElement.querySelector('#regenerate-progress');
+
+        // Step 1: Check for broken references if requested
+        if (checkBroken) {
+            try {
+                const brokenRefs = scanBrokenAssetReferences();
+                if (brokenRefs.length > 0) {
+                    const alreadyWarned = warningsArea?.classList.contains('user-confirmed');
+                    if (!alreadyWarned) {
+                        this.showBrokenWarnings(warningsArea, brokenRefs);
+                        return; // Wait for user to click Regenerate again
+                    }
+                }
+            } catch (error) {
+                console.error('[ModalRegenerateProject] Broken reference scan failed:', error);
+            }
+        }
+
+        // Step 2: Regenerate
+        try {
+            if (this.confirmButton) this.confirmButton.disabled = true;
+            if (progressArea) progressArea.classList.remove('d-none');
+
+            await regenerate({ flattenResources });
+
+            this.preventCloseModal = false;
+            this.close(true);
+
+            eXeLearning.app.alerts.showToast({
+                type: 'success',
+                message: _('Project regenerated successfully'),
+            });
+        } catch (error) {
+            console.error('[ModalRegenerateProject] Regeneration failed:', error);
+            eXeLearning.app.alerts.showToast({
+                type: 'error',
+                message: _('Error regenerating project') + ': ' + error.message,
+            });
+            this.preventCloseModal = false;
+            if (this.confirmButton) this.confirmButton.disabled = false;
+            if (progressArea) progressArea.classList.add('d-none');
+        }
+    }
+
+    /**
+     * Show broken reference warnings in the modal
+     * @param {HTMLElement} warningsArea
+     * @param {Array} brokenRefs
+     */
+    showBrokenWarnings(warningsArea, brokenRefs) {
+        if (!warningsArea) return;
+
+        let html = `<div class="alert alert-warning">`;
+        html += `<strong>${_('Broken references found')} (${brokenRefs.length}):</strong>`;
+        html += `<ul class="mb-0 mt-1" style="max-height: 200px; overflow-y: auto;">`;
+
+        for (const ref of brokenRefs) {
+            html += `<li><code>${this.escapeHtml(ref.assetUrl)}</code> — ${this.escapeHtml(ref.pageName)} (${this.escapeHtml(ref.ideviceType)})</li>`;
+        }
+
+        html += `</ul>`;
+        html += `<p class="mt-2 mb-0"><small>${_('These references will remain in the regenerated file. Click Regenerate again to proceed.')}</small></p>`;
+        html += `</div>`;
+
+        warningsArea.innerHTML = html;
+        warningsArea.classList.remove('d-none');
+        warningsArea.classList.add('user-confirmed');
+    }
+
+    /**
+     * Escape HTML special characters
+     * @param {string} str
+     * @returns {string}
+     */
+    escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str || '';
+        return div.innerHTML;
+    }
+}

--- a/public/app/workarea/modals/modals/pages/modalRegenerateProject.test.js
+++ b/public/app/workarea/modals/modals/pages/modalRegenerateProject.test.js
@@ -1,0 +1,283 @@
+import ModalRegenerateProject from './modalRegenerateProject.js';
+
+// Mock the service module
+vi.mock('../../../utils/RegenerateProjectService.js', () => ({
+    scanBrokenAssetReferences: vi.fn(() => []),
+    regenerate: vi.fn(() => Promise.resolve({ success: true })),
+}));
+
+import { scanBrokenAssetReferences, regenerate } from '../../../utils/RegenerateProjectService.js';
+
+describe('ModalRegenerateProject', () => {
+    let modal;
+    let mockManager;
+    let mockModalElement;
+    let mockBootstrapModal;
+
+    beforeEach(() => {
+        // Mock _ translation function
+        window._ = vi.fn((s) => s);
+
+        // Mock eXeLearning
+        window.eXeLearning = {
+            app: {
+                alerts: {
+                    showToast: vi.fn(),
+                },
+            },
+        };
+
+        // Mock bootstrap
+        mockBootstrapModal = {
+            show: vi.fn(),
+            hide: vi.fn(),
+            _isShown: false,
+        };
+        window.bootstrap = {
+            Modal: function () {
+                return mockBootstrapModal;
+            },
+        };
+
+        // Mock interact
+        window.interact = vi.fn(() => ({
+            draggable: vi.fn(),
+        }));
+
+        // Create mock modal element
+        mockModalElement = document.createElement('div');
+        mockModalElement.id = 'modalRegenerateProject';
+        mockModalElement.innerHTML = `
+            <div class="modal-header">
+                <div class="modal-title"></div>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="confirm btn btn-primary">Regenerate</button>
+                <button type="button" class="close btn btn-secondary">Cancel</button>
+            </div>
+        `;
+        document.body.appendChild(mockModalElement);
+
+        mockManager = {
+            closeModals: vi.fn(() => false),
+        };
+
+        modal = new ModalRegenerateProject(mockManager);
+
+        // Reset mocks
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        document.body.removeChild(mockModalElement);
+        vi.restoreAllMocks();
+        delete window._;
+        delete window.eXeLearning;
+        delete window.bootstrap;
+        delete window.interact;
+    });
+
+    describe('constructor', () => {
+        it('should create with correct id', () => {
+            expect(modal.id).toBe('modalRegenerateProject');
+        });
+
+        it('should find confirm button', () => {
+            expect(modal.confirmButton).toBeTruthy();
+            expect(modal.confirmButton.classList.contains('btn-primary')).toBe(true);
+        });
+    });
+
+    describe('buildBodyHtml', () => {
+        it('should return HTML with checkboxes', () => {
+            const html = modal.buildBodyHtml();
+            expect(html).toContain('regenerate-flatten-resources');
+            expect(html).toContain('regenerate-check-broken');
+            expect(html).toContain('regenerate-progress');
+            expect(html).toContain('regenerate-warnings');
+        });
+
+        it('should use translated strings', () => {
+            modal.buildBodyHtml();
+            expect(window._).toHaveBeenCalledWith('Flatten resources');
+            expect(window._).toHaveBeenCalledWith('Check for broken references');
+        });
+    });
+
+    describe('show', () => {
+        it('should set title and body', () => {
+            vi.useFakeTimers();
+            modal.show();
+            vi.advanceTimersByTime(100);
+
+            expect(mockModalElement.querySelector('.modal-title').innerHTML).toBe('Regenerate project');
+            expect(mockModalElement.querySelector('.modal-body').innerHTML).toContain('regenerate-flatten-resources');
+            vi.useRealTimers();
+        });
+
+        it('should show bootstrap modal', () => {
+            vi.useFakeTimers();
+            modal.show();
+            vi.advanceTimersByTime(100);
+
+            expect(mockBootstrapModal.show).toHaveBeenCalled();
+            vi.useRealTimers();
+        });
+
+        it('should enable confirm button', () => {
+            vi.useFakeTimers();
+            modal.confirmButton.disabled = true;
+            modal.show();
+            vi.advanceTimersByTime(100);
+
+            expect(modal.confirmButton.disabled).toBe(false);
+            vi.useRealTimers();
+        });
+    });
+
+    describe('onConfirm', () => {
+        beforeEach(() => {
+            // Set up modal body with checkboxes
+            mockModalElement.querySelector('.modal-body').innerHTML = modal.buildBodyHtml();
+        });
+
+        it('should call regenerate without flattenResources by default', async () => {
+            await modal.onConfirm();
+
+            expect(regenerate).toHaveBeenCalledWith({ flattenResources: false });
+        });
+
+        it('should call regenerate with flattenResources when checked', async () => {
+            mockModalElement.querySelector('#regenerate-flatten-resources').checked = true;
+
+            await modal.onConfirm();
+
+            expect(regenerate).toHaveBeenCalledWith({ flattenResources: true });
+        });
+
+        it('should show success toast on completion', async () => {
+            await modal.onConfirm();
+
+            expect(window.eXeLearning.app.alerts.showToast).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'success' })
+            );
+        });
+
+        it('should show error toast on failure', async () => {
+            regenerate.mockRejectedValueOnce(new Error('Export failed'));
+
+            await modal.onConfirm();
+
+            expect(window.eXeLearning.app.alerts.showToast).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'error' })
+            );
+        });
+
+        it('should scan broken references when checkbox is checked', async () => {
+            mockModalElement.querySelector('#regenerate-check-broken').checked = true;
+
+            await modal.onConfirm();
+
+            expect(scanBrokenAssetReferences).toHaveBeenCalled();
+        });
+
+        it('should show warnings and not regenerate when broken refs found on first click', async () => {
+            mockModalElement.querySelector('#regenerate-check-broken').checked = true;
+            scanBrokenAssetReferences.mockReturnValueOnce([
+                { assetUrl: 'asset://missing', pageName: 'Page 1', ideviceType: 'FreeText', componentId: 'c1' },
+            ]);
+
+            await modal.onConfirm();
+
+            const warningsArea = mockModalElement.querySelector('#regenerate-warnings');
+            expect(warningsArea.classList.contains('d-none')).toBe(false);
+            expect(regenerate).not.toHaveBeenCalled();
+        });
+
+        it('should proceed with regeneration after warnings are shown and user confirms again', async () => {
+            mockModalElement.querySelector('#regenerate-check-broken').checked = true;
+
+            // First call - show warnings
+            scanBrokenAssetReferences.mockReturnValueOnce([
+                { assetUrl: 'asset://missing', pageName: 'Page 1', ideviceType: 'FreeText', componentId: 'c1' },
+            ]);
+            await modal.onConfirm();
+            expect(regenerate).not.toHaveBeenCalled();
+
+            // Second call - user confirmed warnings
+            scanBrokenAssetReferences.mockReturnValueOnce([
+                { assetUrl: 'asset://missing', pageName: 'Page 1', ideviceType: 'FreeText', componentId: 'c1' },
+            ]);
+            await modal.onConfirm();
+            expect(regenerate).toHaveBeenCalled();
+        });
+
+        it('should disable confirm button during regeneration', async () => {
+            let resolveExport;
+            regenerate.mockImplementationOnce(
+                () => new Promise((resolve) => { resolveExport = resolve; })
+            );
+
+            const promise = modal.onConfirm();
+            expect(modal.confirmButton.disabled).toBe(true);
+
+            resolveExport({ success: true });
+            await promise;
+        });
+
+        it('should show progress spinner during regeneration', async () => {
+            let resolveExport;
+            regenerate.mockImplementationOnce(
+                () => new Promise((resolve) => { resolveExport = resolve; })
+            );
+
+            const promise = modal.onConfirm();
+            const progressArea = mockModalElement.querySelector('#regenerate-progress');
+            expect(progressArea.classList.contains('d-none')).toBe(false);
+
+            resolveExport({ success: true });
+            await promise;
+        });
+    });
+
+    describe('showBrokenWarnings', () => {
+        it('should display warnings in the area', () => {
+            const warningsArea = document.createElement('div');
+            warningsArea.classList.add('d-none');
+
+            modal.showBrokenWarnings(warningsArea, [
+                { assetUrl: 'asset://abc', pageName: 'Page 1', ideviceType: 'Text', componentId: 'c1' },
+            ]);
+
+            expect(warningsArea.classList.contains('d-none')).toBe(false);
+            expect(warningsArea.innerHTML).toContain('asset://abc');
+            expect(warningsArea.innerHTML).toContain('Page 1');
+        });
+
+        it('should mark area as user-confirmed', () => {
+            const warningsArea = document.createElement('div');
+            modal.showBrokenWarnings(warningsArea, [
+                { assetUrl: 'asset://abc', pageName: 'P', ideviceType: 'T', componentId: 'c' },
+            ]);
+            expect(warningsArea.classList.contains('user-confirmed')).toBe(true);
+        });
+
+        it('should handle null warningsArea gracefully', () => {
+            expect(() => modal.showBrokenWarnings(null, [])).not.toThrow();
+        });
+    });
+
+    describe('escapeHtml', () => {
+        it('should escape HTML special characters', () => {
+            expect(modal.escapeHtml('<script>alert("xss")</script>')).toBe(
+                '&lt;script&gt;alert("xss")&lt;/script&gt;'
+            );
+        });
+
+        it('should handle null/undefined', () => {
+            expect(modal.escapeHtml(null)).toBe('');
+            expect(modal.escapeHtml(undefined)).toBe('');
+        });
+    });
+});

--- a/public/app/workarea/modals/modalsManager.js
+++ b/public/app/workarea/modals/modalsManager.js
@@ -22,6 +22,7 @@ import ModalUploadProgress from './modals/pages/modalUploadProgress.js';
 import ModalShare from './modals/pages/modalShare.js';
 import ModalPrintPreview from './modals/pages/modalPrintPreview.js';
 import ModalImageOptimizer from './modals/pages/modalImageOptimizer.js';
+import ModalRegenerateProject from './modals/pages/modalRegenerateProject.js';
 import { GlobalSearchModal } from '../../search/index.js';
 
 export default class ModalsManagement {
@@ -51,6 +52,7 @@ export default class ModalsManagement {
         this.share = null;
         this.printpreview = null;
         this.imageoptimizer = null;
+        this.regenerateproject = null;
         this.globalsearch = null;
     }
 
@@ -82,6 +84,7 @@ export default class ModalsManagement {
         this.share = new ModalShare(this);
         this.printpreview = new ModalPrintPreview(this);
         this.imageoptimizer = new ModalImageOptimizer(this);
+        this.regenerateproject = new ModalRegenerateProject(this);
         this.globalsearch = new GlobalSearchModal(this);
     }
 
@@ -112,6 +115,7 @@ export default class ModalsManagement {
         this.share.behaviour();
         this.printpreview.behaviour();
         this.imageoptimizer.behaviour();
+        this.regenerateproject.behaviour();
         this.globalsearch.behaviour();
     }
 
@@ -145,6 +149,7 @@ export default class ModalsManagement {
             this.share,
             this.printpreview,
             this.imageoptimizer,
+            this.regenerateproject,
             this.globalsearch,
         ];
     }

--- a/public/app/workarea/modals/modalsManager.test.js
+++ b/public/app/workarea/modals/modalsManager.test.js
@@ -23,6 +23,7 @@ import ModalUploadProgress from './modals/pages/modalUploadProgress.js';
 import ModalShare from './modals/pages/modalShare.js';
 import ModalPrintPreview from './modals/pages/modalPrintPreview.js';
 import ModalImageOptimizer from './modals/pages/modalImageOptimizer.js';
+import ModalRegenerateProject from './modals/pages/modalRegenerateProject.js';
 import { GlobalSearchModal } from '../../search/index.js';
 
 // Mock all modal classes
@@ -50,6 +51,7 @@ vi.mock('./modals/pages/modalUploadProgress.js');
 vi.mock('./modals/pages/modalShare.js');
 vi.mock('./modals/pages/modalPrintPreview.js');
 vi.mock('./modals/pages/modalImageOptimizer.js');
+vi.mock('./modals/pages/modalRegenerateProject.js');
 vi.mock('../../search/index.js', () => {
   const MockGlobalSearchModal = vi.fn().mockImplementation(function() {
     this.behaviour = vi.fn();
@@ -114,6 +116,7 @@ describe('ModalsManagement', () => {
       expect(ModalShare).toHaveBeenCalledWith(modalsManager);
       expect(ModalPrintPreview).toHaveBeenCalledWith(modalsManager);
       expect(ModalImageOptimizer).toHaveBeenCalledWith(modalsManager);
+      expect(ModalRegenerateProject).toHaveBeenCalledWith(modalsManager);
       expect(GlobalSearchModal).toHaveBeenCalledWith(modalsManager);
     });
   });
@@ -133,11 +136,12 @@ describe('ModalsManagement', () => {
     it('should return an array of all modals', () => {
       modalsManager.init();
       const list = modalsManager.list();
-      expect(list).toHaveLength(24); // GlobalSearch is 24th
+      expect(list).toHaveLength(25); // RegenerateProject + GlobalSearch
       expect(list).toContain(modalsManager.alert);
       expect(list).toContain(modalsManager.share);
       expect(list).toContain(modalsManager.printpreview);
       expect(list).toContain(modalsManager.imageoptimizer);
+      expect(list).toContain(modalsManager.regenerateproject);
       expect(list).toContain(modalsManager.globalsearch);
     });
   });

--- a/public/app/workarea/utils/RegenerateProjectService.js
+++ b/public/app/workarea/utils/RegenerateProjectService.js
@@ -1,0 +1,155 @@
+/**
+ * RegenerateProjectService
+ *
+ * Provides methods to regenerate a project by re-exporting it as a clean .elpx file.
+ * Optionally flattens resource folder paths and detects broken asset references.
+ */
+
+/**
+ * Scan all HTML content and JSON properties for asset:// references
+ * that do not exist in the asset map.
+ *
+ * @returns {Array<{assetUrl: string, pageName: string, ideviceType: string, componentId: string}>}
+ */
+export function scanBrokenAssetReferences() {
+    const bridge = eXeLearning.app.project._yjsBridge;
+    const docManager = bridge.documentManager;
+    const assetManager = bridge.assetManager;
+
+    const allAssets = assetManager.getAllAssetsMetadata();
+    const assetIds = new Set(Object.keys(allAssets));
+
+    const broken = [];
+    const assetUrlRegex = /asset:\/\/([a-f0-9-]+)/gi;
+
+    const navigation = docManager.getNavigation();
+    if (!navigation) return broken;
+
+    for (const page of navigation) {
+        const pageName = page.title || page.id;
+        const blocks = page.blocks || [];
+
+        for (const block of blocks) {
+            const components = block.components || block.idevices || [];
+
+            for (const component of components) {
+                const componentId = component.id || '';
+                const ideviceType = component.type || component.ideviceType || '';
+
+                // Collect all string content from the component
+                const textsToScan = [];
+                if (component.html) textsToScan.push(component.html);
+                if (component.content) textsToScan.push(component.content);
+
+                // Scan JSON fields
+                const jsonStr = JSON.stringify(component);
+                textsToScan.push(jsonStr);
+
+                for (const text of textsToScan) {
+                    let match;
+                    assetUrlRegex.lastIndex = 0;
+                    while ((match = assetUrlRegex.exec(text)) !== null) {
+                        const assetId = match[1];
+                        if (!assetIds.has(assetId)) {
+                            // Avoid duplicate entries for the same assetUrl in the same component
+                            const alreadyFound = broken.some(
+                                (b) => b.assetUrl === match[0] && b.componentId === componentId
+                            );
+                            if (!alreadyFound) {
+                                broken.push({
+                                    assetUrl: match[0],
+                                    pageName,
+                                    ideviceType,
+                                    componentId,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return broken;
+}
+
+/**
+ * Regenerate the project by exporting a clean .elpx file.
+ *
+ * @param {Object} options
+ * @param {boolean} [options.flattenResources=false] - Remove subfolders from asset paths
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function regenerate(options = {}) {
+    const bridge = eXeLearning.app.project._yjsBridge;
+    const docManager = bridge.documentManager;
+    const assetCache = bridge.assetCache;
+    const resourceFetcher = bridge.resourceFetcher;
+    const assetManager = bridge.assetManager;
+
+    if (!window.SharedExporters?.createExporter) {
+        throw new Error(_('Export system not available. Please reload the page.'));
+    }
+
+    // Update version metadata before export
+    if (docManager._updateVersionMetadata) {
+        await docManager._updateVersionMetadata();
+    }
+
+    const exporter = window.SharedExporters.createExporter(
+        'elpx',
+        docManager,
+        assetCache,
+        resourceFetcher,
+        assetManager
+    );
+
+    const exportOptions = {
+        flattenResources: options.flattenResources || false,
+    };
+
+    // Add Mermaid pre-renderer if available
+    if (window.MermaidPreRenderer) {
+        exportOptions.preRenderMermaid = window.MermaidPreRenderer.preRender.bind(window.MermaidPreRenderer);
+    }
+
+    const result = await exporter.export(exportOptions);
+
+    if (!result.success || !result.data) {
+        throw new Error(result.error || _('Export failed'));
+    }
+
+    // Build filename
+    const meta = docManager.getMetadata();
+    const title = meta?.title || 'project';
+    const sanitized = title
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-zA-Z0-9_-]/g, '_')
+        .toLowerCase();
+    const exportFilename = `${sanitized}_regenerated.elpx`;
+
+    // Download
+    if (eXeLearning?.config?.isOfflineInstallation && window.electronAPI?.saveBuffer) {
+        const uint8Array = new Uint8Array(result.data);
+        let binary = '';
+        for (let i = 0; i < uint8Array.length; i++) {
+            binary += String.fromCharCode(uint8Array[i]);
+        }
+        const base64Data = btoa(binary);
+        const key = window.__currentProjectId || 'default';
+        await window.electronAPI.saveBuffer(base64Data, key, exportFilename);
+    } else {
+        const blob = new Blob([result.data], { type: 'application/zip' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = exportFilename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    return { success: true };
+}

--- a/public/app/workarea/utils/RegenerateProjectService.test.js
+++ b/public/app/workarea/utils/RegenerateProjectService.test.js
@@ -1,0 +1,350 @@
+import { scanBrokenAssetReferences, regenerate } from './RegenerateProjectService.js';
+
+describe('RegenerateProjectService', () => {
+    let mockDocManager;
+    let mockAssetManager;
+    let mockAssetCache;
+    let mockResourceFetcher;
+
+    beforeEach(() => {
+        mockAssetManager = {
+            getAllAssetsMetadata: vi.fn(() => ({
+                'aaa00001-0000-0000-0000-000000000001': { id: 'aaa00001-0000-0000-0000-000000000001', filename: 'image.png' },
+                'aaa00002-0000-0000-0000-000000000002': { id: 'aaa00002-0000-0000-0000-000000000002', filename: 'doc.pdf' },
+            })),
+        };
+
+        mockDocManager = {
+            getNavigation: vi.fn(() => [
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            components: [
+                                {
+                                    id: 'comp-1',
+                                    type: 'FreeText',
+                                    html: '<img src="asset://aaa00001-0000-0000-0000-000000000001/image.png">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]),
+            getMetadata: vi.fn(() => ({ title: 'My Project' })),
+            _updateVersionMetadata: vi.fn(),
+        };
+
+        mockAssetCache = {};
+        mockResourceFetcher = {};
+
+        window.eXeLearning = {
+            app: {
+                project: {
+                    _yjsBridge: {
+                        documentManager: mockDocManager,
+                        assetManager: mockAssetManager,
+                        assetCache: mockAssetCache,
+                        resourceFetcher: mockResourceFetcher,
+                    },
+                },
+                alerts: {
+                    showToast: vi.fn(),
+                },
+            },
+            config: {},
+        };
+
+        // Mock _ translation function
+        window._ = vi.fn((s) => s);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.eXeLearning;
+        delete window._;
+        delete window.SharedExporters;
+        delete window.MermaidPreRenderer;
+    });
+
+    describe('scanBrokenAssetReferences', () => {
+        it('should return empty array when no broken references', () => {
+            const result = scanBrokenAssetReferences();
+            expect(result).toEqual([]);
+        });
+
+        it('should detect broken asset references', () => {
+            mockDocManager.getNavigation.mockReturnValue([
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            components: [
+                                {
+                                    id: 'comp-1',
+                                    type: 'FreeText',
+                                    html: '<img src="asset://dead0000-0000-0000-0000-000000000bad/image.png">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+            const result = scanBrokenAssetReferences();
+            expect(result.length).toBeGreaterThan(0);
+            expect(result[0].assetUrl).toBe('asset://dead0000-0000-0000-0000-000000000bad');
+            expect(result[0].pageName).toBe('Page 1');
+            expect(result[0].ideviceType).toBe('FreeText');
+            expect(result[0].componentId).toBe('comp-1');
+        });
+
+        it('should not flag existing asset references', () => {
+            mockDocManager.getNavigation.mockReturnValue([
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            components: [
+                                {
+                                    id: 'comp-1',
+                                    type: 'FreeText',
+                                    html: '<img src="asset://aaa00001-0000-0000-0000-000000000001/image.png">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+            const result = scanBrokenAssetReferences();
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array when navigation is null', () => {
+            mockDocManager.getNavigation.mockReturnValue(null);
+            const result = scanBrokenAssetReferences();
+            expect(result).toEqual([]);
+        });
+
+        it('should handle multiple broken refs across pages', () => {
+            mockDocManager.getNavigation.mockReturnValue([
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            components: [
+                                {
+                                    id: 'comp-1',
+                                    type: 'FreeText',
+                                    html: '<img src="asset://bad00001-0000-0000-0000-000000000001/x.png">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    id: 'page-2',
+                    title: 'Page 2',
+                    blocks: [
+                        {
+                            id: 'block-2',
+                            components: [
+                                {
+                                    id: 'comp-2',
+                                    type: 'Image',
+                                    html: '<img src="asset://bad00002-0000-0000-0000-000000000002/y.jpg">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+            const result = scanBrokenAssetReferences();
+            expect(result.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('should not duplicate entries for the same assetUrl in the same component', () => {
+            mockDocManager.getNavigation.mockReturnValue([
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            components: [
+                                {
+                                    id: 'comp-1',
+                                    type: 'FreeText',
+                                    html: '<img src="asset://bad00001-0000-0000-0000-000000000001/x.png"><img src="asset://bad00001-0000-0000-0000-000000000001/x.png">',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+            const result = scanBrokenAssetReferences();
+            const matchingComp1 = result.filter(
+                (r) => r.componentId === 'comp-1' && r.assetUrl === 'asset://bad00001-0000-0000-0000-000000000001'
+            );
+            expect(matchingComp1.length).toBe(1);
+        });
+
+        it('should handle components with idevices array instead of components', () => {
+            mockDocManager.getNavigation.mockReturnValue([
+                {
+                    id: 'page-1',
+                    title: 'Page 1',
+                    blocks: [
+                        {
+                            id: 'block-1',
+                            idevices: [
+                                {
+                                    id: 'comp-1',
+                                    ideviceType: 'Gallery',
+                                    content: 'asset://abc00000-0000-0000-0000-00000000dead',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+            const result = scanBrokenAssetReferences();
+            expect(result.length).toBeGreaterThan(0);
+            expect(result[0].ideviceType).toBe('Gallery');
+        });
+    });
+
+    describe('regenerate', () => {
+        let mockExporter;
+
+        beforeEach(() => {
+            mockExporter = {
+                export: vi.fn(() =>
+                    Promise.resolve({
+                        success: true,
+                        data: new ArrayBuffer(10),
+                        filename: 'test.elpx',
+                    })
+                ),
+            };
+
+            window.SharedExporters = {
+                createExporter: vi.fn(() => mockExporter),
+            };
+
+            // Mock DOM for download
+            const mockLink = {
+                href: '',
+                download: '',
+                click: vi.fn(),
+            };
+            vi.spyOn(document, 'createElement').mockReturnValue(mockLink);
+            vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+            vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+            window.URL.createObjectURL = vi.fn(() => 'blob:test');
+            window.URL.revokeObjectURL = vi.fn();
+        });
+
+        it('should create exporter with correct parameters', async () => {
+            await regenerate();
+
+            expect(window.SharedExporters.createExporter).toHaveBeenCalledWith(
+                'elpx',
+                mockDocManager,
+                mockAssetCache,
+                mockResourceFetcher,
+                mockAssetManager
+            );
+        });
+
+        it('should pass flattenResources option', async () => {
+            await regenerate({ flattenResources: true });
+
+            expect(mockExporter.export).toHaveBeenCalledWith(
+                expect.objectContaining({ flattenResources: true })
+            );
+        });
+
+        it('should not flatten resources by default', async () => {
+            await regenerate();
+
+            expect(mockExporter.export).toHaveBeenCalledWith(
+                expect.objectContaining({ flattenResources: false })
+            );
+        });
+
+        it('should throw when SharedExporters not available', async () => {
+            window.SharedExporters = null;
+
+            await expect(regenerate()).rejects.toThrow();
+        });
+
+        it('should throw when export fails', async () => {
+            mockExporter.export.mockResolvedValue({
+                success: false,
+                error: 'Something went wrong',
+            });
+
+            await expect(regenerate()).rejects.toThrow('Something went wrong');
+        });
+
+        it('should return success on successful export', async () => {
+            const result = await regenerate();
+            expect(result).toEqual({ success: true });
+        });
+
+        it('should generate sanitized filename', async () => {
+            mockDocManager.getMetadata.mockReturnValue({ title: 'My Spécial Project!' });
+
+            await regenerate();
+
+            const link = document.createElement.mock.results[0].value;
+            expect(link.download).toBe('my_special_project__regenerated.elpx');
+        });
+
+        it('should call _updateVersionMetadata before export', async () => {
+            await regenerate();
+            expect(mockDocManager._updateVersionMetadata).toHaveBeenCalled();
+        });
+
+        it('should add Mermaid pre-renderer when available', async () => {
+            const mockPreRender = vi.fn();
+            window.MermaidPreRenderer = {
+                preRender: mockPreRender,
+            };
+
+            await regenerate();
+
+            expect(mockExporter.export).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    preRenderMermaid: expect.any(Function),
+                })
+            );
+        });
+
+        it('should use electronAPI in offline mode', async () => {
+            window.eXeLearning.config.isOfflineInstallation = true;
+            window.electronAPI = {
+                saveBuffer: vi.fn(() => Promise.resolve(true)),
+            };
+
+            await regenerate();
+
+            expect(window.electronAPI.saveBuffer).toHaveBeenCalled();
+
+            delete window.electronAPI;
+        });
+    });
+});

--- a/scripts/build-static-bundle.ts
+++ b/scripts/build-static-bundle.ts
@@ -806,6 +806,7 @@ function generateModalsHtml(): string {
         'pages/printpreview.njk',
         'pages/imageoptimizer.njk',
         'pages/globalsearch.njk',
+        'pages/regenerateproject.njk',
     ];
 
     let modalsHtml = '';

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -45,6 +45,8 @@ export abstract class BaseExporter {
     protected assetFilenameMap: Map<string, string> | null = null;
     // Cache for asset export path lookups (folderPath-based)
     protected assetExportPathMap: Map<string, string> | null = null;
+    // When true, all asset folder paths are flattened to root level
+    protected flattenResources: boolean = false;
 
     constructor(document: ExportDocument, resources: ResourceProvider, assets: AssetProvider, zip: ZipProvider) {
         this.document = document;
@@ -470,7 +472,7 @@ export abstract class BaseExporter {
             const assets = await this.assets.getAllAssets();
 
             for (const asset of assets) {
-                let folderPath = asset.folderPath || '';
+                let folderPath = this.flattenResources ? '' : asset.folderPath || '';
                 // Treat 'unknown' same as missing: derive a proper name with extension from MIME
                 const filename =
                     asset.filename && asset.filename !== 'unknown'

--- a/src/shared/export/exporters/ElpxExporter.ts
+++ b/src/shared/export/exporters/ElpxExporter.ts
@@ -58,6 +58,7 @@ export class ElpxExporter extends Html5Exporter {
     async export(options?: ExportOptions): Promise<ExportResult> {
         const exportFilename = options?.filename || this.buildFilename();
         const elpxOptions = options as ElpxExportOptions | undefined;
+        this.flattenResources = elpxOptions?.flattenResources ?? false;
 
         try {
             let pages = this.buildPageList();

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -484,6 +484,8 @@ export interface ElpxExportOptions extends ExportOptions {
     includeHtmlContent?: boolean;
     /** Root page ID for single page export */
     rootPageId?: string;
+    /** Flatten all asset folder paths to root (removes subfolders) */
+    flattenResources?: boolean;
 }
 
 // =============================================================================

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -111,6 +111,8 @@
                     <li><a class="dropdown-item" id="navbar-button-release-notes" href="#">{{ t.release_notes or 'Release notes' }}</a></li>
                     <li><a class="dropdown-item" id="navbar-button-legal-notes" href="#">{{ t.legal_notes or 'Legal notes' }}</a></li>
                     <li class="dropdown-divider"></li>
+                    <li><a class="dropdown-item" id="navbar-button-regenerate-project" href="#">{{ t.regenerate_project or 'Regenerate project...' }}</a></li>
+                    <li class="dropdown-divider"></li>
                     <li><a class="dropdown-item" id="navbar-button-exe-web" href="#">{{ t.exelearning_website or 'eXeLearning website' }}</a></li>
                     <li><a class="dropdown-item" id="navbar-button-report-bug" href="#">{{ t.report_bug or 'Report a bug' }}</a></li>
                 </ul>

--- a/views/workarea/modals/pages/regenerateproject.njk
+++ b/views/workarea/modals/pages/regenerateproject.njk
@@ -1,0 +1,18 @@
+<div class="modal exe-modal-fade" tabindex="-1" id="modalRegenerateProject" role="dialog" aria-hidden="true" data-testid="modal-regenerate-project" data-open="false">
+    <div class="modal-dialog modal-dialog-centered modal-confirm" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <div class="modal-title">{{ 'Regenerate project' | trans }}</div>
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close' | trans }}">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div id="regenerateProjectBody" class="modal-body">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="confirm btn btn-primary">{{ 'Regenerate' | trans }}</button>
+                <button type="button" class="close btn btn-secondary" data-dismiss="modal">{{ 'Cancel' | trans }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/workarea/workarea.njk
+++ b/views/workarea/workarea.njk
@@ -227,6 +227,7 @@
 	        {% include 'workarea/modals/pages/modalShare.njk' %}
 	        {% include 'workarea/modals/pages/printpreview.njk' %}
 	        {% include 'workarea/modals/pages/globalsearch.njk' %}
+	        {% include 'workarea/modals/pages/regenerateproject.njk' %}
 	    </div>
 
     {# Toasts #}


### PR DESCRIPTION
This pull request introduces a new "Regenerate Project" feature accessible from the Help menu, allowing users to export a clean copy of the project as a new `.elpx` file. The implementation includes UI integration, modal logic, and comprehensive test coverage for the new functionality.

**Feature: Regenerate Project**

* Added a new button (`#navbar-button-regenerate-project`) to the Help menu and integrated its event handling in the `NavbarFile` class, enabling users to trigger the regeneration modal. [[1]](diffhunk://#diff-bc3f894590f19f9591cda14fd5fd2a68b8304f646ff24c0a2164712b050733b4R30-R32) [[2]](diffhunk://#diff-bc3f894590f19f9591cda14fd5fd2a68b8304f646ff24c0a2164712b050733b4R48) [[3]](diffhunk://#diff-bc3f894590f19f9591cda14fd5fd2a68b8304f646ff24c0a2164712b050733b4R142-R154) [[4]](diffhunk://#diff-bc3f894590f19f9591cda14fd5fd2a68b8304f646ff24c0a2164712b050733b4R225-R232)
* Implemented `ModalRegenerateProject` in `public/app/workarea/modals/modals/pages/modalRegenerateProject.js`, providing UI for regenerating the project, options for flattening resources and checking for broken references, and handling regeneration logic and warnings.

**Testing and Validation**

* Updated and expanded tests in `navbarHelp.test.js` to cover the new button, event handling, modal invocation, and regeneration logic, ensuring robust validation of the new feature. [[1]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR29-R31) [[2]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR46) [[3]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR61) [[4]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR119-R122) [[5]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR132) [[6]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR147) [[7]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR402-R427) [[8]](diffhunk://#diff-d2e53660df248cdb47c1187cbcf735029304367a3ce6c0c6d6bc14f0028e38baR440)