### PR TITLE
fix(import): preserve odeId/odeVersionId across ELPX import

### DIFF
--- a/doc/elpx-format/ids.md
+++ b/doc/elpx-format/ids.md
@@ -69,7 +69,7 @@ All three forms are accepted by the importer. The modern generator always produc
 | Identifier | Set when | Changes when | Notes |
 |---|---|---|---|
 | `odeId` | Project is created for the first time | Never (stable for the project's lifetime) | Stored in `odeResources`. Retrieved from `meta.odeIdentifier` if already set, otherwise `generateOdeId()` is called once (`OdeXmlGenerator.ts:44`). |
-| `odeVersionId` | Every export / save | Every export / save | Always a freshly generated `generateOdeId()` call (`OdeXmlGenerator.ts:45`). Acts as a change cursor. |
+| `odeVersionId` | Project is created for the first time | Preserved across round-trips | Read from `meta.odeVersionId` when present, otherwise a freshly generated `generateOdeId()` (`OdeXmlGenerator.ts:45`). Imported from `<odeResources>` so an open/save round-trip is byte-stable. |
 | `odePageId` | Page is created | On import (reassigned — see below) | Stable within a project; changes only when the file is re-imported. |
 | `odeBlockId` | Block is created | On import (reassigned) | Stable within a project; changes only when the file is re-imported. |
 | `odeIdeviceId` | iDevice is added | On import (reassigned) | Stable within a project; changes only when the file is re-imported. |

--- a/doc/elpx-format/metadata.md
+++ b/doc/elpx-format/metadata.md
@@ -75,7 +75,7 @@ function generateOdeResourcesXml(odeId: string, versionId: string): string {
 | Key | Description |
 |---|---|
 | `odeId` | Stable project identifier. Retrieved from `meta.odeIdentifier` on export; generated once via `generateOdeId()` if absent. |
-| `odeVersionId` | Regenerated on every export/save via `generateOdeId()`. Acts as a change cursor. |
+| `odeVersionId` | Stable per-version identifier. Read from `meta.odeVersionId` on export; generated once via `generateOdeId()` only when absent. Imported from `<odeResources>` so a round-trip without content changes preserves the value. |
 | `exe_version` | The ODE format version string, currently `'3.0'` (constant `ODE_VERSION` from `constants.ts:1000`). |
 
 **Legacy keys observed in older fixtures:** the v4 generator writes exactly three resources (`odeId`, `odeVersionId`, `exe_version`). Some older fixtures additionally carry `odeVersionName`, `isDownload`, or the misspelling `eXeVersion`. The importer accepts all of these for backward compatibility, but **`generateOdeResourcesXml()` never emits them in v4** — treat them as informational legacy keys when reading older `.elpx` files.

--- a/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
@@ -1154,3 +1154,59 @@ describe('YjsDocumentAdapter', () => {
         });
     });
 });
+
+describe('YjsDocumentAdapter.getMetadata - stable identifiers (#1784)', () => {
+    it('forwards odeIdentifier, odeVersionId and scormIdentifier from the Y.Map (mocked)', () => {
+        const manager = new MockYjsDocumentManager({
+            title: 'Stable IDs',
+            odeIdentifier: '20251201123456ABCDEF',
+            odeVersionId: '20251201123456FEDCBA',
+            scormIdentifier: 'CUSTOM-SCORM-XYZ',
+        });
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const meta = adapter.getMetadata();
+        expect(meta.odeIdentifier).toBe('20251201123456ABCDEF');
+        expect(meta.odeVersionId).toBe('20251201123456FEDCBA');
+        expect(meta.scormIdentifier).toBe('CUSTOM-SCORM-XYZ');
+    });
+
+    it('returns undefined for unset stable identifiers (legacy projects)', () => {
+        const manager = new MockYjsDocumentManager({ title: 'Legacy' });
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const meta = adapter.getMetadata();
+        expect(meta.odeIdentifier).toBeUndefined();
+        expect(meta.odeVersionId).toBeUndefined();
+        expect(meta.scormIdentifier).toBeUndefined();
+    });
+
+    it('reads stable identifiers from a real Y.Doc through YjsDocumentAdapter (no mocks)', async () => {
+        const Y = await import('yjs');
+        const doc = new Y.Doc();
+        const meta = doc.getMap('metadata');
+        meta.set('title', 'Real Y.Doc');
+        meta.set('odeIdentifier', '20251201123456ABCDEF');
+        meta.set('odeVersionId', '20251201123456FEDCBA');
+        // Minimal navigation so the adapter is happy.
+        doc.getArray('navigation');
+
+        const manager = {
+            getMetadata: () => meta,
+            getNavigation: () => doc.getArray('navigation'),
+            getDoc: () => doc,
+            projectId: 'real-yjs-project',
+        };
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+
+        const exportMeta = adapter.getMetadata();
+        expect(exportMeta.odeIdentifier).toBe('20251201123456ABCDEF');
+        expect(exportMeta.odeVersionId).toBe('20251201123456FEDCBA');
+
+        doc.destroy();
+    });
+});

--- a/src/shared/export/adapters/YjsDocumentAdapter.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.ts
@@ -116,6 +116,12 @@ export class YjsDocumentAdapter implements ExportDocument {
 
             // Project screenshot/thumbnail
             screenshot: (meta.get('screenshot') as string) || undefined,
+
+            // Stable identifiers (#1784, #1785) -- preserved across import/export so
+            // that content.xml diffs stay clean and LMS tracking survives SCORM re-uploads.
+            odeIdentifier: (meta.get('odeIdentifier') as string) || undefined,
+            odeVersionId: (meta.get('odeVersionId') as string) || undefined,
+            scormIdentifier: (meta.get('scormIdentifier') as string) || undefined,
         };
     }
 

--- a/src/shared/export/generators/OdeXmlGenerator.spec.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.spec.ts
@@ -331,6 +331,45 @@ describe('OdeXmlGenerator', () => {
             expect(xml).toContain('<value>CUSTOM-VERSION-ID</value>');
         });
 
+        it('should use meta.odeVersionId when options.versionId is not set', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                odeVersionId: '20251201123456FEDCBA',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            expect(xml).toMatch(/<key>odeVersionId<\/key>\s*<value>20251201123456FEDCBA<\/value>/);
+        });
+
+        it('should generate a fresh versionId when neither options.versionId nor meta.odeVersionId is set', () => {
+            const meta: ExportMetadata = { title: 'Test' };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            // Extract the odeVersionId value
+            const match = xml.match(/<key>odeVersionId<\/key>\s*<value>([^<]+)<\/value>/);
+            expect(match).not.toBeNull();
+            expect(match![1]).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+        });
+
+        it('should prefer options.versionId over meta.odeVersionId', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                odeVersionId: '20251201123456FEDCBA',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages, {
+                versionId: '20251231235959AAAAAA',
+            });
+
+            expect(xml).toMatch(/<key>odeVersionId<\/key>\s*<value>20251231235959AAAAAA<\/value>/);
+            expect(xml).not.toContain('20251201123456FEDCBA');
+        });
+
         it('should include DOCTYPE by default', () => {
             const meta: ExportMetadata = { title: 'Test' };
             const pages: ExportPage[] = [];

--- a/src/shared/export/generators/OdeXmlGenerator.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.ts
@@ -42,7 +42,7 @@ export interface OdeXmlOptions {
  */
 export function generateOdeXml(meta: ExportMetadata, pages: ExportPage[], options?: OdeXmlOptions): string {
     const odeId = options?.odeId || meta.odeIdentifier || generateOdeId();
-    const versionId = options?.versionId || generateOdeId();
+    const versionId = options?.versionId || meta.odeVersionId || generateOdeId();
     const includeDoctype = options?.includeDoctype ?? true;
 
     let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';

--- a/src/shared/export/generators/OdeXmlGenerator.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.ts
@@ -20,6 +20,9 @@
 import type { ExportMetadata, ExportPage, ExportBlock, ExportComponent } from '../interfaces';
 import { ODE_DTD_FILENAME } from '../constants';
 import { isExcludedFromXml, getXmlKeyForProperty, valueToXmlString } from '../metadata-properties';
+import { generateOdeId } from '../utils/odeId';
+
+export { generateOdeId };
 
 /**
  * Options for ODE XML generation
@@ -316,29 +319,6 @@ function generateComponentPropertyEntry(key: string, value: string): string {
               <key>${escapeXml(key)}</key>
               <value>${escapeXml(value)}</value>
             </odeComponentsProperty>\n`;
-}
-
-/**
- * Generate ODE identifier
- * Format: YYYYMMDDHHmmss + 6 random alphanumeric chars
- */
-export function generateOdeId(): string {
-    const now = new Date();
-    const timestamp =
-        now.getFullYear().toString() +
-        String(now.getMonth() + 1).padStart(2, '0') +
-        String(now.getDate()).padStart(2, '0') +
-        String(now.getHours()).padStart(2, '0') +
-        String(now.getMinutes()).padStart(2, '0') +
-        String(now.getSeconds()).padStart(2, '0');
-
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    let random = '';
-    for (let i = 0; i < 6; i++) {
-        random += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-
-    return timestamp + random;
 }
 
 /**

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -56,6 +56,7 @@ export interface ExportMetadata {
     // eXeLearning-specific metadata
     exelearningVersion?: string;
     odeIdentifier?: string;
+    odeVersionId?: string;
     createdAt?: string;
     modifiedAt?: string;
 

--- a/src/shared/export/metadata-properties.ts
+++ b/src/shared/export/metadata-properties.ts
@@ -217,6 +217,14 @@ export const METADATA_PROPERTIES: MetadataPropertyConfig[] = [
         category: 'internal',
     },
     {
+        key: 'odeVersionId',
+        xmlKey: 'odeVersionId',
+        type: 'string',
+        defaultValue: '',
+        excludeFromXml: true,
+        category: 'internal',
+    },
+    {
         key: 'createdAt',
         xmlKey: 'createdAt',
         type: 'string',

--- a/src/shared/export/utils/odeId.spec.ts
+++ b/src/shared/export/utils/odeId.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test';
+import { generateOdeId } from './odeId';
+
+describe('generateOdeId', () => {
+    it('returns a 20-character string', () => {
+        const id = generateOdeId();
+        expect(id).toHaveLength(20);
+    });
+
+    it('matches the YYYYMMDDHHmmss + 6 uppercase alphanumeric pattern', () => {
+        const id = generateOdeId();
+        expect(id).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+    });
+
+    it('produces different identifiers across successive calls', () => {
+        const ids = new Set<string>();
+        for (let i = 0; i < 100; i++) {
+            ids.add(generateOdeId());
+        }
+        expect(ids.size).toBe(100);
+    });
+
+    it('encodes the current date in the first 14 chars', () => {
+        const now = new Date();
+        const id = generateOdeId();
+        const year = id.slice(0, 4);
+        const month = id.slice(4, 6);
+        const day = id.slice(6, 8);
+        expect(Number(year)).toBe(now.getFullYear());
+        expect(Number(month)).toBe(now.getMonth() + 1);
+        expect(Number(day)).toBe(now.getDate());
+    });
+});

--- a/src/shared/export/utils/odeId.ts
+++ b/src/shared/export/utils/odeId.ts
@@ -1,0 +1,28 @@
+/**
+ * Stable identifier generator for ODE projects (odeId, odeVersionId).
+ *
+ * Format: `YYYYMMDDHHmmss` + 6 random uppercase alphanumeric chars (20 chars).
+ *
+ * Lives in its own file (no transitive imports) so it can be used from both
+ * the browser-bound importer bundle and the server-side exporters without
+ * pulling Node-only modules (path, fs-extra) into the browser bundle via
+ * `src/shared/export/constants.ts` → `src/services/idevice-config.ts`.
+ */
+export function generateOdeId(): string {
+    const now = new Date();
+    const timestamp =
+        now.getFullYear().toString() +
+        String(now.getMonth() + 1).padStart(2, '0') +
+        String(now.getDate()).padStart(2, '0') +
+        String(now.getHours()).padStart(2, '0') +
+        String(now.getMinutes()).padStart(2, '0') +
+        String(now.getSeconds()).padStart(2, '0');
+
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let random = '';
+    for (let i = 0; i < 6; i++) {
+        random += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+
+    return timestamp + random;
+}

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -2333,6 +2333,45 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
             ydoc.destroy();
         });
 
+        it('should still populate metadata.odeIdentifier when <odeProperties> is absent (DTD edge case)', async () => {
+            // The DTD makes <odeProperties> optional. A valid v4 content.xml
+            // may carry <odeResources> alone. Stable identifiers must reach the
+            // Y.Doc metadata regardless of whether <odeProperties> exists.
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>20251201123456FEDCBA</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+            expect(metadata.get('odeVersionId')).toBe('20251201123456FEDCBA');
+
+            ydoc.destroy();
+        });
+
         it('should tolerate empty <odeResources> block on v4 import', async () => {
             const fflate = await import('fflate');
             const encoder = new TextEncoder();

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -2252,4 +2252,202 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
             ydoc.destroy();
         });
     });
+
+    describe('odeResources preservation', () => {
+        it('should populate metadata.odeIdentifier and metadata.odeVersionId from <odeResources> on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>20251201123456FEDCBA</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>OdeResources Preservation</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+            expect(metadata.get('odeVersionId')).toBe('20251201123456FEDCBA');
+
+            ydoc.destroy();
+        });
+
+        it('should tolerate missing <odeResources> block on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            // v4-style content.xml WITHOUT odeResources
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>No OdeResources</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier');
+            const odeVersionId = metadata.get('odeVersionId');
+            // Either undefined or empty string — export-side fallback will fill them in.
+            expect(odeId === undefined || odeId === '').toBe(true);
+            expect(odeVersionId === undefined || odeVersionId === '').toBe(true);
+
+            ydoc.destroy();
+        });
+
+        it('should tolerate empty <odeResources> block on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources></odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Empty OdeResources</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier');
+            const odeVersionId = metadata.get('odeVersionId');
+            expect(odeId === undefined || odeId === '').toBe(true);
+            expect(odeVersionId === undefined || odeVersionId === '').toBe(true);
+
+            ydoc.destroy();
+        });
+
+        it('should generate odeIdentifier and odeVersionId once on legacy v3 import', async () => {
+            const elpPath = path.join(process.cwd(), 'test/fixtures/old_tema-10-ejemplo.elp');
+            const elpBuffer = await fs.readFile(elpPath);
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(new Uint8Array(elpBuffer));
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier') as string;
+            const odeVersionId = metadata.get('odeVersionId') as string;
+            expect(typeof odeId).toBe('string');
+            expect(typeof odeVersionId).toBe('string');
+            expect(odeId).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+            expect(odeVersionId).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+
+            ydoc.destroy();
+        });
+
+        it('should round-trip odeId and odeVersionId through import -> generateOdeXml -> re-parse', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+            const { generateOdeXml } = await import('../export/generators/OdeXmlGenerator');
+
+            const inputOdeId = '20251201123456ABCDEF';
+            const inputOdeVersionId = '20251201123456FEDCBA';
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>${inputOdeId}</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>${inputOdeVersionId}</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Round Trip</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const exportedXml = generateOdeXml(
+                {
+                    title: 'Round Trip',
+                    author: '',
+                    language: 'en',
+                    theme: 'base',
+                    odeIdentifier: metadata.get('odeIdentifier') as string,
+                    odeVersionId: metadata.get('odeVersionId') as string,
+                },
+                [],
+            );
+
+            const odeIdMatch = exportedXml.match(/<key>odeId<\/key>\s*<value>([^<]+)<\/value>/);
+            const odeVersionIdMatch = exportedXml.match(/<key>odeVersionId<\/key>\s*<value>([^<]+)<\/value>/);
+            expect(odeIdMatch).not.toBeNull();
+            expect(odeVersionIdMatch).not.toBeNull();
+            expect(odeIdMatch![1]).toBe(inputOdeId);
+            expect(odeVersionIdMatch![1]).toBe(inputOdeVersionId);
+
+            ydoc.destroy();
+        });
+    });
 });

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -487,8 +487,13 @@ export class ElpxImporter {
                     this.logger.log('[ElpxImporter] Navigation cleared');
                 }
 
-                // Set metadata only if clearing (replacing) the document
-                if (odeProperties && clearExisting) {
+                // Set metadata only if clearing (replacing) the document.
+                // <odeProperties> is optional per the DTD, so we also write
+                // when <odeResources> alone carried stable identifiers --
+                // otherwise odeIdentifier / odeVersionId would never reach
+                // the Y.Doc on those minimal documents.
+                const hasStableIdentifiers = Boolean(metadataValues.odeIdentifier || metadataValues.odeVersionId);
+                if (clearExisting && (odeProperties || hasStableIdentifiers)) {
                     this.logger.log('[ElpxImporter] Setting metadata...');
                     this.setMetadata(metadata, metadataValues);
                     this.logger.log('[ElpxImporter] Metadata set');

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -49,6 +49,7 @@ import { stripLegacyExeTextWrapper } from './legacyExeTextWrapper';
 
 import { LegacyXmlParser } from './LegacyXmlParser';
 import type { LegacyParseResult, LegacyPage, LegacyBlock, LegacyIdevice, LegacyMetadata } from './LegacyXmlParser';
+import { generateOdeId } from '../export/generators/OdeXmlGenerator';
 
 /**
  * ElpxImporter class
@@ -418,6 +419,17 @@ export class ElpxImporter {
         // Extract metadata
         const odeProperties = this.getElement(xmlDoc, 'odeProperties');
         const metadataValues = this.extractMetadata(xmlDoc, odeProperties);
+
+        // Preserve stable identifiers from <odeResources> (odeId, odeVersionId).
+        // Without this, every round-trip generates a fresh pair, defeating
+        // diff stability and SCORM manifest identity. See #1784.
+        const odeResources = this.extractOdeResources(xmlDoc);
+        if (odeResources.odeId) {
+            metadataValues.odeIdentifier = odeResources.odeId;
+        }
+        if (odeResources.odeVersionId) {
+            metadataValues.odeVersionId = odeResources.odeVersionId;
+        }
 
         // Extract screenshot.png from archive root if present
         const screenshot = this.extractScreenshotFromZip(zip);
@@ -812,6 +824,12 @@ export class ElpxImporter {
 
         metadata.set('extraHeadContent', legacyMeta.extraHeadContent);
         metadata.set('footer', legacyMeta.footer);
+
+        // Legacy contentv3.xml has no <odeResources>. Generate fresh stable
+        // identifiers once at import time so subsequent re-exports of the
+        // converted project keep the same odeId / odeVersionId. See #1784.
+        metadata.set('odeIdentifier', generateOdeId());
+        metadata.set('odeVersionId', generateOdeId());
     }
 
     /**
@@ -873,6 +891,28 @@ export class ElpxImporter {
             this.logger.warn('[ElpxImporter] Failed to read screenshot.png:', error);
             return undefined;
         }
+    }
+
+    /**
+     * Extract <odeResources> entries from a v4 content.xml document.
+     * Returns an empty object when the section is missing or empty so callers
+     * can fall back to fresh identifiers without crashing.
+     */
+    private extractOdeResources(xmlDoc: Document): Record<string, string> {
+        const result: Record<string, string> = {};
+        const container = this.getElement(xmlDoc, 'odeResources');
+        if (!container) return result;
+        const resources = this.getElements(container, 'odeResource');
+        for (const res of resources) {
+            const keyEl = this.getElement(res, 'key');
+            const valEl = this.getElement(res, 'value');
+            const key = keyEl?.textContent?.trim();
+            const value = valEl?.textContent?.trim();
+            if (key && value) {
+                result[key] = value;
+            }
+        }
+        return result;
     }
 
     /**
@@ -946,6 +986,14 @@ export class ElpxImporter {
         // Screenshot (optional, extracted from archive root)
         if (values.screenshot) {
             metadata.set('screenshot', values.screenshot);
+        }
+        // Stable identifiers preserved from <odeResources>. Only set when present —
+        // export-side fallback (OdeXmlGenerator) generates fresh values otherwise.
+        if (values.odeIdentifier) {
+            metadata.set('odeIdentifier', values.odeIdentifier);
+        }
+        if (values.odeVersionId) {
+            metadata.set('odeVersionId', values.odeVersionId);
         }
     }
 

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -49,7 +49,7 @@ import { stripLegacyExeTextWrapper } from './legacyExeTextWrapper';
 
 import { LegacyXmlParser } from './LegacyXmlParser';
 import type { LegacyParseResult, LegacyPage, LegacyBlock, LegacyIdevice, LegacyMetadata } from './LegacyXmlParser';
-import { generateOdeId } from '../export/generators/OdeXmlGenerator';
+import { generateOdeId } from '../export/utils/odeId';
 
 /**
  * ElpxImporter class

--- a/src/shared/import/interfaces.ts
+++ b/src/shared/import/interfaces.ts
@@ -286,4 +286,8 @@ export interface OdeMetadata {
     globalFont: string;
     /** Project screenshot/thumbnail as base64 data URL (optional) */
     screenshot?: string;
+    /** Stable ODE identifier preserved from <odeResources><odeId> (optional) */
+    odeIdentifier?: string;
+    /** Stable ODE version identifier preserved from <odeResources><odeVersionId> (optional) */
+    odeVersionId?: string;
 }


### PR DESCRIPTION
## Summary

The importer never read `<odeResources>` from content.xml, so a project's stable identity (`odeId`, `odeVersionId`) was lost on every round-trip. The export side already honours `meta.odeIdentifier` — this PR just populates it on the import side and adds the matching versionId fallback.

Unblocks #1785 (stable SCORM manifest derived from `odeIdentifier`).

## Changes

- `ElpxImporter.extractOdeResources()` parses `<odeResources>` in the v4 path; writes `odeId` → `metadata.odeIdentifier` and `odeVersionId` → `metadata.odeVersionId`.
- Legacy `.elp` v3 path (`importLegacyFormat`): contentv3.xml has no `<odeResources>`, so generate both once via `generateOdeId()` at import time. Subsequent re-exports of the converted project are stable.
- `OdeXmlGenerator.generateOdeXml()` extends the versionId fallback chain: `options.versionId > meta.odeVersionId > generateOdeId()`.
- `metadata-properties.ts` declares `odeVersionId` as a sibling of `odeIdentifier`, internal (`excludeFromXml: true` — written via `<odeResources>`, not `<odeProperties>`).
- `interfaces.ts` (both export and import) gains the `odeVersionId?: string` field.

## Test plan

- [x] v4 import populates `metadata.odeIdentifier` and `metadata.odeVersionId` from `<odeResources>`
- [x] Legacy v3 import generates both once (pattern `^\d{14}[A-Z0-9]{6}$`) so re-exports are stable
- [x] Missing or empty `<odeResources>` tolerated (export-side fallback runs)
- [x] `OdeXmlGenerator` honours `options.versionId` > `meta.odeVersionId` > `generateOdeId()`
- [x] Round-trip: import → `generateOdeXml` → re-parse → identifiers match
- [x] `bun test src/shared/import/ElpxImporter.spec.ts src/shared/export/generators/OdeXmlGenerator.spec.ts` → 116 pass
- [x] `make fix` / `make lint` clean

Closes #1784