### PR TITLE
fix(updater): re-enable auto-update on official beta/rc builds (#1662)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -439,7 +439,14 @@ function determineDevMode() {
  * 1. CLI flag (--no-update-check or --disable-updates)
  * 2. Environment variable (DISABLE_AUTO_UPDATE=1)
  * 3. CI environment (CI=1 or CI=true)
- * 4. Development version (0.0.0, *-alpha, *-beta, *-dev)
+ * 4. Running from source (`make run-app`, not a packaged binary)
+ * 5. Sentinel version from Makefile/CI (0.0.0 / 0.0.0-alpha / 0.0.0-alpha-build<sha>):
+ *    builds that don't correspond to a release tag.
+ *
+ * Official pre-release tags (v4.0.0-beta3, v4.0.0-rc1, ...) are full
+ * releases and MUST receive auto-updates — they are explicitly NOT filtered.
+ * See issue #1662: the previous `version.includes('-beta')` substring check
+ * disabled the updater on every published beta build.
  *
  * @returns {{ disabled: boolean, reason: string }}
  */
@@ -463,11 +470,17 @@ function shouldDisableAutoUpdate() {
         return { disabled: true, reason: 'CI environment detected (CI=1)' };
     }
 
-    // Development version
+    // Running from source (make run-app, electron .) — not a packaged binary
+    if (!app.isPackaged) {
+        return { disabled: true, reason: 'Running from source (app.isPackaged=false)' };
+    }
+
+    // Sentinel version: Makefile/CI use 0.0.0-alpha[-build<sha>] when there
+    // is no release tag. Official tags like v4.0.0-beta3, v4.0.0-rc1, v4.0.0
+    // and v3.0.2 are NOT sentinels and must receive updates.
     const version = app.getVersion();
-    if (version === '0.0.0' || version === '0.0.0-alpha' ||
-        version.includes('-alpha') || version.includes('-beta') || version.includes('-dev')) {
-        return { disabled: true, reason: `Development version detected (${version})` };
+    if (version === '0.0.0' || version.startsWith('0.0.0-alpha')) {
+        return { disabled: true, reason: `Sentinel version (${version})` };
     }
 
     return { disabled: false, reason: '' };


### PR DESCRIPTION
Closes #1662.

## Root cause

`shouldDisableAutoUpdate()` in `app/main.js` disabled the updater on any version whose string contained the substrings `-alpha`, `-beta` or `-dev`:

```js
if (version === '0.0.0' || version === '0.0.0-alpha' ||
    version.includes('-alpha') || version.includes('-beta') || version.includes('-dev')) {
    return { disabled: true, reason: \`Development version detected (\${version})\` };
}
```

The intent of that check was to skip CI builds tagged `0.0.0-alpha-build<sha>` so they wouldn't auto-update on developer machines. But the substring match also matches every official pre-release tag — `v4.0.0-beta1`, `v4.0.0-beta2`, `v4.0.0-beta3` all contain `-beta`. As a result, every packaged beta installed by users had the auto-updater **fully disabled before `initAutoUpdater()` was even called**. No `setFeedURL`, no `checkForUpdates`, no dialog. Silent.

This was diagnosed by reading the actual electron-log file from a real `4.0.0-beta3` install at `~/Library/Application Support/exelearning/logs/main.log` (the file lives there, **not** under `~/Library/Logs/eXeLearning/` — that surprised me too):

```
[2026-04-13 09:20:11.799] [info]  [AutoUpdate] Disabled: Development version detected (4.0.0-beta3)
```

The `4.0.0-rc1` build was not affected by this particular bug because `-rc` happens not to be in the filter list, but its log shows a different transient case worth mentioning (see issue comment).

## Fix

Replace the substring filter with two explicit checks:

1. `!app.isPackaged` — catches dev runs (`make run-app`, `electron .`). This is the canonical Electron API for "running from source vs running an installer".
2. `version === '0.0.0'` or `version.startsWith('0.0.0-alpha')` — catches the literal Makefile/CI sentinels (`0.0.0`, `0.0.0-alpha`, `0.0.0-alpha-build<sha>`).

Official tags `v4.0.0-beta3`, `v4.0.0-rc1`, `v4.0.0`, `v3.0.2`, etc. no longer match anything in `shouldDisableAutoUpdate` and the updater initializes normally on every installed pre-release and stable build.

## Effect on the installed base

- **From v4.0.0-rc2 onwards**: every release notifies users on previously installed builds that ship this fix, following the existing GitHub "Latest" gate flow (create release as `--prerelease` → verify installers → unmark `--prerelease` to publish → all clients see it).
- **Already-installed v4.0.0-beta1/2/3 and v4.0.0-rc1**: those binaries shipped the broken `shouldDisableAutoUpdate`, so they will not pick up the next release automatically — users will need to download v4.0.0-rc2 (or whatever ships next) manually one last time. The release notes / web announcement should call this out.

## Why \`allowPrerelease\` is not touched

Earlier diagnostic notes (in the issue and in chat) suggested toggling \`autoUpdater.allowPrerelease\`. After reading the electron-updater source, this flag is **not** the cause:

- It is documented in code as *\"GitHub provider only\"* and \`grep allowPrerelease\` over \`node_modules/electron-updater/out/\` confirms it is only consulted in \`GitHubProvider.js\` / \`PrivateGitHubProvider.js\`. Our app overrides the feed at runtime to \`provider: 'generic'\` in \`app/update-manager.js\`, where the flag is a no-op.
- Even with the github provider, \`allowPrerelease=false\` calls \`getLatestTagName()\` which hits \`https://github.com/<owner>/<repo>/releases/latest\` — the same redirect target that \`releases/latest/download/\` resolves to. So either provider end-to-end follows the GitHub "Latest" gate, which is exactly the workflow already in use.

## Test plan

- [x] \`make lint\` clean.
- [ ] Build a packaged \`v4.0.0-rc2\` installer (DMG/EXE/DEB) following the existing flow.
- [ ] Install it on a clean machine, confirm \`~/Library/Application Support/exelearning/logs/main.log\` shows \`AU: checking-for-update\` (not \`Disabled: ...\`) and that the update dialog appears when a newer release is published and unmarked from prerelease.
- [ ] Verify dev workflow is still skipped: \`make run-app\` should log \`AutoUpdate Disabled: Running from source\`.
- [ ] Verify CI builds without a tag are still skipped: a build with \`app.getVersion() === '0.0.0-alpha-build<sha>'\` should log \`AutoUpdate Disabled: Sentinel version (0.0.0-alpha-build<sha>)\`.