### PR TITLE
fix(api): fix updateComponent call signature in route handler

### DIFF
--- a/src/routes/api/v1/components.spec.ts
+++ b/src/routes/api/v1/components.spec.ts
@@ -340,6 +340,41 @@ describe('Components API v1', () => {
             // Should return 404 or 400 when component not found
             expect([400, 404]).toContain(response.status);
         });
+
+        it('should call updateComponent with correct argument order (regression)', async () => {
+            // Regression test: updateComponent(ydoc, componentId, updates)
+            // Previously the route passed an object as second arg:
+            //   updateComponent(ydoc, { componentId, ... })
+            // which caused "Component [object Object] not found" errors.
+            await db
+                .insertInto('projects')
+                .values({
+                    uuid: 'regression-update-comp',
+                    title: 'Regression Test Project',
+                    owner_id: userId,
+                    created_at: now(),
+                })
+                .execute();
+
+            const response = await app.handle(
+                new Request('http://localhost/projects/regression-update-comp/components/some-comp-id', {
+                    method: 'PUT',
+                    headers: {
+                        Authorization: `Bearer ${userToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ title: 'Updated Title' }),
+                }),
+            );
+
+            // If the fix is correct, the endpoint should NOT return an error
+            // about "Component [object Object] not found".
+            // It should return 404 (component doesn't exist in Y.Doc) or 400,
+            // but NOT a 500 or a malformed error.
+            expect(response.status).not.toBe(500);
+            const body = (await response.json()) as { error?: { message?: string } };
+            expect(body.error?.message).not.toContain('[object Object]');
+        });
     });
 
     describe('PUT /projects/:uuid/components/:componentId/html', () => {

--- a/src/routes/api/v1/components.ts
+++ b/src/routes/api/v1/components.ts
@@ -26,7 +26,6 @@ import {
     UpdateComponentBody,
     SetHtmlBody,
     BlockIdParam,
-    PageBlockParam,
     ComponentIdParam,
     type AuthenticatedUser,
     type ApiErrorResponse,
@@ -91,7 +90,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
 
     // Create a new component in a block
     .post(
-        '/:uuid/pages/:pageId/blocks/:blockId/components',
+        '/:uuid/blocks/:blockId/components',
         async ({ headers, params, body, set }) => {
             const authResult = await authenticateRequest(headers);
             if (!authResult.success) {
@@ -108,7 +107,6 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
 
             const { result } = await withDocument(params.uuid, { source: 'rest-api', userId: auth.userId }, ydoc =>
                 createComponent(ydoc, {
-                    pageId: params.pageId,
                     blockId: params.blockId,
                     ideviceType: body.ideviceType,
                     initialData: body.initialData,
@@ -125,7 +123,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
             return successResponse(result.data);
         },
         {
-            params: PageBlockParam,
+            params: BlockIdParam,
             body: CreateComponentBody,
             detail: {
                 summary: 'Create Component',

--- a/src/routes/api/v1/components.ts
+++ b/src/routes/api/v1/components.ts
@@ -26,6 +26,7 @@ import {
     UpdateComponentBody,
     SetHtmlBody,
     BlockIdParam,
+    PageBlockParam,
     ComponentIdParam,
     type AuthenticatedUser,
     type ApiErrorResponse,
@@ -90,7 +91,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
 
     // Create a new component in a block
     .post(
-        '/:uuid/blocks/:blockId/components',
+        '/:uuid/pages/:pageId/blocks/:blockId/components',
         async ({ headers, params, body, set }) => {
             const authResult = await authenticateRequest(headers);
             if (!authResult.success) {
@@ -107,6 +108,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
 
             const { result } = await withDocument(params.uuid, { source: 'rest-api', userId: auth.userId }, ydoc =>
                 createComponent(ydoc, {
+                    pageId: params.pageId,
                     blockId: params.blockId,
                     ideviceType: body.ideviceType,
                     initialData: body.initialData,
@@ -123,7 +125,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
             return successResponse(result.data);
         },
         {
-            params: BlockIdParam,
+            params: PageBlockParam,
             body: CreateComponentBody,
             detail: {
                 summary: 'Create Component',
@@ -187,8 +189,7 @@ export const componentsRoutes = new Elysia({ prefix: '/projects' })
             }
 
             const { result } = await withDocument(params.uuid, { source: 'rest-api', userId: auth.userId }, ydoc =>
-                updateComponent(ydoc, {
-                    componentId: params.componentId,
+                updateComponent(ydoc, params.componentId, {
                     htmlContent: body.htmlContent,
                     htmlView: body.htmlView,
                     properties: body.properties,


### PR DESCRIPTION
## Summary

The `PUT /:uuid/components/:componentId` route handler was calling `updateComponent()` with the wrong argument structure, causing `"Component [object Object] not found"` errors on every component update attempt.

## Root Cause

The function signature is:
```typescript
updateComponent(ydoc: Y.Doc, componentId: string, updates: UpdateComponentInput): OperationResult
```

But the route was passing a single object as the second argument:
```typescript
updateComponent(ydoc, {
    componentId: params.componentId,
    htmlContent: body.htmlContent,
    // ...
})
```

## Fix

Extract `params.componentId` as the second argument and pass the remaining fields as the third argument:
```typescript
updateComponent(ydoc, params.componentId, {
    htmlContent: body.htmlContent,
    // ...
})
```

Note: `createComponent()` takes `(ydoc, input)` as a single input object, but `updateComponent()` takes `(ydoc, componentId, updates)` — different patterns in the same module.