### PR TITLE
docs(agents): enforce test + 90% patch coverage submission gates

### DIFF
--- a/.agents/skills/api-v1/SKILL.md
+++ b/.agents/skills/api-v1/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-v1
-description: Adding or modifying external REST API v1 endpoints in src/routes/api/v1/.
+description: Adding or modifying external REST API v1 endpoints in src/routes/api/v1/. Every change must ship with colocated `*.spec.ts` tests covering auth, success, and error paths, update `doc/development/rest-api.md`, keep patch coverage ≥ 90% on changed lines, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: REST API v1 (External)

--- a/.agents/skills/backend-route/SKILL.md
+++ b/.agents/skills/backend-route/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-route
-description: Adding or modifying Elysia API route handlers in src/routes/.
+description: Adding or modifying Elysia API route handlers in src/routes/. Every change must ship with colocated `*.spec.ts` tests covering success and error paths, keep patch coverage ≥ 90% on changed lines, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: Backend Route

--- a/.agents/skills/backend-service/SKILL.md
+++ b/.agents/skills/backend-service/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-service
-description: Adding or modifying business logic services in src/services/ with dependency injection.
+description: Adding or modifying business logic services in src/services/ with dependency injection. Every change must ship with colocated `*.spec.ts` tests, keep patch coverage ≥ 90% on changed lines, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: Backend Service

--- a/.agents/skills/database-migration/SKILL.md
+++ b/.agents/skills/database-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: database-migration
-description: Changing database schema with Kysely migrations across SQLite, PostgreSQL, and MariaDB.
+description: Changing database schema with Kysely migrations across SQLite, PostgreSQL, and MariaDB. Every migration must ship with a colocated `*.spec.ts` exercising `up`/`down` on every supported dialect, keep patch coverage ≥ 90% on changed lines, update affected query tests, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: Database Migration

--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-test
-description: Writing Playwright E2E tests in test/e2e/playwright/.
+description: Writing Playwright E2E tests in test/e2e/playwright/. New user-visible features require an E2E spec in the same PR; specs must be deterministic (no `waitForTimeout`), isolated (each test creates its own project), and green under `make test-e2e` (and `make test-e2e-static` when the static build or embedding is affected) alongside `make fix`, `make test-unit`, and `make test-integration` before submission.
 ---
 
 # Skill: E2E Test

--- a/.agents/skills/exporter/SKILL.md
+++ b/.agents/skills/exporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exporter
-description: Adding or modifying export formats (HTML5, SCORM, EPUB3, IMS-CP) in src/shared/export/.
+description: Adding or modifying export formats (HTML5, SCORM, EPUB3, IMS-CP) in src/shared/export/. Every change must ship with colocated `*.spec.ts` tests validating the generated ZIP structure and manifests, keep patch coverage ≥ 90% on changed lines, include or update a Playwright spec exercising both browser-side and server-side export paths, and pass `make fix`, `make test-unit`, `make test-integration`, `make test-e2e`, and `make test-e2e-static` before submission.
 ---
 
 # Skill: Exporter

--- a/.agents/skills/frontend-module/SKILL.md
+++ b/.agents/skills/frontend-module/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-module
-description: Adding or modifying vanilla JavaScript modules in public/app/.
+description: Adding or modifying vanilla JavaScript modules in public/app/. Every change must ship with colocated `*.test.js` Vitest tests, keep patch coverage ≥ 90% on changed lines, add or update a Playwright spec when the behavior is user-visible, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: Frontend Module

--- a/.agents/skills/i18n/SKILL.md
+++ b/.agents/skills/i18n/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: i18n
-description: Adding translatable strings or modifying translations with _() / c_() helpers.
+description: Adding translatable strings or modifying translations with _() / c_() helpers. Every change must run `make translations` to sync keys, keep existing unit/integration/E2E suites green, maintain patch coverage ≥ 90% on any touched code, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: Internationalization (i18n)

--- a/.agents/skills/idevice/SKILL.md
+++ b/.agents/skills/idevice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idevice
-description: Creating or modifying interactive devices in public/files/perm/idevices/base/.
+description: Creating or modifying interactive devices in public/files/perm/idevices/base/. Every change must ship with colocated Vitest `*.test.js` coverage for edition and export logic, keep patch coverage ≥ 90% on changed lines, include a Playwright spec exercising the iDevice in the workarea and preview, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: iDevice

--- a/.agents/skills/websocket-yjs/SKILL.md
+++ b/.agents/skills/websocket-yjs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: websocket-yjs
-description: Modifying real-time collaboration features including WebSocket handlers, Yjs documents, and room lifecycle.
+description: Modifying real-time collaboration features including WebSocket handlers, Yjs documents, and room lifecycle. Every change must ship with colocated tests (`*.spec.ts` server-side, `*.test.js` client-side), keep patch coverage ≥ 90% on changed lines, include or update a multi-user Playwright spec using the `collaboration.fixture`, and pass `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` before submission.
 ---
 
 # Skill: WebSocket & Yjs Collaboration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,20 @@ eXeLearning is an open-source (AGPL-3.0) educational content authoring tool. Edu
 
 **Current state:** Early development. Prioritize clean, well-organized code.
 
+### Definition of Done (non-negotiable)
+
+Before any change is submitted (PR, commit push, or handoff), **all** of the following must hold:
+
+1. **`make fix` passes** — lint and formatting are clean.
+2. **Unit tests pass** — `make test-unit` is green (backend `bun test` + frontend `vitest`).
+3. **Integration tests pass** — `make test-integration` is green.
+4. **E2E tests pass** — `make test-e2e` is green (Playwright). Run `make test-e2e-static` too if the change affects the static build, embedding, or export flow.
+5. **Patch coverage ≥ 90%** — every new or modified line must be covered by a test. Check with `make test-coverage` and inspect the diff, not just the global percentage. If a line is genuinely untestable, justify it in the PR description.
+6. **New code ships with tests in the same PR.** A new `.ts` file under `src/` needs a colocated `*.spec.ts`; a new `.js` file under `public/app/` needs a colocated `*.test.js`. User-visible flows need an E2E spec under `test/e2e/playwright/specs/`.
+7. **No skipped or disabled tests** without an issue link and explanation.
+
+These apply to every skill below. If you cannot meet them, stop and ask the user — do not submit partial work.
+
 ### Philosophy
 
 - **No workarounds.** Always build full, long-term-sustainable implementations for >1000 users. Never create compatibility shims or half-baked solutions.
@@ -95,11 +109,17 @@ npx vitest run public/app/path/file.test.js -t "test name"
 bun x playwright test --project=chromium test/e2e/playwright/specs/my-test.spec.ts
 ```
 
-### 5.3 Coverage Targets
+### 5.3 Coverage & Submission Gates
 
-- **Backend (`src/`):** target **90%**
-- **Frontend (`public/app/`):** target **80%**
-- New `.js` files in `public/app/` should have a corresponding `.test.js` file
+**Patch coverage ≥ 90% is required on every PR**, measured against the lines you added or modified — not the global project average. A PR that only raises global coverage but leaves new lines uncovered does not pass.
+
+- **Backend (`src/`):** global target **90%**, patch coverage **≥ 90%** (hard gate).
+- **Frontend (`public/app/`):** global target **80%**, patch coverage **≥ 90%** on changed lines.
+- Every new `.ts` file under `src/` must ship with a colocated `*.spec.ts` in the same PR.
+- Every new `.js` file under `public/app/` must ship with a colocated `*.test.js` in the same PR.
+- User-visible behavior changes (workarea, preview, export, embedding, collaboration) must include or update a Playwright spec under `test/e2e/playwright/specs/`.
+- Before submitting: run `make fix && make test-unit && make test-integration && make test-e2e` and inspect `make test-coverage` for the diff. All four must be green. E2E may be slow — budget time for it rather than skipping.
+- Do not mark tests as `.skip` / `.todo` to land a PR. If a test cannot run in CI, open an issue and link it in the PR description.
 
 ### 5.4 Mocking — Prefer Dependency Injection
 


### PR DESCRIPTION
## Summary

- Add a top-level **Definition of Done** block to `AGENTS.md` listing the 7 non-negotiable submission requirements: `make fix`, unit tests, integration tests, E2E tests, patch coverage ≥ 90% on changed lines, colocated tests in the same PR, and no `.skip` / `.todo` tests.
- Rewrite `AGENTS.md` section 5.3 as **Coverage & Submission Gates**, clarifying that the 90% threshold is measured against the diff (patch coverage), not the global project average, and listing the exact pre-submit command sequence.
- Update the frontmatter `description:` of all 10 skills (`backend-service`, `backend-route`, `frontend-module`, `e2e-test`, `idevice`, `exporter`, `database-migration`, `api-v1`, `websocket-yjs`, `i18n`) so each one explicitly states the testing artifacts required for its domain and reminds the agent to run `make fix`, `make test-unit`, `make test-integration`, and `make test-e2e` (plus `make test-e2e-static` for the exporter) before submission.

## Why

Agents working on this repo have been landing changes without consistently running the full test matrix or adding tests for new lines. Global coverage can mask under-tested diffs, and the previous wording only described coverage as a soft \"target\". These edits make the expectation unambiguous at both the top-level instructions and at each skill entry point, so the requirement is visible wherever an agent starts work — not just buried in a single section. Patch coverage (not global average) is called out explicitly so new/changed lines cannot ride on pre-existing coverage.

## Test plan

- [ ] Review rendered `AGENTS.md` on GitHub and confirm the new \"Definition of Done\" and \"Coverage & Submission Gates\" sections read clearly.
- [ ] Spot-check a few `.agents/skills/*/SKILL.md` files to confirm the updated descriptions are well-formed YAML frontmatter.