### PR TITLE
fix(import): Keep indentation inside <pre> tags when parsing legacy .elp files

### DIFF
--- a/src/shared/import/LegacyXmlParser.spec.ts
+++ b/src/shared/import/LegacyXmlParser.spec.ts
@@ -164,6 +164,13 @@ describe('LegacyXmlParser', () => {
             const result = parser.preprocessLegacyXml(input);
             expect(result).toContain('&#10;');
         });
+
+        it('should keep encoded pre content inside unicode value attribute', () => {
+            const input = 'x     <unicode value="before\t&lt;pre&gt;\tkeep     spacing&lt;/pre&gt;\tafter     end"/>';
+            const result = parser.preprocessLegacyXml(input);
+
+            expect(result).toBe('x<unicode value="before&lt;pre&gt;\tkeep     spacing&lt;/pre&gt;afterend"/>');
+        });
     });
 
     describe('parse', () => {

--- a/src/shared/import/LegacyXmlParser.ts
+++ b/src/shared/import/LegacyXmlParser.ts
@@ -349,8 +349,25 @@ export class LegacyXmlParser {
         let xml = xmlContent;
 
         // 1. Remove indentations (5 spaces, tabs)
+        const protectedPreBlocks: string[] = [];
+        const protectPreBlock = (match: string): string => {
+            const token = `__LEGACY_PRE_BLOCK_${protectedPreBlocks.length}__`;
+            protectedPreBlocks.push(match);
+            return token;
+        };
+        xml = xml.replace(/<unicode\b[^>]*>/gi, tag => {
+            return tag.replace(/\bvalue=(['"])([\s\S]*?)\1/i, (_match, quote, value) => {
+                const protectedValue = value.replace(/&lt;pre\b[\s\S]*?&lt;\/pre&gt;/gi, encodedPre => {
+                    return protectPreBlock(encodedPre);
+                });
+                return `value=${quote}${protectedValue}${quote}`;
+            });
+        });
         xml = xml.replace(/ {5}/g, '');
         xml = xml.replace(/\t/g, '');
+        xml = xml.replace(/__LEGACY_PRE_BLOCK_(\d+)__/g, (_match, index) => {
+            return protectedPreBlocks[Number(index)] || '';
+        });
 
         // 2. Unify newlines to Unix LF
         xml = xml.replace(/\r/g, '\n');


### PR DESCRIPTION
This PR skips preprocessing content inside ```<pre>``` blocks inside text areas when parsing legacy .elp files as the current implementation corrupts indentation.

The issue is rather visible when importing files that contain source code text.

# Why
```<pre>``` blocks should keep spacing and indentation as-is when displaying their content. Current legacy parsing takes the imported content and does this:
```js
xml = xml.replace(/ {5}/g, '');
xml = xml.replace(/\t/g, '');
```
The intent of those lines is to fix encoding issues from eXe 2.x exports. The problem is that these replacements affect everything, including the content inside ```<pre>``` blocks, so they unintendedly remove tabs and 5 spaces groups which should be kept.

# What changed
To fix the problem we introduce two changes:

1. Before applying those replacement rules, we replace those ```<pre>``` blocks encoded into the ```value``` attribute of the XML ```<unicode>``` tag into a marker ```__LEGACY_PRE_BLOCK_id__```, where ```id``` is a incrementing counter.
2. After applying the existing preprocessing, we undo the markers replacement by reinstating the original content.

# Before
<img width="1232" height="956" alt="image" src="https://github.com/user-attachments/assets/0190fd5f-c535-4dca-bbff-e3570dcbbc4e" />

# After
<img width="1188" height="912" alt="image" src="https://github.com/user-attachments/assets/54dfe1af-56ad-4f07-a5fa-32cdbfd50741" />

