### PR TITLE
fix(export): Export Page/Box/iDevice now writes files in Electron (#1659)

### DIFF
--- a/public/app/workarea/project/idevices/content/componentDownloadHelper.js
+++ b/public/app/workarea/project/idevices/content/componentDownloadHelper.js
@@ -2,32 +2,22 @@ const rememberedComponentKeys = new Set();
 const STORAGE_PREFIX = '__exe_component_download:';
 
 /**
- * Convert a Blob to base64 string.
- * Used for Electron downloads where blob: URLs cannot be streamed via Node.js HTTP.
- * @param {Blob} blob - The blob to convert
- * @returns {Promise<string>} Base64 encoded string
- */
-async function blobToBase64(blob) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-            const dataUrl = reader.result;
-            // Extract base64 part after "data:...;base64,"
-            const base64 = dataUrl.split(',')[1];
-            resolve(base64);
-        };
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
-}
-
-/**
  * Check if a URL is a blob: URL that needs special handling in Electron.
  * @param {string} url - The URL to check
  * @returns {boolean} True if it's a blob: URL
  */
 function isBlobUrl(url) {
     return typeof url === 'string' && url.startsWith('blob:');
+}
+
+// The Electron main process (normalizeBinaryPayload in app/main.js) accepts
+// Uint8Array / ArrayBuffer / Array as the first positional arg. When the
+// handler resolves with { saved: false, ... } the helper must treat that as
+// a failure so the browser fallback can fire.
+function isElectronSaveSuccessful(result) {
+    if (result === true) return true;
+    if (result && typeof result === 'object') return result.saved === true;
+    return false;
 }
 
 function isKeyRemembered(storageKey) {
@@ -99,23 +89,25 @@ async function runElectronDownload(
     if (!electronAPI) return false;
 
     try {
-        // Handle blob: URLs specially - they cannot be streamed via Node.js HTTP
-        // Instead, fetch the blob, convert to base64, and use buffer APIs
+        // Handle blob: URLs specially - they cannot be streamed via Node.js HTTP.
+        // Pass a Uint8Array to the buffer APIs; the main process expects binary
+        // (Uint8Array/ArrayBuffer/Array), not a base64 string — see #1659.
         if (isBlobUrl(url)) {
             const bufferMode = mode === 'save' ? 'saveBuffer' : 'saveBufferAs';
             if (typeof electronAPI[bufferMode] !== 'function') return false;
 
-            // Fetch blob from URL and convert to base64
             const response = await fetch(url);
-            const blob = await response.blob();
-            const base64 = await blobToBase64(blob);
+            const arrayBuffer = await response.arrayBuffer();
+            const bytes = new Uint8Array(arrayBuffer);
 
-            return await electronAPI[bufferMode](base64, storageKey, fileName);
+            const result = await electronAPI[bufferMode](bytes, storageKey, fileName);
+            return isElectronSaveSuccessful(result);
         }
 
         // Standard URL handling via streaming
         if (typeof electronAPI[mode] !== 'function') return false;
-        return await electronAPI[mode](url, storageKey, fileName);
+        const result = await electronAPI[mode](url, storageKey, fileName);
+        return isElectronSaveSuccessful(result);
     } catch (_e) {
         return false;
     }

--- a/public/app/workarea/project/idevices/content/componentDownloadHelper.test.js
+++ b/public/app/workarea/project/idevices/content/componentDownloadHelper.test.js
@@ -341,42 +341,24 @@ describe('componentDownloadHelper', () => {
 
             describe('blob: URL handling', () => {
                 let mockBlob;
-                let mockBase64;
+                let mockBytes;
                 let originalFetch;
-                let originalFileReader;
 
                 beforeEach(() => {
-                    // Create mock blob and base64 data
-                    mockBlob = new Blob(['test content'], { type: 'application/zip' });
-                    mockBase64 = 'dGVzdCBjb250ZW50'; // base64 of "test content"
+                    // "test content" as raw bytes — the main process expects a
+                    // Uint8Array / ArrayBuffer here (see app/main.js normalizeBinaryPayload).
+                    mockBytes = new TextEncoder().encode('test content');
+                    mockBlob = new Blob([mockBytes], { type: 'application/zip' });
 
-                    // Mock fetch for blob: URLs
                     originalFetch = global.fetch;
                     global.fetch = vi.fn(() => Promise.resolve({
                         blob: () => Promise.resolve(mockBlob),
+                        arrayBuffer: () => Promise.resolve(mockBytes.buffer.slice(0)),
                     }));
-
-                    // Mock FileReader for blobToBase64
-                    originalFileReader = global.FileReader;
-                    global.FileReader = class MockFileReader {
-                        constructor() {
-                            this.result = null;
-                            this.onload = null;
-                            this.onerror = null;
-                        }
-                        readAsDataURL() {
-                            // Simulate async behavior with setTimeout
-                            setTimeout(() => {
-                                this.result = `data:application/zip;base64,${mockBase64}`;
-                                if (this.onload) this.onload();
-                            }, 0);
-                        }
-                    };
                 });
 
                 afterEach(() => {
                     global.fetch = originalFetch;
-                    global.FileReader = originalFileReader;
                 });
 
                 it('should use saveBufferAs for blob: URLs when not remembered', async () => {
@@ -388,12 +370,11 @@ describe('componentDownloadHelper', () => {
 
                     // Should NOT call saveAs (uses HTTP which fails for blob:)
                     expect(mockElectronAPI.saveAs).not.toHaveBeenCalled();
-                    // Should call saveBufferAs with base64 data
-                    expect(mockElectronAPI.saveBufferAs).toHaveBeenCalledWith(
-                        mockBase64,
-                        expect.any(String),
-                        'test.zip'
-                    );
+                    // Should call saveBufferAs with a Uint8Array payload
+                    expect(mockElectronAPI.saveBufferAs).toHaveBeenCalledTimes(1);
+                    const [payload, , fileName] = mockElectronAPI.saveBufferAs.mock.calls[0];
+                    expect(payload).toBeInstanceOf(Uint8Array);
+                    expect(fileName).toBe('test.zip');
                 });
 
                 it('should use saveBuffer for blob: URLs when key is remembered', async () => {
@@ -405,12 +386,11 @@ describe('componentDownloadHelper', () => {
 
                     // Should NOT call save (uses HTTP which fails for blob:)
                     expect(mockElectronAPI.save).not.toHaveBeenCalled();
-                    // Should call saveBuffer with base64 data
-                    expect(mockElectronAPI.saveBuffer).toHaveBeenCalledWith(
-                        mockBase64,
-                        expect.any(String),
-                        'test.zip'
-                    );
+                    // Should call saveBuffer with a Uint8Array payload
+                    expect(mockElectronAPI.saveBuffer).toHaveBeenCalledTimes(1);
+                    const [payload, , fileName] = mockElectronAPI.saveBuffer.mock.calls[0];
+                    expect(payload).toBeInstanceOf(Uint8Array);
+                    expect(fileName).toBe('test.zip');
                 });
 
                 it('should fall back to saveBufferAs when saveBuffer fails for blob: URL', async () => {
@@ -636,6 +616,71 @@ describe('componentDownloadHelper', () => {
                 // save should be called first since key is remembered
                 expect(mockElectronAPI.save).toHaveBeenCalled();
             });
+        });
+    });
+
+    // Regression #1659: Export Page / Export Box / Export iDevice in the Electron
+    // desktop app showed the save dialog but never wrote a file. Root cause: the
+    // blob: branch of runElectronDownload handed a base64 string to saveBufferAs,
+    // but the main process's normalizeBinaryPayload only treats the first arg as
+    // binary when it is a Uint8Array / ArrayBuffer / Array, so it returned null
+    // and fs.writeFileSync never ran. These tests lock in the Uint8Array contract
+    // and the fallback behavior when the main process reports {saved:false}.
+    describe('downloadComponentFile — Electron blob handling (regression #1659)', () => {
+        let originalFetch;
+
+        beforeEach(() => {
+            global.eXeLearning = { config: { isOfflineInstallation: true } };
+            window.__currentProjectId = 'project-1659';
+
+            originalFetch = global.fetch;
+            global.fetch = vi.fn().mockResolvedValue({
+                blob: async () => new Blob([new Uint8Array([80, 75, 3, 4])]),
+                arrayBuffer: async () => new Uint8Array([80, 75, 3, 4]).buffer,
+            });
+        });
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+        });
+
+        it('passes a Uint8Array (not a base64 string) to saveBufferAs for blob: URLs', async () => {
+            const saveBufferAs = vi
+                .fn()
+                .mockResolvedValue({ saved: true, filePath: '/tmp/out.elpx' });
+            window.electronAPI = { saveBufferAs };
+
+            await downloadComponentFile('blob:mock-url', 'page.elpx', {
+                typeKeySuffix: 'page',
+                alwaysAskLocation: true,
+            });
+
+            expect(saveBufferAs).toHaveBeenCalledTimes(1);
+            const [payload, , suggestedName] = saveBufferAs.mock.calls[0];
+            expect(typeof payload).not.toBe('string');
+            expect(payload).toBeInstanceOf(Uint8Array);
+            expect(suggestedName).toBe('page.elpx');
+        });
+
+        it('falls back to browser download when electron save reports {saved:false}', async () => {
+            const saveBufferAs = vi.fn().mockResolvedValue({
+                saved: false,
+                error: 'Failed to normalize binary payload',
+            });
+            window.electronAPI = { saveBufferAs };
+
+            const anchorClick = vi.fn();
+            global.document.createElement = vi.fn(() => ({
+                click: anchorClick,
+                style: {},
+            }));
+
+            await downloadComponentFile('blob:mock-url', 'page.elpx', {
+                typeKeySuffix: 'page',
+                alwaysAskLocation: true,
+            });
+
+            expect(anchorClick).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1659. On the Electron desktop build (reported on Windows), **Export Page**, **Export Box**, and **Export iDevice** opened the save dialog, let the user pick a folder — and then silently wrote nothing. The fix is a single renderer-side contract bug: all three partial-export flows funnel through `componentDownloadHelper.runElectronDownload`, which converted the blob to a **base64 string** and passed it as the first positional arg to `electronAPI.saveBufferAs`.

The main process helper `normalizeBinaryPayload` (`app/main.js:1419`) only treats the first arg as binary when it is a `Uint8Array` / `ArrayBuffer` / `Array`; a string falls through to check a `base64Data` arg that the preload never forwards. So the helper returned `null`, `saveBufferWithDialog` short-circuited with `"Failed to normalize binary payload"`, and `fs.writeFileSync` never ran. To make things worse, the old renderer treated any resolved value as success, so the `{ saved: false, error: ... }` response was swallowed and the browser fallback did not fire either.

The working save-project path (`YjsProjectBridge.js:3185`) and the working per-iDevice exports (`checklist.js`, `rubric.js`, `progress-report.js`) all already pass a `Uint8Array`. This helper was the outlier.

### Changes

- `public/app/workarea/project/idevices/content/componentDownloadHelper.js`
  - Blob branch now reads `response.arrayBuffer()` and hands a `Uint8Array` to `saveBuffer` / `saveBufferAs`, aligning with the working pattern.
  - Removed the now-unused `blobToBase64` helper (no workaround, single source of truth).
  - Added `isElectronSaveSuccessful` so `{ saved: false, ... }` is treated as a failure and the browser-download fallback can still fire.
- `public/app/workarea/project/idevices/content/componentDownloadHelper.test.js`
  - Added 2 TDD regression tests for #1659:
    - `saveBufferAs` receives a `Uint8Array` (not a base64 string) for `blob:` URLs.
    - Browser download fallback fires when Electron reports `{ saved: false }`.
  - Updated 3 pre-existing `blob:` URL tests that were pinning the old (buggy) base64-string contract to the new `Uint8Array` contract.

No changes to `app/main.js` or `app/preload.js`.

## Test plan

- [x] New regression tests confirmed **red** on the unfixed code (`expected 'string' not to be 'string'`, fallback not fired), **green** after the fix.
- [x] `npx vitest run public/app/workarea/project/idevices/content/componentDownloadHelper.test.js` — 56/56 passed.
- [x] `make test-frontend` — 11,637/11,637 passed.
- [x] `make fix` — no lint issues.
- [ ] Manual Electron smoke on `make run-app` (macOS + Windows):
  - [ ] Export Page writes an `.elpx` file at the selected folder.
  - [ ] Export Box writes an `.elpx` file at the selected folder.
  - [ ] Export iDevice writes an `.elpx` file at the selected folder.
  - [ ] Main project Save / Save As still works (no regression on the `YjsProjectBridge` Uint8Array path).