### PR TITLE
Fix Definition lists inside effects in the desktop version

### DIFF
--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -145,7 +145,7 @@ var $exe = {
         $exe.math.init();
         $exe.mermaid.init();
         setTimeout(function(){
-            $exe.dl.init();
+            $exe.dl.init(); // #1603
         }, 0);
         // Add a zoom icon to the images using CSS
         $("a.exe-enlarge").each(function (i) {


### PR DESCRIPTION
Add a definition list inside an accordion an click on preview using the desktop version (`make run-app`). Please try it in the other version too.