### PR TITLE
fix(deploy): adapt postgres:18-alpine volume layout for PG18+

### DIFF
--- a/doc/deploy/docker-compose.postgres.yml
+++ b/doc/deploy/docker-compose.postgres.yml
@@ -27,7 +27,7 @@ services:
       DB_USER: "${DB_USER:-postgres}"
       DB_PASSWORD: "${DB_PASSWORD:-postgres}"
       DB_CHARSET: "${DB_CHARSET:-utf8}"
-      DB_SERVER_VERSION: 17
+      DB_SERVER_VERSION: 18
       
       # Files directory
       FILES_DIR: "/mnt/data/"
@@ -54,7 +54,7 @@ services:
     # ports:
     #   - "${DB_PORT:-5432}:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
 
 volumes:
   exelearning-data:

--- a/doc/deploy/docker-compose.redis.yml
+++ b/doc/deploy/docker-compose.redis.yml
@@ -57,7 +57,7 @@ services:
       DB_USER: "${DB_USER:-postgres}"
       DB_PASSWORD: "${DB_PASSWORD:-postgres}"
       DB_CHARSET: "${DB_CHARSET:-utf8}"
-      DB_SERVER_VERSION: 17
+      DB_SERVER_VERSION: 18
 
       # Files directory (shared volume)
       FILES_DIR: "/mnt/data/"
@@ -112,7 +112,7 @@ services:
       DB_USER: "${DB_USER:-postgres}"
       DB_PASSWORD: "${DB_PASSWORD:-postgres}"
       DB_CHARSET: "${DB_CHARSET:-utf8}"
-      DB_SERVER_VERSION: 17
+      DB_SERVER_VERSION: 18
 
       # Files directory (shared volume)
       FILES_DIR: "/mnt/data/"
@@ -153,7 +153,7 @@ services:
       POSTGRES_USER: "${DB_USER:-postgres}"
       POSTGRES_DB: "${DB_NAME:-exelearning}"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-exelearning}"]
       interval: 10s


### PR DESCRIPTION
## Summary

- `make test-e2e-postgres` has been timing out in CI because the `postgres:18-alpine` image refuses to start with the previous volume mount.
- PG18+ images store data under a major-version-specific subdirectory inside `/var/lib/postgresql`. Mounting the volume at the legacy `/var/lib/postgresql/data` path makes PG18 log _"in 18+, these Docker images are configured to store database data in a format which is compatible with pg_ctlcluster... Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql/data (unused mount/volume)"_ and exit, so the app never becomes reachable on `:8080`.
- Fix: mount the volume one level up (`/var/lib/postgresql`) in both `docker-compose.postgres.yml` and `docker-compose.redis.yml`, and bump the reported `DB_SERVER_VERSION` to `18` for accuracy in `/system-info`.

Refs: [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259), [docker-library/postgres#37](https://github.com/docker-library/postgres/issues/37).

## Test plan

- [ ] `make test-e2e-postgres` passes locally (postgres container stays healthy, app reaches ready state before the 30-attempt poll).
- [ ] CI `e2e-db-matrix` PostgreSQL job is green.
- [ ] `doc/deploy/docker-compose.redis.yml` stack (app + redis + postgres) boots end-to-end.