### PR TITLE
Run external preview workflow only when PR is labeled

### DIFF
--- a/.github/workflows/external-pr-preview.yml
+++ b/.github/workflows/external-pr-preview.yml
@@ -18,7 +18,6 @@ on:
   pull_request_target:
     types:
       - labeled
-      - synchronize
       - closed
     paths-ignore:
       - 'doc/**'
@@ -36,11 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.head.repo.fork == true
-      && github.event.action != 'closed'
-      && (
-        (github.event.action == 'labeled' && github.event.label.name == 'external-pr-preview')
-        || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'external-pr-preview'))
-      )
+      && github.event.action == 'labeled'
+      && github.event.label.name == 'external-pr-preview'
     steps:
       - name: Checkout PR head safely
         uses: actions/checkout@v6


### PR DESCRIPTION
This PR continues the work on #1566 and updates the external preview workflow so it only runs when a PR is labeled with `external-pr-preview`.

## What changed

- Removed the `synchronize` trigger from `pull_request_target`
- Simplified the deploy job condition to only run on:
  - forked PRs
  - `labeled` events
  - the `external-pr-preview` label

## Why

GitHub Actions cannot prevent the workflow from being triggered based on labels at the workflow level. The previous setup caused the workflow to appear on every PR update and then get skipped.

With this change, the workflow only starts when the label is added, which reduces noise in the Actions tab.

## Trade-off

Preview deployments will no longer refresh automatically after new commits are pushed to an already labeled PR.

To refresh the preview, remove and add the `external-pr-preview` label again.