### PR TITLE
1706 some strings are not translated

### DIFF
--- a/public/files/perm/idevices/base/classify/edition/classify.js
+++ b/public/files/perm/idevices/base/classify/edition/classify.js
@@ -84,7 +84,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'
@@ -297,7 +297,7 @@ var $exeDevice = {
                             </span>                              
                             <label for="clasificaEPercentajeFB" class="mb-0">${_('Percent')}</label>
                             <input type="number" name="clasificaEPercentajeFB" id="clasificaEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" style="width:6ch" />
-                            <span>${_('&percnt; right to see the feedback')}</span>
+                            <span>${_('% right to see the feedback')}</span>
                         </div>
                         <p id="clasificaEFeedbackP" class="CQE-EFeedbackP">
                             <textarea id="clasificaEFeedBackEditor" class="exe-html-editor form-control" rows="4"></textarea>

--- a/public/files/perm/idevices/base/complete/edition/complete.js
+++ b/public/files/perm/idevices/base/complete/edition/complete.js
@@ -54,7 +54,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'
@@ -196,7 +196,7 @@ var $exeDevice = {
                                     <label for="cmptEEstrictCheck" class="toggle-label">${_('Allow errors in typed words')}.</label>
                                 </span>
                                 <span id="cmptEPercentajeErrorsDiv" class="CMPT-Hide  align-items-center gap-2 flex-nowrap">
-                                    <label for="cmptEPercentajeError">${_('Incorrect letters allowed (&percnt;)')}:</label><input type="number" name="cmptEPercentajeError" id="cmptEPercentajeError" value="20" min="0" max="100" step="5" class="form-control" />
+                                    <label for="cmptEPercentajeError">${_('Incorrect letters allowed (%)')}:</label><input type="number" name="cmptEPercentajeError" id="cmptEPercentajeError" value="20" min="0" max="100" step="5" class="form-control" />
                                 </span>
                             </div>
                             <div id="cmptECaseSensitiveDiv" class="mb-3">
@@ -235,7 +235,7 @@ var $exeDevice = {
                                     <label for="cmptEHasFeedBack" class="toggle-label">${_('Feedback')}.</label>
                                 </span>
                                 <span class="d-flex align-items-center gap-2 flex-nowrap">
-                                    <input type="number" name="cmptEPercentajeFB" id="cmptEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" /><label for="cmptEPercentajeFB">${_('&percnt; right to see the feedback')}.</label>
+                                    <input type="number" name="cmptEPercentajeFB" id="cmptEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" /><label for="cmptEPercentajeFB">${_('% right to see the feedback')}.</label>
                                 </span>
                             </div>
                             <div id="cmptEFeedbackP" class="CMPT-EFeedbackP mb-3">

--- a/public/files/perm/idevices/base/crossword/edition/crossword.js
+++ b/public/files/perm/idevices/base/crossword/edition/crossword.js
@@ -79,7 +79,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgWrote: c_(
                 'Write the correct word and click on Reply. If you hesitate, click on Move on.'
@@ -219,7 +219,7 @@ var $exeDevice = {
                                 <label class="toggle-label" for="ccgmEHasFeedBack">${_('Feedback')}.</label>
                             </span>
                            <input type="number" name="ccgmEPercentajeFB" id="ccgmEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" style="width:6ch" />
-                           <label for="ccgmEPercentajeFB" class="ms-0">${_('&percnt; right to see the feedback')}</label>
+                           <label for="ccgmEPercentajeFB" class="ms-0">${_('% right to see the feedback')}</label>
                         </div>
                         <div id="ccgmEFeedbackP" class="CCGM-EFeedbackP">
                             <textarea id="ccgmEFeedBackEditor" class="exe-html-editor form-control" rows="4"></textarea>

--- a/public/files/perm/idevices/base/discover/edition/discover.js
+++ b/public/files/perm/idevices/base/discover/edition/discover.js
@@ -68,7 +68,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'

--- a/public/files/perm/idevices/base/dragdrop/edition/dragdrop.js
+++ b/public/files/perm/idevices/base/dragdrop/edition/dragdrop.js
@@ -95,7 +95,7 @@ var $exeDevice = {
             msgAudio: c_('Audio'),
             msgNumQuestions: c_('Number of cards'),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameM: c_('You finished the game. Your score is %s.'),
             msgUncompletedActivity: c_('Incomplete activity'),

--- a/public/files/perm/idevices/base/flipcards/edition/flipcards.js
+++ b/public/files/perm/idevices/base/flipcards/edition/flipcards.js
@@ -104,7 +104,7 @@ var $exeDevice = {
             msgTrue: c_('True'),
             msgFalse: c_('False'),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             mgsAllQuestions: c_('Questions completed!'),
             msgTrue1: c_("Right. That's the card."),

--- a/public/files/perm/idevices/base/guess/edition/guess.js
+++ b/public/files/perm/idevices/base/guess/edition/guess.js
@@ -100,7 +100,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgWrote: c_(
                 'Write the correct word and click on Reply. If you hesitate, click on Move on.'
@@ -289,7 +289,7 @@ var $exeDevice = {
                                     <label class="toggle-label" for="adivinaEHasFeedBack">${_('Feedback')}.</label>
                                 </div>
                                 <input type="number" name="adivinaEPercentajeFB" id="adivinaEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" />
-                                <label for="adivinaEPercentajeFB">${_('&percnt; right to see the feedback')}</label>
+                                <label for="adivinaEPercentajeFB">${_('% right to see the feedback')}</label>
                             </div>
                             <div id="adivinaEFeedbackP" class="ADVNE-EFeedbackP mb-3">
                                 <textarea id="adivinaEFeedBackEditor" class="exe-html-editor form-control" rows="4"></textarea>

--- a/public/files/perm/idevices/base/identify/edition/identify.js
+++ b/public/files/perm/idevices/base/identify/edition/identify.js
@@ -93,7 +93,7 @@ var $exeDevice = {
                 'You can do this activity as many times as you want'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgClose: c_('Close'),
             msgClue: c_('Hint'),
@@ -497,7 +497,7 @@ var $exeDevice = {
                                 <div class="d-flex align-items-center gap-2 flex-nowrap">
                                     <label for="idfEPercentajeFB" class="mb-0">%FB</label>
                                     <input type="number" name="idfEPercentajeFB" id="idfEPercentajeFB" class="form-control" value="100" min="5" max="100" step="5" disabled />
-                                    <span class="ms-2">${_('&percnt; right to see the feedback')}</span>
+                                    <span class="ms-2">${_('% right to see the feedback')}</span>
                                 </div>
                             </div>
                             <div id="idfEFeedbackP" class="IDFE-EFeedbackP mb-3">

--- a/public/files/perm/idevices/base/map/edition/map.js
+++ b/public/files/perm/idevices/base/map/edition/map.js
@@ -104,7 +104,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'
@@ -156,7 +156,7 @@ var $exeDevice = {
             msgSearch: c_('Find'),
             msgClickOn: c_('Click on'),
             msgReviewContents: c_(
-                'You must review %s&percnt; of the contents of the activity before completing the questionnaire.'
+                'You must review %s% of the contents of the activity before completing the questionnaire.'
             ),
             msgScore10: c_(
                 'Everything is perfect! Do you want to repeat this activity?'

--- a/public/files/perm/idevices/base/mathematicaloperations/edition/mathematicaloperations.js
+++ b/public/files/perm/idevices/base/mathematicaloperations/edition/mathematicaloperations.js
@@ -77,7 +77,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'

--- a/public/files/perm/idevices/base/mathproblems/edition/mathproblems.js
+++ b/public/files/perm/idevices/base/mathproblems/edition/mathproblems.js
@@ -90,7 +90,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'
@@ -213,7 +213,7 @@ var $exeDevice = {
                                 <div class="d-flex align-items-center gap-2 flex-nowrap">
                                     <label for="eCQPercentajeFB" class="mb-0">%FB</label>
                                     <input type="number" name="eCQPercentajeFB" id="eCQPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" style="width:6ch" />
-                                    <span>${_('&percnt; right to see the feedback')}.</span>
+                                    <span>${_('% right to see the feedback')}.</span>
                                 </div>
                             </div>
                             <div id="eCQFeedbackP" class="MTOE-EFeedbackP mb-3" style="display:none">

--- a/public/files/perm/idevices/base/periodic-table/edition/periodic-table.js
+++ b/public/files/perm/idevices/base/periodic-table/edition/periodic-table.js
@@ -69,7 +69,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'
@@ -432,7 +432,7 @@ var $exeDevice = {
                                     </span>
                                     <label class="toggle-label" for="ptEHasFeedBack">${_('Feedback')}.</label>
                                 </span>
-                                <input type="number" name="ptEPercentajeFB" id="ptEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" style="width:6ch" /><label for="ptEPercentajeFB" class="ms-2">${_('&percnt; right to see the feedback')}</label>
+                                <input type="number" name="ptEPercentajeFB" id="ptEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" style="width:6ch" /><label for="ptEPercentajeFB" class="ms-2">${_('% right to see the feedback')}</label>
                             </div>
                             <div id="ptEFeedbackP" class="PTE-EFeedbackP mb-3">
                                 <textarea id="ptEFeedBackEditor" class="exe-html-editor form-control" rows="4"></textarea>

--- a/public/files/perm/idevices/base/puzzle/edition/puzzle.js
+++ b/public/files/perm/idevices/base/puzzle/edition/puzzle.js
@@ -70,7 +70,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'

--- a/public/files/perm/idevices/base/quick-questions-multiple-choice/edition/quick-questions-multiple-choice.js
+++ b/public/files/perm/idevices/base/quick-questions-multiple-choice/edition/quick-questions-multiple-choice.js
@@ -139,7 +139,7 @@ var $exeDevice = {
                 'You can do this activity as many times as you want'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgVideoIntro: c_('Video Intro'),
             msgClose: c_('Close'),
@@ -1364,7 +1364,7 @@ var $exeDevice = {
                                 </div>
                                 <div class="mb-0 d-flex align-items-center gap-2">
                                     <input type="number" name="seleccionaEPercentajeFB" id="seleccionaEPercentajeFB" value="100" min="5" max="100" step="5" disabled class="form-control" />
-                                    <label for="seleccionaEPercentajeFB">${_('&percnt; right to see the feedback')}</label>
+                                    <label for="seleccionaEPercentajeFB">${_('% right to see the feedback')}</label>
                                 </div>
                             </div>
                             <div id="seleccionaEFeedbackP" class="SLCNE-EFeedbackP mb-3">

--- a/public/files/perm/idevices/base/quick-questions-video/edition/quick-questions-video.js
+++ b/public/files/perm/idevices/base/quick-questions-video/edition/quick-questions-video.js
@@ -123,7 +123,7 @@ var $exeDevice = {
                 'You can do this activity as many times as you want'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgClose: c_('Close'),
             msgOption: c_('Option'),
@@ -916,7 +916,7 @@ var $exeDevice = {
                                         <label class="toggle-label" for="vquextEHasFeedBack">${_('Feedback')}.</label>
                                     </div>
                                     <input class="form-control" type="number" name="vquextEPercentajeFB" id="vquextEPercentajeFB" value="100" min="5" max="100" step="5" disabled style="width: 9.5ch !important; max-width:9.5ch !important;"/>
-                                    <label for="vquextEPercentajeFB" class="mb-0">${_('&percnt; right to see the feedback')}</label>
+                                    <label for="vquextEPercentajeFB" class="mb-0">${_('% right to see the feedback')}</label>
                                 </div>
                                 <div id="vquextEFeedbackP" class="VDQXTE-EFeedbackP mb-3">
                                     <textarea id="vquextEFeedBackEditor" class="exe-html-editor"></textarea>

--- a/public/files/perm/idevices/base/quick-questions/edition/quick-questions.js
+++ b/public/files/perm/idevices/base/quick-questions/edition/quick-questions.js
@@ -124,7 +124,7 @@ var $exeDevice = {
                 'You can do this activity as many times as you want'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgVideoIntro: c_('Video Intro'),
             msgClose: c_('Close'),

--- a/public/files/perm/idevices/base/relate/edition/relate.js
+++ b/public/files/perm/idevices/base/relate/edition/relate.js
@@ -95,7 +95,7 @@ var $exeDevice = {
             msgAudio: c_('Audio'),
             msgNumQuestions: c_('Number of cards'),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameM: c_('You finished the game. Your score is %s.'),
             msgUncompletedActivity: c_('Incomplete activity'),

--- a/public/files/perm/idevices/base/select-media-files/edition/select-media-files.js
+++ b/public/files/perm/idevices/base/select-media-files/edition/select-media-files.js
@@ -68,7 +68,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'

--- a/public/files/perm/idevices/base/sort/edition/sort.js
+++ b/public/files/perm/idevices/base/sort/edition/sort.js
@@ -71,7 +71,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgEndGameScore: c_(
                 'Please start the game before saving your score.'

--- a/public/files/perm/idevices/base/word-search/edition/word-search.js
+++ b/public/files/perm/idevices/base/word-search/edition/word-search.js
@@ -70,7 +70,7 @@ var $exeDevice = {
                 'It was not that! | Incorrect! | Not correct! | Sorry! | Error!'
             ),
             msgTryAgain: c_(
-                'You need at least %s&percnt; of correct answers to get the information. Please try again.'
+                'You need at least %s% of correct answers to get the information. Please try again.'
             ),
             msgScoreScorm: c_(
                 "The score can't be saved because this page is not part of a SCORM package."
@@ -400,7 +400,7 @@ var $exeDevice = {
                             <div class="d-flex flex-nowrap align-items-center gap-2">
                                 <label for="sopaEPercentajeFB" class="mb-0"></label>
                                 <input type="number" class="form-control" name="sopaEPercentajeFB" id="sopaEPercentajeFB" value="100" min="5" max="100" step="5" disabled />
-                                <span class="mb-0">${_('&percnt; right to see the feedback')}</span>
+                                <span class="mb-0">${_('% right to see the feedback')}</span>
                             </div>
                         </div>
                         <div id="sopaEFeedbackP" class="SPE-EFeedbackP mb-3">

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -994,7 +994,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     private: trans('Private', {}, locale),
                     public: trans('Public', {}, locale),
                     preferences: trans('Preferences', {}, locale),
-                    admin_panel: trans('Admin panel', {}, locale),
+                    admin_panel: 'Admin', // Admin panel is English-only; replace 'en' with `locale` to re-enable translations
                     logout: trans('Logout', {}, locale),
                     toggle_panels: trans('Toggle panels', {}, locale),
                     structure_panel: trans('Structure panel', {}, locale),

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>~Rúbrica importada</target>
       </trans-unit>
+      <trans-unit id="ec80ush" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Si us plau, completeu la rúbrica abans de desar la vostra puntuació.</target>
+      </trans-unit>
+      <trans-unit id="m7nms5m" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~La vostra puntuació es desarà després de cada canvi. Només podeu completar-la una vegada.</target>
+      </trans-unit>
+      <trans-unit id="kmfv717" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~La vostra puntuació es desarà automàticament després de cada canvi.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>Aplica</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Completa la taula per definir una guia de puntuació. Defineix la puntuació o el valor de cada descriptor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Aprèn com aplicar una rúbrica</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Rúbrica d'exemple</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="qicfdve" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>~Importar (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="ozgw08p" resname="Download as">
-        <source>Download as</source>
-        <target>~Descarregar com</target>
       </trans-unit>
       <trans-unit id="x6bop4n" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -5513,9 +5513,9 @@
         <source>Cool!</source>
         <target>Genial!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[Necessites almenys %s&percnt; de respostes correctes per obtenir la informació. Si us plau, torna-ho a provar.__You need at least %s&percnt; of correct answers to get the information. Please try again.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target>Necessites almenys %s% de respostes correctes per obtenir la informació. Si us plau, torna-ho a provar.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5633,9 +5633,9 @@
         <source>Percent</source>
         <target>Percentatge</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[&percnt; dret a veure la retroalimentació__&percnt; right to see the feedback]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target>% dret a veure la retroalimentació</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5753,9 +5753,9 @@
         <source>Allow errors in typed words</source>
         <target>Permet errors en paraules teclejades</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[Lletres incorrectes permeses (&percnt;)__Incorrect letters allowed (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target>Lletres incorrectes permeses (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9465,8 +9465,8 @@
         <source>Representation</source>
         <target>Representació</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target>Acció i expressió</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12105,8 +12105,8 @@
         <source>Line highlight</source>
         <target>Resaltat de línia</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target>Has de revisar el %s&amp;percnt; del contingut de l’activitat abans de completar el qüestionari.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -5517,9 +5517,9 @@
         <source>Cool!</source>
         <target>~Cool!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[__You need at least %s&percnt; of correct answers to get the information. Please try again.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5637,9 +5637,9 @@
         <source>Percent</source>
         <target>~Prozent</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[__&percnt; right to see the feedback]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5757,9 +5757,9 @@
         <source>Allow errors in typed words</source>
         <target>~Fehler bei eingegebenen Wörtern zulassen</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[__Incorrect letters allowed (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9469,9 +9469,9 @@
         <source>Representation</source>
         <target>~Darstellung</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
-        <target><![CDATA[__Action & Expression]]></target>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>
@@ -12109,9 +12109,9 @@
         <source>Line highlight</source>
         <target>~Zeilenhervorhebung</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
-        <target><![CDATA[~Sie müssen %s&percnt; des Inhalts der Aktivität überprüfen, bevor Sie den Fragebogen ausfüllen.]]></target>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
+        <target>~Sie müssen %s% des Inhalts der Aktivität überprüfen, bevor Sie den Fragebogen ausfüllen.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -5519,7 +5519,7 @@
       </trans-unit>
       <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
         <source>You need at least %s% of correct answers to get the information. Please try again.</source>
-        <target></target>
+        <target>~Sie benötigen mindestens %s% richtige Antworten, um die Information zu erhalten. Bitte versuchen Sie es erneut.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5639,7 +5639,7 @@
       </trans-unit>
       <trans-unit id="I4MH_aK" resname="% right to see the feedback">
         <source>% right to see the feedback</source>
-        <target></target>
+        <target>~% richtig, um das Feedback zu sehen</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5759,7 +5759,7 @@
       </trans-unit>
       <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
         <source>Incorrect letters allowed (%)</source>
-        <target></target>
+        <target>~Erlaubte Fehler (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9471,7 +9471,7 @@
       </trans-unit>
       <trans-unit id="o84Jjwl" resname="Action & Expression">
         <source>Action & Expression</source>
-        <target></target>
+        <target>~Aktion &amp; Ausdruck</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -8793,14 +8793,6 @@
         <source>Apply</source>
         <target>~Anwenden  </target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>~Fülle die Tabelle aus, um eine Bewertungsrichtlinie zu definieren. Lege die Punktzahl oder den Wert für jede Beschreibung fest.  </target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>~Lerne, wie man eine Bewertungsrichtlinie anwendet  </target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>~Beispiel für eine Bewertungsrichtlinie  </target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="b5nu2qa" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>~Importieren (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="1hinbxp" resname="Download as">
-        <source>Download as</source>
-        <target>~Herunterladen als</target>
       </trans-unit>
       <trans-unit id="0ejnebe" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>~Importierte Rubrik</target>
       </trans-unit>
+      <trans-unit id="iym58kc" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Bitte vervollständigen Sie die Rubrik, bevor Sie Ihre Punktzahl speichern.</target>
+      </trans-unit>
+      <trans-unit id="eo0qyx7" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~Ihre Punktzahl wird nach jeder Änderung gespeichert. Sie können nur einmal abschließen.</target>
+      </trans-unit>
+      <trans-unit id="zc6ug0f" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~Ihre Punktzahl wird nach jeder Änderung automatisch gespeichert.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="ekboded" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kty2woh" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fdgncjm" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -8793,14 +8793,6 @@
         <source>Apply</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target></target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target></target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target></target>
@@ -14072,10 +14064,6 @@
       <trans-unit id="x5zcfcz" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Import (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="hhaxeze" resname="Download as">
-        <source>Download as</source>
-        <target>Download as</target>
       </trans-unit>
       <trans-unit id="sd586e9" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -5517,9 +5517,9 @@
         <source>Cool!</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[__You need at least %s&percnt; of correct answers to get the information. Please try again.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5637,9 +5637,9 @@
         <source>Percent</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[__&percnt; right to see the feedback]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5757,9 +5757,9 @@
         <source>Allow errors in typed words</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[__Incorrect letters allowed (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9469,9 +9469,9 @@
         <source>Representation</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
-        <target><![CDATA[__Action & Expression]]></target>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>
@@ -12109,8 +12109,8 @@
         <source>Line highlight</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target></target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>~Apliki</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>~Plenigu la tabelon por difini taksogvidilon. Difinu la poentaron aŭ valoron de ĉiu priskribo.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>~Lerni kiel apliki rubricon</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>~Ekzempla rubrico</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="rkgc8z4" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>~Importi (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="5qzib1r" resname="Download as">
-        <source>Download as</source>
-        <target>~Elŝuti kiel</target>
       </trans-unit>
       <trans-unit id="5eaeiph" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -5515,7 +5515,7 @@
       </trans-unit>
       <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
         <source>You need at least %s% of correct answers to get the information. Please try again.</source>
-        <target></target>
+        <target>~Vi bezonas almenaŭ %s% da ĝustaj respondoj por ricevi la informon. Bonvolu provi denove.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5635,7 +5635,7 @@
       </trans-unit>
       <trans-unit id="I4MH_aK" resname="% right to see the feedback">
         <source>% right to see the feedback</source>
-        <target></target>
+        <target>~% ĝuste por vidi la retrosciigon</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5755,7 +5755,7 @@
       </trans-unit>
       <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
         <source>Incorrect letters allowed (%)</source>
-        <target></target>
+        <target>~Permesitaj malĝustaj literoj (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9467,7 +9467,7 @@
       </trans-unit>
       <trans-unit id="o84Jjwl" resname="Action & Expression">
         <source>Action & Expression</source>
-        <target></target>
+        <target>~Ago &amp; Esprimo</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>
@@ -12107,7 +12107,7 @@
       </trans-unit>
       <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
         <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
-        <target></target>
+        <target>~Vi devas trarigardi %s% de la enhavoj de la agado antaŭ ol kompletigi la demandaron.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -5513,9 +5513,9 @@
         <source>Cool!</source>
         <target>~Bone!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[__You need at least %s&amp;percnt;  of correct answers to get the information. Please try again.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5633,9 +5633,9 @@
         <source>Percent</source>
         <target>~Procento</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[__&percnt; right to see the feedback]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5753,9 +5753,9 @@
         <source>Allow errors in typed words</source>
         <target>~Permesi erarojn en tajpitaj vortoj</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[__Incorrect letters allowed (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9465,9 +9465,9 @@
         <source>Representation</source>
         <target>~Reprezentado</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
-        <target><![CDATA[__Action & Expression]]></target>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>
@@ -12105,9 +12105,9 @@
         <source>Line highlight</source>
         <target>~Linia emfazado</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
-        <target><![CDATA[__You must review %s&percnt; of the contents of the activity before completing the questionnaire.]]></target>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>~Importita rubrik</target>
       </trans-unit>
+      <trans-unit id="tar0eks" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Bonvolu kompletigi la rubron antaŭ konservi vian poentaron.</target>
+      </trans-unit>
+      <trans-unit id="lly5w0h" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~Via poentaro estos konservita post ĉiu ŝanĝo. Vi povas kompletigi nur unufoje.</target>
+      </trans-unit>
+      <trans-unit id="21qeoch" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~Via poentaro estos aŭtomate konservita post ĉiu ŝanĝo.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -5517,9 +5517,9 @@
         <source>Cool!</source>
         <target>¡Bien!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[Necesitas al menos %s&percnt; de respuestas correctas para obtener la información. Inténtalo de nuevo.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target>Necesitas al menos %s% de respuestas correctas para obtener la información. Inténtalo de nuevo.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5637,9 +5637,9 @@
         <source>Percent</source>
         <target>Porcentaje</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[&percnt; de aciertos requerido para ver la retroalimentación]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target>% de aciertos requerido para ver la retroalimentación</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5757,9 +5757,9 @@
         <source>Allow errors in typed words</source>
         <target>Permitir errores en los palabras introducidas</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[Letras incorrectas permitidas (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target>Letras incorrectas permitidas (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9469,8 +9469,8 @@
         <source>Representation</source>
         <target>Comprensión</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target>Acción y expresión</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12109,9 +12109,9 @@
         <source>Line highlight</source>
         <target>Resaltado de línea</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
-        <target><![CDATA[Debes revisar el %s&percnt; de los contenidos de la actividad antes de completar el cuestionario.]]></target>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
+        <target>Debes revisar el %s% de los contenidos de la actividad antes de completar el cuestionario.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>Rúbrica importada</target>
       </trans-unit>
+      <trans-unit id="o0z9l2g" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>Completa la rúbrica antes de guardar tu puntuación.</target>
+      </trans-unit>
+      <trans-unit id="4f8wq8r" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>Tu puntuación se guardará después de cada cambio. Solo puedes completarla una vez.</target>
+      </trans-unit>
+      <trans-unit id="mgwpyfz" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>Tu puntuación se guardará automáticamente después de cada cambio.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -8793,14 +8793,6 @@
         <source>Apply</source>
         <target>Aplicar</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Complete la tabla para definir una guía de calificación. Defina la puntuación o el valor de cada descriptor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Aprenda a aplicar una rúbrica</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Rúbrica de ejemplo</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="d7ujg5l" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Importar (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="cu0ajzl" resname="Download as">
-        <source>Download as</source>
-        <target>Descargar como</target>
       </trans-unit>
       <trans-unit id="f8dtp2c" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -12107,7 +12107,7 @@
       </trans-unit>
       <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
         <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
-        <target></target>
+        <target>~Galdetegia osatu aurretik jardueraren edukien %s% berrikusi behar duzu.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -12310,7 +12310,7 @@
         <target>Orrialdea ez da aurkitu</target>
       </trans-unit>
       <trans-unit id="22ovvv5" resname="Server error">
-        <source>Server error</source>d
+        <source>Server error</source>
         <target>Errorea zerbitzarian</target>
       </trans-unit>
       <trans-unit id="mwsy5zj" resname="Sorry, but the page cannot be displayed.">
@@ -12503,7 +12503,7 @@
       </trans-unit>
       <trans-unit id="vpiyoit" resname="Original">
         <source>Original</source>
-        <target>Jatorrikoa</target>Estimated
+        <target>Jatorrikoa</target>
       </trans-unit>
       <trans-unit id="z3su8em" resname="Estimated">
         <source>Estimated</source>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>Inportatutako errubrika</target>
       </trans-unit>
+      <trans-unit id="qlacqik" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Mesedez, osatu errubrika zure puntuazioa gorde aurretik.</target>
+      </trans-unit>
+      <trans-unit id="vi46ol5" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~Zure puntuazioa aldaketa bakoitzaren ondoren gordeko da. Behin bakarrik osa dezakezu.</target>
+      </trans-unit>
+      <trans-unit id="x1iyh3o" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~Zure puntuazioa automatikoki gordeko da aldaketa bakoitzaren ondoren.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>Aplikatu</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Osatu taula puntuazio gida definitzeko. Definitu deskribatzaile bakoitzaren puntuazioa edo balioa.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Ikasi nola aplikatu behar den errubrika bat</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Adibide moduko errubrika</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="h69zf3b" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Inportatu (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="qbsekk0" resname="Download as">
-        <source>Download as</source>
-        <target>Deskargatu honela</target>
       </trans-unit>
       <trans-unit id="y28ca74" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -5513,9 +5513,9 @@
         <source>Cool!</source>
         <target>Primeran!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[Gutxienez %s&percnt; erantzun zuzena eman behar duzu informazioa lortzeko. Saiatu berriro.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target>Gutxienez %s% erantzun zuzena eman behar duzu informazioa lortzeko. Saiatu berriro.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5633,9 +5633,9 @@
         <source>Percent</source>
         <target>Ehunekoa</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[&percnt; prest iruzkinak ikusteko]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target>% prest iruzkinak ikusteko</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5753,9 +5753,9 @@
         <source>Allow errors in typed words</source>
         <target>Onartu erroreak sartutako hitzetan</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[Letra okerrak onartzen dira (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target>Letra okerrak onartzen dira (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9465,8 +9465,8 @@
         <source>Representation</source>
         <target>Ulermena</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target><![CDATA[Ekintza & Adierazpena]]></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12105,8 +12105,8 @@
         <source>Line highlight</source>
         <target>Lerroa nabarmentzea</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target></target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>Aplicar</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Completa a táboa para definir unha guía de cualificación. Define a puntuación ou o valor de cada descritor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Aprende a aplicar unha rúbrica</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Rúbrica de exemplo</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="m5lpk8q" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Importar (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="qxz5fma" resname="Download as">
-        <source>Download as</source>
-        <target>Descargar como</target>
       </trans-unit>
       <trans-unit id="qcip520" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>Rúbrica importada</target>
       </trans-unit>
+      <trans-unit id="3mpguf8" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Por favor, completa a rúbrica antes de gardar a túa puntuación.</target>
+      </trans-unit>
+      <trans-unit id="v0mb6tf" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~A túa puntuación gardarase despois de cada cambio. Só podes completala unha vez.</target>
+      </trans-unit>
+      <trans-unit id="tavri14" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~A túa puntuación gardarase automaticamente despois de cada cambio.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -5513,8 +5513,8 @@
         <source>Cool!</source>
         <target>Xenial!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
         <target>Precisas polo menos %s&amp;percnt; de respostas correctas para obter a información. Téntao de novo.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
@@ -5633,8 +5633,8 @@
         <source>Percent</source>
         <target>Porcentaxe</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
         <target>&amp;percnt; de acertos requiridos para ver a retroalimentación</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
@@ -5753,8 +5753,8 @@
         <source>Allow errors in typed words</source>
         <target>Permitir erros nas palabras introducidas</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
         <target>Permítense letras incorrectas (&amp;percnt;)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
@@ -9465,8 +9465,8 @@
         <source>Representation</source>
         <target>Representación</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target>Acción e expresión</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12105,8 +12105,8 @@
         <source>Line highlight</source>
         <target>Resaltado de liñas</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target>Debes revisar %s&amp;percnt; dos contidos da actividade antes de completar o cuestionario.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -8793,14 +8793,6 @@
         <source>Apply</source>
         <target>Applica</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Completa la tabella per definire una guida al punteggio. Definisci il punteggio o il valore di ogni descriptor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Scopri come applicare una griglia di valutazione</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Esempio di griglia</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="9remzoe" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Importa (.elpx...)</target>
-      </trans-unit>
-      <trans-unit id="1upcsut" resname="Download as">
-        <source>Download as</source>
-        <target>Scarica come</target>
       </trans-unit>
       <trans-unit id="09pe22y" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -5517,8 +5517,8 @@
         <source>Cool!</source>
         <target>Fantastico!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
         <target>Hai bisogno di almeno una percentuale di risposte corrette per ottenere le informazioni. riprova.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
@@ -5637,8 +5637,8 @@
         <source>Percent</source>
         <target>Percentuale</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
         <target>&amp;percnt; di risposte corrette per vedere il feedback</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
@@ -5757,8 +5757,8 @@
         <source>Allow errors in typed words</source>
         <target>Consenti errori nelle parole digitate</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
         <target>Lettere errate consentite (&amp;percnt;)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
@@ -9469,8 +9469,8 @@
         <source>Representation</source>
         <target>Rappresentazione</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target>Azione ed espressione</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12109,8 +12109,8 @@
         <source>Line highlight</source>
         <target>Evidenziazione riga</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target>Devi rivedere il %s&amp;percnt; dei contenuti dell'attività prima di completare il questionario.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>Griglia importata</target>
       </trans-unit>
+      <trans-unit id="yth6crp" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Si prega di completare la griglia prima di salvare il punteggio.</target>
+      </trans-unit>
+      <trans-unit id="widz42p" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~Il tuo punteggio verrà salvato dopo ogni modifica. Puoi completarla solo una volta.</target>
+      </trans-unit>
+      <trans-unit id="fzx8qmc" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~Il tuo punteggio verrà salvato automaticamente dopo ogni modifica.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>~Rubrica importada</target>
       </trans-unit>
+      <trans-unit id="5amz64b" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Por favor, complete a rubrica antes de guardar a sua pontuação.</target>
+      </trans-unit>
+      <trans-unit id="0xf9995" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~A sua pontuação será guardada após cada alteração. Só pode completar uma vez.</target>
+      </trans-unit>
+      <trans-unit id="dxxydz8" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~A sua pontuação será guardada automaticamente após cada alteração.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -5515,7 +5515,7 @@
       </trans-unit>
       <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
         <source>You need at least %s% of correct answers to get the information. Please try again.</source>
-        <target></target>
+        <target>~Você precisa de pelo menos %s% de respostas corretas para obter a informação. Por favor, tente novamente.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5635,7 +5635,7 @@
       </trans-unit>
       <trans-unit id="I4MH_aK" resname="% right to see the feedback">
         <source>% right to see the feedback</source>
-        <target></target>
+        <target>~% correto para ver o feedback</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5755,7 +5755,7 @@
       </trans-unit>
       <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
         <source>Incorrect letters allowed (%)</source>
-        <target></target>
+        <target>~Letras incorretas permitidas (%)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9467,7 +9467,7 @@
       </trans-unit>
       <trans-unit id="o84Jjwl" resname="Action & Expression">
         <source>Action & Expression</source>
-        <target></target>
+        <target>~Ação &amp; Expressão</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -5513,9 +5513,9 @@
         <source>Cool!</source>
         <target>~Legal!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
-        <target><![CDATA[__You need at least %s&percnt; of correct answers to get the information. Please try again.]]></target>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>
@@ -5633,9 +5633,9 @@
         <source>Percent</source>
         <target>~Porcentagem</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[__&percnt; right to see the feedback]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5753,9 +5753,9 @@
         <source>Allow errors in typed words</source>
         <target>~Permitir erros em palavras digitadas  </target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[__Incorrect letters allowed (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9465,9 +9465,9 @@
         <source>Representation</source>
         <target>~Representação</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
-        <target><![CDATA[__Action & Expression]]></target>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
         <source>Presentation</source>
@@ -12105,9 +12105,9 @@
         <source>Line highlight</source>
         <target>~Destaque da linha</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
-        <target><![CDATA[~Você deve revisar %s&percnt; do conteúdo da atividade antes de concluir o questionário.]]></target>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
+        <target>~Você deve revisar %s% do conteúdo da atividade antes de concluir o questionário.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">
         <source>Error while uploading the file.</source>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>~Aplicar  </target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>~Preencha a tabela para definir um guia de pontuação. Defina a pontuação ou valor de cada descritor.  </target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>~Aprenda como aplicar uma rubrica  </target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>~Exemplo de rubrica  </target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="2vn2ncy" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>~Importar (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="jvpmbxv" resname="Download as">
-        <source>Download as</source>
-        <target>~Descarregar como</target>
       </trans-unit>
       <trans-unit id="qmaj9kb" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>Aplică</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Completează tabelul pentru a defini un ghid de punctaj. Definește scorul sau valoarea fiecărui descriptor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Află cum să aplici un barem</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Exemplu de barem</target>
@@ -14084,10 +14076,6 @@
       <trans-unit id="flvvvyd" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Importă (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="8406fy0" resname="Download as">
-        <source>Download as</source>
-        <target>Descarcă ca</target>
       </trans-unit>
       <trans-unit id="bxvsxea" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -12613,7 +12613,7 @@
         <source>Delete "%1"?</source>
         <target>Ștergi "%1"?</target>
       </trans-unit>
-      <trans-unit id="pitu10s" resname="Invalid filename. Avoid special characters like / \\ : * ? &quot; &lt; > |">
+      <trans-unit id="pitu10s" resname="Invalid filename. Avoid special characters like / \\ : * ? &quot; &lt; &gt; |">
         <source>Invalid filename. Avoid special characters like / \\ : * ? " &lt; &gt; |</source>
         <target>Numele fișierului nu este valid. Evită caracterele speciale precum / \\ : * ? " &lt; &gt; |</target>
       </trans-unit>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -14237,6 +14237,18 @@
         <source>Imported rubric</source>
         <target>Rubrică importată</target>
       </trans-unit>
+      <trans-unit id="d379fgz" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Vă rugăm să completați rubrica înainte de a salva scorul.</target>
+      </trans-unit>
+      <trans-unit id="9pohxm9" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~Scorul dvs. va fi salvat după fiecare modificare. Puteți completa o singură dată.</target>
+      </trans-unit>
+      <trans-unit id="7z9sd7x" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~Scorul dvs. va fi salvat automat după fiecare modificare.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -5513,8 +5513,8 @@
         <source>Cool!</source>
         <target>Super!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
         <target>Ai nevoie de măcar %s&amp;percnt; răspunsuri corecte pentru a primi informația. Te rog să încerci din nou.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
@@ -5633,8 +5633,8 @@
         <source>Percent</source>
         <target>Procentaj</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
         <target>&amp;percnt; drept de a vedea feedback-ul</target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
@@ -5753,8 +5753,8 @@
         <source>Allow errors in typed words</source>
         <target>Permite erori în cuvintele tastate</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
         <target>Litere incorecte permise (&amp;percnt;)</target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
@@ -9465,8 +9465,8 @@
         <source>Representation</source>
         <target>Reprezentare</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target>Acțiune și expresie</target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12105,8 +12105,8 @@
         <source>Line highlight</source>
         <target>Evidențiere linie</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target>Trebuie să revizuiți %s&amp;percnt; din conținutul activității înainte de a completa chestionarul.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -13505,67 +13505,54 @@
         <source>Generating ELPX file...</source>
         <target>S’està generant el fitxer ELPX...</target>
       </trans-unit>
-
       <trans-unit id="jd7qzd0" resname="File generated and downloaded.">
         <source>File generated and downloaded.</source>
         <target>El fitxer s’ha generat i descarregat.</target>
       </trans-unit>
-
       <trans-unit id="8e7gh3x" resname="Error generating ELPX file.">
         <source>Error generating ELPX file.</source>
         <target>Error en generar el fitxer ELPX.</target>
       </trans-unit>
-
       <trans-unit id="h24yuzm" resname="Saving document...">
         <source>Saving document...</source>
         <target>Guardant el document...</target>
       </trans-unit>
-
       <trans-unit id="n3t58u0" resname="Saving...">
         <source>Saving...</source>
         <target>Guardant...</target>
       </trans-unit>
-
       <trans-unit id="vqfqjdb" resname="Offline Mode">
         <source>Offline Mode</source>
         <target>Mode fora de línia</target>
       </trans-unit>
-
       <trans-unit id="g1l6o52" resname="Your project is automatically saved in your browser. Use File &gt; Export to download a copy.">
         <source>Your project is automatically saved in your browser. Use File &gt; Export to download a copy.</source>
         <target>El teu projecte es guarda automàticament en el navegador. Utilitza Fitxer &gt; Exportar per a descarregar-ne una còpia.</target>
       </trans-unit>
-
       <trans-unit id="njspmuf" resname="Cannot save project to server because your storage quota has been exceeded. You can download the project locally.">
         <source>Cannot save project to server because your storage quota has been exceeded. You can download the project locally.</source>
         <target>No s’ha pogut guardar el projecte al servidor perquè has superat la quota d’emmagatzematge. Pots descarregar el projecte localment.</target>
       </trans-unit>
-
       <trans-unit id="62nlxne" resname="Quota exceeded">
         <source>Quota exceeded</source>
         <target>Quota superada</target>
       </trans-unit>
-
       <trans-unit id="i5knvk6" resname="Project saved successfully">
         <source>Project saved successfully</source>
         <target>El projecte s’ha guardat correctament</target>
       </trans-unit>
-
       <trans-unit id="qm5mq65" resname="Failed to save project">
         <source>Failed to save project</source>
         <target>No s’ha pogut guardar el projecte</target>
       </trans-unit>
-
       <trans-unit id="4pl6f30" resname="Project saved">
         <source>Project saved</source>
         <target>Projecte guardat</target>
       </trans-unit>
-
       <trans-unit id="kvcsk7s" resname="Failed to import style">
         <source>Failed to import style</source>
         <target>No s’ha pogut importar l’estil</target>
       </trans-unit>
-
       <trans-unit id="37wjnam" resname="Legacy license, please review">
         <source>Legacy license, please review</source>
         <target>Llicència heretada, revisa-la</target>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -5515,7 +5515,7 @@
       </trans-unit>
       <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
         <source>You need at least %s% of correct answers to get the information. Please try again.</source>
-        <target></target>
+        <target>~Necessiteu almenys un %s% de respostes correctes per obtenir la informació. Torneu-ho a intentar.</target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
         <source>Time is up. Please try again</source>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -8789,14 +8789,6 @@
         <source>Apply</source>
         <target>Aplicar</target>
       </trans-unit>
-      <trans-unit id="Zlk8BL5" resname="Complete the table to define a scoring guide. Define the score or value of each descriptor.">
-        <source>Complete the table to define a scoring guide. Define the score or value of each descriptor.</source>
-        <target>Completeu la taula per a definir una guia de qualificació. Definiu la puntuació o el valor de cada descriptor.</target>
-      </trans-unit>
-      <trans-unit id="pILraKV" resname="Learn how to apply a rubric">
-        <source>Learn how to apply a rubric</source>
-        <target>Aprenga a aplicar una rúbrica</target>
-      </trans-unit>
       <trans-unit id="2niDz93" resname="Example rubric">
         <source>Example rubric</source>
         <target>Rúbrica d'exemple</target>
@@ -14097,10 +14089,6 @@
       <trans-unit id="6ar3yqh" resname="Import (.elpx…)">
         <source>Import (.elpx…)</source>
         <target>Importar (.elpx…)</target>
-      </trans-unit>
-      <trans-unit id="nzmi95w" resname="Download as">
-        <source>Download as</source>
-        <target>Descarregar com</target>
       </trans-unit>
       <trans-unit id="xfnhb6m" resname="0 iDevices">
         <source>0 iDevices</source>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -5513,8 +5513,8 @@
         <source>Cool!</source>
         <target>Genial!</target>
       </trans-unit>
-      <trans-unit id="3EmhqPa" resname="You need at least %s&amp;percnt; of correct answers to get the information. Please try again.">
-        <source>You need at least %s&amp;percnt; of correct answers to get the information. Please try again.</source>
+      <trans-unit id="3EmhqPa" resname="You need at least %s% of correct answers to get the information. Please try again.">
+        <source>You need at least %s% of correct answers to get the information. Please try again.</source>
         <target></target>
       </trans-unit>
       <trans-unit id="p_aCAey" resname="Time is up. Please try again">
@@ -5633,9 +5633,9 @@
         <source>Percent</source>
         <target>Percentatge</target>
       </trans-unit>
-      <trans-unit id="I4MH_aK" resname="&amp;percnt; right to see the feedback">
-        <source>&amp;percnt; right to see the feedback</source>
-        <target><![CDATA[&percnt; veure els comentaris]]></target>
+      <trans-unit id="I4MH_aK" resname="% right to see the feedback">
+        <source>% right to see the feedback</source>
+        <target><![CDATA[% veure els comentaris]]></target>
       </trans-unit>
       <trans-unit id="a_DSSKc" resname="Image back">
         <source>Image back</source>
@@ -5753,9 +5753,9 @@
         <source>Allow errors in typed words</source>
         <target>Permetre errors a les paraules introduïdes</target>
       </trans-unit>
-      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (&amp;percnt;)">
-        <source>Incorrect letters allowed (&amp;percnt;)</source>
-        <target><![CDATA[Es permeten lletres incorrectes (&percnt;)]]></target>
+      <trans-unit id="jhOcP6n" resname="Incorrect letters allowed (%)">
+        <source>Incorrect letters allowed (%)</source>
+        <target><![CDATA[Es permeten lletres incorrectes (%)]]></target>
       </trans-unit>
       <trans-unit id="XV5EOaM" resname="Field width proportional to the words length">
         <source>Field width proportional to the words length</source>
@@ -9465,8 +9465,8 @@
         <source>Representation</source>
         <target>Comprensió</target>
       </trans-unit>
-      <trans-unit id="o84Jjwl" resname="Action &amp; Expression">
-        <source>Action &amp; Expression</source>
+      <trans-unit id="o84Jjwl" resname="Action & Expression">
+        <source>Action & Expression</source>
         <target><![CDATA[Acció & Expressió]]></target>
       </trans-unit>
       <trans-unit id="t.hHQcC" resname="Presentation">
@@ -12105,8 +12105,8 @@
         <source>Line highlight</source>
         <target>Línia destacada</target>
       </trans-unit>
-      <trans-unit id="cIfYpvB" resname="You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.">
-        <source>You must review %s&amp;percnt; of the contents of the activity before completing the questionnaire.</source>
+      <trans-unit id="cIfYpvB" resname="You must review %s% of the contents of the activity before completing the questionnaire.">
+        <source>You must review %s% of the contents of the activity before completing the questionnaire.</source>
         <target>Heu de revisar %s&amp;percnt; del contingut de l'activitat abans de completar el qüestionari.</target>
       </trans-unit>
       <trans-unit id="BeLvQEU" resname="Error while uploading the file.">

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -14250,6 +14250,18 @@
         <source>Imported rubric</source>
         <target>Rúbrica importada</target>
       </trans-unit>
+      <trans-unit id="wxeh20s" resname="Please complete the rubric before saving your score.">
+        <source>Please complete the rubric before saving your score.</source>
+        <target>~Si us plau, completeu la rúbrica abans de guardar la vostra puntuació.</target>
+      </trans-unit>
+      <trans-unit id="f3mm7iu" resname="Your score will be saved after each change. You can only complete once.">
+        <source>Your score will be saved after each change. You can only complete once.</source>
+        <target>~La vostra puntuació es guardarà després de cada canvi. Sols podeu completar-la una vegada.</target>
+      </trans-unit>
+      <trans-unit id="1jpalng" resname="Your score will be automatically saved after each change.">
+        <source>Your score will be automatically saved after each change.</source>
+        <target>~La vostra puntuació es guardarà automàticament després de cada canvi.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This PR introduces sensitive changes and needs manual testing.

@mnarvaezm: please verify that your iDevices work correctly and properly recognize the updated strings.

The change consists of replacing `&percnt;` with `%` in all strings. Example: `% right to see the feedback` instead of `&percnt; right to see the feedback`.

Those strings should display correctly and in the appropriate language, both in the application (`_` and `c_`) and exported contents.

Could you please test it?

The change is important because this type of strings was not being translated, and it can also be a problem for contributors, as it complicates the translation process.

Thanks.