### PR TITLE
fix(i18n): strip "~" fuzzy marker from exports and UI (#1701)

### DIFF
--- a/public/app/common/common_edition.js
+++ b/public/app/common/common_edition.js
@@ -41,14 +41,23 @@ var $exeDevicesEdition = {
             }
 
             // Replace the _ function (see locale.js)
+            // Strip the leading "~" marker used to flag machine-translated
+            // placeholder entries. The marker stays in the XLF files for
+            // translator review but must never reach the iDevice editor UI.
+            var stripFuzzy = function (value) {
+                if (typeof value === "string" && value.charAt(0) === "~") {
+                    return value.substring(1);
+                }
+                return value;
+            };
             _ = function (str) {
                 if (typeof ($exeDevice.i18n) != "undefined") {
                     var lang = $("HTML").attr("lang");
                     if (typeof ($exeDevice.i18n[lang]) != "undefined") {
-                        return top.translations[str] || $exeDevice.i18n[lang][str] || str;
+                        return stripFuzzy(top.translations[str] || $exeDevice.i18n[lang][str] || str);
                     }
                 }
-                return top.translations[str] || str;
+                return stripFuzzy(top.translations[str] || str);
             }
 
             // Enable the iDevice

--- a/public/app/common/common_edition.test.js
+++ b/public/app/common/common_edition.test.js
@@ -1861,5 +1861,28 @@ describe('common_edition.js', () => {
 
       expect(globalThis._('Unknown')).toBe('Unknown');
     });
+
+    it('_ function strips the "~" fuzzy marker from top.translations', () => {
+      // XLF files use a leading "~" to flag machine-translated placeholders.
+      // The marker stays in the files for translator review but must never
+      // reach the iDevice editor UI.
+      document.documentElement.setAttribute('lang', 'fr');
+      globalThis.$exeDevice.i18n = undefined;
+      globalThis.top.translations = { Next: '~Siguiente' };
+
+      globalThis.$exeDevicesEdition.iDevice.init();
+
+      expect(globalThis._('Next')).toBe('Siguiente');
+    });
+
+    it('_ function strips the "~" fuzzy marker from $exeDevice.i18n', () => {
+      document.documentElement.setAttribute('lang', 'es');
+      globalThis.$exeDevice.i18n = { es: { Next: '~Siguiente' } };
+      globalThis.top.translations = {};
+
+      globalThis.$exeDevicesEdition.iDevice.init();
+
+      expect(globalThis._('Next')).toBe('Siguiente');
+    });
   });
 });

--- a/public/app/locate/locale.js
+++ b/public/app/locate/locale.js
@@ -162,10 +162,9 @@ export default class Locale {
                 this.strings.translations &&
                 stringConcIdevice in this.strings.translations
             ) {
-                return this.strings.translations[stringConcIdevice].replace(
-                    /\\"/g,
-                    '"'
-                );
+                let res = this.strings.translations[stringConcIdevice].replace(/\\"/g, '"');
+                if (res.startsWith('~')) res = res.substring(1);
+                return res;
             }
         }
 
@@ -175,7 +174,9 @@ export default class Locale {
             this.strings.translations &&
             string in this.strings.translations
         ) {
-            return this.strings.translations[string].replace(/\\"/g, '"');
+            let res = this.strings.translations[string].replace(/\\"/g, '"');
+            if (res.startsWith('~')) res = res.substring(1);
+            return res;
         } else {
             return string.replace(/\\"/g, '"');
         }

--- a/public/app/locate/locale.test.js
+++ b/public/app/locate/locale.test.js
@@ -73,8 +73,20 @@ describe('Locale translations', () => {
   it('getTranslation resolves idevice-specific keys before default', () => {
     locale.strings = translations;
     expect(locale.getTranslation('hello', null, 'idevice')).toBe('Idevice Hola');
-    expect(locale.getTranslation('hello')).toBe('~Hola');
+    // "~" marks machine-translated placeholders in the XLF files and must
+    // never leak into the UI, so getTranslation strips it like the GUI/content
+    // helpers already do.
+    expect(locale.getTranslation('hello')).toBe('Hola');
     expect(locale.getTranslation('missing')).toBe('missing');
+  });
+
+  it('getTranslation strips the "~" fuzzy marker from idevice-specific translations', () => {
+    locale.strings = {
+      translations: {
+        'idevice.next': '~Siguiente',
+      },
+    };
+    expect(locale.getTranslation('next', null, 'idevice')).toBe('Siguiente');
   });
 
   it('window _ and c_ helpers delegate to translation helpers and adjust elp suffix', () => {

--- a/scripts/build-static-bundle.spec.ts
+++ b/scripts/build-static-bundle.spec.ts
@@ -266,6 +266,30 @@ describe('parseXlfContent', () => {
         const result = parseXlfContent('');
         expect(result).toEqual({});
     });
+
+    it('should strip the leading "~" fuzzy marker from translations', () => {
+        const xlf = `<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+    <file source-language="en" target-language="es">
+        <body>
+            <trans-unit id="1">
+                <source>Next</source>
+                <target>~Siguiente</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Reviewed</source>
+                <target>Revisado</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>`;
+
+        const result = parseXlfContent(xlf);
+        expect(result).toEqual({
+            Next: 'Siguiente',
+            Reviewed: 'Revisado',
+        });
+    });
 });
 
 // =============================================================================

--- a/scripts/build-static-bundle.ts
+++ b/scripts/build-static-bundle.ts
@@ -208,13 +208,13 @@ export function parseXlfContent(content: string): Record<string, string> {
                 const source = unit.source;
                 const target = unit.target;
                 if (source && target) {
-                    translations[source] = target;
+                    translations[source] = stripFuzzyMarker(target);
                 }
             }
         } else if (transUnits) {
             // Single translation
             if (transUnits.source && transUnits.target) {
-                translations[transUnits.source] = transUnits.target;
+                translations[transUnits.source] = stripFuzzyMarker(transUnits.target);
             }
         }
     } catch {
@@ -222,6 +222,17 @@ export function parseXlfContent(content: string): Record<string, string> {
     }
 
     return translations;
+}
+
+/**
+ * Strip the leading "~" fuzzy marker used to flag machine-translated
+ * placeholder entries in the XLF files. The marker must never reach
+ * the static bundle — it is kept only on disk so translators can spot
+ * entries that still need review.
+ */
+function stripFuzzyMarker(target: string): string {
+    if (typeof target !== 'string') return target;
+    return target.startsWith('~') ? target.slice(1) : target;
 }
 
 /**

--- a/src/services/translation.spec.ts
+++ b/src/services/translation.spec.ts
@@ -223,6 +223,19 @@ describe('translation service', () => {
             const catalogue = getCatalogueWithFallback('xx');
             expect(typeof catalogue).toBe('object');
         });
+
+        it('should never expose the "~" fuzzy marker in the catalogue', () => {
+            // XLF files keep "~" as a marker for machine-translated placeholders
+            // (so human translators can spot entries needing review), but the
+            // catalogue returned to the frontend must already have the marker
+            // stripped — otherwise it leaks into the UI and exports.
+            for (const locale of getAvailableLocales()) {
+                const catalogue = getCatalogueWithFallback(locale);
+                for (const value of Object.values(catalogue)) {
+                    expect(value.startsWith('~')).toBe(false);
+                }
+            }
+        });
     });
 
     describe('setGlobalParameters', () => {

--- a/src/services/translation.ts
+++ b/src/services/translation.ts
@@ -174,7 +174,11 @@ function parseXlfContent(content: string): XlfParseResult {
 
     for (const unit of transUnits) {
         const source = extractText(unit.source);
-        const target = extractText(unit.target);
+        const rawTarget = extractText(unit.target);
+        // Strip the "~" fuzzy marker used to flag machine-translated placeholder
+        // entries. The marker is kept on disk so translators can spot entries
+        // needing review, but it must never reach the UI or exports.
+        const target = rawTarget.startsWith('~') ? rawTarget.slice(1) : rawTarget;
         // Use resname or id as key (for error.page_not_found style keys)
         const resname = unit['@_resname'];
         const id = unit['@_id'];

--- a/src/shared/export/generators/I18nGenerator.spec.ts
+++ b/src/shared/export/generators/I18nGenerator.spec.ts
@@ -97,6 +97,24 @@ describe('parseXlfTranslations', () => {
         expect(map.get('World')).toBe('Mundo');
     });
 
+    it('should strip the leading "~" fuzzy marker at parse time', () => {
+        const xlfWithFuzzy = `<xliff>
+  <body>
+    <trans-unit id="1"><source>Next</source><target>~Siguiente</target></trans-unit>
+    <trans-unit id="2"><source>creative commons: cc0 1.0</source><target>~Creative Commons: CC0 1.0 Universal (dominio público)</target></trans-unit>
+    <trans-unit id="3"><source>Reviewed</source><target>Revisado</target></trans-unit>
+  </body>
+</xliff>`;
+        const map = parseXlfTranslations(xlfWithFuzzy);
+
+        expect(map.get('Next')).toBe('Siguiente');
+        expect(map.get('creative commons: cc0 1.0')).toBe('Creative Commons: CC0 1.0 Universal (dominio público)');
+        expect(map.get('Reviewed')).toBe('Revisado');
+        for (const value of map.values()) {
+            expect(value.startsWith('~')).toBe(false);
+        }
+    });
+
     it('should handle multiline source and target values', () => {
         const xlf = `<xliff>
   <body>

--- a/src/shared/export/generators/I18nGenerator.ts
+++ b/src/shared/export/generators/I18nGenerator.ts
@@ -52,7 +52,11 @@ export function parseXlfTranslations(xlfContent: string): Map<string, string> {
 
         if (sourceMatch && targetMatch) {
             const source = decodeXmlEntities(sourceMatch[1].trim());
-            const target = decodeXmlEntities(targetMatch[1].trim());
+            const decodedTarget = decodeXmlEntities(targetMatch[1].trim());
+            // Strip the "~" fuzzy marker used to flag machine-translated
+            // placeholder entries. The marker stays in the XLF files so
+            // translators can review them, but must never reach exports.
+            const target = decodedTarget.startsWith('~') ? decodedTarget.slice(1) : decodedTarget;
             if (source && target) {
                 translations.set(source, target);
             }

--- a/src/shared/parsers/translation-parser.spec.ts
+++ b/src/shared/parsers/translation-parser.spec.ts
@@ -133,6 +133,58 @@ describe('translation-parser', () => {
             expect(translations).toEqual({});
         });
 
+        it('should strip leading "~" fuzzy marker from machine-translated placeholders', () => {
+            const xlfContent = `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+    <file source-language="en" target-language="es">
+        <body>
+            <trans-unit id="1">
+                <source>Next</source>
+                <target>~Siguiente</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>creative commons: cc0 1.0</source>
+                <target>~Creative Commons: CC0 1.0 Universal (dominio público)</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Already reviewed</source>
+                <target>Ya revisado</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>`;
+
+            const translations = parseXlfContent(xlfContent);
+
+            expect(translations.Next).toBe('Siguiente');
+            expect(translations['creative commons: cc0 1.0']).toBe(
+                'Creative Commons: CC0 1.0 Universal (dominio público)',
+            );
+            expect(translations['Already reviewed']).toBe('Ya revisado');
+            // No value should leak a leading "~"
+            for (const value of Object.values(translations)) {
+                expect(value.startsWith('~')).toBe(false);
+            }
+        });
+
+        it('should strip the leading "~" on a single trans-unit XLF', () => {
+            const xlfContent = `<?xml version="1.0"?>
+<xliff version="1.2">
+    <file>
+        <body>
+            <trans-unit id="1">
+                <source>Save</source>
+                <target>~Guardar</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>`;
+
+            const translations = parseXlfContent(xlfContent);
+
+            expect(translations).toEqual({ Save: 'Guardar' });
+        });
+
         it('should handle translations with special characters', () => {
             const xlfContent = `<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2">

--- a/src/shared/parsers/translation-parser.ts
+++ b/src/shared/parsers/translation-parser.ts
@@ -75,13 +75,13 @@ export function parseXlfContent(content: string): TranslationMap {
                 const source = unit.source;
                 const target = unit.target;
                 if (source && target) {
-                    translations[source] = target;
+                    translations[source] = stripFuzzyMarker(target);
                 }
             }
         } else if (transUnits) {
             // Single translation
             if (transUnits.source && transUnits.target) {
-                translations[transUnits.source] = transUnits.target;
+                translations[transUnits.source] = stripFuzzyMarker(transUnits.target);
             }
         }
     } catch {
@@ -89,6 +89,17 @@ export function parseXlfContent(content: string): TranslationMap {
     }
 
     return translations;
+}
+
+/**
+ * Strip the leading "~" fuzzy marker used to flag machine-translated
+ * placeholder entries in the XLF files. The marker must never reach
+ * the UI or exports — it is kept only on disk so translators can spot
+ * entries that still need review.
+ */
+function stripFuzzyMarker(target: string): string {
+    if (typeof target !== 'string') return target;
+    return target.startsWith('~') ? target.slice(1) : target;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1701.

Machine-translated placeholders in the XLF files are prefixed with `~` so
translators can find entries that still need review. That marker must
stay in the files on disk, but it must never be shown in the editor, the
preview or any exported content. Today it leaks in a handful of places —
for example `<target>~Creative Commons: CC0 1.0 Universal (dominio público)</target>`
renders with the `~` still attached in the Spanish export footer.

### Root cause

Stripping was scattered and incomplete:

- `src/services/translation.ts` `trans()` stripped `~` on every call, but
  `getCatalogueWithFallback()` (served by `GET /api/translations/:locale`
  and consumed by `ResourceFetcher` / `BaseExporter.fetchNavLabels`) did
  not, so the raw string reached the client whenever a consumer read
  from the catalogue directly.
- The frontend `Locale.getTranslation()` (used by `window._(str, idevice)`
  for iDevice-specific lookups) and `common_edition.js`'s override of
  `_()` both read from `strings.translations` / `top.translations`
  without stripping.
- The four XLF parsers (`src/services/translation.ts`, shared
  `translation-parser.ts`, `I18nGenerator.parseXlfTranslations`,
  `scripts/build-static-bundle.ts`) all returned raw target values, so
  every downstream consumer had to remember to strip.

### Fix

Strip the `~` prefix once, at parse time, in every catalogue loader.
The XLF files on disk are untouched; only the in-memory / API-facing
representation is cleaned. The two frontend lookup paths that bypassed
the existing helpers also get an explicit strip as a safety net.

Files changed:

- `src/services/translation.ts` — strip when populating the catalogue.
- `src/shared/parsers/translation-parser.ts` — strip in `parseXlfContent`.
- `src/shared/export/generators/I18nGenerator.ts` — strip in
  `parseXlfTranslations` (affects `fetchNavLabels` and
  `common_i18n.{lang}.js` generation).
- `scripts/build-static-bundle.ts` — strip in its copy of `parseXlfContent`
  so the static `bundle.json` is also clean.
- `public/app/locate/locale.js` — strip in `getTranslation()` /
  iDevice lookup.
- `public/app/common/common_edition.js` — strip in the `_()` override
  used inside iDevice editors.

## Test plan

- [x] `make fix` clean.
- [x] New and updated unit tests cover every touched parser and lookup:
  - `src/shared/parsers/translation-parser.spec.ts`
  - `src/services/translation.spec.ts` (catalogue must never expose `~`)
  - `src/shared/export/generators/I18nGenerator.spec.ts`
  - `scripts/build-static-bundle.spec.ts`
  - `public/app/locate/locale.test.js`
  - `public/app/common/common_edition.test.js`
- [x] Rebuilt `common_i18n.{lang}.js` bundles and `exporters.bundle.js`
      — no regressions in the generated output.
- [x] Manual check: Spanish project with license `creative commons: cc0 1.0`
      now renders "Creative Commons: CC0 1.0 Universal (dominio público)"
      in the preview/export footer — the leading `~` is gone.