### PR TITLE
fix(tests): resolve deterministic CI failures from test pollution (JWT_SECRET & translations cwd)

### DIFF
--- a/src/cli/commands/translations.ts
+++ b/src/cli/commands/translations.ts
@@ -16,7 +16,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Glob } from 'bun';
 
-const TRANSLATIONS_DIR = path.join(process.cwd(), 'translations');
+// Resolved lazily so tests that mock process.cwd() after importing this module
+// (translations.spec.ts, translations-sort.spec.ts) still see the expected path.
+function getTranslationsDir(): string {
+    return path.join(process.cwd(), 'translations');
+}
 
 export interface TranslationsResult {
     success: boolean;
@@ -345,7 +349,7 @@ async function processLocale(
     cleanOnly: boolean,
     removeObsolete: boolean,
 ): Promise<{ extracted: number; cleaned: boolean; removed: number }> {
-    const xlfPath = path.join(TRANSLATIONS_DIR, `messages.${locale}.xlf`);
+    const xlfPath = path.join(getTranslationsDir(), `messages.${locale}.xlf`);
 
     if (!fs.existsSync(xlfPath)) {
         warning(`XLF file not found: ${xlfPath}`);
@@ -412,10 +416,11 @@ export async function execute(
     }
 
     // Check translations directory exists
-    if (!fs.existsSync(TRANSLATIONS_DIR)) {
+    const translationsDir = getTranslationsDir();
+    if (!fs.existsSync(translationsDir)) {
         return {
             success: false,
-            message: `Translations directory not found: ${TRANSLATIONS_DIR}`,
+            message: `Translations directory not found: ${translationsDir}`,
         };
     }
 

--- a/src/routes/user.spec.ts
+++ b/src/routes/user.spec.ts
@@ -12,6 +12,11 @@ const TEST_JWT_SECRET = process.env.APP_SECRET || 'test-secret-for-user-routes-t
 
 // Override APP_SECRET for tests
 const originalAppSecret = process.env.APP_SECRET;
+// user.ts:getJwtSecret() prefers JWT_SECRET over APP_SECRET. Other specs in the
+// same Bun process (auth.spec.ts, admin.spec.ts, api/v1/*.spec.ts, ...) set
+// process.env.JWT_SECRET and don't clean it up, which would make jwt.verify()
+// use a different secret than the one this test signs with, breaking auth.
+const originalJwtSecret = process.env.JWT_SECRET;
 
 describe('User Routes', () => {
     let app: Elysia;
@@ -67,8 +72,10 @@ describe('User Routes', () => {
     }
 
     beforeEach(async () => {
-        // Set test secret
+        // Set test secret on both vars so getJwtSecret() (JWT_SECRET || APP_SECRET)
+        // always resolves to the same value this spec signs with.
         process.env.APP_SECRET = TEST_JWT_SECRET;
+        process.env.JWT_SECRET = TEST_JWT_SECRET;
 
         savedPreferences = new Map();
         mockUsers = new Map();
@@ -107,11 +114,16 @@ describe('User Routes', () => {
     });
 
     afterEach(() => {
-        // Restore original APP_SECRET
+        // Restore original APP_SECRET / JWT_SECRET
         if (originalAppSecret) {
             process.env.APP_SECRET = originalAppSecret;
         } else {
             delete process.env.APP_SECRET;
+        }
+        if (originalJwtSecret !== undefined) {
+            process.env.JWT_SECRET = originalJwtSecret;
+        } else {
+            delete process.env.JWT_SECRET;
         }
     });
 


### PR DESCRIPTION
## Summary

Fixes two independent pre-existing test-pollution bugs that deterministically fail on GitHub Actions (Linux) but pass locally (macOS) because `bun test` runs every spec in the same process and `readdir()` returns files in a different order on each platform. Together they account for **67 failing tests** (`User Routes` + `Translations Command`) that have been blocking unrelated PRs (e.g. #1660).

Neither failure is caused by any code under test — both are shared-process leaks between spec files.

## Bug 1 — `user.spec.ts` leaks through `JWT_SECRET`

`src/routes/user.ts:29`:

```ts
return process.env.JWT_SECRET || process.env.APP_SECRET || 'elysia-dev-secret-change-me';
```

`getJwtSecret()` prefers `JWT_SECRET` over `APP_SECRET`, but `user.spec.ts` only overrides `APP_SECRET` in `beforeEach`. Meanwhile, 15+ other specs in the same Bun process set `process.env.JWT_SECRET` and never clean it up:

- `src/routes/auth.spec.ts`
- `src/routes/admin.spec.ts`
- `src/routes/admin-themes.spec.ts`
- `src/routes/admin-templates.spec.ts`
- `src/routes/pages.spec.ts`
- `src/routes/project.spec.ts`
- `src/routes/api/v1/metadata.spec.ts`
- `src/routes/api/v1/blocks.spec.ts`
- `src/routes/api/v1/assets.spec.ts`
- `src/routes/api/v1/export.spec.ts`
- `src/routes/api/v1/users.spec.ts`
- `src/routes/api/v1/components.spec.ts`
- `src/routes/api/v1/projects.spec.ts`
- `src/routes/api/v1/pages.spec.ts`
- `src/routes/api/v1/types.spec.ts`

When any of them runs before `user.spec.ts`, the app verifies JWTs with a contaminated secret while the spec still signs them with `TEST_JWT_SECRET`. `jwt.verify()` returns `false`, `currentUser` becomes `null`, the preferences endpoint returns `{ userPreferences: {} }`, and every authenticated test fails with:

```
TypeError: undefined is not an object (evaluating 'body.userPreferences.locale.value')
```

**Reproduced locally:**

```
$ JWT_SECRET=contaminated-secret bun test src/routes/user.spec.ts
 11 pass / 28 fail   (before)
 39 pass /  0 fail   (after)
```

**Fix:** save/restore `JWT_SECRET` around each test and set it to `TEST_JWT_SECRET` in `beforeEach` so both branches of `getJwtSecret()` resolve to the same value the spec signs with.

## Bug 2 — `translations.ts` freezes `TRANSLATIONS_DIR` at import time

`src/cli/commands/translations.ts:19` used to be:

```ts
const TRANSLATIONS_DIR = path.join(process.cwd(), 'translations');
```

This is a top-level const computed once at import time. `src/cli/commands/translations-sort.ts:12` imports from `./translations`, so whichever spec imports `translations-sort.ts` first locks `TRANSLATIONS_DIR` to the real project directory. When `translations.spec.ts` later mocks `process.cwd()` in `beforeEach`, the constant is already frozen — `execute()` keeps reading from the real `translations/` directory instead of the test fixtures under `test/temp/translations-test/`, and all 44 tests fail with `result.success === false`.

On Linux (CI) the `readdir()` order makes `translations-sort.spec.ts` load before `translations.spec.ts`. On macOS APFS it's the other way around, which is why this only failed in CI.

**Reproduced locally** (pre-importing `translations.ts` to freeze `cwd` before the spec runs, mirroring the CI ordering):

```
$ bun test --preload <preimport> src/cli/commands/translations.spec.ts
  0 pass / 44 fail   (before)
 44 pass /  0 fail   (after)
```

**Fix:** replace the top-level `TRANSLATIONS_DIR` constant with a `getTranslationsDir()` function that re-resolves `process.cwd()` on every call — same pattern already used by `user.ts:getJwtSecret()` and `auth.ts`.

## Test plan

- [x] `JWT_SECRET=contaminated-secret bun test src/routes/user.spec.ts` — 39/39 pass (was 11/39 before).
- [x] `bun test --preload <preimport> src/cli/commands/translations.spec.ts` — 44/44 pass (was 0/44 before).
- [x] `bun test src/routes/user.spec.ts src/cli/commands/translations.spec.ts` — 83/83 pass with no pollution (baseline still green).
- [x] `make lint` — clean.
- [ ] CI `build_and_test` on this PR — should make the 67 User Routes + Translations Command failures disappear.