### PR TITLE
TinyMCE media plugin. YouTube live and shorts compatibility.

### DIFF
--- a/public/libs/tinymce_5/js/tinymce/plugins/exemedia/plugin.min.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/exemedia/plugin.min.js
@@ -1068,6 +1068,22 @@
             allowFullscreen: true
         },
         {
+            regex: /youtube\.com\/live\/([a-z0-9_\-]+)\??([^#]*)/i,
+            type: 'iframe',
+            w: 560,
+            h: 314,
+            url: 'www.youtube.com/embed/$1?$2',
+            allowFullscreen: true
+        },
+        {
+            regex: /youtube\.com\/shorts\/([a-z0-9_\-]+)\??([^#]*)/i,
+            type: 'iframe',
+            w: 315,
+            h: 560,
+            url: 'www.youtube.com/embed/$1?$2',
+            allowFullscreen: true
+        },
+        {
             regex: /vimeo\.com\/([0-9]+)/,
             type: 'iframe',
             w: 425,


### PR DESCRIPTION
Added support for YouTube `live` and `short` URLs.

**Supported types:**

```
https://youtu.be/{id}
https://www.youtube.com/watch?v={id}&t=30
https://www.youtube.com/embed/{id}?rel=1
https://www.youtube.com/live/{id}?t=11
https://www.youtube.com/shorts/{id}
```