### PR TITLE
fix(ids): unify generateId(prefix) into shared module

### DIFF
--- a/public/app/yjs/ComponentImporter.js
+++ b/public/app/yjs/ComponentImporter.js
@@ -466,13 +466,16 @@ class ComponentImporter {
   }
 
   /**
-   * Generate a unique ID
+   * Generate a unique ID.
+   *
+   * Mirrors src/shared/ids.ts::generateId — keep in sync. See issue #1782.
+   *
    * @param {string} prefix - ID prefix
    * @returns {string}
    */
   generateId(prefix) {
     const timestamp = Date.now().toString(36);
-    const random = Math.random().toString(36).substr(2, 9);
+    const random = Math.random().toString(36).substring(2, 11);
     return `${prefix}-${timestamp}-${random}`;
   }
 }

--- a/public/app/yjs/YjsStructureBinding.js
+++ b/public/app/yjs/YjsStructureBinding.js
@@ -2821,8 +2821,18 @@ class YjsStructureBinding {
     };
   }
 
+  /**
+   * Generate a unique ID.
+   *
+   * Mirrors src/shared/ids.ts::generateId — keep in sync. See issue #1782.
+   *
+   * @param {string} prefix - ID prefix
+   * @returns {string}
+   */
   generateId(prefix) {
-    return `${prefix}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substring(2, 11);
+    return `${prefix}-${timestamp}-${random}`;
   }
 
   // ===== Import from API Structure =====

--- a/src/shared/ids.spec.ts
+++ b/src/shared/ids.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for canonical ID generator (src/shared/ids.ts).
+ *
+ * Single source of truth for navigation entity IDs — see issue
+ * exelearning/exelearning#1782.
+ */
+import { describe, it, expect } from 'bun:test';
+import { generateId } from './ids';
+
+describe('generateId', () => {
+    it('returns an ID matching the canonical page format', () => {
+        const id = generateId('page');
+        expect(id).toMatch(/^page-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('returns an ID starting with block- for block prefix', () => {
+        const id = generateId('block');
+        expect(id.startsWith('block-')).toBe(true);
+        expect(id).toMatch(/^block-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('returns an ID starting with idevice- for idevice prefix', () => {
+        const id = generateId('idevice');
+        expect(id.startsWith('idevice-')).toBe(true);
+        expect(id).toMatch(/^idevice-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('produces distinct IDs on consecutive calls', () => {
+        const a = generateId('page');
+        const b = generateId('page');
+        expect(a).not.toBe(b);
+    });
+
+    it('throws when the prefix is empty', () => {
+        expect(() => generateId('')).toThrow();
+    });
+});

--- a/src/shared/ids.ts
+++ b/src/shared/ids.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical ID generator for navigation entities (pages, blocks, iDevices).
+ *
+ * Format: `<prefix>-<base36 timestamp>-<base36 random>` (e.g. `page-mp0fppw7-8djmx3rm8`).
+ * Single source of truth — see issue exelearning/exelearning#1782.
+ *
+ * NOTE: do NOT use this for project/session IDs (use src/utils/id-generator.util.ts)
+ * or SCORM/manifest IDs (use src/shared/export/exporters/BaseExporter.generateId).
+ *
+ * Browser mirrors of this function live in:
+ *   - public/app/yjs/YjsStructureBinding.js
+ *   - public/app/yjs/ComponentImporter.js
+ * Keep them byte-equivalent until those files can import this module directly.
+ *
+ * @param prefix Non-empty prefix tag (e.g. `'page'`, `'block'`, `'idevice'`).
+ * @returns Unique string ID combining a base36 timestamp and a 9-char random suffix.
+ * @throws {Error} When `prefix` is empty.
+ */
+export function generateId(prefix: string): string {
+    if (!prefix) {
+        throw new Error('generateId: prefix is required');
+    }
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substring(2, 11);
+    return `${prefix}-${timestamp}-${random}`;
+}

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -48,6 +48,7 @@ import {
 import { stripLegacyExeTextWrapper } from './legacyExeTextWrapper';
 
 import { LegacyXmlParser } from './LegacyXmlParser';
+import { generateId } from '../ids';
 import type { LegacyParseResult, LegacyPage, LegacyBlock, LegacyIdevice, LegacyMetadata } from './LegacyXmlParser';
 
 /**
@@ -652,11 +653,11 @@ export class ElpxImporter {
         // Legacy IDs are stable inside .elp files (e.g. page-4, idevice-2).
         // On repeated imports into the same Y.Doc we must remap to unique IDs to avoid collisions.
         for (const legacyPage of legacyPages) {
-            pageIdRemap.set(legacyPage.id, this.generateId('page'));
+            pageIdRemap.set(legacyPage.id, generateId('page'));
         }
 
         for (const legacyPage of legacyPages) {
-            const pageId = pageIdRemap.get(legacyPage.id) || this.generateId('page');
+            const pageId = pageIdRemap.get(legacyPage.id) || generateId('page');
             const parentId =
                 legacyPage.parent_id === null ? rootParentId : (pageIdRemap.get(legacyPage.parent_id) ?? rootParentId);
             const order = legacyPage.parent_id === null ? rootOrderOffset + legacyPage.position : legacyPage.position;
@@ -692,7 +693,7 @@ export class ElpxImporter {
      * Convert legacy block to BlockData format
      */
     private convertLegacyBlockToBlockData(legacyBlock: LegacyBlock): BlockData {
-        const blockId = this.generateId('block');
+        const blockId = generateId('block');
 
         const blockData: BlockData = {
             id: blockId,
@@ -718,7 +719,7 @@ export class ElpxImporter {
      * Convert legacy iDevice to ComponentData format
      */
     private convertLegacyIdeviceToComponentData(legacyIdevice: LegacyIdevice): ComponentData {
-        const componentId = this.generateId('idevice');
+        const componentId = generateId('idevice');
 
         // Build HTML view with feedback if present
         let htmlView = legacyIdevice.htmlView || '';
@@ -966,7 +967,7 @@ export class ElpxImporter {
 
         for (const navNode of navNodes) {
             const originalPageId = this.getPageId(navNode);
-            const newPageId = this.generateId('page');
+            const newPageId = generateId('page');
 
             if (originalPageId) {
                 idRemap.set(originalPageId, newPageId);
@@ -1056,7 +1057,7 @@ export class ElpxImporter {
         const blockId =
             pagNode.getAttribute('odePagStructureId') ||
             this.getTextContent(pagNode, 'odeBlockId') ||
-            this.generateId('block');
+            generateId('block');
         const blockName = pagNode.getAttribute('blockName') || this.getTextContent(pagNode, 'blockName') || '';
         const order = this.getPagOrder(pagNode);
         const iconName = pagNode.getAttribute('iconName') || this.getTextContent(pagNode, 'iconName') || '';
@@ -1096,7 +1097,7 @@ export class ElpxImporter {
         const componentId =
             compNode.getAttribute('odeComponentId') ||
             this.getTextContent(compNode, 'odeIdeviceId') ||
-            this.generateId('idevice');
+            generateId('idevice');
 
         let ideviceType =
             compNode.getAttribute('odeIdeviceTypeDirName') ||
@@ -1816,15 +1817,6 @@ export class ElpxImporter {
     private getTextContent(parent: Element, tagName: string): string | null {
         const el = this.getElement(parent, tagName);
         return el ? el.textContent : null;
-    }
-
-    /**
-     * Generate a unique ID
-     */
-    private generateId(prefix: string): string {
-        const timestamp = Date.now().toString(36);
-        const random = Math.random().toString(36).substring(2, 11);
-        return `${prefix}-${timestamp}-${random}`;
     }
 
     /**

--- a/src/yjs/structure-binding.ts
+++ b/src/yjs/structure-binding.ts
@@ -12,6 +12,7 @@
  * called within a transaction (via doc-manager.withDocument).
  */
 import * as Y from 'yjs';
+import { generateId } from '../shared/ids';
 import type {
     PageData,
     CreatePageInput,
@@ -32,14 +33,12 @@ import type {
 // ============================================================================
 
 /**
- * Generate a unique ID with prefix
- * Same algorithm as client-side for consistency
+ * Generate a unique ID with prefix.
+ *
+ * Re-exported from the canonical module so existing imports across
+ * `src/*` keep working — see issue exelearning/exelearning#1782.
  */
-export function generateId(prefix: string): string {
-    const timestamp = Date.now().toString(36);
-    const random = Math.random().toString(36).substring(2, 11);
-    return `${prefix}-${timestamp}-${random}`;
-}
+export { generateId };
 
 /**
  * Get the navigation array from a Y.Doc


### PR DESCRIPTION
## Summary

Collapse the four parallel `generateId(prefix)` implementations into a single canonical module at `src/shared/ids.ts`. Eliminates mixed-format IDs inside the same `content.xml`.

- `src/yjs/structure-binding.ts` re-exports from the shared module to preserve the public API.
- `src/shared/import/ElpxImporter.ts` imports directly; private method removed.
- The two browser-side sites (`public/app/yjs/YjsStructureBinding.js`, `public/app/yjs/ComponentImporter.js`) keep byte-equivalent mirror copies of Format A with a `// keep in sync` comment. Format B is gone.
- Deprecated `String.prototype.substr` replaced with `.substring(2, 11)`.

## Test plan

- [x] New `src/shared/ids.spec.ts` (5 cases, 100% coverage on the new file)
- [x] Existing `bun test src/yjs/structure-binding.spec.ts` passes (92 tests)
- [x] Existing `bun test src/shared/import/ElpxImporter.spec.ts` passes (58 tests)
- [x] Frontend specs (`YjsStructureBinding.test.js`, `ComponentImporter.test.js`) pass (281 tests)
- [x] `make fix` and `make lint` clean
- [x] `make bundle` regenerates `public/app/yjs/importers.bundle.js` with the canonical helper (gitignored)

Closes #1782