### PR TITLE
fix(styles): hide single-tab styleslist when imports are blocked

### DIFF
--- a/public/app/workarea/menus/navbar/items/navbarStyles.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.js
@@ -62,6 +62,10 @@ export default class NavbarFile {
     /**
      * Hide the "Imported" tab and its pane, and force-activate the
      * "System" tab if the "Imported" one was the default in the HTML.
+     * Also hides the entire tablist <ul>: with imports blocked there is
+     * only one tab left ("System") and rendering a single-tab nav is
+     * visually pointless — the workarea.njk template already does this
+     * with `{% if config.userStyles == false %} d-none{% endif %}`.
      * @private
      */
     _hideImportedStylesTab() {
@@ -82,6 +86,10 @@ export default class NavbarFile {
         }
         if (systemPane && !systemPane.classList.contains('show')) {
             systemPane.classList.add('show', 'active');
+        }
+        const tablist = document.getElementById('styleslist');
+        if (tablist) {
+            tablist.classList.add('d-none');
         }
     }
 

--- a/public/app/workarea/menus/navbar/items/navbarStyles.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.test.js
@@ -1000,7 +1000,7 @@ describe('NavbarStyles', () => {
         // Minimal DOM scaffolding matching the bootstrap HTML structure.
         function scaffoldTabs() {
             document.body.innerHTML = `
-                <ul class="nav">
+                <ul class="nav nav-tabs" id="styleslist" role="tablist">
                     <li class="nav-item"><button id="exestylescontent-tab">System</button></li>
                     <li class="nav-item"><button id="importedstylescontent-tab" class="active">Imported</button></li>
                 </ul>
@@ -1049,6 +1049,19 @@ describe('NavbarStyles', () => {
             expect(systemTab.classList.contains('active')).toBe(true);
             const systemPane = document.getElementById('exestylescontent');
             expect(systemPane.classList.contains('show')).toBe(true);
+            const tablist = document.getElementById('styleslist');
+            expect(tablist.classList.contains('d-none')).toBe(true);
+        });
+
+        it('_hideImportedStylesTab tolerates a missing tablist <ul>', () => {
+            // Tab + pane present but no <ul id="styleslist"> wrapper.
+            document.body.innerHTML = `
+                <li class="nav-item"><button id="importedstylescontent-tab" class="active">Imported</button></li>
+                <div id="importedstylescontent" class="show active"></div>
+            `;
+            const ns = Object.create(NavbarStyles.prototype);
+            expect(() => ns._hideImportedStylesTab()).not.toThrow();
+            expect(document.getElementById('styleslist')).toBeNull();
         });
 
         it('_hideImportedStylesTab falls back to the tab element when no nav-item wrapper exists', () => {


### PR DESCRIPTION
## Summary

When the host integration blocks imported styles (`themeRegistryOverride.blockImportInstall` or the legacy `ONLINE_THEMES_INSTALL=false`), `_hideImportedStylesTab()` removes the "Imported" tab item but leaves the `<ul id="styleslist">` rendering a single "System" tab — visually pointless. The `workarea.njk` template already collapses it with `{% if config.userStyles == false %} d-none{% endif %}`, but the static-bundle entrypoint relies on the runtime path. Toggle `d-none` on the tablist there too so both paths agree.

## Changes

- `public/app/workarea/menus/navbar/items/navbarStyles.js`: add `d-none` to the `<ul id="styleslist">` inside `_hideImportedStylesTab()`.
- Tests: update tab scaffolding to include the `<ul>`, assert it picks up `d-none`, and cover the missing-tablist fallback.

## Test plan

- [x] `bun run lint:public` — clean
- [x] `npx vitest run public/app/workarea/menus/navbar/items/navbarStyles.test.js` — 52/52 pass
- [x] Patch coverage: both new branches in `_hideImportedStylesTab()` exercised