### PR TITLE
fix: change eXeLearning URL to https

### DIFF
--- a/public/files/perm/idevices/base/download-source-file/edition/download-source-file.js
+++ b/public/files/perm/idevices/base/download-source-file/edition/download-source-file.js
@@ -263,7 +263,7 @@ var $exeDevice = {
 			<p style="text-align:center">' +
             str6.replace(
                 'eXeLearning',
-                '<a href="http://exelearning.net/">eXeLearning</a>'
+                '<a href="https://exelearning.net/">eXeLearning</a>'
             ) +
             '</p>';
 


### PR DESCRIPTION
Change the exlearning.net URL from HTTP to HTTPS within the iDevice Download Source File