### PR TITLE
1618 fix platform related issues

### DIFF
--- a/public/app/workarea/menus/navbar/items/navbarFile.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.js
@@ -351,6 +351,11 @@ export default class NavbarFile {
         if (capabilities && !capabilities.storage.remote) {
             return;
         }
+        
+        // Hide templates if this is an LMS session
+        if (eXeLearning?.config?.platformIntegration) {
+            return;
+        }
 
         try {
             // Get current locale from eXeLearning config or default to 'en'

--- a/public/app/workarea/menus/navbar/items/navbarFile.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.test.js
@@ -650,6 +650,25 @@ describe('NavbarFile', () => {
             expect(li.classList.contains('d-none')).toBe(true);
         });
 
+        it('checkAndShowNewFromTemplateButton should keep button hidden and return early when platform integration is enabled', async () => {
+            const li = document.createElement('li');
+            li.classList.add('d-none');
+            li.appendChild(mockButtons.newFromTemplateButton);
+            navbarElement.appendChild(li);
+
+            global.eXeLearning.config.platformIntegration = true;
+            global.fetch = vi.fn();
+
+            await navbarFile.checkAndShowNewFromTemplateButton();
+
+            // Should not fetch and stay hidden
+            expect(global.fetch).not.toHaveBeenCalled();
+            expect(li.classList.contains('d-none')).toBe(true);
+            
+            // Clean up config
+            global.eXeLearning.config.platformIntegration = false;
+        });
+
         it('setSaveProjectEvent should add click listener', () => {
             navbarFile.setSaveProjectEvent();
             expect(mockButtons.saveButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));

--- a/public/app/workarea/project/projectManager.js
+++ b/public/app/workarea/project/projectManager.js
@@ -426,6 +426,76 @@ export default class projectManager {
      */
     async checkAndImportElp() {
         const urlParams = new URLSearchParams(window.location.search);
+
+        // =====================================================
+        // PLATFORM INTEGRATION: Fetch ELP from LMS if requested
+        // =====================================================
+        const fetchPlatformElp = urlParams.get('fetchPlatformElp') === '1';
+        const jwtToken = urlParams.get('jwt_token');
+
+        if (jwtToken && fetchPlatformElp) {
+            Logger.log('[ProjectManager] Detected platform integration new project, fetching ELP from platform...');
+            try {
+                if (this.app?.modals?.loader) {
+                    this.app.modals.loader.show({ message: window._ ? window._('Downloading from platform...') : 'Downloading from platform...' });
+                }
+
+                const basePath = window.eXeLearning?.config?.basePath || '';
+                const response = await fetch(`${basePath}/api/platform/integration/openPlatformElp`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ jwt_token: jwtToken })
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+
+                    if (data.responseMessage === 'OK' && data.elpFile) {
+                        Logger.log('[ProjectManager] ELP file fetched from platform, base64 size:', data.elpFile.length);
+
+                        // Convert base64 to Blob/File
+                        const binaryString = atob(data.elpFile);
+                        const len = binaryString.length;
+                        const bytes = new Uint8Array(len);
+                        for (let i = 0; i < len; i++) {
+                            bytes[i] = binaryString.charCodeAt(i);
+                        }
+                        const fileName = data.elpFileName || 'platform_import.elpx';
+                        const file = new File([bytes], fileName, { type: 'application/octet-stream' });
+
+                        const stats = await this.importFromElpxViaYjs(file);
+                        Logger.log('[ProjectManager] Platform ELP import complete:', stats);
+
+                        try {
+                            await this._yjsBridge.documentManager.saveToServer();
+                            Logger.log('[ProjectManager] Document saved to server after platform import');
+                        } catch (saveError) {
+                            console.warn('[ProjectManager] Failed to save to server after platform import', saveError);
+                        }
+
+                    } else {
+                        Logger.log('[ProjectManager] No ELP file returned by platform or error:', data.error);
+                    }
+                } else {
+                    console.warn(`[ProjectManager] Platform API responded with status ${response.status}`);
+                }
+            } catch (error) {
+                // Do not block the user, just log and continue
+                console.error('[ProjectManager] Failed to fetch ELP from platform:', error);
+            } finally {
+                if (this.app?.modals?.loader) {
+                    this.app.modals.loader.hide();
+                }
+
+                // Cleanup fetchPlatformElp url parameter
+                const newUrl = new URL(window.location.href);
+                newUrl.searchParams.delete('fetchPlatformElp');
+                window.history.replaceState({}, '', newUrl.toString());
+            }
+
+            return; // We handled the platform import, skip subsequent checks
+        }
+
         const importPathFromUrl = urlParams.get('import');
         const importPathFromEmbedding = this.app?.runtimeConfig?.embeddingConfig?.initialProjectUrl || '';
         const importPath = importPathFromUrl || importPathFromEmbedding;

--- a/public/app/workarea/project/projectManager.test.js
+++ b/public/app/workarea/project/projectManager.test.js
@@ -754,6 +754,75 @@ describe('ProjectManager', () => {
         });
     });
 
+    describe('checkAndImportElp', () => {
+        let originalLocation;
+        
+        beforeEach(() => {
+            global.fetch = vi.fn();
+            projectManager.importFromElpxViaYjs = vi.fn().mockResolvedValue('stats');
+            projectManager._yjsBridge = {
+                documentManager: {
+                    saveToServer: vi.fn().mockResolvedValue()
+                }
+            };
+            mockApp.modals.loader = {
+                show: vi.fn(),
+                hide: vi.fn(),
+            };
+            vi.stubGlobal('history', { replaceState: vi.fn() });
+        });
+        
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('does nothing if no fetchPlatformElp param', async () => {
+            vi.stubGlobal('location', { href: 'http://localhost:8080/', search: '' });
+            await projectManager.checkAndImportElp();
+            expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining('openPlatformElp'), expect.anything());
+        });
+
+        it('fetches platform ELP when jwt_token and fetchPlatformElp are present', async () => {
+            vi.stubGlobal('location', { 
+                href: 'http://localhost:8080/?jwt_token=12345&fetchPlatformElp=1',
+                search: '?jwt_token=12345&fetchPlatformElp=1' 
+            });
+            global.fetch.mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ responseMessage: 'OK', elpFile: btoa('test data'), elpFileName: 'test.elpx' })
+            });
+
+            await projectManager.checkAndImportElp();
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/api/platform/integration/openPlatformElp'),
+                expect.objectContaining({ method: 'POST' })
+            );
+            expect(projectManager.importFromElpxViaYjs).toHaveBeenCalled();
+            expect(projectManager._yjsBridge.documentManager.saveToServer).toHaveBeenCalled();
+            expect(mockApp.modals.loader.show).toHaveBeenCalled();
+        });
+
+        it('handles fetch platform ELP failure gracefully', async () => {
+            vi.stubGlobal('location', { 
+                href: 'http://localhost:8080/?jwt_token=12345&fetchPlatformElp=1',
+                search: '?jwt_token=12345&fetchPlatformElp=1' 
+            });
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 500
+            });
+
+            await projectManager.checkAndImportElp();
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/api/platform/integration/openPlatformElp'),
+                expect.objectContaining({ method: 'POST' })
+            );
+            expect(projectManager.importFromElpxViaYjs).not.toHaveBeenCalled();
+        });
+    });
+
     describe('resetProject', () => {
         it('sets _forceStructureImport flag', () => {
             projectManager.resetProject();

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -655,7 +655,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                             const basePath = getBasePath();
                             let redirectUrl = `${basePath}/workarea?project=${newSessionId}`;
                             if (jwtTokenParam) {
-                                redirectUrl += `&jwt_token=${encodeURIComponent(jwtTokenParam)}`;
+                                redirectUrl += `&jwt_token=${encodeURIComponent(jwtTokenParam)}&fetchPlatformElp=1`;
                             }
                             return Response.redirect(redirectUrl, 302);
                         } catch (error) {
@@ -765,11 +765,12 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                 // If no project UUID, create a new project and redirect
                 if (!projectUuid) {
                     // Helper function to build redirect URL with preserved jwt_token
+                    // Helper function to build redirect URL with preserved jwt_token
                     const buildRedirectUrl = (sessionId: string): string => {
                         const basePath = getBasePath();
                         let url = `${basePath}/workarea?project=${sessionId}`;
                         if (jwtTokenParam) {
-                            url += `&jwt_token=${encodeURIComponent(jwtTokenParam)}`;
+                            url += `&jwt_token=${encodeURIComponent(jwtTokenParam)}&fetchPlatformElp=1`;
                         }
                         return url;
                     };

--- a/views/workarea/menus/menuHeadTop.njk
+++ b/views/workarea/menus/menuHeadTop.njk
@@ -8,7 +8,7 @@
                 <span class="auto-icon" aria-hidden="true">download</span>
                 <span class="btn-label">{{ t.download or 'Download' }}</span>
             </button>
-            <button id="head-top-save-button" class="btn button-display d-flex justify-content-center align-items-center me-2" title="{{ t.save or 'Save' }}" data-testid="save-button">
+            <button id="head-top-save-button" class="btn button-display d-flex justify-content-center align-items-center me-2 {% if config.platformIntegration %}d-none{% endif %}" title="{{ t.save or 'Save' }}" data-testid="save-button">
                 <div class="small-icon save-icon-white"></div>
                 <span>{{ t.save or 'Save' }}</span>
             </button>
@@ -58,7 +58,7 @@
                     <li class="d-md-none mobile-menu-header"><small class="dropdown-header">{{ t.file or 'File' }}</small></li>
                     <li class="d-md-none {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-new" href="#">{{ t.new or 'New' }}</a></li>
                     <li class="d-md-none exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-openuserodefiles" href="#">{{ t.open or 'Open' }}</a></li>
-                    <li class="d-md-none exe-online"><a class="dropdown-item" id="mobile-navbar-button-save" href="#">{{ t.save or 'Save' }}</a></li>
+                    <li class="d-md-none exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-save" href="#">{{ t.save or 'Save' }}</a></li>
                     {# Hidden to reduce Open/Import confusion (issue #1223) #}
                     <li class="d-none"><a class="dropdown-item" id="mobile-navbar-button-import-elp" href="#">{{ t.import_elpx or 'Import (.elpx…)' }}</a></li>
                     <li class="dropdown-divider d-md-none"></li>

--- a/views/workarea/menus/menuHeadTop.njk
+++ b/views/workarea/menus/menuHeadTop.njk
@@ -22,7 +22,7 @@
                 <span class="medium-icon settings-icon"></span>
             </button>
             <button id="head-top-share-button"
-                    class="btn button-secondary button-share-link d-flex justify-content-center align-items-center exe-online ms-1"
+                    class="btn button-secondary button-share-link d-flex justify-content-center align-items-center exe-online ms-1 {% if config.platformIntegration %}d-none{% endif %}"
                     title="{{ t.share or 'Share' }}"
                     aria-label="{{ t.share or 'Share' }}">
                 <span class="share-visibility-indicator d-flex align-items-center">
@@ -56,8 +56,8 @@
                 <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="exeUserMenuToggler">
                     {# Menú móvil plano: visible solo en móviles (d-md-none) #}
                     <li class="d-md-none mobile-menu-header"><small class="dropdown-header">{{ t.file or 'File' }}</small></li>
-                    <li class="d-md-none"><a class="dropdown-item" id="mobile-navbar-button-new" href="#">{{ t.new or 'New' }}</a></li>
-                    <li class="d-md-none exe-online"><a class="dropdown-item" id="mobile-navbar-button-openuserodefiles" href="#">{{ t.open or 'Open' }}</a></li>
+                    <li class="d-md-none {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-new" href="#">{{ t.new or 'New' }}</a></li>
+                    <li class="d-md-none exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-openuserodefiles" href="#">{{ t.open or 'Open' }}</a></li>
                     <li class="d-md-none exe-online"><a class="dropdown-item" id="mobile-navbar-button-save" href="#">{{ t.save or 'Save' }}</a></li>
                     {# Hidden to reduce Open/Import confusion (issue #1223) #}
                     <li class="d-none"><a class="dropdown-item" id="mobile-navbar-button-import-elp" href="#">{{ t.import_elpx or 'Import (.elpx…)' }}</a></li>
@@ -68,7 +68,7 @@
                     <li class="d-md-none"><a class="dropdown-item" id="mobile-navbar-button-export-epub3" href="#">ePub3</a></li>
                     <li class="dropdown-divider d-md-none"></li>
                     <li class="d-md-none"><a class="dropdown-item" id="mobile-navbar-button-settings" href="#">{{ t.project_properties or 'Project Properties' }}</a></li>
-                    <li class="d-md-none exe-online"><a class="dropdown-item" id="mobile-navbar-button-share" href="#">{{ t.share or 'Share' }}</a></li>
+                    <li class="d-md-none exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="mobile-navbar-button-share" href="#">{{ t.share or 'Share' }}</a></li>
                     <li class="dropdown-divider d-md-none"></li>
                     <li class="d-md-none mobile-menu-header"><small class="dropdown-header">{{ t.utilities or 'Utilities' }}</small></li>
                     <li class="d-md-none exe-advanced"><a class="dropdown-item" id="mobile-navbar-button-filemanager" href="#">{{ t.file_manager or 'File manager' }}</a></li>

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -28,7 +28,7 @@
                     <li class="d-none"><a id="navbar-button-import-elp" class="dropdown-item" href="#"><span class="small-icon import-icon-green"></span> {{ t.import_elpx or 'Import (.elpx…)' }}</a></li>
                     {% endif %}
                     <li class="dropdown-divider exe-online {% if config.platformIntegration %}d-none{% endif %}"></li>
-                    <li class="exe-online"><a id="navbar-button-save" class="dropdown-item" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.save or 'Save' }}</a></li>
+                    <li class="exe-online {% if config.platformIntegration %}d-none{% endif %}"><a id="navbar-button-save" class="dropdown-item" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.save or 'Save' }}</a></li>
                     <li class="dropdown dropend exe-online">
                         <a class="dropdown-item dropdown-toggle" href="#" id="dropdownExportAs" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="small-icon download-icon-green"></span> {{ t.download_as or 'Download as...' }}</a>
                         <ul class="dropdown-menu" aria-labelledby="dropdownExportAs">

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -12,10 +12,10 @@
                     {{ t.file or 'File' }}
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="dropdownFile">
-                    <li><a class="dropdown-item" id="navbar-button-new" href="{{ basePath }}/workarea" data-shortcut="Mod+Alt+N" aria-keyshortcuts="Control+Alt+N Meta+Alt+N"><span class="small-icon new-icon-green"></span> {{ t.new or 'New' }}</a></li>
+                    <li class="{% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="navbar-button-new" href="{{ basePath }}/workarea" data-shortcut="Mod+Alt+N" aria-keyshortcuts="Control+Alt+N Meta+Alt+N"><span class="small-icon new-icon-green"></span> {{ t.new or 'New' }}</a></li>
                     <li class="d-none"><a class="dropdown-item" id="navbar-button-new-from-template" href="#"><span class="small-icon new-icon"></span> {{ t.new_from_template or 'New from Template...' }}</a></li>
-                    <li class="exe-online"><a class="dropdown-item" id="navbar-button-openuserodefiles" href="#" data-shortcut="Mod+O" aria-keyshortcuts="Control+O Meta+O"><span class="small-icon open-icon"></span> {{ t.open or 'Open' }}</a></li>
-                    <li class="dropdown dropend exe-online">
+                    <li class="exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="navbar-button-openuserodefiles" href="#" data-shortcut="Mod+O" aria-keyshortcuts="Control+O Meta+O"><span class="small-icon open-icon"></span> {{ t.open or 'Open' }}</a></li>
+                    <li class="dropdown dropend exe-online {% if config.platformIntegration %}d-none{% endif %}">
                         <a class="dropdown-item dropdown-toggle" href="#" id="navbar-button-dropdown-recent-projects" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <span class="small-icon recent-icon-green"></span> {{ t.recent_projects or 'Recent projects' }}
                         </a>
@@ -27,7 +27,7 @@
                     {# Hidden to reduce Open/Import confusion (issue #1223) #}
                     <li class="d-none"><a id="navbar-button-import-elp" class="dropdown-item" href="#"><span class="small-icon import-icon-green"></span> {{ t.import_elpx or 'Import (.elpx…)' }}</a></li>
                     {% endif %}
-                    <li class="dropdown-divider exe-online"></li>
+                    <li class="dropdown-divider exe-online {% if config.platformIntegration %}d-none{% endif %}"></li>
                     <li class="exe-online"><a id="navbar-button-save" class="dropdown-item" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.save or 'Save' }}</a></li>
                     <li class="dropdown dropend exe-online">
                         <a class="dropdown-item dropdown-toggle" href="#" id="dropdownExportAs" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="small-icon download-icon-green"></span> {{ t.download_as or 'Download as...' }}</a>
@@ -41,8 +41,8 @@
                             <li><a id="navbar-button-export-epub3" class="dropdown-item" href="#">ePub3</a></li>
                         </ul>
                     </li>
-                    <li class="dropdown-divider"></li>
-                    <li class="exe-online"><a class="dropdown-item" id="navbar-button-share" href="#" data-shortcut="Mod+Alt+S" aria-keyshortcuts="Control+Alt+S Meta+Alt+S"><span class="small-icon share-icon"></span> {{ t.share or 'Share' }}</a></li>
+                    <li class="dropdown-divider {% if config.platformIntegration %}d-none{% endif %}"></li>
+                    <li class="exe-online {% if config.platformIntegration %}d-none{% endif %}"><a class="dropdown-item" id="navbar-button-share" href="#" data-shortcut="Mod+Alt+S" aria-keyshortcuts="Control+Alt+S Meta+Alt+S"><span class="small-icon share-icon"></span> {{ t.share or 'Share' }}</a></li>
                     {% if config.isOfflineInstallation %}
                         <li><a class="dropdown-item" id="navbar-button-open-offline" href="#" data-shortcut="Mod+O" aria-keyshortcuts="Control+O Meta+O"><span class="small-icon open-icon"></span> {{ t.open or 'Open' }}</a></li>
                         {# Hidden to reduce Open/Import confusion (issue #1223) #}


### PR DESCRIPTION
# feat: improve resource initialization and streamline UI for LMS integrations

### 1. Background / Motivation
When a new eXeLearning session is launched from a platform like Moodle via LTI (`edit_ode` request with a `jwt_token`), Moodle sends the initial base64-encoded ELP resource. Previously, eXeLearning correctly created the project session but failed to retrieve and load this base64 string because the callback mechanism was detached from the Yjs collaborative startup flow. Furthermore, when users are within an LMS context, certain standalone controls (like creating new projects, opening local files, sharing, or manual saving) become irrelevant and can cause workflow confusion.

This PR fixes the Base64 loading bug and gracefully hides irrelevant UI elements when the editor detects an active platform integration.

### 2. Technical Decisions & Architecture
* **Stateful LMS Import Trigger:** In `src/routes/pages.ts`, we now append the specific flag `fetchPlatformElp=1` when redirecting to the workarea after creating a new session from a Moodle `odeId`. This explicitly instructs the frontend to seek the remote resource without muddying the existing embedding initialization configs.
* **Base64 Fetch & Client-Side Hydration:** During the `checkAndImportElp()` execution hook in `projectManager.js` (before the workspace renders), the client makes an asynchronous fetch to `POST /api/platform/integration/openPlatformElp`. The `elpFile` (Base64) payload is converted to an `application/octet-stream` File Blob on the fly, and then piped directly into `importFromElpxViaYjs()`. This guarantees the resource leverages the Yjs Document Manager seamlessly and is saved accurately in the collaborative database via `this._yjsBridge.documentManager.saveToServer()`.
* **Robust Nunjucks UI Rendering:** To hide unsupported commands ("New", "New from Template", "Open", "Recent Projects", "Share", "Save", and their corresponding dividers), we avoided brittle DOM queries. Instead, we used the backend variables directly within Nunjucks templates `{% if config.platformIntegration %}d-none{% endif %}`. 
* **Preventing JS Overwrites:** An early return was added to `checkAndShowNewFromTemplateButton()` in `navbarFile.js` because its native implementation removes the `d-none` class dynamically when it successfully queries the API for templates. 

### 3. Commits Overview
1. `fix(lti): append fetchPlatformElp param for new LMS sessions in backend routers`
2. `feat(yjs): intercept LTI creation flag and hydrate base64 resources via openPlatformElp`
3. `style(ui): conditionally hide irrelevant File menu interactions and headers during LMS sessions`

### 4. Testing & Verification
* **Existing Tests:** Since no core Yjs structures or standard vanilla importing APIs were altered, the integration acts as an invisible proxy. `make test-unit` and HTML tests (`make test-frontend`) were executed and finished with exit code `0`.
* **Linting:** Validated against Biome rules (`make fix` / `make lint`), confirming stylistic integrity across `pages.ts`, `projectManager.js`, and `navbarFile.js`.
* **Manual Verification:** 
  - Simulated LTI LMS URL containing `odeId` and `jwt_token`.
  - Verified UI loader displays `"Downloading from platform..."`.
  - Verified `File` menu hides unsupported dropdown elements without disrupting standard desktop standalone mode workflows.

