### PR TITLE
fix(desktop): ship save-utils.js in electron asar to unblock rc2 installers

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "files": [
       "main.js",
       "preload.js",
+      "save-utils.js",
       "update-manager.js",
       "package.json",
       "node_modules/**/*",


### PR DESCRIPTION
## Summary

- Desktop builds from v4.0.0-rc2 fail at startup on Windows with `Error: Cannot find module './save-utils'` because `save-utils.js` is missing from the electron-builder `files` whitelist.
- `build.disableDefaultIgnoredFiles: true` in `package.json` packages **only** the files explicitly listed under `build.files`. `save-utils.js` was introduced in #1666 but never added, so `app.asar` ships without it.
- Adds `save-utils.js` to the whitelist alongside `main.js`, `preload.js`, and `update-manager.js`. The colocated `save-utils.spec.ts` is not affected (not listed, so still excluded from the bundle).

## Crash excerpt (Windows installer, rc2)

```
uncaughtException: Error: Cannot find module './save-utils'
Require stack:
- C:\Users\runneradmin\AppData\Local\Programs\eXeLearning\resources\app.asar\main.js
```

## Test plan

- [ ] `make fix` passes
- [ ] CI `build-electron-installers` workflow produces signed Windows / macOS / Linux artifacts
- [ ] Install the produced Windows build in a clean VM and confirm the app launches past the splash screen
- [ ] Verify Save / Save As still work (exercises the `save-utils` module that was missing)