### PR TITLE
fix(filemanager): correct reference count after deleting image in desktop version (#1674)

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalFileManager.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.js
@@ -2371,8 +2371,13 @@ export default class ModalFilemanager extends Modal {
 
                         let found = false;
 
-                        // Check htmlView or htmlContent (Y.Text or string)
-                        const htmlContent = compMap.get('htmlView') || compMap.get('htmlContent');
+                        // Check htmlContent (Y.Text or string) or htmlView (legacy fallback).
+                        // htmlContent is refreshed on every save; htmlView is only populated
+                        // during initial ELP import and never updated after edits, so reading
+                        // it first causes stale reference counts after image deletion in
+                        // iDevices whose save path only touches jsonProperties/htmlContent
+                        // (issue #1674).
+                        const htmlContent = compMap.get('htmlContent') || compMap.get('htmlView');
                         if (htmlContent) {
                             const content = htmlContent.toString ? htmlContent.toString() : String(htmlContent);
                             if (assetRegex.test(content)) {

--- a/public/app/workarea/modals/modals/pages/modalFileManager.test.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.test.js
@@ -3900,6 +3900,64 @@ describe('ModalFilemanager', () => {
       const count = modal.countAssetReferences('null-test');
       expect(count).toBe(0);
     });
+
+    // Regression test for issue #1674: after deleting an image from a Text iDevice
+    // in the desktop (Electron) build, the File Manager still reported 1 reference
+    // because the counter read the stale `htmlView` string (set once during ELP
+    // import) instead of the freshly updated `htmlContent` Y.Text.
+    it('should prefer fresh htmlContent over stale htmlView (issue #1674)', () => {
+      const mockComponent = {
+        get: vi.fn((key) => {
+          if (key === 'htmlContent') {
+            // Fresh content after the user deleted the image — no asset reference.
+            return { toString: () => '<p>image removed</p>' };
+          }
+          if (key === 'htmlView') {
+            // Stale string from ELP import, still references the deleted asset.
+            return '<p><img src="asset://stale-asset-1674/image.jpg"></p>';
+          }
+          return null;
+        })
+      };
+
+      const mockBlock = {
+        get: vi.fn((key) => {
+          if (key === 'components') {
+            return { length: 1, get: () => mockComponent };
+          }
+          return null;
+        })
+      };
+
+      const mockPage = {
+        get: vi.fn((key) => {
+          if (key === 'blocks') {
+            return { length: 1, get: () => mockBlock };
+          }
+          return null;
+        })
+      };
+
+      window.eXeLearning = {
+        app: {
+          project: {
+            _yjsBridge: {
+              documentManager: {
+                ydoc: {
+                  getArray: vi.fn().mockReturnValue({
+                    length: 1,
+                    get: () => mockPage
+                  })
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const count = modal.countAssetReferences('stale-asset-1674');
+      expect(count).toBe(0);
+    });
   });
 
   describe('duplicateSelectedAsset edge cases', () => {

--- a/public/app/yjs/YjsStructureBinding.js
+++ b/public/app/yjs/YjsStructureBinding.js
@@ -1979,6 +1979,14 @@ class YjsStructureBinding {
             ytext.delete(0, ytext.length);
             ytext.insert(0, safeValue);
           }
+
+          // Once htmlContent/content holds the authoritative value, drop any stale
+          // htmlView plain-string fallback populated by the initial import path
+          // (createComponentMapFromApi / ElpxImporter). Keeping it around causes
+          // stale reference counts in the File Manager after in-place edits (issue #1674).
+          if ((key === 'htmlContent' || key === 'content') && compMap.get('htmlView') !== undefined) {
+            compMap.delete('htmlView');
+          }
         } else if (key === 'properties' && typeof value === 'object') {
           // Handle properties as a Y.Map with checkbox conversion
           let propsMap = compMap.get('properties');

--- a/public/app/yjs/YjsStructureBinding.test.js
+++ b/public/app/yjs/YjsStructureBinding.test.js
@@ -1749,6 +1749,31 @@ describe('YjsStructureBinding', () => {
       expect(typeof stored).toBe('string');
       expect(JSON.parse(stored)).toEqual(jsonObj);
     });
+
+    // Regression test for issue #1674: updateComponent must drop the stale
+    // `htmlView` plain-string fallback when refreshing `htmlContent`, otherwise
+    // readers (e.g. File Manager reference counter) see stale content after
+    // in-place edits in the desktop/Electron build.
+    it('clears stale htmlView string when htmlContent is updated (issue #1674)', () => {
+      const navigation = mockDocManager.getNavigation();
+      const pageMap = navigation.get(0);
+      const blocks = pageMap.get('blocks');
+      const block = blocks.get(0);
+      const components = block.get('components');
+      const comp = components.get(0);
+
+      // Simulate post-import state: htmlView holds the imported HTML string
+      // (exactly how ElpxImporter/createComponentMapFromApi populate it).
+      comp.set('htmlView', '<p><img src="asset://stale-1674/img.jpg"></p>');
+      expect(comp.get('htmlView')).toBeDefined();
+
+      binding.updateComponent('comp-1', { htmlContent: '<p>image removed</p>' });
+
+      // htmlView must have been deleted so it can't mask the fresh htmlContent.
+      expect(comp.get('htmlView')).toBeUndefined();
+      const fresh = comp.get('htmlContent');
+      expect(fresh.toString()).toBe('<p>image removed</p>');
+    });
   });
 
   describe('deleteComponent', () => {


### PR DESCRIPTION
## Summary

Fixes #1674. After deleting an image from a Text iDevice in the desktop (Electron) build and saving, the File Manager still reported 1 reference (blue) instead of 0 (red). Reopening the project corrected the count.

**Root cause.** `countAssetReferences` in `modalFileManager.js` read `compMap.get('htmlView') || compMap.get('htmlContent')`. `htmlView` is only populated during initial ELP import (`ElpxImporter.createComponentYMap` / `YjsStructureBinding.createComponentMapFromApi`) and is never refreshed by `updateComponent`, which writes to the `htmlContent` Y.Text. For iDevices whose save path only touches `jsonProperties` + triggers `apiSaveIdeviceViewHTML` (Text iDevice is the canonical case), the stale import string kept the `asset://` URL alive for the counter even though the authoritative content no longer referenced it. Reopening the project rebuilt Y.Doc without the stale key, masking the issue — which is why the web app (where the session is refreshed more aggressively) didn't show it.

## Fix

- `public/app/workarea/modals/modals/pages/modalFileManager.js` — `countAssetReferences` now prefers `htmlContent` (refreshed on every save) over `htmlView` (legacy import fallback).
- `public/app/yjs/YjsStructureBinding.js` — `updateComponent` deletes the stale `htmlView` plain-string entry once `htmlContent` / `content` holds the authoritative value, so no other reader can hit the same footgun.

Both paths are covered by new regression unit tests.

## Test plan

- [x] `make test-frontend` — 11640/11640 pass (includes the two new regression tests)
- [x] `make test-unit` — 6804/6804 pass, coverage threshold (90%) still met for all 207 files
- [x] `make fix` — no lint issues
- [ ] Manual: reproduce #1674 in Electron build and confirm the File Manager shows 0 (red) immediately after the delete-and-save cycle