### PR TITLE
Remove Homebrew pipeline and package support

### DIFF
--- a/.github/workflows/docs-and-repos.yml
+++ b/.github/workflows/docs-and-repos.yml
@@ -411,37 +411,3 @@ jobs:
           # version: ${{ github.event.release.tag_name }}          
           token: ${{ env.WINGET_TOKEN }}
           fork-user: exelearning
-
-  publish-homebrew-cask:
-    if: github.event_name == 'release' && github.event.action == 'released' && github.repository == 'exelearning/exelearning'
-    runs-on: macos-latest
-    env:
-      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-    steps:
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@main
-
-      - name: Bump Homebrew cask PR
-        if: env.WINGET_TOKEN != ''
-        # Publishes to homebrew/cask via brew bump-cask-pr.
-        # Pre-releases (tags containing -beta or -rc) update the exelearning@beta cask;
-        # stable releases update the main exelearning cask.
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ env.WINGET_TOKEN }}
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-
-          if [[ "$VERSION" == *-beta* || "$VERSION" == *-rc* ]]; then
-            CASK="exelearning@beta"
-          else
-            CASK="exelearning"
-          fi
-
-          # Force-tap homebrew/cask as a git repo (required by bump-cask-pr to fork & create PR)
-          brew tap homebrew/cask --force
-
-          brew bump-cask-pr "$CASK" \
-            --version "$VERSION" \
-            --no-audit \
-            --no-browse

--- a/doc/install.md
+++ b/doc/install.md
@@ -40,13 +40,7 @@ choco install exelearning
 
 ## macOS
 
-#### Option 1 — Homebrew
-
-```bash title="brew"
-brew install --cask exelearning
-```
-
-#### Option 2 — Installer from Releases
+#### Installer from Releases
 
 1. Download the `.dmg` from **Releases** and open it.
 2. Drag **eXeLearning** into **Applications**.


### PR DESCRIPTION
Closes #1589.

The Homebrew cask has been removed from the tap in https://github.com/Homebrew/homebrew-cask/pull/255487. This PR removes the related pipeline jobs, packaging logic, and any documentation references to Homebrew installation.
