### PR TITLE
TinyMCE link plugin. Get file size and extension.

### DIFF
--- a/public/libs/tinymce_5/js/tinymce/plugins/exelink/plugin.min.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/exelink/plugin.min.js
@@ -1698,8 +1698,7 @@
         return Promise.resolve(url);
     }
     // Sets the "File extension" field from a blob:// or asset:// URL.
-    // blobUrl is optional; used as fallback when the asset URL uses the asset://uuid.ext format
-    // (no path separator), where extractFilenameFromAssetUrl returns null.
+    // blobUrl is optional; used as fallback when the asset URL uses the asset://uuid.ext format (extractFilenameFromAssetUrl returns null).
     function setExtensionFromUrl(api, url, blobUrl) {
         var resolver = top.eXeLearningAssetResolver;
         if (!url || !resolver) return;


### PR DESCRIPTION
"Include File Information" retrieves the file size and extension. The data is now properly updated when changing the file or the unit (B, KB, MB).

Minor HTML error fixed: an extra space before a closing parenthesis.