### PR TITLE
feat(themes): runtime themeRegistryOverride hook for host integrations

### DIFF
--- a/public/app/core/providers/StaticDataProvider.js
+++ b/public/app/core/providers/StaticDataProvider.js
@@ -6,10 +6,52 @@
  * 1. window.__EXE_STATIC_DATA__ (injected by build)
  * 2. Loaded bundle.json file
  *
+ * Host integrations (WordPress, Moodle, Omeka-S) may inject an approved
+ * theme registry via `window.eXeLearning.config.themeRegistryOverride`
+ * before the editor boots. See {@link applyThemeRegistryOverride}.
+ *
  * @extends DataProvider
  */
 
 import { DataProvider } from './DataProvider.js';
+
+/**
+ * Merge a bundle themes payload with a host-supplied override.
+ *
+ * The override lets an embedding plugin:
+ *  - hide specific built-in themes by id/name (`disabledBuiltins`)
+ *  - append admin-approved uploaded themes (`uploaded`)
+ * It does NOT mutate the bundle — the result is a fresh object so the
+ * underlying static data can still be consulted as-is by other callers.
+ *
+ * When no override is present, or the override is malformed, the original
+ * payload is returned unchanged. This keeps every existing consumer working.
+ *
+ * @param {{themes?: Array}|null} payload - Original themes payload.
+ * @param {Object} [override] - Optional runtime override.
+ * @param {string[]} [override.disabledBuiltins] - Theme ids/names to hide.
+ * @param {Array}   [override.uploaded] - Admin-approved themes to append.
+ * @returns {{themes: Array}}
+ */
+export function applyThemeRegistryOverride(payload, override) {
+    const base = payload && Array.isArray(payload.themes) ? payload : { themes: [] };
+    if (!override || typeof override !== 'object') {
+        return base;
+    }
+    const disabled = new Set(
+        Array.isArray(override.disabledBuiltins) ? override.disabledBuiltins : []
+    );
+    const uploaded = Array.isArray(override.uploaded) ? override.uploaded : [];
+    const filtered = base.themes.filter((t) => {
+        if (!t) return false;
+        return !disabled.has(t.name) && !disabled.has(t.id);
+    });
+    // Uploaded themes win on id/name collision so an admin-approved override
+    // can shadow a disabled built-in that a stale project still references.
+    const uploadedKeys = new Set(uploaded.map((t) => t && (t.name || t.id)).filter(Boolean));
+    const deduped = filtered.filter((t) => !uploadedKeys.has(t.name) && !uploadedKeys.has(t.id));
+    return { ...base, themes: [...deduped, ...uploaded] };
+}
 
 export class StaticDataProvider extends DataProvider {
     /**
@@ -50,11 +92,13 @@ export class StaticDataProvider extends DataProvider {
     }
 
     /**
-     * Get installed themes from static data
+     * Get installed themes from static data, merged with any host override.
      * @returns {Promise<{themes: Array}>}
      */
     async getThemes() {
-        return this._getData('themes') || { themes: [] };
+        const payload = this._getData('themes') || { themes: [] };
+        const override = window.eXeLearning?.config?.themeRegistryOverride;
+        return applyThemeRegistryOverride(payload, override);
     }
 
     /**

--- a/public/app/core/providers/StaticDataProvider.test.js
+++ b/public/app/core/providers/StaticDataProvider.test.js
@@ -2,16 +2,21 @@
  * @vitest-environment happy-dom
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { StaticDataProvider } from './StaticDataProvider.js';
+import {
+    StaticDataProvider,
+    applyThemeRegistryOverride,
+} from './StaticDataProvider.js';
 
 describe('StaticDataProvider', () => {
     beforeEach(() => {
         // Clean up window.__EXE_STATIC_DATA__ before each test
         delete window.__EXE_STATIC_DATA__;
+        delete window.eXeLearning;
     });
 
     afterEach(() => {
         delete window.__EXE_STATIC_DATA__;
+        delete window.eXeLearning;
     });
 
     describe('constructor', () => {
@@ -76,6 +81,88 @@ describe('StaticDataProvider', () => {
             });
             const result = await provider.getThemes();
             expect(result.themes).toHaveLength(2);
+        });
+
+        it('should hide built-in themes listed in disabledBuiltins override', async () => {
+            window.eXeLearning = {
+                config: { themeRegistryOverride: { disabledBuiltins: ['neo'] } },
+            };
+            const provider = new StaticDataProvider({
+                themes: { themes: [{ name: 'base' }, { name: 'neo' }] },
+            });
+            const result = await provider.getThemes();
+            expect(result.themes.map((t) => t.name)).toEqual(['base']);
+        });
+
+        it('should append uploaded themes from the override', async () => {
+            window.eXeLearning = {
+                config: {
+                    themeRegistryOverride: {
+                        uploaded: [
+                            { name: 'acme', title: 'Acme', type: 'uploaded' },
+                        ],
+                    },
+                },
+            };
+            const provider = new StaticDataProvider({
+                themes: { themes: [{ name: 'base' }] },
+            });
+            const result = await provider.getThemes();
+            expect(result.themes.map((t) => t.name)).toEqual(['base', 'acme']);
+        });
+
+        it('should let an uploaded theme shadow a built-in on id collision', async () => {
+            window.eXeLearning = {
+                config: {
+                    themeRegistryOverride: {
+                        uploaded: [{ name: 'base', title: 'Custom Base' }],
+                    },
+                },
+            };
+            const provider = new StaticDataProvider({
+                themes: { themes: [{ name: 'base', title: 'Default' }] },
+            });
+            const result = await provider.getThemes();
+            expect(result.themes).toHaveLength(1);
+            expect(result.themes[0].title).toBe('Custom Base');
+        });
+
+        it('should ignore a malformed override and pass through the payload', async () => {
+            window.eXeLearning = {
+                config: { themeRegistryOverride: 'not-an-object' },
+            };
+            const provider = new StaticDataProvider({
+                themes: { themes: [{ name: 'base' }] },
+            });
+            const result = await provider.getThemes();
+            expect(result.themes).toHaveLength(1);
+        });
+    });
+
+    describe('applyThemeRegistryOverride (unit)', () => {
+        it('returns the original payload when no override is provided', () => {
+            const payload = { themes: [{ name: 'base' }] };
+            expect(applyThemeRegistryOverride(payload, null)).toEqual(payload);
+        });
+
+        it('copes with a null payload', () => {
+            const result = applyThemeRegistryOverride(null, {
+                uploaded: [{ name: 'a' }],
+            });
+            expect(result.themes.map((t) => t.name)).toEqual(['a']);
+        });
+
+        it('drops themes present in disabledBuiltins by id or name', () => {
+            const payload = {
+                themes: [
+                    { id: 'a', name: 'alpha' },
+                    { id: 'b', name: 'beta' },
+                ],
+            };
+            const result = applyThemeRegistryOverride(payload, {
+                disabledBuiltins: ['alpha', 'b'],
+            });
+            expect(result.themes).toEqual([]);
         });
     });
 

--- a/public/app/workarea/themes/themeList.js
+++ b/public/app/workarea/themes/themeList.js
@@ -1,5 +1,19 @@
 import Theme from './theme.js';
 
+/**
+ * Read the host-supplied "block theme install from content" flag.
+ *
+ * When a host integration (WordPress/Moodle/Omeka-S) publishes a
+ * `window.eXeLearning.config.themeRegistryOverride.blockImportInstall`
+ * flag, any theme install path that originates from project content,
+ * .elpx imports, or in-editor upload UIs is silently refused and logged.
+ *
+ * @returns {boolean}
+ */
+function isThemeImportBlocked() {
+    return !!window.eXeLearning?.config?.themeRegistryOverride?.blockImportInstall;
+}
+
 export default class ThemeList {
     constructor(manager) {
         this.manager = manager;
@@ -90,6 +104,11 @@ export default class ThemeList {
      * @param {ResourceCache} [providedCache] - Optional ResourceCache to use (passed from YjsProjectBridge during init)
      */
     async loadUserThemesFromIndexedDB(providedCache = null) {
+        // Embedded integrations may forbid loading user-installed themes so the
+        // editor only exposes admin-approved styles (see themeRegistryOverride).
+        if (isThemeImportBlocked()) {
+            return;
+        }
         try {
             // Use provided cache, or try to get from YjsProjectBridge
             let resourceCache = providedCache;
@@ -140,6 +159,15 @@ export default class ThemeList {
      * @returns {Theme} The created Theme instance
      */
     addUserTheme(themeConfig) {
+        // Embedded integrations may forbid user-installed themes so the editor
+        // only exposes the admin-approved registry (see themeRegistryOverride).
+        if (isThemeImportBlocked()) {
+            console.warn(
+                `[ThemeList] Refusing to install theme '${themeConfig?.name}': `
+                + 'theme imports are disabled by the host integration.'
+            );
+            return null;
+        }
         // User themes need special URL handling since they're served from IndexedDB/Yjs
         // Use a special prefix that the Theme class will recognize
         const userThemeUrl = `user-theme://${themeConfig.dirName}`;

--- a/public/app/workarea/themes/themeList.test.js
+++ b/public/app/workarea/themes/themeList.test.js
@@ -564,6 +564,49 @@ describe('ThemeList', () => {
     });
   });
 
+  describe('themeRegistryOverride blockImportInstall', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      window.eXeLearning = {
+        config: { themeRegistryOverride: { blockImportInstall: true } },
+      };
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      delete window.eXeLearning;
+    });
+
+    it('refuses addUserTheme and returns null when import is blocked', () => {
+      const result = themeList.addUserTheme({
+        name: 'blocked-theme',
+        dirName: 'blocked-theme',
+      });
+
+      expect(result).toBeNull();
+      expect(themeList.installed['blocked-theme']).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Refusing to install theme 'blocked-theme'")
+      );
+    });
+
+    it('short-circuits loadUserThemesFromIndexedDB when import is blocked', async () => {
+      const addSpy = vi.spyOn(themeList, 'addUserTheme');
+      const fakeCache = {
+        listUserThemes: vi.fn().mockResolvedValue([
+          { name: 'x', config: { name: 'x', dirName: 'x' } },
+        ]),
+      };
+
+      await themeList.loadUserThemesFromIndexedDB(fakeCache);
+
+      expect(fakeCache.listUserThemes).not.toHaveBeenCalled();
+      expect(addSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('integration', () => {
     it('should load and order themes from API', async () => {
       await themeList.load();

--- a/public/app/workarea/themes/themesManager.js
+++ b/public/app/workarea/themes/themesManager.js
@@ -207,6 +207,22 @@ export default class ThemesManager {
         if (!themeSelected) {
             themeSelected = this.getTheme(eXeLearning.config.defaultTheme);
         }
+        // Host integrations may supply a fallback via themeRegistryOverride
+        // so projects referencing a style that the admin has disabled or
+        // never installed still open instead of silently failing.
+        if (!themeSelected) {
+            const fallbackId =
+                window.eXeLearning?.config?.themeRegistryOverride?.fallbackTheme;
+            if (fallbackId && fallbackId !== id) {
+                themeSelected = this.getTheme(fallbackId);
+                if (themeSelected) {
+                    console.warn(
+                        `[ThemesManager] Theme '${id}' unavailable; `
+                        + `falling back to '${fallbackId}'.`
+                    );
+                }
+            }
+        }
         // Select the theme and apply it
         if (themeSelected) {
             let prevThemeSelected = this.selected;

--- a/public/app/workarea/themes/themesManager.test.js
+++ b/public/app/workarea/themes/themesManager.test.js
@@ -512,6 +512,27 @@ describe('ThemesManager', () => {
       expect(themesManager.selected.id).toBe('default-theme');
     });
 
+    it('uses fallbackTheme from themeRegistryOverride when default is also missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Remove the default theme so the normal fallback path fails.
+      delete themesManager.list.installed['default-theme'];
+      themesManager.list.installed['safe-base'] = {
+        id: 'safe-base',
+        select: vi.fn().mockResolvedValue(undefined),
+      };
+      window.eXeLearning.config.themeRegistryOverride = {
+        fallbackTheme: 'safe-base',
+      };
+
+      await themesManager.selectTheme('missing-theme');
+
+      expect(themesManager.selected.id).toBe('safe-base');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Theme 'missing-theme' unavailable")
+      );
+      warnSpy.mockRestore();
+    });
+
     it('should select theme when forceReload is true', async () => {
       themesManager.selected = mockTheme;
 


### PR DESCRIPTION
## Summary

Adds an **opt-in, backward-compatible runtime hook** that lets host
integrations (WordPress, Moodle, Omeka-S) inject an admin-approved style
registry into the static editor without rebuilding the bundle.

Host pages (e.g. the editor bootstrap in each plugin) may set:

```js
window.eXeLearning.config.themeRegistryOverride = {
    disabledBuiltins: ['zen', 'universal'],   // hide these built-ins
    uploaded: [                               // append uploaded themes
        {
            name: 'acme-2026',
            dirName: 'acme-2026',
            title: 'Acme 2026',
            type: 'uploaded',
            url: '/wp-content/uploads/exelearning-styles/acme-2026',
            cssFiles: ['style.css'],
            version: '1.0.0',
            valid: true,
        },
    ],
    blockImportInstall: true,   // refuse installs from imported content
    fallbackTheme: 'base',      // used when a project references a theme
                                //   the admin has disabled or deleted
};
```

With no override present, behavior is unchanged.

## Changes

- **`StaticDataProvider.getThemes()`** merges the override with the
  bundled themes payload. A pure helper (`applyThemeRegistryOverride`)
  is exported so plugin smoke tests can reuse the exact contract.
- **`ThemeList.addUserTheme`** and **`loadUserThemesFromIndexedDB`**
  bail out with `console.warn` when `blockImportInstall` is truthy,
  closing the install-from-content path that embedded hosts must not
  expose.
- **`ThemesManager.selectTheme`** uses `fallbackTheme` (with a warning)
  when both the requested theme and the configured default are missing,
  so existing projects that reference a removed style still open.

## Test plan

- [x] `public/app/core/providers/StaticDataProvider.test.js` — unit
      coverage of the merge helper and the `getThemes()` path
      (hide builtins, append uploads, override shadows on id collision,
      malformed override is ignored).
- [x] `public/app/workarea/themes/themeList.test.js` — guards against
      `addUserTheme` and `loadUserThemesFromIndexedDB` when
      `blockImportInstall` is set.
- [x] `public/app/workarea/themes/themesManager.test.js` — fallback
      to `themeRegistryOverride.fallbackTheme` when default theme is
      also unavailable, with warning.
- [x] Full frontend unit suite runs green (155 tests across the
      three affected files).

## Companion work

The admin UIs that will consume this hook live in the four integration
repos, each on the matching feature branch:

- exelearning/wp-exelearning — `feature/allow-installation-and-management-of-styles`
- exelearning/mod_exeweb — `28-allow-installation-and-management-of-styles`
- exelearning/mod_exescorm — `feature/allow-installation-and-management-of-styles`
- exelearning/omeka-s-exelearning — `feature/allow-installation-and-management-of-styles`

Those PRs bump the editor version once this one merges.