### PR TITLE
fix(export): stop bundling each asset twice in saved/exported packages (#1769)

### DIFF
--- a/src/shared/export/exporters/BaseExporter.spec.ts
+++ b/src/shared/export/exporters/BaseExporter.spec.ts
@@ -1045,38 +1045,58 @@ describe('BaseExporter', () => {
             expect(trackingList).toContain('content/resources/track.css');
         });
 
-        // Regression coverage for exelearning/mod_exeweb#42 and exelearning/mod_exescorm#55:
-        // when an `asset://` reference in the rendered HTML cannot be resolved against the
-        // export path map, addFilenamesToAssetUrls falls back to a literal
-        // `content/resources/<id><ext>` URL. addAssetsToZipWithResourcePath must mirror that
-        // by writing each asset under its `<id><ext>` path too, so the URL resolves on
-        // downstream platforms (Moodle pluginfile.php) instead of returning 404.
-        it('should also write each asset under the <id><ext> fallback path', async () => {
+        // Regression coverage for exelearning/exelearning#1769 (hotfix/duplicate-assets):
+        // saving and exporting must NOT write each asset twice (once under the friendly
+        // filename and again under the literal `<assetId><ext>` UUID path). The earlier
+        // "defensive" fallback (PR #1740) did exactly that, leaving every saved .elpx and
+        // every .html5/.scorm/.ims/.epub3 export with duplicated `content/resources/`
+        // entries. The fix in this PR keeps a single, friendly entry per asset.
+        it('should not duplicate each asset under the <id><ext> UUID path', async () => {
             const forEachAssets = new MockAssetProviderWithForEach();
             forEachAssets.addAsset(
                 '12345678-1234-1234-1234-123456789012',
-                'photo.png',
+                'pie_pagina_FEDER_2027.png',
                 'image/png',
                 Buffer.from('png-data'),
+            );
+            forEachAssets.addAsset(
+                '49d44e76-3d6a-4b21-b911-41746ab60814',
+                'photo_2024-09-05_12-31-44.jpg',
+                'image/jpeg',
+                Buffer.from('jpg-data'),
             );
 
             const forEachZip = new MockZipProvider();
             const forEachDoc = new MockDocument({}, []);
             const forEachExporter = new TestExporter(forEachDoc, new MockResourceProvider(), forEachAssets, forEachZip);
 
-            await forEachExporter.addAssetsToZipWithResourcePath();
+            const trackingList: string[] = [];
+            const count = await forEachExporter.addAssetsToZipWithResourcePath(trackingList);
 
-            expect(forEachZip.files.has('content/resources/photo.png')).toBe(true);
-            expect(forEachZip.files.has('content/resources/12345678-1234-1234-1234-123456789012.png')).toBe(true);
+            // Each asset must be written exactly once, under its friendly path.
+            expect(count).toBe(2);
+            expect(forEachZip.files.size).toBe(2);
+            expect(forEachZip.files.has('content/resources/pie_pagina_FEDER_2027.png')).toBe(true);
+            expect(forEachZip.files.has('content/resources/photo_2024-09-05_12-31-44.jpg')).toBe(true);
+
+            // The UUID-named duplicates that PR #1740 used to write must NOT be present.
+            expect(forEachZip.files.has('content/resources/12345678-1234-1234-1234-123456789012.png')).toBe(false);
+            expect(forEachZip.files.has('content/resources/49d44e76-3d6a-4b21-b911-41746ab60814.jpg')).toBe(false);
+
+            // Tracking list (used by the ELPX manifest) must list each entry exactly once.
+            expect(trackingList).toEqual([
+                'content/resources/pie_pagina_FEDER_2027.png',
+                'content/resources/photo_2024-09-05_12-31-44.jpg',
+            ]);
         });
 
-        it('should not write the fallback when the resolved path is already <id><ext>', async () => {
-            // When the asset metadata does not yield a friendly filename, the resolved path
-            // already matches the fallback. Skip the duplicate write so we do not pollute
-            // the archive (or the ELPX manifest) with two pointers to the same path.
+        it('should write a single entry when an asset filename equals its UUID', async () => {
+            // Edge case: the asset metadata already yields a UUID-shaped filename. Before
+            // the fix this branch happened to write a single entry only because the
+            // resolved path matched the fallback path; the test still pins the invariant.
             const forEachAssets = new MockAssetProviderWithForEach();
             forEachAssets.addAsset(
-                'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png',
+                'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png',
                 'image/png',
                 Buffer.from('png'),
@@ -1089,13 +1109,15 @@ describe('BaseExporter', () => {
 
             await forEachExporter.addAssetsToZipWithResourcePath(trackingList);
 
-            const fallbackHits = trackingList.filter(
-                p => p === 'content/resources/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png',
-            );
-            expect(fallbackHits.length).toBe(1);
+            const hits = trackingList.filter(p => p === 'content/resources/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png');
+            expect(hits.length).toBe(1);
+            expect(forEachZip.files.size).toBe(1);
         });
 
-        it('should derive the fallback extension from the mime when filename is missing', async () => {
+        it('should not write a UUID-named copy when the filename is missing', async () => {
+            // Even when only the MIME type is available to derive the export filename,
+            // the export must still produce a single `content/resources/<derived>` entry
+            // and never the UUID-suffixed duplicate.
             const forEachAssets = new MockAssetProviderWithForEach();
             forEachAssets.addAsset('99999999-1111-2222-3333-444444444444', '', 'image/jpeg', Buffer.from('jpg'));
 
@@ -1105,10 +1127,9 @@ describe('BaseExporter', () => {
 
             await forEachExporter.addAssetsToZipWithResourcePath();
 
-            // The mime-derived friendly name (asset-99999999.jpg) plus the literal UUID fallback
-            // path must both end up in the archive.
-            const fallbackPath = 'content/resources/99999999-1111-2222-3333-444444444444.jpg';
-            expect(forEachZip.files.has(fallbackPath)).toBe(true);
+            const uuidPath = 'content/resources/99999999-1111-2222-3333-444444444444.jpg';
+            expect(forEachZip.files.has(uuidPath)).toBe(false);
+            expect(forEachZip.files.size).toBe(1);
         });
     });
 

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -425,18 +425,13 @@ export abstract class BaseExporter {
      * Add assets to ZIP with content/resources/ prefix
      * Uses folderPath-based structure for cleaner exports
      *
-     * Each asset is written to the resolved export path (the friendly filename
-     * derived from metadata) AND, when it differs, to a `<assetId><ext>`
-     * fallback path. The fallback covers downstream consumers (e.g. Moodle
-     * mod_exeweb / mod_exescorm activities -- exelearning/mod_exeweb#42 and
-     * exelearning/mod_exescorm#55) that load the package as a static site:
-     * if the HTML carries an unresolved `asset://uuid.ext` reference, the
-     * transformation in {@link addFilenamesToAssetUrls} falls back to a
-     * literal `content/resources/<uuid><ext>` URL. Without the fallback file
-     * in the ZIP that URL would 404 on the platform side. The cost of the
-     * extra entry is minimal (a duplicate file pointer in the same archive)
-     * and avoids broken images on legitimate exports while the upstream
-     * mismatch is being addressed.
+     * Each asset is written exactly once, under its resolved export path
+     * (the friendly filename derived from metadata). HTML and content.xml
+     * always reference the same path because both transformations resolve
+     * `asset://uuid.ext` URLs through {@link buildAssetExportPathMap}, so a
+     * literal `content/resources/<uuid><ext>` URL only appears for genuinely
+     * missing assets — and writing the file under that path would not help,
+     * because the asset is not in the iteration in the first place.
      *
      * @param trackingList - Optional array to track added file paths (for ELPX manifest)
      */
@@ -455,20 +450,12 @@ export abstract class BaseExporter {
                 }
 
                 const zipPath = `content/resources/${exportPath}`;
+                if (this.zip.hasFile(zipPath)) {
+                    return;
+                }
                 this.zip.addFile(zipPath, asset.data);
                 if (trackingList) trackingList.push(zipPath);
                 assetsAdded++;
-
-                // Write the same content under the `<assetId><ext>` fallback
-                // path that addFilenamesToAssetUrls falls back to when an
-                // asset:// URL cannot be resolved. Skip when the resolved path
-                // already matches the fallback to avoid creating a duplicate
-                // entry in the same location.
-                const fallbackPath = this.buildUuidFallbackZipPath(asset);
-                if (fallbackPath && fallbackPath !== zipPath && !this.zip.hasFile(fallbackPath)) {
-                    this.zip.addFile(fallbackPath, asset.data);
-                    if (trackingList) trackingList.push(fallbackPath);
-                }
             };
 
             await this.forEachAsset(processAsset);
@@ -481,28 +468,6 @@ export abstract class BaseExporter {
         }
 
         return assetsAdded;
-    }
-
-    /**
-     * Build the `content/resources/<assetId><ext>` fallback path for an
-     * asset, matching the literal URL produced by addFilenamesToAssetUrls
-     * when an `asset://` reference cannot be resolved against the export
-     * path map. Returns null when the asset metadata is not enough to derive
-     * a stable filename.
-     */
-    private buildUuidFallbackZipPath(asset: ExportAsset): string | null {
-        if (!asset.id) {
-            return null;
-        }
-        const filename = asset.filename ?? '';
-        let ext = '';
-        const dotIndex = filename.lastIndexOf('.');
-        if (dotIndex !== -1 && dotIndex < filename.length - 1) {
-            ext = filename.substring(dotIndex);
-        } else if (asset.mime) {
-            ext = this.getExtensionFromMime(asset.mime);
-        }
-        return `content/resources/${asset.id}${ext}`;
     }
 
     // =========================================================================

--- a/src/shared/export/exporters/Html5Exporter.spec.ts
+++ b/src/shared/export/exporters/Html5Exporter.spec.ts
@@ -735,6 +735,57 @@ describe('Html5Exporter', () => {
             expect(result.success).toBe(true);
         });
 
+        // Regression test for exelearning/exelearning#1769:
+        // saving and exporting must NOT bundle each asset twice (once under its
+        // friendly filename and once under a UUID-shaped duplicate). The screenshot
+        // attached to that issue showed `pie_pagina_FEDER_2027.png` and a paired
+        // `2c161d17-249b-9bcd-7e0d-f9a4d758bae9.png` with identical content/CRC32.
+        it('should not duplicate assets under UUID-shaped paths (issue #1769)', async () => {
+            const assetsWithUuids: AssetProvider = {
+                async getAsset() {
+                    return null;
+                },
+                async getAllAssets() {
+                    return [
+                        {
+                            id: '2c161d17-249b-9bcd-7e0d-f9a4d758bae9',
+                            filename: 'pie_pagina_FEDER_2027.png',
+                            originalPath: 'pie_pagina_FEDER_2027.png',
+                            folderPath: '',
+                            mime: 'image/png',
+                            data: Buffer.from('feder-banner-data'),
+                        },
+                        {
+                            id: '49d44e76-3d6a-4b21-b911-41746ab60814',
+                            filename: 'photo_2024-09-05_12-31-44.jpg',
+                            originalPath: 'photo_2024-09-05_12-31-44.jpg',
+                            folderPath: '',
+                            mime: 'image/jpeg',
+                            data: Buffer.from('photo-data'),
+                        },
+                    ];
+                },
+                async getProjectAssets() {
+                    return this.getAllAssets();
+                },
+            };
+
+            const exporterWithUuidAssets = new Html5Exporter(document, resources, assetsWithUuids, zip);
+            const result = await exporterWithUuidAssets.export();
+
+            expect(result.success).toBe(true);
+
+            // Friendly filenames are present...
+            expect(zip.files.has('content/resources/pie_pagina_FEDER_2027.png')).toBe(true);
+            expect(zip.files.has('content/resources/photo_2024-09-05_12-31-44.jpg')).toBe(true);
+
+            // ...and the UUID-shaped duplicates that PR #1740 used to write must NOT be.
+            const uuidDuplicates = Array.from(zip.files.keys()).filter(p =>
+                /content\/resources\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.[a-z0-9]+$/i.test(p),
+            );
+            expect(uuidDuplicates).toEqual([]);
+        });
+
         it('should export root assets directly under content/resources/', async () => {
             // Assets without folderPath (at root level)
             const assetsWithoutFolder: AssetProvider = {

--- a/test/e2e/playwright/specs/page-export-import.spec.ts
+++ b/test/e2e/playwright/specs/page-export-import.spec.ts
@@ -182,6 +182,50 @@ test.describe('Page Export with Images', () => {
         console.log('Page export with images verified successfully');
     });
 
+    test('should not bundle each asset twice under a UUID-shaped path (issue #1769)', async ({ authenticatedPage }) => {
+        /**
+         * Regression test for exelearning/exelearning#1769:
+         * saving and exporting must not write each asset twice (once under its
+         * friendly filename, once under content/resources/<assetId><ext>).
+         */
+        const page = authenticatedPage;
+
+        if (!fs.existsSync(FIXTURE_ELPX_WITH_IMAGES)) {
+            test.skip();
+            return;
+        }
+
+        await openElpFile(page, FIXTURE_ELPX_WITH_IMAGES, 2);
+        await waitForAppReady(page);
+
+        await navigateToPageByTitle(page, 'Inicio');
+        await page.waitForTimeout(500);
+
+        const nodeId = await page.evaluate(() => {
+            const selected = document.querySelector('.nav-element.selected');
+            return selected?.getAttribute('nav-id') || null;
+        });
+        if (!nodeId) {
+            throw new Error('Could not find node ID for "Inicio" page');
+        }
+
+        const download = await exportPage(page, nodeId);
+        const filePath = path.join(tempDir, download.suggestedFilename());
+        await download.saveAs(filePath);
+
+        const zipFiles = getZipFileNames(filePath);
+        const resourceFiles = zipFiles.filter(f => f.startsWith('content/resources/'));
+        expect(resourceFiles.length).toBeGreaterThan(0);
+
+        // No file under content/resources/ should be a literal <uuid><ext> duplicate
+        // — that was the symptom in #1769 (image attached to the issue showed both
+        // pie_pagina_FEDER_2027.png and 2c161d17-...-bae9.png with identical CRC32).
+        const uuidPattern =
+            /^content\/resources\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.[a-z0-9]+$/i;
+        const uuidDuplicates = resourceFiles.filter(f => uuidPattern.test(f));
+        expect(uuidDuplicates).toEqual([]);
+    });
+
     test('should export page from legacy .elp file with images', async ({ authenticatedPage, createProject }) => {
         /**
          * This test verifies that page export works with legacy Python eXeLearning files


### PR DESCRIPTION
## Summary

Fixes [#1769](https://github.com/exelearning/exelearning/issues/1769): every asset added through Tiny or the File Manager ended up twice in every saved `.elpx` and every exported HTML5 / SCORM / IMS / EPUB3 package — once under its friendly filename and once under a duplicate `content/resources/<assetId><ext>` UUID copy.

## Root cause

[PR #1740](https://github.com/exelearning/exelearning/pull/1740) added a "defensive" UUID-shaped fallback write inside `BaseExporter.addAssetsToZipWithResourcePath`. The intent was to backstop hypothetical unresolved `asset://uuid.ext` references in HTML so that downstream Moodle plugins (`mod_exeweb` / `mod_exescorm`) wouldn't 404 on missing resources. But the iteration already loops over every asset reachable from the document, so the "fallback" runs for **every single asset on every export and save**, not only for unresolved ones — and the originally reported 404 was already fixed by the same PR's client-side `quickExport` flow, which guarantees those references resolve correctly.

Net result: the export and save flows always produced two ZIP entries per asset:

- `content/resources/pie_pagina_FEDER_2027.png`  ✅ friendly path
- `content/resources/2c161d17-249b-9bcd-7e0d-f9a4d758bae9.png`  ❌ duplicate UUID copy

…matching exactly the screenshot attached to the issue (identical file size and CRC32, two filenames):

| filename | size | CRC32 |
|----------|------|-------|
| `2c161d17-249b-9bcd-7e0d-f9a4d758bae9.png` | 68 329 | `ED4B12BC` |
| `pie_pagina_FEDER_2027.png` | 68 329 | `ED4B12BC` |
| `49d44e76-3d6a-4b21-b911-41746ab60814.jpg` | 97 946 | `11A94E16` |
| `photo_2024-09-05_12-31-44.jpg` | 97 946 | `11A94E16` |

## Fix

`BaseExporter.addAssetsToZipWithResourcePath` now writes each asset exactly once, at the resolved export path produced by `buildAssetExportPathMap`. The unused `buildUuidFallbackZipPath` helper is removed. HTML and `content.xml` already reference assets through the same path map, so the literal `content/resources/<uuid><ext>` URL only ever appears for assets that aren't in the iteration in the first place — writing a file under that path would not have helped, only bloated the archive.

Saved `.elpx` files and all exports (HTML5, SCORM 1.2/2004, IMS, EPUB3, Print) shrink accordingly and their `content/resources/` directory now has one copy of every asset.

## Tests

- `BaseExporter.spec.ts` — replaces the three previous "fallback path" expectations with regression tests that pin the new invariant: each asset is added once, the ZIP file count matches the number of assets, the ELPX manifest tracking list contains no duplicates, and no UUID-shaped duplicate path appears.
- `Html5Exporter.spec.ts` — adds an end-to-end regression test using the exact UUIDs and filenames from the screenshot in #1769, asserting that no `content/resources/<uuid>.<ext>` entry leaks into the produced package.

## Verification

- `make fix` ✅
- `make test-unit` — 6916 pass, coverage ≥ 90% ✅
- `make test-integration` — 700 pass ✅
- `make test-frontend` — green ✅

## Test plan

- [x] Unit regression tests reproduce the duplicate-asset behaviour (would fail before the fix)
- [x] Integration tests pass
- [x] Frontend tests pass
- [x] Manually inspect a saved `.elpx` and an HTML5/SCORM export — `content/resources/` contains exactly one copy per asset