### PR TITLE
Update default title for legacy projects

### DIFF
--- a/src/shared/import/LegacyXmlParser.ts
+++ b/src/shared/import/LegacyXmlParser.ts
@@ -579,7 +579,7 @@ export class LegacyXmlParser {
      */
     private extractMetadata(): LegacyMetadata {
         const meta: LegacyMetadata = {
-            title: 'Legacy Project',
+            title: _('Untitled document'),
             author: '',
             description: '',
             language: '',


### PR DESCRIPTION
This PR changes the default placeholder text assigned to untitled projects created with older versions of eXeLearning.
Updated the default value from "Legacy Project" to "Untitled document".