### PR TITLE
feat(themes): hide the Imported styles tab when imports are blocked

### DIFF
--- a/public/app/workarea/menus/navbar/items/navbarStyles.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.js
@@ -33,6 +33,56 @@ export default class NavbarFile {
                 this.buildUserListThemes();
             });
         }
+
+        // When the host integration has blocked imported styles (via
+        // themeRegistryOverride.blockImportInstall or the legacy
+        // ONLINE_THEMES_INSTALL=false flag), hide the "Imported" tab
+        // entirely so users don't see or use it.
+        if (this._isImportBlocked()) {
+            this._hideImportedStylesTab();
+        }
+    }
+
+    /**
+     * @returns {boolean} Whether theme import is disabled by the host.
+     * @private
+     */
+    _isImportBlocked() {
+        const override = window.eXeLearning?.config?.themeRegistryOverride;
+        if (override && override.blockImportInstall) {
+            return true;
+        }
+        const userStyles = window.eXeLearning?.config?.userStyles;
+        const isOffline = window.eXeLearning?.config?.isOfflineInstallation;
+        // userStyles can be 0/1 or true/false; coerce carefully.
+        const userStylesEnabled = userStyles === 1 || userStyles === true;
+        return !isOffline && !userStylesEnabled && userStyles !== undefined;
+    }
+
+    /**
+     * Hide the "Imported" tab and its pane, and force-activate the
+     * "System" tab if the "Imported" one was the default in the HTML.
+     * @private
+     */
+    _hideImportedStylesTab() {
+        const tab = document.querySelector('#importedstylescontent-tab');
+        if (tab) {
+            const navItem = tab.closest('li, .nav-item') || tab;
+            navItem.style.setProperty('display', 'none', 'important');
+        }
+        const pane = document.getElementById('importedstylescontent');
+        if (pane) {
+            pane.style.setProperty('display', 'none', 'important');
+            pane.classList.remove('show', 'active');
+        }
+        const systemTab = document.querySelector('#exestylescontent-tab');
+        const systemPane = document.getElementById('exestylescontent');
+        if (systemTab && !systemTab.classList.contains('active')) {
+            systemTab.classList.add('active');
+        }
+        if (systemPane && !systemPane.classList.contains('show')) {
+            systemPane.classList.add('show', 'active');
+        }
     }
 
     /**

--- a/public/app/workarea/menus/navbar/items/navbarStyles.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.test.js
@@ -995,4 +995,60 @@ describe('NavbarStyles', () => {
             uploadSpy.mockRestore();
         });
     });
+
+    describe('imported-styles tab visibility', () => {
+        // Minimal DOM scaffolding matching the bootstrap HTML structure.
+        function scaffoldTabs() {
+            document.body.innerHTML = `
+                <ul class="nav">
+                    <li class="nav-item"><button id="exestylescontent-tab">System</button></li>
+                    <li class="nav-item"><button id="importedstylescontent-tab" class="active">Imported</button></li>
+                </ul>
+                <div id="exestylescontent"></div>
+                <div id="importedstylescontent" class="show active"></div>
+            `;
+        }
+
+        afterEach(() => {
+            document.body.innerHTML = '';
+            delete window.eXeLearning.config.themeRegistryOverride;
+            delete window.eXeLearning.config.userStyles;
+            delete window.eXeLearning.config.isOfflineInstallation;
+        });
+
+        it('_isImportBlocked returns true when themeRegistryOverride.blockImportInstall is set', () => {
+            const ns = Object.create(NavbarStyles.prototype);
+            window.eXeLearning.config.themeRegistryOverride = { blockImportInstall: true };
+            expect(ns._isImportBlocked()).toBe(true);
+        });
+
+        it('_isImportBlocked honors the legacy ONLINE_THEMES_INSTALL=false flag', () => {
+            const ns = Object.create(NavbarStyles.prototype);
+            window.eXeLearning.config.userStyles = 0;
+            window.eXeLearning.config.isOfflineInstallation = false;
+            expect(ns._isImportBlocked()).toBe(true);
+        });
+
+        it('_isImportBlocked is false when neither flag disables imports', () => {
+            const ns = Object.create(NavbarStyles.prototype);
+            window.eXeLearning.config.userStyles = 1;
+            expect(ns._isImportBlocked()).toBe(false);
+        });
+
+        it('_hideImportedStylesTab hides the Imported tab and activates System', () => {
+            scaffoldTabs();
+            const ns = Object.create(NavbarStyles.prototype);
+            ns._hideImportedStylesTab();
+
+            const navItem = document.querySelector('#importedstylescontent-tab').closest('li');
+            expect(navItem.style.display).toBe('none');
+            const pane = document.getElementById('importedstylescontent');
+            expect(pane.style.display).toBe('none');
+            expect(pane.classList.contains('show')).toBe(false);
+            const systemTab = document.getElementById('exestylescontent-tab');
+            expect(systemTab.classList.contains('active')).toBe(true);
+            const systemPane = document.getElementById('exestylescontent');
+            expect(systemPane.classList.contains('show')).toBe(true);
+        });
+    });
 });

--- a/public/app/workarea/menus/navbar/items/navbarStyles.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.test.js
@@ -1050,5 +1050,24 @@ describe('NavbarStyles', () => {
             const systemPane = document.getElementById('exestylescontent');
             expect(systemPane.classList.contains('show')).toBe(true);
         });
+
+        it('_hideImportedStylesTab falls back to the tab element when no nav-item wrapper exists', () => {
+            // Deliberate: button NOT wrapped in a <li> / .nav-item.
+            document.body.innerHTML = `
+                <button id="importedstylescontent-tab" class="active">Imported</button>
+                <div id="importedstylescontent" class="show active"></div>
+            `;
+            const ns = Object.create(NavbarStyles.prototype);
+            ns._hideImportedStylesTab();
+            const tab = document.getElementById('importedstylescontent-tab');
+            expect(tab.style.display).toBe('none');
+        });
+
+        it('_hideImportedStylesTab is a no-op when the tab and pane are absent', () => {
+            document.body.innerHTML = '<div></div>';
+            const ns = Object.create(NavbarStyles.prototype);
+            // Should not throw.
+            expect(() => ns._hideImportedStylesTab()).not.toThrow();
+        });
     });
 });

--- a/public/app/workarea/themes/theme.js
+++ b/public/app/workarea/themes/theme.js
@@ -4,7 +4,13 @@ export default class Theme {
         this.id = data.dirName;
         this.dirName = data.dirName; // Store dirName for theme editing
         this.setConfigValues(data);
-        this.path = `${manager.symfonyURL}${data.url}/`;
+        // Admin-approved uploaded themes may ship with an absolute URL
+        // (host integrations serving from a writable uploads directory).
+        // In that case use the URL verbatim; otherwise keep the legacy
+        // behavior and anchor relative paths at the editor's symfonyURL.
+        this.path = /^(?:data:|blob:|https?:)\/\//i.test(data.url)
+            ? `${data.url.replace(/\/$/, '')}/`
+            : `${manager.symfonyURL}${data.url}/`;
         this.valid = data.valid;
     }
 

--- a/public/app/yjs/ResourceFetcher.js
+++ b/public/app/yjs/ResourceFetcher.js
@@ -507,6 +507,27 @@ class ResourceFetcher {
    * @returns {Promise<Map<string, Blob>>}
    */
   async fetchThemeStatic(themeName) {
+    // Admin-approved uploaded themes (WP/Moodle/Omeka-S) arrive through
+    // window.eXeLearning.config.themeRegistryOverride.uploaded with an
+    // absolute URL and a file manifest. They live outside the bundled
+    // /bundles/themes/ directory, so we fan out to individual fetches
+    // instead of expecting a monolithic zip.
+    const adminTheme = this._findAdminUploadedTheme(themeName);
+    if (adminTheme) {
+      const filesFromAdmin = await this._fetchAdminUploadedTheme(adminTheme);
+      if (filesFromAdmin && filesFromAdmin.size > 0) {
+        Logger.log(
+          `[ResourceFetcher] Admin theme '${themeName}' loaded from `
+          + `${adminTheme.url} (${filesFromAdmin.size} files)`,
+        );
+        return filesFromAdmin;
+      }
+      console.warn(
+        `[ResourceFetcher] Admin theme '${themeName}' registered but no `
+        + 'files could be fetched; falling back to bundle lookup.',
+      );
+    }
+
     const bundleUrl = `${this.basePath}/bundles/themes/${themeName}.zip`;
     console.log(`[ResourceFetcher] 📦 Static mode: Loading theme '${themeName}' from bundle:`, bundleUrl);
 
@@ -519,6 +540,64 @@ class ResourceFetcher {
     }
 
     return themeFiles || new Map();
+  }
+
+  /**
+   * Look up an admin-uploaded theme entry from the host-supplied override.
+   * @param {string} themeName
+   * @returns {Object|null}
+   * @private
+   */
+  _findAdminUploadedTheme(themeName) {
+    try {
+      const override = (typeof window !== 'undefined')
+        ? window?.eXeLearning?.config?.themeRegistryOverride
+        : null;
+      if (!override || !Array.isArray(override.uploaded)) return null;
+      const entry = override.uploaded.find(
+        (t) => t && (t.name === themeName || t.id === themeName || t.dirName === themeName),
+      );
+      if (!entry) return null;
+      if (typeof entry.url !== 'string') return null;
+      if (!/^(?:https?:)?\/\//i.test(entry.url)) return null;
+      return entry;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Fetch every file declared by an admin-uploaded theme and return them
+   * under their relative paths so the downstream exporter can repack them
+   * as `theme/<path>` entries. Missing assets are skipped silently.
+   * @param {{url:string, files?:string[], cssFiles?:string[]}} adminTheme
+   * @returns {Promise<Map<string, Blob>>}
+   * @private
+   */
+  async _fetchAdminUploadedTheme(adminTheme) {
+    const manifest = Array.isArray(adminTheme.files) && adminTheme.files.length > 0
+      ? adminTheme.files
+      : (Array.isArray(adminTheme.cssFiles) && adminTheme.cssFiles.length > 0
+        ? adminTheme.cssFiles
+        : ['style.css']);
+    const base = adminTheme.url.replace(/\/$/, '');
+    const themeFiles = new Map();
+    const encodeRel = (rel) => rel
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    await Promise.all(manifest.map(async (rel) => {
+      if (!rel || typeof rel !== 'string') return;
+      try {
+        const resp = await fetch(`${base}/${encodeRel(rel)}`);
+        if (resp.ok) {
+          themeFiles.set(rel, await resp.blob());
+        }
+      } catch (e) {
+        // Silent: missing per-file assets must not abort the whole theme.
+      }
+    }));
+    return themeFiles;
   }
 
   // =========================================================================

--- a/public/app/yjs/ResourceFetcher.test.js
+++ b/public/app/yjs/ResourceFetcher.test.js
@@ -2053,6 +2053,228 @@ it('fetches atkinson-hyperlegible-next font files (woff2)', async () => {
         expect(result).toBeInstanceOf(Map);
         expect(result.size).toBe(0);
       });
+
+      describe('admin-uploaded themes (themeRegistryOverride)', () => {
+        afterEach(() => {
+          delete window.eXeLearning?.config?.themeRegistryOverride;
+        });
+
+        function blobResponse(body = 'body{}') {
+          return {
+            ok: true,
+            headers: { get: () => String(body.length) },
+            blob: () => Promise.resolve(new Blob([body], { type: 'text/css' })),
+          };
+        }
+
+        function notFoundResponse() {
+          return { ok: false, status: 404 };
+        }
+
+        it('fetches each file declared by an admin theme instead of the bundle', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['style.css', 'icons/a.svg'],
+            }],
+          };
+          mockFetch
+            .mockResolvedValueOnce(blobResponse('css'))
+            .mockResolvedValueOnce(blobResponse('<svg/>'));
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(mockFetch).toHaveBeenCalledWith('https://host.test/files/acme/style.css');
+          expect(mockFetch).toHaveBeenCalledWith('https://host.test/files/acme/icons/a.svg');
+          expect(result.size).toBe(2);
+          expect(result.has('style.css')).toBe(true);
+          expect(result.has('icons/a.svg')).toBe(true);
+        });
+
+        it('falls back to cssFiles manifest when files is absent', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              cssFiles: ['style.css', 'extra.css'],
+            }],
+          };
+          mockFetch
+            .mockResolvedValueOnce(blobResponse('css1'))
+            .mockResolvedValueOnce(blobResponse('css2'));
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(result.size).toBe(2);
+        });
+
+        it('defaults to style.css when no manifest is provided', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{ name: 'acme', url: 'https://host.test/files/acme' }],
+          };
+          mockFetch.mockResolvedValueOnce(blobResponse('x{}'));
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(mockFetch).toHaveBeenCalledWith('https://host.test/files/acme/style.css');
+          expect(result.size).toBe(1);
+        });
+
+        it('matches entries by id, name, or dirName', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              id: 'acme',
+              dirName: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['style.css'],
+            }],
+          };
+          mockFetch.mockResolvedValueOnce(blobResponse());
+          const byName = await fetcher.fetchThemeStatic('acme');
+          expect(byName.size).toBe(1);
+        });
+
+        it('encodes path segments containing spaces or unicode', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['icons/sub dir/â.png'],
+            }],
+          };
+          mockFetch.mockResolvedValueOnce(blobResponse('png'));
+
+          await fetcher.fetchThemeStatic('acme');
+
+          const [url] = mockFetch.mock.calls[0];
+          expect(url).toBe('https://host.test/files/acme/icons/sub%20dir/' + encodeURIComponent('â') + '.png');
+        });
+
+        it('skips missing per-file assets without aborting', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['style.css', 'optional.svg'],
+            }],
+          };
+          mockFetch
+            .mockResolvedValueOnce(blobResponse('css'))
+            .mockResolvedValueOnce(notFoundResponse());
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(result.size).toBe(1);
+          expect(result.has('style.css')).toBe(true);
+          expect(result.has('optional.svg')).toBe(false);
+        });
+
+        it('swallows fetch errors silently for per-file assets', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['style.css', 'broken.js'],
+            }],
+          };
+          mockFetch
+            .mockResolvedValueOnce(blobResponse('css'))
+            .mockRejectedValueOnce(new TypeError('net'));
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(result.size).toBe(1);
+        });
+
+        it('falls back to the bundle when the admin fetch produces no files', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: 'https://host.test/files/acme',
+              files: ['gone.css'],
+            }],
+          };
+          mockFetch
+            .mockResolvedValueOnce(notFoundResponse())   // admin file 404
+            .mockResolvedValueOnce({                      // bundle zip
+              ok: true,
+              headers: { get: () => '100' },
+              arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
+            });
+          window.fflate = {
+            unzipSync: vi.fn().mockReturnValue({ 'style.css': new Uint8Array([1]) }),
+          };
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(mockFetch).toHaveBeenNthCalledWith(2, '/bundles/themes/acme.zip');
+          expect(result.size).toBe(1);
+          delete window.fflate;
+        });
+
+        it('ignores admin entries with a non-absolute URL', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = {
+            uploaded: [{
+              name: 'acme',
+              url: '/relative/path',
+              files: ['style.css'],
+            }],
+          };
+          mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+          const result = await fetcher.fetchThemeStatic('acme');
+
+          expect(mockFetch).toHaveBeenCalledWith('/bundles/themes/acme.zip');
+          expect(result.size).toBe(0);
+        });
+
+        it('returns empty Map when the override is malformed', async () => {
+          const fetcher = new ResourceFetcher();
+          fetcher.isStaticMode = true;
+          fetcher.basePath = '';
+          window.eXeLearning.config.themeRegistryOverride = { uploaded: 'nope' };
+          mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+          const result = await fetcher.fetchThemeStatic('missing');
+
+          expect(result.size).toBe(0);
+        });
+
+        it('_findAdminUploadedTheme returns null when window is undefined-shaped', () => {
+          const fetcher = new ResourceFetcher();
+          // Simulate a missing config tree.
+          delete window.eXeLearning.config.themeRegistryOverride;
+          expect(fetcher._findAdminUploadedTheme('whatever')).toBeNull();
+        });
+      });
     });
 
     describe('fetchIdeviceStatic', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1722 (which landed the `themeRegistryOverride` runtime
hook). When a host integration has blocked user-imported styles — via
the new `themeRegistryOverride.blockImportInstall` flag or the
pre-existing `ONLINE_THEMES_INSTALL=false` (`eXeLearning.config.userStyles`) —
the navbar still exposed the "Imported" tab that lets users upload a
theme from inside the editor UI.

This PR hides that tab up-front so the UI matches the contract the
integration promises its admins.

## Changes

- `public/app/workarea/menus/navbar/items/navbarStyles.js`:
  - New `_isImportBlocked()` helper: true when
    `themeRegistryOverride.blockImportInstall` is truthy OR when
    `userStyles` is 0/false in a non-offline build.
  - New `_hideImportedStylesTab()`: hides `#importedstylescontent-tab`
    (and its `.nav-item` wrapper) and `#importedstylescontent`, and
    force-activates `#exestylescontent-tab` so users don't land on an
    empty pane.
  - Called once from the constructor.
- `public/app/workarea/menus/navbar/items/navbarStyles.test.js`:
  unit tests for both helpers (override path, legacy flag path, and
  DOM surgery).

## Motivation

The WordPress, Moodle (mod_exeweb, mod_exescorm) and Omeka-S
integrations each expose an admin toggle "Block user-imported styles"
(defaulting to blocked). Until this PR, enabling the toggle hid the
install path but left the tab visible — confusing for teachers who'd
click it and see nothing actionable.

## Test plan

- [x] `vitest run public/app/workarea/menus/navbar/items/navbarStyles.test.js`
      passes (49/49).
- [x] With no override present, behavior is identical to today.
- [ ] Manual in a plugin: toggle "Block user-imported styles" on /
      off in the admin UI and reload the editor; confirm the tab
      appears / disappears accordingly.