### PR TITLE
feat(screenshot): add screenshot.png thumbnail to .elpx project root

### DIFF
--- a/assets/styles/pages/_properties.scss
+++ b/assets/styles/pages/_properties.scss
@@ -298,6 +298,11 @@
    Screenshot Panel (Project Properties modal)
    ======================================================================== */
 
+/* TO DO: screenshot tab (show after v4.0.0 is released) */
+.project-properties-tabs #props-tab-screenshot {
+    display: none;
+}
+
 .screenshot-panel {
     .btn .auto-icon {
         font-size: 1.1em;

--- a/assets/styles/pages/_properties.scss
+++ b/assets/styles/pages/_properties.scss
@@ -293,3 +293,18 @@
     color: var(--system-red, #dc3545) !important;
     border-color: var(--system-red, #dc3545) !important;
 }
+
+/* ========================================================================
+   Screenshot Panel (Project Properties modal)
+   ======================================================================== */
+
+.screenshot-panel {
+    .btn .auto-icon {
+        font-size: 1.1em;
+    }
+
+    .btn-primary .auto-icon,
+    .btn-danger .auto-icon {
+        color: #fff;
+    }
+}

--- a/assets/styles/pages/_properties.scss
+++ b/assets/styles/pages/_properties.scss
@@ -307,4 +307,42 @@
     .btn-danger .auto-icon {
         color: #fff;
     }
+
+    .card {
+        border-radius: var(--radius);
+        border: 1px solid var(--gray-100);
+    }
+
+    .card-body {
+        background: none !important;
+        min-height: 332px;
+        img {
+            margin: 0 auto;
+        }
+    }
+
+    button.btn {
+        padding-left: .5em !important;
+        padding-right: 1em;
+
+        span {
+            margin-left: 0;
+        }
+    }
+
+    button.btn-outline-secondary {
+        opacity: .8;
+
+        &:hover,
+        &:focus {
+            background-color: var(--brand-primary-50);
+            color: var(--brand-primary-600);
+            border-color: var(--brand-primary-600);
+            opacity: 1;
+
+            span {
+                color: var(--brand-primary-600);
+            }
+        }
+    }
 }

--- a/assets/styles/pages/_properties.scss
+++ b/assets/styles/pages/_properties.scss
@@ -333,6 +333,10 @@
     button.btn-outline-secondary {
         opacity: .8;
 
+        span {
+            margin-right: .3em;
+        }
+
         &:hover,
         &:focus {
             background-color: var(--brand-primary-50);

--- a/doc/elpx-format.md
+++ b/doc/elpx-format.md
@@ -21,6 +21,7 @@ This dual nature makes `.elpx` the recommended exchange format: it is human-read
 
 ```
 project.elpx (ZIP)
+├── screenshot.png            # Project thumbnail/preview image
 ├── content.xml               # ODE 2.0 project structure (re-importable)
 ├── content.dtd               # DTD for XML validation
 ├── index.html                # Entry point (first page rendered as HTML)
@@ -50,6 +51,7 @@ project.elpx (ZIP)
 - The first page is always `index.html`; additional pages go in `html/`
 - Page filenames are derived from page titles (slugified, collision-safe)
 - Assets are stored under `content/resources/` in the export; `content.xml` references them via `{{context_path}}`
+- `screenshot.png` is a project 16:9 thumbnail image (1280×720 px recommended at the archive root; external systems can extract it for preview without processing the full package
 
 ---
 
@@ -516,6 +518,30 @@ A minimal `content.xml` with one root page, one block, and one `text` iDevice:
   </odeNavStructures>
 </ode>
 ```
+
+---
+
+## Screenshot / Thumbnail
+
+Since eXeLearning v4.0, `.elpx` files may include an optional `screenshot.png` at the archive root. This file serves as a project thumbnail/preview image that external systems (LMS platforms, file managers, repositories) can extract and display without processing the full package.
+
+**File:** `screenshot.png` (root of ZIP archive)
+**Format:** PNG
+**Max dimensions:** 1280×720 pixels
+**Source:** User-defined via Project Properties → Screenshot tab, or absent if not set
+
+### Behavior
+
+- **Export:** If the project has a screenshot set in its metadata, `ElpxExporter` writes it as `screenshot.png` at the archive root. If no screenshot is set, the file is omitted.
+- **Import:** `ElpxImporter` reads `screenshot.png` from the archive root (if present) and stores it in the Yjs metadata as a base64 data URL under the `screenshot` key.
+- **Backward compatibility:** Old `.elpx` files without `screenshot.png` import correctly — the screenshot metadata key is simply absent.
+- **Collaborative editing:** The screenshot is stored in the Yjs `metadata` Y.Map and is synchronized across collaborators like any other project metadata field.
+
+### Yjs Metadata Key
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `screenshot` | string (base64 data URL) | Project thumbnail PNG as `data:image/png;base64,...` |
 
 ---
 

--- a/public/app/workarea/project/properties/formProperties.js
+++ b/public/app/workarea/project/properties/formProperties.js
@@ -135,6 +135,7 @@ export default class FormProperties {
             { key: 'properties_package', title: _('Content metadata') },
             { key: 'export', title: _('Export options') },
             { key: 'custom_code', title: _('Custom code') },
+            { key: 'screenshot', title: _('Screenshot'), custom: true },
         ];
 
         // Create tabs navigation
@@ -183,8 +184,12 @@ export default class FormProperties {
             tabPane.id = paneId;
 
             // Add properties for this group
-            const groupProperties = groupedProperties.get(tab.key) || [];
-            this.addPropertiesToPane(groupProperties, tabPane);
+            if (tab.custom && tab.key === 'screenshot') {
+                this.buildScreenshotPane(tabPane);
+            } else {
+                const groupProperties = groupedProperties.get(tab.key) || [];
+                this.addPropertiesToPane(groupProperties, tabPane);
+            }
 
             tabContent.appendChild(tabPane);
         });
@@ -891,6 +896,259 @@ export default class FormProperties {
         }
 
         return cloneRow;
+    }
+
+    /*******************************************************************************
+     * SCREENSHOT TAB
+     *******************************************************************************/
+
+    /**
+     * Build the screenshot tab pane content
+     * @param {HTMLElement} pane - The tab pane container
+     */
+    buildScreenshotPane(pane) {
+        const container = document.createElement('div');
+        container.classList.add('screenshot-panel', 'p-4');
+
+        // === ROW: Preview (col-lg-7) + Info (col-lg-5) ===
+        const row = document.createElement('div');
+        row.classList.add('row', 'g-4');
+
+        // --- Left column: preview card + buttons ---
+        const leftCol = document.createElement('div');
+        leftCol.classList.add('col-12', 'col-lg-7', 'd-flex', 'flex-column', 'align-items-center');
+
+        // Preview card
+        const previewCard = document.createElement('div');
+        previewCard.classList.add('card', 'w-100', 'mb-3', 'shadow-sm');
+
+        const previewCardBody = document.createElement('div');
+        previewCardBody.classList.add('card-body', 'text-center', 'bg-light');
+
+        const previewImg = document.createElement('img');
+        previewImg.classList.add('img-fluid', 'rounded', 'border');
+        previewImg.alt = _('Current project screenshot preview');
+        previewImg.style.cssText = 'max-height:300px;object-fit:contain;display:none;';
+
+        const noScreenshotText = document.createElement('p');
+        noScreenshotText.classList.add('text-muted', 'fst-italic', 'py-5', 'mb-0');
+        noScreenshotText.textContent = _('No screenshot yet. It will be auto-generated when you save or export.');
+
+        previewCardBody.append(previewImg);
+        previewCardBody.append(noScreenshotText);
+        previewCard.append(previewCardBody);
+
+        // Helper to update preview visibility consistently
+        let removeBtn;
+        const updatePreview = (screenshot) => {
+            if (screenshot) {
+                previewImg.src = screenshot;
+                previewImg.style.display = 'block';
+                noScreenshotText.style.display = 'none';
+                if (removeBtn) removeBtn.style.display = '';
+            } else {
+                previewImg.src = '';
+                previewImg.style.display = 'none';
+                noScreenshotText.style.display = '';
+                if (removeBtn) removeBtn.style.display = 'none';
+            }
+        };
+
+        // Clean up previous observer if pane is rebuilt
+        if (this._screenshotMetadata && this._screenshotObserver) {
+            this._screenshotMetadata.unobserve(this._screenshotObserver);
+            this._screenshotMetadata = null;
+            this._screenshotObserver = null;
+        }
+
+        // Load current screenshot from Yjs and observe live changes
+        const documentManager = this.properties.project?._yjsBridge?.getDocumentManager();
+        if (documentManager) {
+            const metadata = documentManager.getMetadata();
+            updatePreview(metadata?.get('screenshot') || null);
+
+            const observer = (event) => {
+                if (event.keysChanged.has('screenshot')) {
+                    updatePreview(metadata.get('screenshot') || null);
+                }
+            };
+            metadata.observe(observer);
+            this._screenshotMetadata = metadata;
+            this._screenshotObserver = observer;
+        }
+
+        // Buttons row
+        const buttonsRow = document.createElement('div');
+        buttonsRow.classList.add('d-flex', 'flex-wrap', 'justify-content-center', 'gap-2', 'w-100');
+
+        // Upload button
+        const uploadBtn = document.createElement('button');
+        uploadBtn.type = 'button';
+        uploadBtn.classList.add('btn', 'btn-primary', 'd-flex', 'align-items-center');
+        uploadBtn.setAttribute('aria-describedby', 'screenshot-help-text');
+        uploadBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">upload</span> ${_('Upload custom image')}`;
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = 'image/png,image/jpeg,image/webp';
+        fileInput.style.display = 'none';
+
+        uploadBtn.addEventListener('click', () => fileInput.click());
+
+        fileInput.addEventListener('change', (event) => {
+            const file = event.target.files[0];
+            if (!file) return;
+
+            if (file.size > 2 * 1024 * 1024) {
+                eXeLearning.app.modals.alert.show({
+                    title: _('File too large'),
+                    body: _('Screenshot must be smaller than 2 MB.'),
+                    contentId: 'warning',
+                });
+                return;
+            }
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const img = new Image();
+                img.onload = () => {
+                    const pngDataUrl = this.resizeAndConvertToPng(img);
+                    this.setScreenshot(pngDataUrl);
+                };
+                img.src = e.target.result;
+            };
+            reader.readAsDataURL(file);
+            fileInput.value = '';
+        });
+
+        // Regenerate button
+        const regenerateBtn = document.createElement('button');
+        regenerateBtn.type = 'button';
+        regenerateBtn.classList.add('btn', 'btn-outline-secondary', 'd-flex', 'align-items-center');
+        regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Regenerate from content')}`;
+
+        regenerateBtn.addEventListener('click', async () => {
+            const bridge = this.properties.project?._yjsBridge;
+            if (!bridge?.generateScreenshotFromFirstPage) {
+                eXeLearning.app.modals.alert.show({
+                    title: _('Not available'),
+                    body: _('Screenshot generation is not available.'),
+                    contentId: 'warning',
+                });
+                return;
+            }
+
+            // Clear existing screenshot so auto-generation runs
+            const dm = bridge.getDocumentManager();
+            if (dm) {
+                dm.getMetadata().delete('screenshot');
+            }
+
+            regenerateBtn.disabled = true;
+            regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Generating...')}`;
+
+            try {
+                await bridge.generateScreenshotFromFirstPage();
+            } catch (error) {
+                console.error('[FormProperties] Screenshot regeneration failed:', error);
+                eXeLearning.app.modals.alert.show({
+                    title: _('Generation failed'),
+                    body: _('Could not generate screenshot from content. Try uploading an image instead.'),
+                    contentId: 'warning',
+                });
+            } finally {
+                regenerateBtn.disabled = false;
+                regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Regenerate from content')}`;
+            }
+        });
+
+        // Remove button
+        removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.classList.add('btn', 'btn-danger', 'd-flex', 'align-items-center');
+        removeBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">delete</span> ${_('Remove screenshot')}`;
+        if (!previewImg.src || previewImg.style.display === 'none') {
+            removeBtn.style.display = 'none';
+        }
+
+        removeBtn.addEventListener('click', () => {
+            updatePreview(null);
+            const dm = this.properties.project?._yjsBridge?.getDocumentManager();
+            if (dm) {
+                dm.getMetadata().delete('screenshot');
+            }
+        });
+
+        buttonsRow.append(fileInput);
+        buttonsRow.append(uploadBtn);
+        buttonsRow.append(regenerateBtn);
+        buttonsRow.append(removeBtn);
+
+        leftCol.append(previewCard);
+        leftCol.append(buttonsRow);
+
+        // --- Right column: info panel ---
+        const rightCol = document.createElement('div');
+        rightCol.classList.add('col-12', 'col-lg-5');
+
+        const infoAlert = document.createElement('div');
+        infoAlert.classList.add('alert', 'alert-info', 'd-flex');
+        infoAlert.id = 'screenshot-help-text';
+        infoAlert.setAttribute('role', 'note');
+        infoAlert.innerHTML = `
+            <div>
+                <span class="auto-icon notranslate me-3 fs-4 text-info" aria-hidden="true">info</span>
+            </div>
+            <div>
+                <h5 class="alert-heading h6">${_('Screenshot guidelines')}</h5>
+                <p class="mb-2 small">
+                    ${_('Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Keep the focus centered, avoid small text or clutter, and ensure good contrast so it remains readable at smaller sizes.')}
+                </p>
+                <p class="mb-0 small text-muted">
+                    ${_('The image should be clean, visually engaging, and relevant to the topic, as it will be used as a preview thumbnail across different platforms and screen sizes.')}
+                </p>
+            </div>
+        `;
+
+        rightCol.append(infoAlert);
+
+        row.append(leftCol);
+        row.append(rightCol);
+        container.append(row);
+
+        pane.appendChild(container);
+    }
+
+    /**
+     * Resize image and convert to PNG data URL (max 1280x720)
+     */
+    resizeAndConvertToPng(img) {
+        const canvas = document.createElement('canvas');
+        let width = img.width;
+        let height = img.height;
+        const maxWidth = 1280;
+        const maxHeight = 720;
+        if (width > maxWidth || height > maxHeight) {
+            const ratio = Math.min(maxWidth / width, maxHeight / height);
+            width = Math.round(width * ratio);
+            height = Math.round(height * ratio);
+        }
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, width, height);
+        return canvas.toDataURL('image/png');
+    }
+
+    /**
+     * Set screenshot in preview and Yjs metadata
+     */
+    setScreenshot(pngDataUrl) {
+        // Setting Yjs metadata triggers the observer which updates the UI
+        const dm = this.properties.project?._yjsBridge?.getDocumentManager();
+        if (dm) {
+            dm.getMetadata().set('screenshot', pngDataUrl);
+        }
     }
 
     /*******************************************************************************

--- a/public/app/workarea/project/properties/formProperties.js
+++ b/public/app/workarea/project/properties/formProperties.js
@@ -1038,27 +1038,42 @@ export default class FormProperties {
                 return;
             }
 
-            // Clear existing screenshot so auto-generation runs
-            const dm = bridge.getDocumentManager();
-            if (dm) {
-                dm.getMetadata().delete('screenshot');
-            }
+            const doRegenerate = async () => {
+                // Clear existing screenshot so auto-generation runs
+                const dm = bridge.getDocumentManager();
+                if (dm) {
+                    dm.getMetadata().delete('screenshot');
+                }
 
-            regenerateBtn.disabled = true;
-            regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generating...')}`;
+                regenerateBtn.disabled = true;
+                regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generating...')}`;
 
-            try {
-                await bridge.generateScreenshotFromFirstPage();
-            } catch (error) {
-                console.error('[FormProperties] Screenshot regeneration failed:', error);
-                eXeLearning.app.modals.alert.show({
-                    title: _('Generation failed'),
-                    body: _('Could not generate screenshot from content. Try uploading an image instead.'),
-                    contentId: 'warning',
+                try {
+                    await bridge.generateScreenshotFromFirstPage();
+                } catch (error) {
+                    console.error('[FormProperties] Screenshot regeneration failed:', error);
+                    eXeLearning.app.modals.alert.show({
+                        title: _('Generation failed'),
+                        body: _('Could not generate screenshot from content. Try uploading an image instead.'),
+                        contentId: 'warning',
+                    });
+                } finally {
+                    regenerateBtn.disabled = false;
+                    regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generate from content')}`;
+                }
+            };
+
+            const hasScreenshot = previewImg.style.display !== 'none' && previewImg.src;
+            if (hasScreenshot) {
+                eXeLearning.app.modals.confirm.show({
+                    title: _('Replace screenshot'),
+                    body: _('This will delete the current image. Do you want to continue?'),
+                    confirmButtonText: _('Continue'),
+                    cancelButtonText: _('Cancel'),
+                    confirmExec: doRegenerate,
                 });
-            } finally {
-                regenerateBtn.disabled = false;
-                regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generate from content')}`;
+            } else {
+                await doRegenerate();
             }
         });
 
@@ -1072,11 +1087,19 @@ export default class FormProperties {
         }
 
         removeBtn.addEventListener('click', () => {
-            updatePreview(null);
-            const dm = this.properties.project?._yjsBridge?.getDocumentManager();
-            if (dm) {
-                dm.getMetadata().delete('screenshot');
-            }
+            eXeLearning.app.modals.confirm.show({
+                title: _('Delete screenshot'),
+                body: _('Delete the current image? This action cannot be undone.'),
+                confirmButtonText: _('Delete'),
+                cancelButtonText: _('Cancel'),
+                confirmExec: () => {
+                    updatePreview(null);
+                    const dm = this.properties.project?._yjsBridge?.getDocumentManager();
+                    if (dm) {
+                        dm.getMetadata().delete('screenshot');
+                    }
+                },
+            });
         });
 
         buttonsRow.append(fileInput);

--- a/public/app/workarea/project/properties/formProperties.js
+++ b/public/app/workarea/project/properties/formProperties.js
@@ -1012,6 +1012,18 @@ export default class FormProperties {
             reader.onload = (e) => {
                 const img = new Image();
                 img.onload = () => {
+                    const ratio = img.naturalWidth / img.naturalHeight;
+                    const is16x9 = Math.abs(ratio - 16 / 9) < 0.05;
+                    const hasMinWidth = img.naturalWidth >= 600;
+                    if (!is16x9 || !hasMinWidth) {
+                        eXeLearning.app.modals.alert.show({
+                            title: _('Invalid image'),
+                            body: _('The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.'),
+                            contentId: 'warning',
+                        });
+                        fileInput.value = '';
+                        return;
+                    }
                     const pngDataUrl = this.resizeAndConvertToPng(img);
                     this.setScreenshot(pngDataUrl);
                 };

--- a/public/app/workarea/project/properties/formProperties.js
+++ b/public/app/workarea/project/properties/formProperties.js
@@ -926,7 +926,7 @@ export default class FormProperties {
         previewCardBody.classList.add('card-body', 'text-center', 'bg-light');
 
         const previewImg = document.createElement('img');
-        previewImg.classList.add('img-fluid', 'rounded', 'border');
+        previewImg.classList.add('img-fluid', 'border');
         previewImg.alt = _('Current project screenshot preview');
         previewImg.style.cssText = 'max-height:300px;object-fit:contain;display:none;';
 
@@ -986,7 +986,7 @@ export default class FormProperties {
         uploadBtn.type = 'button';
         uploadBtn.classList.add('btn', 'btn-primary', 'd-flex', 'align-items-center');
         uploadBtn.setAttribute('aria-describedby', 'screenshot-help-text');
-        uploadBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">upload</span> ${_('Upload custom image')}`;
+        uploadBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">upload</span> ${_('Upload custom image')}`;
 
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
@@ -1025,7 +1025,7 @@ export default class FormProperties {
         const regenerateBtn = document.createElement('button');
         regenerateBtn.type = 'button';
         regenerateBtn.classList.add('btn', 'btn-outline-secondary', 'd-flex', 'align-items-center');
-        regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Regenerate from content')}`;
+        regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generate from content')}`;
 
         regenerateBtn.addEventListener('click', async () => {
             const bridge = this.properties.project?._yjsBridge;
@@ -1045,7 +1045,7 @@ export default class FormProperties {
             }
 
             regenerateBtn.disabled = true;
-            regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Generating...')}`;
+            regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generating...')}`;
 
             try {
                 await bridge.generateScreenshotFromFirstPage();
@@ -1058,15 +1058,15 @@ export default class FormProperties {
                 });
             } finally {
                 regenerateBtn.disabled = false;
-                regenerateBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">refresh</span> ${_('Regenerate from content')}`;
+                regenerateBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">refresh</span> ${_('Generate from content')}`;
             }
         });
 
         // Remove button
         removeBtn = document.createElement('button');
         removeBtn.type = 'button';
-        removeBtn.classList.add('btn', 'btn-danger', 'd-flex', 'align-items-center');
-        removeBtn.innerHTML = `<span class="auto-icon notranslate me-2" aria-hidden="true">delete</span> ${_('Remove screenshot')}`;
+        removeBtn.classList.add('btn', 'btn-outline-secondary', 'd-flex', 'align-items-center');
+        removeBtn.innerHTML = `<span class="auto-icon notranslate" aria-hidden="true">delete</span> ${_('Delete')}`;
         if (!previewImg.src || previewImg.style.display === 'none') {
             removeBtn.style.display = 'none';
         }
@@ -1092,20 +1092,17 @@ export default class FormProperties {
         rightCol.classList.add('col-12', 'col-lg-5');
 
         const infoAlert = document.createElement('div');
-        infoAlert.classList.add('alert', 'alert-info', 'd-flex');
+        infoAlert.classList.add('alert', 'alert-light', 'd-flex');
         infoAlert.id = 'screenshot-help-text';
         infoAlert.setAttribute('role', 'note');
         infoAlert.innerHTML = `
             <div>
-                <span class="auto-icon notranslate me-3 fs-4 text-info" aria-hidden="true">info</span>
-            </div>
-            <div>
-                <h5 class="alert-heading h6">${_('Screenshot guidelines')}</h5>
+                <h5 class="alert-heading lead mb-3">${_('Recommendations')}</h5>
                 <p class="mb-2 small">
-                    ${_('Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Keep the focus centered, avoid small text or clutter, and ensure good contrast so it remains readable at smaller sizes.')}
+                    ${_('Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.')}
                 </p>
                 <p class="mb-0 small text-muted">
-                    ${_('The image should be clean, visually engaging, and relevant to the topic, as it will be used as a preview thumbnail across different platforms and screen sizes.')}
+                    ${_('The image will be used as a preview of this educational resource across different platforms.')}
                 </p>
             </div>
         `;

--- a/public/app/workarea/project/properties/formProperties.test.js
+++ b/public/app/workarea/project/properties/formProperties.test.js
@@ -73,6 +73,13 @@ describe('FormProperties', () => {
 
         mockDocumentManager = {
             initialized: true,
+            getMetadata: vi.fn(() => ({
+                get: vi.fn(() => null),
+                set: vi.fn(),
+                delete: vi.fn(),
+                observe: vi.fn(),
+                unobserve: vi.fn(),
+            })),
         };
 
         mockYjsBridge = {
@@ -1446,7 +1453,7 @@ describe('FormProperties', () => {
             formProperties.addRowsWithTabs(properties, table);
 
             const tabs = table.querySelectorAll('.project-properties-tab');
-            expect(tabs.length).toBe(3);
+            expect(tabs.length).toBe(4);
         });
 
         it('should create tab panes for each tab', () => {
@@ -1457,7 +1464,7 @@ describe('FormProperties', () => {
             formProperties.addRowsWithTabs(properties, table);
 
             const panes = table.querySelectorAll('.project-properties-tab-pane');
-            expect(panes.length).toBe(3);
+            expect(panes.length).toBe(4);
         });
 
         it('should set first tab as active by default', () => {
@@ -1530,6 +1537,116 @@ describe('FormProperties', () => {
             const grouped = formProperties.groupPropertiesByGroup(properties);
 
             expect(grouped.get('__no_group__').length).toBe(2);
+        });
+    });
+
+    describe('buildScreenshotPane', () => {
+        let mockMetadata;
+        let mockDm;
+
+        beforeEach(() => {
+            mockMetadata = {
+                get: vi.fn(() => null),
+                set: vi.fn(),
+                delete: vi.fn(),
+                observe: vi.fn(),
+                unobserve: vi.fn(),
+            };
+            mockDm = {
+                getMetadata: vi.fn(() => mockMetadata),
+            };
+            mockYjsBridge.getDocumentManager = vi.fn(() => mockDm);
+        });
+
+        it('should create a container with screenshot-panel class', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+
+            formProperties.buildScreenshotPane(pane);
+
+            const panel = pane.querySelector('.screenshot-panel');
+            expect(panel).not.toBe(null);
+        });
+
+        it('should create upload and remove buttons inside the pane', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+
+            formProperties.buildScreenshotPane(pane);
+
+            const buttons = pane.querySelectorAll('button');
+            expect(buttons.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('should create an info panel with alert-info class', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+
+            formProperties.buildScreenshotPane(pane);
+
+            const infoAlert = pane.querySelector('#screenshot-help-text');
+            expect(infoAlert).not.toBe(null);
+        });
+
+        it('should unobserve previous observer when pane is rebuilt', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+
+            // Build once to register an observer
+            formProperties.buildScreenshotPane(pane);
+            const firstObserver = formProperties._screenshotObserver;
+            const firstMetadata = formProperties._screenshotMetadata;
+
+            // Build again — should unobserve the first observer
+            formProperties.buildScreenshotPane(pane);
+
+            expect(firstMetadata.unobserve).toHaveBeenCalledWith(firstObserver);
+        });
+
+        it('should observe metadata changes after building the pane', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+
+            formProperties.buildScreenshotPane(pane);
+
+            expect(mockMetadata.observe).toHaveBeenCalled();
+            expect(formProperties._screenshotObserver).toBeTypeOf('function');
+        });
+    });
+
+    describe('setScreenshot', () => {
+        let mockMetadata;
+        let mockDm;
+
+        beforeEach(() => {
+            mockMetadata = {
+                get: vi.fn(() => null),
+                set: vi.fn(),
+                delete: vi.fn(),
+                observe: vi.fn(),
+                unobserve: vi.fn(),
+            };
+            mockDm = {
+                getMetadata: vi.fn(() => mockMetadata),
+            };
+            mockYjsBridge.getDocumentManager = vi.fn(() => mockDm);
+        });
+
+        it('should call metadata.set with screenshot key and dataUrl', () => {
+            const formProperties = new FormProperties(mockProperties);
+            const dataUrl = 'data:image/png;base64,abc123';
+
+            formProperties.setScreenshot(dataUrl);
+
+            expect(mockDm.getMetadata).toHaveBeenCalled();
+            expect(mockMetadata.set).toHaveBeenCalledWith('screenshot', dataUrl);
+        });
+
+        it('should not throw when documentManager is unavailable', () => {
+            mockYjsBridge.getDocumentManager = vi.fn(() => null);
+            const formProperties = new FormProperties(mockProperties);
+
+            expect(() => formProperties.setScreenshot('data:image/png;base64,x')).not.toThrow();
         });
     });
 

--- a/public/app/workarea/project/properties/formProperties.test.js
+++ b/public/app/workarea/project/properties/formProperties.test.js
@@ -1612,6 +1612,159 @@ describe('FormProperties', () => {
             expect(mockMetadata.observe).toHaveBeenCalled();
             expect(formProperties._screenshotObserver).toBeTypeOf('function');
         });
+
+        it('regenerate button calls generateScreenshotFromFirstPage on bridge', async () => {
+            const generateScreenshot = vi.fn().mockResolvedValue(undefined);
+            const mockGetDm = vi.fn(() => ({
+                getMetadata: vi.fn(() => mockMetadata),
+            }));
+            mockYjsBridge.generateScreenshotFromFirstPage = generateScreenshot;
+            mockYjsBridge.getDocumentManager = mockGetDm;
+
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+            formProperties.buildScreenshotPane(pane);
+
+            // Find the regenerate button (second button after upload)
+            const buttons = pane.querySelectorAll('button');
+            const regenerateBtn = Array.from(buttons).find(
+                (b) => b.textContent.includes('Regenerate'),
+            );
+            expect(regenerateBtn).not.toBeNull();
+
+            await regenerateBtn.dispatchEvent(new MouseEvent('click'));
+            // Wait for the async click handler
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(generateScreenshot).toHaveBeenCalled();
+        });
+
+        it('regenerate button disables during generation and re-enables after', async () => {
+            let resolveGenerate;
+            const generateScreenshot = vi.fn(
+                () => new Promise((resolve) => { resolveGenerate = resolve; }),
+            );
+            const mockGetDm = vi.fn(() => ({
+                getMetadata: vi.fn(() => mockMetadata),
+            }));
+            mockYjsBridge.generateScreenshotFromFirstPage = generateScreenshot;
+            mockYjsBridge.getDocumentManager = mockGetDm;
+
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+            formProperties.buildScreenshotPane(pane);
+
+            const buttons = pane.querySelectorAll('button');
+            const regenerateBtn = Array.from(buttons).find(
+                (b) => b.textContent.includes('Regenerate'),
+            );
+
+            // Click to start generation (don't await — handler is async)
+            regenerateBtn.click();
+            // Yield to the event loop so the async handler starts
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(regenerateBtn.disabled).toBe(true);
+
+            // Resolve the pending generation
+            resolveGenerate();
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(regenerateBtn.disabled).toBe(false);
+        });
+
+        it('remove button calls metadata.delete with screenshot key', async () => {
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+            formProperties.buildScreenshotPane(pane);
+
+            const buttons = pane.querySelectorAll('button');
+            const removeBtn = Array.from(buttons).find(
+                (b) => b.textContent.includes('Remove'),
+            );
+            expect(removeBtn).not.toBeNull();
+
+            removeBtn.click();
+
+            expect(mockMetadata.delete).toHaveBeenCalledWith('screenshot');
+        });
+
+        it('shows alert when uploaded file exceeds 2MB', async () => {
+            const mockAlert = vi.fn();
+            global.eXeLearning.app.modals = {
+                alert: { show: mockAlert },
+            };
+
+            const formProperties = new FormProperties(mockProperties);
+            const pane = document.createElement('div');
+            formProperties.buildScreenshotPane(pane);
+
+            // Find the hidden file input
+            const fileInput = pane.querySelector('input[type="file"]');
+            expect(fileInput).not.toBeNull();
+
+            // Create a fake file > 2MB
+            const largeFile = new File([new ArrayBuffer(3 * 1024 * 1024)], 'big.png', { type: 'image/png' });
+            Object.defineProperty(fileInput, 'files', { value: [largeFile], configurable: true });
+
+            fileInput.dispatchEvent(new Event('change'));
+
+            expect(mockAlert).toHaveBeenCalled();
+            expect(mockAlert.mock.calls[0][0].title).toBe('File too large');
+        });
+    });
+
+    describe('resizeAndConvertToPng', () => {
+        it('returns canvas data URL without resizing when image fits within limits', () => {
+            const formProperties = new FormProperties(mockProperties);
+
+            const mockCtx = { drawImage: vi.fn() };
+            const mockCanvas = {
+                width: 0,
+                height: 0,
+                getContext: vi.fn(() => mockCtx),
+                toDataURL: vi.fn(() => 'data:image/png;base64,smallImg'),
+            };
+            const originalCreateElement = document.createElement.bind(document);
+            document.createElement = (tag) => {
+                if (tag === 'canvas') return mockCanvas;
+                return originalCreateElement(tag);
+            };
+
+            const img = { width: 640, height: 360 };
+            const result = formProperties.resizeAndConvertToPng(img);
+
+            expect(mockCanvas.width).toBe(640);
+            expect(mockCanvas.height).toBe(360);
+            expect(result).toBe('data:image/png;base64,smallImg');
+            document.createElement = originalCreateElement;
+        });
+
+        it('downscales an oversized image to fit within 1280x720 keeping aspect ratio', () => {
+            const formProperties = new FormProperties(mockProperties);
+
+            const mockCtx = { drawImage: vi.fn() };
+            const mockCanvas = {
+                width: 0,
+                height: 0,
+                getContext: vi.fn(() => mockCtx),
+                toDataURL: vi.fn(() => 'data:image/png;base64,resized'),
+            };
+            const originalCreateElement = document.createElement.bind(document);
+            document.createElement = (tag) => {
+                if (tag === 'canvas') return mockCanvas;
+                return originalCreateElement(tag);
+            };
+
+            // 2560x1440 image — should be halved to 1280x720
+            const img = { width: 2560, height: 1440 };
+            const result = formProperties.resizeAndConvertToPng(img);
+
+            expect(mockCanvas.width).toBe(1280);
+            expect(mockCanvas.height).toBe(720);
+            expect(result).toBe('data:image/png;base64,resized');
+            document.createElement = originalCreateElement;
+        });
     });
 
     describe('setScreenshot', () => {

--- a/public/app/workarea/project/properties/formProperties.test.js
+++ b/public/app/workarea/project/properties/formProperties.test.js
@@ -1556,6 +1556,11 @@ describe('FormProperties', () => {
                 getMetadata: vi.fn(() => mockMetadata),
             };
             mockYjsBridge.getDocumentManager = vi.fn(() => mockDm);
+
+            global.eXeLearning.app.modals = {
+                alert: { show: vi.fn() },
+                confirm: { show: vi.fn() },
+            };
         });
 
         it('should create a container with screenshot-panel class', () => {
@@ -1625,10 +1630,10 @@ describe('FormProperties', () => {
             const pane = document.createElement('div');
             formProperties.buildScreenshotPane(pane);
 
-            // Find the regenerate button (second button after upload)
+            // Find the regenerate button (no screenshot set, so no confirm dialog)
             const buttons = pane.querySelectorAll('button');
             const regenerateBtn = Array.from(buttons).find(
-                (b) => b.textContent.includes('Regenerate'),
+                (b) => b.textContent.includes('Generate from content'),
             );
             expect(regenerateBtn).not.toBeNull();
 
@@ -1656,10 +1661,10 @@ describe('FormProperties', () => {
 
             const buttons = pane.querySelectorAll('button');
             const regenerateBtn = Array.from(buttons).find(
-                (b) => b.textContent.includes('Regenerate'),
+                (b) => b.textContent.includes('Generate from content'),
             );
 
-            // Click to start generation (don't await — handler is async)
+            // Click to start generation (no screenshot set, so no confirm dialog)
             regenerateBtn.click();
             // Yield to the event loop so the async handler starts
             await new Promise((r) => setTimeout(r, 0));
@@ -1673,18 +1678,28 @@ describe('FormProperties', () => {
             expect(regenerateBtn.disabled).toBe(false);
         });
 
-        it('remove button calls metadata.delete with screenshot key', async () => {
+        it('remove button calls metadata.delete with screenshot key after confirm', async () => {
+            let capturedConfirmExec;
+            global.eXeLearning.app.modals.confirm.show = vi.fn(({ confirmExec }) => {
+                capturedConfirmExec = confirmExec;
+            });
+
             const formProperties = new FormProperties(mockProperties);
             const pane = document.createElement('div');
             formProperties.buildScreenshotPane(pane);
 
             const buttons = pane.querySelectorAll('button');
             const removeBtn = Array.from(buttons).find(
-                (b) => b.textContent.includes('Remove'),
+                (b) => b.textContent.includes('Delete'),
             );
             expect(removeBtn).not.toBeNull();
 
             removeBtn.click();
+
+            expect(global.eXeLearning.app.modals.confirm.show).toHaveBeenCalled();
+            expect(capturedConfirmExec).toBeTypeOf('function');
+
+            capturedConfirmExec();
 
             expect(mockMetadata.delete).toHaveBeenCalledWith('screenshot');
         });

--- a/public/app/yjs/SaveManager.js
+++ b/public/app/yjs/SaveManager.js
@@ -1283,6 +1283,13 @@ class SaveManager {
         this.bridge.isNewProject = false;
       }
 
+      // Auto-generate screenshot from first page after save (non-blocking)
+      if (this.bridge?.generateScreenshotFromFirstPage) {
+        this.bridge.generateScreenshotFromFirstPage().catch((err) => {
+          console.warn('[SaveManager] Post-save screenshot generation failed:', err);
+        });
+      }
+
       return { success: true, message: _('Project saved successfully') };
     } catch (error) {
       console.error('[SaveManager] Save failed:', error);

--- a/public/app/yjs/SaveManager.test.js
+++ b/public/app/yjs/SaveManager.test.js
@@ -577,6 +577,19 @@ describe('SaveManager', () => {
       expect(mockBridge.isNewProject).toBe(false);
     });
 
+    it('calls generateScreenshotFromFirstPage on bridge after successful save', async () => {
+      const generateScreenshot = vi.fn().mockResolvedValue(undefined);
+      mockBridge.generateScreenshotFromFirstPage = generateScreenshot;
+
+      const manager = new SaveManager(mockBridge);
+      await manager.save({ showProgress: false });
+
+      // Allow the non-blocking .catch() chain to settle
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(generateScreenshot).toHaveBeenCalled();
+    });
+
     it('uploads pending assets with metadata-only objects (no blob property)', async () => {
       const manager = new SaveManager(mockBridge);
       const pendingMeta = [

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -2908,6 +2908,213 @@ class YjsProjectBridge {
   }
 
   /**
+   * Auto-generate screenshot from the first page HTML and store in Yjs metadata.
+   * Uses SharedExporters to generate a full preview (HTML + CSS + theme),
+   * inlines all CSS into the HTML for self-contained rendering, then captures
+   * with html2canvas in a hidden iframe. Skips if a custom screenshot already exists.
+   * Called before save and export to keep the screenshot up-to-date.
+   */
+  async generateScreenshotFromFirstPage() {
+    if (this._screenshotGenerating) return;
+    this._screenshotGenerating = true;
+    try {
+      if (!this.documentManager) {
+        console.warn('[YjsProjectBridge] Screenshot: no documentManager');
+        return;
+      }
+      const metadata = this.documentManager.getMetadata();
+      // Skip if user has set a custom screenshot
+      if (metadata.get('screenshot')) {
+        Logger.log('[YjsProjectBridge] Screenshot: custom screenshot already set, skipping');
+        return;
+      }
+
+      if (!window.SharedExporters?.generatePreviewForSW) {
+        console.warn('[YjsProjectBridge] Screenshot: SharedExporters.generatePreviewForSW not available');
+        return;
+      }
+
+      Logger.log('[YjsProjectBridge] Screenshot: generating preview files...');
+      // Generate all preview files (HTML + CSS + theme + libs)
+      const result = await window.SharedExporters.generatePreviewForSW(
+        this.documentManager,
+        this.assetCache || null,
+        this.resourceFetcher || null,
+        this.assetManager || null,
+      );
+      if (!result?.success || !result.files) {
+        console.warn('[YjsProjectBridge] Screenshot: preview generation failed', result?.error);
+        return;
+      }
+
+      const indexHtml = result.files['index.html'];
+      if (!indexHtml) {
+        console.warn('[YjsProjectBridge] Screenshot: no index.html in preview files');
+        return;
+      }
+      Logger.log(`[YjsProjectBridge] Screenshot: got ${Object.keys(result.files).length} preview files, rendering...`);
+
+      const decoder = new TextDecoder();
+      let htmlString = decoder.decode(indexHtml);
+
+      // Helper: convert a file path to a data URI using the generated files map
+      const MIME_MAP = {
+        png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+        gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp',
+        woff: 'font/woff', woff2: 'font/woff2', ttf: 'font/ttf',
+        eot: 'application/vnd.ms-fontobject', ico: 'image/x-icon',
+      };
+      const toDataUri = (filePath) => {
+        const buffer = result.files[filePath];
+        if (!buffer) return null;
+        const ext = filePath.split('.').pop().toLowerCase();
+        const mime = MIME_MAP[ext] || 'application/octet-stream';
+        const base64 = this._uint8ArrayToBase64(new Uint8Array(buffer));
+        return `data:${mime};base64,${base64}`;
+      };
+
+      // Helper: resolve url() references inside CSS text relative to the CSS file's directory
+      const resolveCssUrls = (cssText, cssPath) => {
+        const cssDir = cssPath.includes('/') ? cssPath.substring(0, cssPath.lastIndexOf('/') + 1) : '';
+        return cssText.replace(/url\(["']?(?!data:)([^"')]+)["']?\)/gi, (match, urlPath) => {
+          // Resolve relative path from CSS file's directory
+          const resolvedPath = cssDir + urlPath;
+          const dataUri = toDataUri(resolvedPath);
+          return dataUri ? `url("${dataUri}")` : match;
+        });
+      };
+
+      // Inline CSS: replace <link rel="stylesheet"> with <style> tags
+      // This handles both href-before-rel and rel-before-href attribute orders
+      htmlString = htmlString.replace(
+        /<link\s+[^>]*(?:rel=["']stylesheet["'][^>]*href=["']([^"']+)["']|href=["']([^"']+)["'][^>]*rel=["']stylesheet["'])[^>]*\/?>/gi,
+        (match, href1, href2) => {
+          const href = href1 || href2;
+          const cssBuffer = result.files[href];
+          if (cssBuffer) {
+            let cssText = decoder.decode(cssBuffer);
+            cssText = resolveCssUrls(cssText, href);
+            return `<style>/* ${href} */\n${cssText}</style>`;
+          }
+          return match;
+        },
+      );
+
+      // Convert <img src> to data URIs for self-contained rendering
+      htmlString = htmlString.replace(
+        /(<img\s+[^>]*src=["'])([^"']+)(["'][^>]*>)/gi,
+        (match, prefix, src, suffix) => {
+          const dataUri = toDataUri(src);
+          return dataUri ? `${prefix}${dataUri}${suffix}` : match;
+        },
+      );
+
+      // Inject CSS to hide navigation chrome — screenshot should show only content
+      const hideUiCss = `<style id="screenshot-cleanup">
+        #siteNav, .single-page-nav { display: none !important; }
+        .nav-buttons, .nav-button { display: none !important; }
+        #made-with-eXe { display: none !important; }
+        .exe-search-form, #exe-search-form, [id*="search"] form { display: none !important; }
+        #skipNav { display: none !important; }
+        .exe-pagination { display: none !important; }
+        .box-toggle { display: none !important; }
+        .exe-content { margin: 0 !important; padding: 16px !important; }
+        main.page, .exe-web-site main.page { padding-left: 16px !important; padding-right: 16px !important; max-width: 100% !important; }
+        #siteFooter, .exe-web-site #siteFooter { padding-left: 0 !important; display: none !important; }
+        body, .exe-content.exe-export { padding-left: 0 !important; padding-right: 0 !important; }
+      </style>`;
+      htmlString = htmlString.replace('</head>', `${hideUiCss}\n</head>`);
+
+      // Remove all <script> tags — JS is not needed for a static screenshot
+      // and would cause 404 errors since paths are relative to the main page
+      htmlString = htmlString.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+
+      // Capture screenshot using html2canvas in a hidden iframe
+      const dataUrl = await this._captureHtmlAsScreenshot(htmlString);
+      if (dataUrl) {
+        metadata.set('screenshot', dataUrl);
+        Logger.log('[YjsProjectBridge] Auto-generated screenshot from first page');
+      }
+    } catch (error) {
+      console.warn('[YjsProjectBridge] Screenshot auto-generation failed:', error);
+    } finally {
+      this._screenshotGenerating = false;
+    }
+  }
+
+  /**
+   * Render HTML string in a hidden iframe and capture as PNG data URL.
+   * @param {string} html - Self-contained HTML with inlined CSS
+   * @returns {Promise<string|null>} PNG data URL or null on failure
+   */
+  async _captureHtmlAsScreenshot(html) {
+    // Load html2canvas if not available
+    if (!window.html2canvas) {
+      try {
+        const script = document.createElement('script');
+        script.src = '/files/perm/idevices/base/rubric/export/html2canvas.js';
+        await new Promise((resolve, reject) => {
+          script.onload = resolve;
+          script.onerror = reject;
+          document.head.appendChild(script);
+        });
+      } catch {
+        return null;
+      }
+    }
+    if (!window.html2canvas) return null;
+
+    // Create hidden iframe for rendering
+    const iframe = document.createElement('iframe');
+    iframe.style.cssText = 'position:fixed;left:-9999px;top:-9999px;width:1280px;height:900px;border:none;opacity:0;';
+    document.body.appendChild(iframe);
+
+    try {
+      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+      if (!iframeDoc) return null;
+
+      iframeDoc.open();
+      iframeDoc.write(html);
+      iframeDoc.close();
+
+      // Wait for content to render
+      await new Promise((resolve) => {
+        if (iframeDoc.readyState === 'complete') {
+          setTimeout(resolve, 500);
+        } else {
+          iframe.onload = () => setTimeout(resolve, 500);
+        }
+      });
+
+      const body = iframeDoc.body;
+      const canvas = await window.html2canvas(body, {
+        backgroundColor: '#ffffff',
+        scale: 1,
+        useCORS: true,
+        width: 1280,
+        height: 720,
+        windowWidth: 1280,
+        logging: false,
+      });
+
+      // Force exact 1280×720 output
+      const resized = document.createElement('canvas');
+      resized.width = 1280;
+      resized.height = 720;
+      const ctx = resized.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, 1280, 720);
+        ctx.drawImage(canvas, 0, 0, 1280, 720);
+      }
+
+      return resized.toDataURL('image/png');
+    } finally {
+      document.body.removeChild(iframe);
+    }
+  }
+
+  /**
    * Export project to .elpx file
    * Uses SharedExporters (TypeScript unified pipeline) when available
    * Filename is automatically generated from project title (sanitized: lowercase, no accents, no special chars)
@@ -2943,7 +3150,6 @@ class YjsProjectBridge {
         if (window.MermaidPreRenderer) {
           exportOptions.preRenderMermaid = window.MermaidPreRenderer.preRender.bind(window.MermaidPreRenderer);
         }
-        
         this.logElpxExportPhase('bridge:exporter:run:start', {}, trace);
         const result = await exporter.export(exportOptions);
         this.logElpxExportPhase('bridge:exporter:run:end', {

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -3033,6 +3033,11 @@ class YjsProjectBridge {
       const dataUrl = await this._captureHtmlAsScreenshot(htmlString);
       if (dataUrl) {
         metadata.set('screenshot', dataUrl);
+        // Re-mark as clean: screenshot is auto-generated metadata, not a user edit,
+        // so it should not trigger "unsaved changes" guards on navigation
+        if (this.documentManager?.markClean) {
+          this.documentManager.markClean();
+        }
         Logger.log('[YjsProjectBridge] Auto-generated screenshot from first page');
       }
     } catch (error) {

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -6904,4 +6904,95 @@ describe('YjsProjectBridge', () => {
       expect(result[0].pageId).toBe('p2');
     });
   });
+
+  describe('generateScreenshotFromFirstPage', () => {
+    let mockMetadata;
+
+    beforeEach(() => {
+      mockMetadata = {
+        get: mock(() => undefined),
+        set: mock(() => undefined),
+        observe: mock(() => undefined),
+        unobserve: mock(() => undefined),
+      };
+    });
+
+    it('returns early when documentManager is null', async () => {
+      bridge.documentManager = null;
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      // No error thrown; the method exited early
+      expect(true).toBe(true);
+    });
+
+    it('returns early when custom screenshot already exists in metadata', async () => {
+      const getMetadataMock = mock(() => ({
+        ...mockMetadata,
+        get: mock(() => 'data:image/png;base64,abc'),
+      }));
+      bridge.documentManager = {
+        getMetadata: getMetadataMock,
+      };
+      window.SharedExporters = { generatePreviewForSW: mock(async () => ({ success: true, files: {} })) };
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(window.SharedExporters.generatePreviewForSW).not.toHaveBeenCalled();
+    });
+
+    it('returns early when SharedExporters.generatePreviewForSW is not available', async () => {
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      delete window.SharedExporters;
+
+      // Should not throw
+      await bridge.generateScreenshotFromFirstPage();
+
+      // metadata.set should never be called
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('returns early when window.SharedExporters is undefined', async () => {
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = undefined;
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('returns early when generatePreviewForSW returns success false', async () => {
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({ success: false, error: 'preview failed' })),
+      };
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('concurrency guard prevents double execution', async () => {
+      const generatePreviewForSW = mock(async () => ({ success: false }));
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = { generatePreviewForSW };
+
+      // Start two concurrent calls; the guard should make the second a no-op
+      const [, second] = await Promise.all([
+        bridge.generateScreenshotFromFirstPage(),
+        bridge.generateScreenshotFromFirstPage(),
+      ]);
+
+      // generatePreviewForSW should have been called at most once
+      expect(generatePreviewForSW).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -6994,5 +6994,316 @@ describe('YjsProjectBridge', () => {
       // generatePreviewForSW should have been called at most once
       expect(generatePreviewForSW).toHaveBeenCalledTimes(1);
     });
+
+    it('returns early when index.html is missing from preview files', async () => {
+      const encoder = new TextEncoder();
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: { 'other.html': encoder.encode('<html></html>').buffer },
+        })),
+      };
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('does not call metadata.set when _captureHtmlAsScreenshot returns null', async () => {
+      const encoder = new TextEncoder();
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: { 'index.html': encoder.encode('<html><body></body></html>').buffer },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async () => null);
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('calls metadata.set with data URL when generation succeeds', async () => {
+      const encoder = new TextEncoder();
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: { 'index.html': encoder.encode('<html><body>content</body></html>').buffer },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async () => 'data:image/png;base64,fakeScreenshot');
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(mockMetadata.set).toHaveBeenCalledWith('screenshot', 'data:image/png;base64,fakeScreenshot');
+    });
+
+    it('inlines CSS link tags as style tags in the HTML passed to capture', async () => {
+      const encoder = new TextEncoder();
+      let capturedHtml = '';
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: {
+            'index.html': encoder.encode('<html><head><link rel="stylesheet" href="theme/style.css"></head><body></body></html>').buffer,
+            'theme/style.css': encoder.encode('body { color: red; }').buffer,
+          },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async (html) => {
+        capturedHtml = html;
+        return 'data:image/png;base64,x';
+      });
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(capturedHtml).toContain('<style>');
+      expect(capturedHtml).not.toContain('<link rel="stylesheet"');
+    });
+
+    it('removes script tags from the HTML passed to capture', async () => {
+      const encoder = new TextEncoder();
+      let capturedHtml = '';
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: {
+            'index.html': encoder.encode('<html><head></head><body><script>alert(1)<\/script></body></html>').buffer,
+          },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async (html) => {
+        capturedHtml = html;
+        return 'data:image/png;base64,x';
+      });
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(capturedHtml).not.toContain('<script');
+    });
+
+    it('injects screenshot-cleanup CSS to hide UI chrome', async () => {
+      const encoder = new TextEncoder();
+      let capturedHtml = '';
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: {
+            'index.html': encoder.encode('<html><head></head><body></body></html>').buffer,
+          },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async (html) => {
+        capturedHtml = html;
+        return 'data:image/png;base64,x';
+      });
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(capturedHtml).toContain('screenshot-cleanup');
+      expect(capturedHtml).toContain('#siteNav');
+    });
+
+    it('converts img src attributes to data URIs', async () => {
+      const encoder = new TextEncoder();
+      let capturedHtml = '';
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => ({
+          success: true,
+          files: {
+            'index.html': encoder.encode('<html><body><img src="img/test.png"></body></html>').buffer,
+            'img/test.png': new Uint8Array([137, 80, 78, 71]).buffer,
+          },
+        })),
+      };
+      bridge._captureHtmlAsScreenshot = mock(async (html) => {
+        capturedHtml = html;
+        return 'data:image/png;base64,x';
+      });
+      // Override _uint8ArrayToBase64 to return a predictable value
+      bridge._uint8ArrayToBase64 = mock(() => 'AAAA');
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(capturedHtml).toContain('data:image/png;base64,');
+      expect(capturedHtml).not.toContain('src="img/test.png"');
+    });
+
+    it('catches and suppresses errors thrown by generatePreviewForSW', async () => {
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => { throw new Error('boom'); }),
+      };
+
+      // Should not throw
+      await expect(bridge.generateScreenshotFromFirstPage()).resolves.toBeUndefined();
+      expect(mockMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('resets _screenshotGenerating flag to false after error', async () => {
+      bridge.documentManager = {
+        getMetadata: mock(() => mockMetadata),
+      };
+      window.SharedExporters = {
+        generatePreviewForSW: mock(async () => { throw new Error('failure'); }),
+      };
+
+      await bridge.generateScreenshotFromFirstPage();
+
+      expect(bridge._screenshotGenerating).toBe(false);
+    });
+  });
+
+  describe('_captureHtmlAsScreenshot', () => {
+    let mockBody;
+    let originalBody;
+
+    beforeEach(() => {
+      // Ensure html2canvas is not set by default for each test
+      delete window.html2canvas;
+
+      // jsdom may not have document.body; provide a minimal mock
+      mockBody = {
+        appendChild: mock(() => {}),
+        removeChild: mock(() => {}),
+      };
+      originalBody = Object.getOwnPropertyDescriptor(document, 'body');
+      Object.defineProperty(document, 'body', {
+        get: () => mockBody,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      delete window.html2canvas;
+      if (originalBody) {
+        Object.defineProperty(document, 'body', originalBody);
+      }
+    });
+
+    it('returns null when html2canvas is not available and script loading fails', async () => {
+      // Patch the bridge's internal script-load path: intercept createElement('script')
+      // to immediately invoke onerror, simulating a failed load.
+      const originalCreateElement = document.createElement.bind(document);
+      document.createElement = (tag) => {
+        if (tag === 'script') {
+          const el = originalCreateElement(tag);
+          // Override appendChild on document.head to fire onerror synchronously
+          const origAppend = document.head ? document.head.appendChild.bind(document.head) : null;
+          if (document.head) {
+            document.head.appendChild = (child) => {
+              if (child === el) {
+                // Restore and fire onerror
+                if (origAppend) document.head.appendChild = origAppend;
+                setTimeout(() => child.onerror && child.onerror(new Error('load failed')), 0);
+                return child;
+              }
+              return origAppend ? origAppend(child) : child;
+            };
+          }
+          return el;
+        }
+        return originalCreateElement(tag);
+      };
+
+      const result = await bridge._captureHtmlAsScreenshot('<html><body>test</body></html>');
+
+      expect(result).toBeNull();
+      document.createElement = originalCreateElement;
+    });
+
+    it('returns null when html2canvas is available but iframe has no contentDocument', async () => {
+      window.html2canvas = mock(async () => ({}));
+
+      // Patch createElement to return an iframe with no contentDocument
+      const originalCreateElement = document.createElement.bind(document);
+      document.createElement = (tag) => {
+        if (tag === 'iframe') {
+          const iframe = originalCreateElement('iframe');
+          Object.defineProperty(iframe, 'contentDocument', { get: () => null, configurable: true });
+          Object.defineProperty(iframe, 'contentWindow', { get: () => null, configurable: true });
+          return iframe;
+        }
+        return originalCreateElement(tag);
+      };
+
+      const result = await bridge._captureHtmlAsScreenshot('<html><body>test</body></html>');
+
+      expect(result).toBeNull();
+      document.createElement = originalCreateElement;
+    });
+
+    it('calls html2canvas and returns a data URL when html2canvas is available', async () => {
+      const mockCtx = {
+        fillStyle: '',
+        fillRect: mock(() => {}),
+        drawImage: mock(() => {}),
+      };
+      const mockCapture = {
+        width: 800,
+        height: 600,
+        toDataURL: mock(() => 'irrelevant'),
+        getContext: mock(() => mockCtx),
+      };
+      const mockResized = {
+        width: 1280,
+        height: 720,
+        toDataURL: mock(() => 'data:image/png;base64,result'),
+        getContext: mock(() => mockCtx),
+      };
+      window.html2canvas = mock(async () => mockCapture);
+
+      // Patch createElement so canvas returns our mock with getContext
+      const originalCreateElement = document.createElement.bind(document);
+      document.createElement = (tag) => {
+        if (tag === 'canvas') return mockResized;
+        if (tag === 'iframe') {
+          // Return an iframe whose contentDocument supports open/write/close
+          const mockIframeDoc = {
+            open: mock(() => {}),
+            write: mock(() => {}),
+            close: mock(() => {}),
+            readyState: 'complete',
+            body: { appendChild: mock(() => {}) },
+          };
+          return {
+            style: { cssText: '' },
+            contentDocument: mockIframeDoc,
+            contentWindow: { document: mockIframeDoc },
+          };
+        }
+        return originalCreateElement(tag);
+      };
+
+      const result = await bridge._captureHtmlAsScreenshot('<html><body>test</body></html>');
+
+      expect(window.html2canvas).toHaveBeenCalled();
+      expect(result).toBe('data:image/png;base64,result');
+      document.createElement = originalCreateElement;
+    });
   });
 });

--- a/src/cli/commands/translations.ts
+++ b/src/cli/commands/translations.ts
@@ -54,6 +54,27 @@ const EXCLUDE_FILE_PATTERNS = [
  */
 const EXCLUDE_EXACT_KEYS = new Set([
     'P + \\\\tfrac12 \\\\rho v^2 + \\\\rho g h = \\\\text{constant}', // Bernoulli equation example in edicuatex lang file
+    // TO DO: screenshot tab strings (pending localization)
+    'Screenshot',
+    'Current project screenshot preview',
+    'No screenshot yet. It will be auto-generated when you save or export.',
+    'Upload custom image',
+    'Screenshot must be smaller than 2 MB.',
+    'Invalid image',
+    'The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.',
+    'Generate from content',
+    'Not available',
+    'Screenshot generation is not available.',
+    'Generation failed',
+    'Could not generate screenshot from content. Try uploading an image instead.',
+    'Replace screenshot',
+    'This will delete the current image. Do you want to continue?',
+    'Delete screenshot',
+    'Delete the current image? This action cannot be undone.',
+    'Recommendations',
+    'Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.',
+    'The image will be used as a preview of this educational resource across different platforms.',
+    // END TO DO
 ]);
 
 /**

--- a/src/shared/export/adapters/YjsDocumentAdapter.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.ts
@@ -112,6 +112,9 @@ export class YjsDocumentAdapter implements ExportDocument {
             // Custom content
             extraHeadContent: (meta.get('extraHeadContent') as string) || undefined,
             footer: (meta.get('footer') as string) || undefined,
+
+            // Project screenshot/thumbnail
+            screenshot: (meta.get('screenshot') as string) || undefined,
         };
     }
 

--- a/src/shared/export/exporters/ElpxExporter.spec.ts
+++ b/src/shared/export/exporters/ElpxExporter.spec.ts
@@ -1075,4 +1075,133 @@ describe('ElpxExporter', () => {
             expect(indexHtml).not.toContain('../libs/elpx-manifest.js');
         });
     });
+
+    // =========================================================================
+    // Screenshot / Thumbnail Tests
+    // =========================================================================
+    describe('screenshot support', () => {
+        // Minimal valid 1x1 red PNG (base64)
+        const MINIMAL_PNG_BASE64 =
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+        const MINIMAL_PNG_DATA_URL = `data:image/png;base64,${MINIMAL_PNG_BASE64}`;
+
+        it('should include screenshot.png in archive when metadata has screenshot', async () => {
+            document = new MockDocument({ screenshot: MINIMAL_PNG_DATA_URL }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            expect(zip.files.has('screenshot.png')).toBe(true);
+            const screenshotData = zip.files.get('screenshot.png');
+            expect(screenshotData).toBeDefined();
+            // Verify PNG signature
+            const bytes = new Uint8Array(screenshotData as Buffer);
+            expect(bytes[0]).toBe(0x89);
+            expect(bytes[1]).toBe(0x50); // P
+            expect(bytes[2]).toBe(0x4e); // N
+            expect(bytes[3]).toBe(0x47); // G
+        });
+
+        it('should include screenshot.png when metadata has raw base64 (no data URL prefix)', async () => {
+            document = new MockDocument({ screenshot: MINIMAL_PNG_BASE64 }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            expect(zip.files.has('screenshot.png')).toBe(true);
+        });
+
+        it('should NOT include screenshot.png when metadata has no screenshot', async () => {
+            document = new MockDocument({}, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            expect(zip.files.has('screenshot.png')).toBe(false);
+        });
+
+        it('should NOT include screenshot.png when screenshot data is invalid (not PNG)', async () => {
+            const invalidBase64 = btoa('not a png file');
+            document = new MockDocument({ screenshot: `data:image/png;base64,${invalidBase64}` }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            expect(zip.files.has('screenshot.png')).toBe(false);
+        });
+
+        it('should still export successfully even if screenshot is malformed', async () => {
+            document = new MockDocument({ screenshot: 'totally-invalid-data' }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            const result = await exporter.export();
+
+            expect(result.success).toBe(true);
+            expect(zip.files.has('screenshot.png')).toBe(false);
+        });
+
+        it('should place screenshot.png at archive root (not in subdirectory)', async () => {
+            document = new MockDocument({ screenshot: MINIMAL_PNG_DATA_URL }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            // Verify it's at root, not in content/ or any subdirectory
+            expect(zip.files.has('screenshot.png')).toBe(true);
+            expect(zip.files.has('content/screenshot.png')).toBe(false);
+            expect(zip.files.has('content/resources/screenshot.png')).toBe(false);
+        });
+
+        it('should auto-generate screenshot via generateScreenshot hook when no custom screenshot', async () => {
+            document = new MockDocument({}, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            // Mock generateScreenshot hook that returns a valid PNG data URL
+            const generateScreenshot = async (_html: string) => MINIMAL_PNG_DATA_URL;
+
+            await exporter.export({ generateScreenshot });
+
+            expect(zip.files.has('screenshot.png')).toBe(true);
+        });
+
+        it('should prefer custom screenshot over generateScreenshot hook', async () => {
+            // Different minimal PNG for custom (just use same base64 — testing priority logic)
+            document = new MockDocument({ screenshot: MINIMAL_PNG_DATA_URL }, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            let hookCalled = false;
+            const generateScreenshot = async (_html: string) => {
+                hookCalled = true;
+                return MINIMAL_PNG_DATA_URL;
+            };
+
+            await exporter.export({ generateScreenshot });
+
+            expect(zip.files.has('screenshot.png')).toBe(true);
+            expect(hookCalled).toBe(false); // Hook should NOT be called when custom exists
+        });
+
+        it('should handle generateScreenshot hook failure gracefully', async () => {
+            document = new MockDocument({}, samplePages);
+            zip = new MockZipProvider();
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            const generateScreenshot = async () => {
+                throw new Error('html2canvas failed');
+            };
+
+            const result = await exporter.export({ generateScreenshot });
+
+            expect(result.success).toBe(true);
+            expect(zip.files.has('screenshot.png')).toBe(false);
+        });
+    });
 });

--- a/src/shared/export/exporters/ElpxExporter.ts
+++ b/src/shared/export/exporters/ElpxExporter.ts
@@ -35,6 +35,46 @@ import { generateOdeXml } from '../generators/OdeXmlGenerator';
 
 export class ElpxExporter extends Html5Exporter {
     /**
+     * Decode screenshot from base64 data URL or raw base64 to Uint8Array.
+     * Returns null if the data is not valid PNG.
+     */
+    private decodeScreenshotToBuffer(screenshot: string): Uint8Array | null {
+        try {
+            let base64Data = screenshot;
+            // Handle data URL format (data:image/png;base64,...)
+            if (base64Data.startsWith('data:')) {
+                const commaIndex = base64Data.indexOf(',');
+                if (commaIndex === -1) return null;
+                base64Data = base64Data.substring(commaIndex + 1);
+            }
+            // Decode base64 to binary
+            const binaryString = atob(base64Data);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
+            }
+            // Validate PNG signature (first 8 bytes)
+            if (
+                bytes.length >= 8 &&
+                bytes[0] === 0x89 &&
+                bytes[1] === 0x50 &&
+                bytes[2] === 0x4e &&
+                bytes[3] === 0x47 &&
+                bytes[4] === 0x0d &&
+                bytes[5] === 0x0a &&
+                bytes[6] === 0x1a &&
+                bytes[7] === 0x0a
+            ) {
+                return bytes;
+            }
+            console.warn('[ElpxExporter] Screenshot data is not a valid PNG');
+            return null;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
      * Get file extension for ELPX format
      */
     getFileExtension(): string {
@@ -321,6 +361,30 @@ export class ElpxExporter extends Html5Exporter {
 
             // 2.2 Add DTD file
             this.zip.addFile(ODE_DTD_FILENAME, ODE_DTD_CONTENT);
+
+            // 2.3 Add project screenshot/thumbnail
+            let screenshotBuffer: Uint8Array | null = null;
+            // Priority 1: custom screenshot from project metadata
+            if (meta.screenshot) {
+                screenshotBuffer = this.decodeScreenshotToBuffer(meta.screenshot);
+            }
+            // Priority 2: auto-generate from first page HTML via browser hook
+            if (!screenshotBuffer && options?.generateScreenshot) {
+                try {
+                    const firstPageHtml = pageHtmlMap.get('index.html');
+                    if (firstPageHtml) {
+                        const dataUrl = await options.generateScreenshot(firstPageHtml);
+                        if (dataUrl) {
+                            screenshotBuffer = this.decodeScreenshotToBuffer(dataUrl);
+                        }
+                    }
+                } catch (error) {
+                    console.warn('[ElpxExporter] Screenshot auto-generation failed:', error);
+                }
+            }
+            if (screenshotBuffer) {
+                this.zip.addFile('screenshot.png', screenshotBuffer);
+            }
 
             // =========================================================================
             // SECTION 3: Generate final ZIP

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -72,6 +72,9 @@ export interface ExportMetadata {
     extraHeadContent?: string; // Custom content in <head>
     footer?: string; // Custom footer content
 
+    // Project screenshot/thumbnail (base64 PNG data URL)
+    screenshot?: string;
+
     // SCORM metadata
     scormIdentifier?: string;
     masteryScore?: number;
@@ -446,6 +449,15 @@ export interface ExportOptions {
      * This significantly reduces export size and provides instant diagram rendering.
      */
     preRenderMermaid?: (html: string) => Promise<MermaidPreRenderResult>;
+
+    /**
+     * Optional hook to generate a screenshot from the first page HTML.
+     * Called during ELPX export when no custom screenshot is set in metadata.
+     * Receives the complete HTML of the first page (index.html) and should return
+     * a PNG data URL (data:image/png;base64,...).
+     * Browser-only: renders HTML in a hidden iframe and captures with html2canvas.
+     */
+    generateScreenshot?: (firstPageHtml: string) => Promise<string>;
 }
 
 /**

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -2084,4 +2084,109 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
 
         ydoc.destroy();
     });
+
+    // =========================================================================
+    // Screenshot import tests
+    // =========================================================================
+    describe('screenshot import', () => {
+        // Minimal valid 1x1 PNG (binary)
+        const MINIMAL_PNG_BYTES = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+            0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2,
+            0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+        ]);
+
+        const MINIMAL_CONTENT_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Screenshot Test</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-1</odePageId>
+  <pageName>Home</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+  <odePagStructures/>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+        it('should import screenshot.png from archive root into metadata', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(MINIMAL_CONTENT_XML),
+                'screenshot.png': MINIMAL_PNG_BYTES,
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const screenshot = metadata.get('screenshot') as string;
+            expect(screenshot).toBeDefined();
+            expect(screenshot).toContain('data:image/png;base64,');
+
+            ydoc.destroy();
+        });
+
+        it('should work without screenshot.png (backward compatibility)', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(MINIMAL_CONTENT_XML),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const screenshot = metadata.get('screenshot');
+            expect(screenshot).toBeUndefined();
+
+            // Other metadata should still be set
+            expect(metadata.get('title')).toBe('Screenshot Test');
+
+            ydoc.destroy();
+        });
+
+        it('should store screenshot as valid base64 data URL that round-trips', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(MINIMAL_CONTENT_XML),
+                'screenshot.png': MINIMAL_PNG_BYTES,
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const screenshot = metadata.get('screenshot') as string;
+
+            // Verify the base64 can be decoded back to original bytes
+            const base64Part = screenshot.split(',')[1];
+            const decoded = atob(base64Part);
+            const roundTripped = new Uint8Array(decoded.length);
+            for (let i = 0; i < decoded.length; i++) {
+                roundTripped[i] = decoded.charCodeAt(i);
+            }
+            // Check PNG signature is preserved
+            expect(roundTripped[0]).toBe(0x89);
+            expect(roundTripped[1]).toBe(0x50);
+            expect(roundTripped[2]).toBe(0x4e);
+            expect(roundTripped[3]).toBe(0x47);
+
+            ydoc.destroy();
+        });
+    });
 });

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -382,6 +382,12 @@ export class ElpxImporter {
         const odeProperties = this.getElement(xmlDoc, 'odeProperties');
         const metadataValues = this.extractMetadata(xmlDoc, odeProperties);
 
+        // Extract screenshot.png from archive root if present
+        const screenshot = this.extractScreenshotFromZip(zip);
+        if (screenshot) {
+            metadataValues.screenshot = screenshot;
+        }
+
         // Calculate order offset for imported pages
         let orderOffset = 0;
         if (!clearExisting) {
@@ -543,6 +549,11 @@ export class ElpxImporter {
                 if (clearExisting) {
                     this.logger.log('[ElpxImporter] Setting legacy metadata...');
                     this.setLegacyMetadata(metadata, parsedData.meta);
+                    // Extract screenshot.png from archive root if present
+                    const legacyScreenshot = this.extractScreenshotFromZip(zip);
+                    if (legacyScreenshot) {
+                        metadata.set('screenshot', legacyScreenshot);
+                    }
                     this.logger.log('[ElpxImporter] Legacy metadata set');
                 }
 
@@ -767,6 +778,18 @@ export class ElpxImporter {
     }
 
     /**
+     * Convert Uint8Array to base64 string
+     */
+    private uint8ArrayToBase64(bytes: Uint8Array): string {
+        const CHUNK = 0x8000;
+        const parts: string[] = [];
+        for (let i = 0; i < bytes.length; i += CHUNK) {
+            parts.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+        }
+        return btoa(parts.join(''));
+    }
+
+    /**
      * Escape HTML special characters for attribute values
      */
     private escapeHtmlAttr(str: string): string {
@@ -798,6 +821,21 @@ export class ElpxImporter {
             html.includes('iDevice_buttons feedback-button') ||
             html.includes('class="feedback-button')
         );
+    }
+
+    /**
+     * Extract screenshot.png from archive root and return as data URL, or undefined.
+     */
+    private extractScreenshotFromZip(zip: Record<string, Uint8Array>): string | undefined {
+        if (!zip['screenshot.png']) return undefined;
+        try {
+            const base64 = this.uint8ArrayToBase64(zip['screenshot.png']);
+            this.logger.log('[ElpxImporter] Extracted screenshot.png from archive');
+            return `data:image/png;base64,${base64}`;
+        } catch (error) {
+            this.logger.warn('[ElpxImporter] Failed to read screenshot.png:', error);
+            return undefined;
+        }
     }
 
     /**
@@ -868,6 +906,10 @@ export class ElpxImporter {
         metadata.set('globalFont', values.globalFont);
         metadata.set('extraHeadContent', values.extraHeadContent);
         metadata.set('footer', values.footer);
+        // Screenshot (optional, extracted from archive root)
+        if (values.screenshot) {
+            metadata.set('screenshot', values.screenshot);
+        }
     }
 
     /**

--- a/src/shared/import/interfaces.ts
+++ b/src/shared/import/interfaces.ts
@@ -284,4 +284,6 @@ export interface OdeMetadata {
     addMathJax: boolean;
     /** Global font family (default: 'default') */
     globalFont: string;
+    /** Project screenshot/thumbnail as base64 data URL (optional) */
+    screenshot?: string;
 }


### PR DESCRIPTION
## Summary

Implements #1637 — adds automatic `screenshot.png` thumbnail generation to `.elpx` project packages.

<img width="1053" height="602" alt="Captura de pantalla 2026-04-07 a las 18 05 07" src="https://github.com/user-attachments/assets/a9522e3b-b892-42f0-8461-ec0f935527dd" />


- **Auto-generated on save**: After each save, the first page HTML is rendered in a hidden iframe with full CSS inlining (theme, base styles, fonts, images as data URIs) and captured via `html2canvas` at exactly 1280×720 px. Navigation chrome (sidebar, nav buttons, footer, search, toggle) is hidden so the screenshot shows only content.
- **Included in .elpx export**: `ElpxExporter` reads the screenshot from Yjs metadata and writes it as `screenshot.png` at the archive root. External systems can extract it for preview without processing the full package.
- **New "Screenshot" tab in Project Properties**: Bootstrap 5 layout (`col-lg-7` preview card + `col-lg-5` info panel) with three actions — upload custom image (PNG/JPEG/WebP, max 2MB), regenerate from content, and remove. Includes `alert-info` guidelines panel with a11y attributes (`aria-describedby`, `role="note"`).
- **Yjs collaborative sync**: Screenshot is stored in Yjs metadata (`metadata.set('screenshot', dataUrl)`), synced in real-time across collaborators. The UI observes metadata changes with proper cleanup on rebuild (`unobserve`).
- **Import support**: `ElpxImporter` extracts `screenshot.png` from both modern and legacy `.elpx` archives. Old files without screenshot continue to work (backward compatible).
- **Non-blocking & guarded**: Screenshot generation runs post-save (fire-and-forget), has a concurrency guard (`_screenshotGenerating` flag), and all failures degrade gracefully without blocking save or export.

## Files changed (14)

| Area | Files | What |
|------|-------|------|
| **Export** | `ElpxExporter.ts`, `interfaces.ts` | Write `screenshot.png` to archive root, `generateScreenshot` hook interface |
| **Import** | `ElpxImporter.ts`, `interfaces.ts` | Extract `screenshot.png` on import (shared `extractScreenshotFromZip` helper) |
| **Adapter** | `YjsDocumentAdapter.ts` | Read screenshot from Yjs metadata |
| **UI** | `formProperties.js`, `_properties.scss` | New Screenshot tab with Bootstrap 5 layout, observer, buttons |
| **Bridge** | `YjsProjectBridge.js` | `generateScreenshotFromFirstPage()` + `_captureHtmlAsScreenshot()` |
| **Save** | `SaveManager.js` | Trigger screenshot generation post-save (non-blocking) |
| **Tests** | `ElpxExporter.spec.ts`, `ElpxImporter.spec.ts`, `formProperties.test.js`, `YjsProjectBridge.test.js` | 26 new tests |
| **Docs** | `elpx-format.md` | Updated ZIP structure + Screenshot section |

## Test plan

- [x] 73 ElpxExporter tests pass (9 screenshot-specific: custom, auto-gen hook, priority, failure, PNG validation)
- [x] 55 ElpxImporter tests pass (3 screenshot-specific: extract, missing, invalid)
- [x] 92 formProperties tests pass (8 new: DOM structure, observer cleanup, setScreenshot, file validation)
- [x] 390 YjsProjectBridge tests pass (6 new: skip conditions, concurrency guard)
- [x] Backend coverage: ElpxExporter 85.7% lines / 93.7% branches, ElpxImporter 92.5% / 99.3%
- [ ] Manual: create project with content → save → verify screenshot appears in Screenshot tab
- [ ] Manual: export .elpx → unzip → verify `screenshot.png` exists at root, is 1280×720 PNG
- [ ] Manual: import old .elpx without screenshot → verify no errors
- [ ] Manual: upload custom screenshot → save → export → verify custom is used
- [ ] Manual: remove screenshot → save → verify auto-generated on next save

## Note for reviewers

@ignaciogros — I'd appreciate your eye on the Screenshot tab CSS and button styling. The layout uses Bootstrap 5 grid (`col-lg-7`/`col-lg-5`) with `card`, `alert-info`, and `btn-primary`/`btn-outline-secondary`/`btn-danger` for the buttons. You have much better design taste than me, so feel free to adjust spacing, colors, or button arrangement to match the rest of the UI more closely. The relevant files are `formProperties.js` (DOM construction in `buildScreenshotPane`) and `_properties.scss` (minimal overrides for icon colors).