### PR TITLE
fix(export): write actual eXeLearning version into content.xml (#1731)

### DIFF
--- a/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
@@ -193,6 +193,44 @@ describe('YjsDocumentAdapter', () => {
             expect(metadata.theme).toBe('base');
         });
 
+        it('should fall back to APP_VERSION env var when neither yjs field nor window are set', () => {
+            const originalAppVersion = process.env.APP_VERSION;
+            process.env.APP_VERSION = 'v9.9.9-test';
+            try {
+                manager = new MockYjsDocumentManager({});
+                adapter = new YjsDocumentAdapter(manager as any);
+
+                const metadata = adapter.getMetadata();
+
+                expect(metadata.exelearningVersion).toBe('v9.9.9-test');
+            } finally {
+                if (originalAppVersion === undefined) {
+                    delete process.env.APP_VERSION;
+                } else {
+                    process.env.APP_VERSION = originalAppVersion;
+                }
+            }
+        });
+
+        it('should prefer the yjs exelearning_version field over APP_VERSION', () => {
+            const originalAppVersion = process.env.APP_VERSION;
+            process.env.APP_VERSION = 'v9.9.9-test';
+            try {
+                manager = new MockYjsDocumentManager({ exelearning_version: '4.1.0' });
+                adapter = new YjsDocumentAdapter(manager as any);
+
+                const metadata = adapter.getMetadata();
+
+                expect(metadata.exelearningVersion).toBe('4.1.0');
+            } finally {
+                if (originalAppVersion === undefined) {
+                    delete process.env.APP_VERSION;
+                } else {
+                    process.env.APP_VERSION = originalAppVersion;
+                }
+            }
+        });
+
         it('should include custom styles when present', () => {
             manager = new MockYjsDocumentManager({
                 customStyles: '.custom { color: red; }',

--- a/src/shared/export/adapters/YjsDocumentAdapter.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.ts
@@ -94,7 +94,8 @@ export class YjsDocumentAdapter implements ExportDocument {
             theme: (meta.get('theme') as string) || 'base',
             exelearningVersion:
                 (meta.get('exelearning_version') as string) ||
-                (typeof window !== 'undefined' ? window.eXeLearning?.version : undefined),
+                (typeof window !== 'undefined' ? window.eXeLearning?.version : undefined) ||
+                (typeof process !== 'undefined' ? process.env?.APP_VERSION : undefined),
             createdAt: (meta.get('createdAt') as string) || new Date().toISOString(),
             modified: (meta.get('modifiedAt') as string) || new Date().toISOString(),
             // Custom styles support

--- a/src/shared/export/constants.ts
+++ b/src/shared/export/constants.ts
@@ -995,11 +995,6 @@ export function normalizeIdeviceType(typeName: string): string {
 export const ODE_DTD_FILENAME = 'content.dtd';
 
 /**
- * ODE format version (exported in content.xml odeResources section as exe_version)
- */
-export const ODE_VERSION = '3.0';
-
-/**
  * ODE Content DTD
  * Embedded DTD for exports that include content.xml - validates content.xml structure
  */

--- a/src/shared/export/generators/OdeXmlGenerator.spec.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.spec.ts
@@ -3,7 +3,14 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { generateOdeXml, generateOdeId, escapeXml, escapeCdata, transformAssetUrlsForXml } from './OdeXmlGenerator';
+import {
+    generateOdeXml,
+    generateOdeId,
+    escapeXml,
+    escapeCdata,
+    transformAssetUrlsForXml,
+    normalizeExeVersion,
+} from './OdeXmlGenerator';
 import type { ExportMetadata, ExportPage } from '../interfaces';
 
 describe('OdeXmlGenerator', () => {
@@ -53,6 +60,41 @@ describe('OdeXmlGenerator', () => {
             expect(xml).toContain('<key>odeVersionId</key>');
             expect(xml).toContain('<key>exe_version</key>');
             expect(xml).toContain('</odeResources>');
+        });
+
+        it('should write exe_version from meta.exelearningVersion', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                exelearningVersion: '4.0.0',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            expect(xml).toMatch(/<key>exe_version<\/key>\s*<value>4\.0\.0<\/value>/);
+            expect(xml).not.toContain('<value>3.0</value>');
+        });
+
+        it('should strip the leading v prefix from exelearningVersion', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                exelearningVersion: 'v4.0.0-rc3',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            expect(xml).toMatch(/<key>exe_version<\/key>\s*<value>4\.0\.0-rc3<\/value>/);
+        });
+
+        it('should write empty exe_version when exelearningVersion is missing', () => {
+            const meta: ExportMetadata = { title: 'Test' };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            expect(xml).toMatch(/<key>exe_version<\/key>\s*<value><\/value>/);
+            expect(xml).not.toContain('<value>3.0</value>');
         });
 
         it('should include odeProperties section with metadata', () => {
@@ -423,6 +465,30 @@ describe('OdeXmlGenerator', () => {
             const id2 = generateOdeId();
 
             expect(id1).not.toBe(id2);
+        });
+    });
+
+    describe('normalizeExeVersion', () => {
+        it('should strip a leading v prefix', () => {
+            expect(normalizeExeVersion('v4.0.0')).toBe('4.0.0');
+        });
+
+        it('should leave bare versions unchanged', () => {
+            expect(normalizeExeVersion('4.0.0')).toBe('4.0.0');
+        });
+
+        it('should preserve pre-release suffixes', () => {
+            expect(normalizeExeVersion('v4.0.0-rc3')).toBe('4.0.0-rc3');
+        });
+
+        it('should trim surrounding whitespace', () => {
+            expect(normalizeExeVersion('  v3.1.0  ')).toBe('3.1.0');
+        });
+
+        it('should return empty string for null, undefined, or empty input', () => {
+            expect(normalizeExeVersion(null)).toBe('');
+            expect(normalizeExeVersion(undefined)).toBe('');
+            expect(normalizeExeVersion('')).toBe('');
         });
     });
 

--- a/src/shared/export/generators/OdeXmlGenerator.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.ts
@@ -18,7 +18,7 @@
  */
 
 import type { ExportMetadata, ExportPage, ExportBlock, ExportComponent } from '../interfaces';
-import { ODE_DTD_FILENAME, ODE_VERSION } from '../constants';
+import { ODE_DTD_FILENAME } from '../constants';
 import { isExcludedFromXml, getXmlKeyForProperty, valueToXmlString } from '../metadata-properties';
 
 /**
@@ -55,7 +55,7 @@ export function generateOdeXml(meta: ExportMetadata, pages: ExportPage[], option
     xml += generateUserPreferencesXml(meta);
 
     // ODE resources (version info, IDs)
-    xml += generateOdeResourcesXml(odeId, versionId);
+    xml += generateOdeResourcesXml(odeId, versionId, normalizeExeVersion(meta.exelearningVersion));
 
     // ODE properties (metadata)
     xml += generateOdePropertiesXml(meta);
@@ -94,13 +94,23 @@ function generateUserPreferenceEntry(key: string, value: string): string {
 /**
  * Generate ODE resources section (identifiers, version)
  */
-function generateOdeResourcesXml(odeId: string, versionId: string): string {
+function generateOdeResourcesXml(odeId: string, versionId: string, exeVersion: string): string {
     let xml = '<odeResources>\n';
     xml += generateOdeResourceEntry('odeId', odeId);
     xml += generateOdeResourceEntry('odeVersionId', versionId);
-    xml += generateOdeResourceEntry('exe_version', ODE_VERSION);
+    xml += generateOdeResourceEntry('exe_version', exeVersion);
     xml += '</odeResources>\n';
     return xml;
+}
+
+/**
+ * Normalize the eXeLearning version string for use in content.xml.
+ * Strips any leading 'v' so the value matches the historical bare-semver
+ * format (e.g. '4.0.0' rather than 'v4.0.0').
+ */
+export function normalizeExeVersion(version: string | undefined | null): string {
+    if (!version) return '';
+    return String(version).trim().replace(/^v/, '');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1731 — `exe_version` in `content.xml` was hardcoded to `3.0`.

`OdeXmlGenerator` now writes `meta.exelearningVersion` (stripped of any leading `v`) instead of the static `ODE_VERSION` constant. The metadata source already populated this from the Yjs `exelearning_version` field and `window.eXeLearning.version`, and now also falls back to `process.env.APP_VERSION` for server-side CLI/REST exports.

## Changes

- `OdeXmlGenerator.ts`: pass `meta.exelearningVersion` through `normalizeExeVersion()` into the `<odeResources>` `exe_version` entry.
- `YjsDocumentAdapter.ts`: add `process.env.APP_VERSION` fallback so server-side exports (CLI, REST) get a sensible value when the Yjs field is empty and there is no `window`.
- `constants.ts`: remove the unused `ODE_VERSION` constant.
- New unit tests cover `normalizeExeVersion`, the new `<value>...</value>` content, the empty-version case, the `v` prefix, and the `APP_VERSION` fallback.

## Test plan

- [x] `make fix` clean
- [x] `make test-unit` — 6883 backend tests pass, all files ≥90% coverage
- [x] `make test-frontend` — 11877 tests pass
- [x] Manually verified bundled `public/app/yjs/exporters.bundle.js` reflects the change and preserves the `typeof process` browser guard
- [ ] Manual repro per issue: create a new package, save it, open `content.xml` — `<value>` for `exe_version` should now match the running app version (no longer `3.0`)