### PR TITLE
fix(ids): unify and harden the four stable-identifier PRs (#1786 bundle)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@elysiajs/static": "^1.4.7",
         "@elysiajs/swagger": "^1.3.1",
         "@sinclair/typebox": "^0.34.48",
-        "@xmldom/xmldom": "^0.8.11",
+        "@xmldom/xmldom": "^0.9.9",
         "bcryptjs": "^3.0.3",
         "dotenv": "^17.3.1",
         "elysia": "^1.4.27",
@@ -29,8 +29,8 @@
         "mime-types": "^3.0.2",
         "mysql2": "^3.18.2",
         "nunjucks": "^3.2.4",
-        "pdfjs-dist": "5.5.207",
-        "uuid": "^13.0.0",
+        "pdfjs-dist": "5.7.284",
+        "uuid": "^14.0.0",
         "ws": "^8.19.0",
         "y-websocket": "^3.0.0",
         "yjs": "^13.6.29",
@@ -39,7 +39,7 @@
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.0",
         "@biomejs/biome": "^2.4.5",
-        "@codecov/bundle-analyzer": "^1.9.1",
+        "@codecov/bundle-analyzer": "^2.0.1",
         "@electron/notarize": "^3.1.1",
         "@playwright/test": "^1.58.2",
         "@types/bcryptjs": "^3.0.0",
@@ -52,14 +52,14 @@
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.18",
         "cross-env": "^10.1.0",
-        "electron": "^41.0.0",
+        "electron": "^42.0.0",
         "electron-builder": "^26.8.1",
-        "esbuild": "^0.27.3",
+        "esbuild": "^0.28.0",
         "happy-dom": "^20.8.0",
-        "http-proxy-middleware": "^3.0.5",
+        "http-proxy-middleware": "^4.0.0",
         "kill-port": "^2.0.1",
         "sass": "^1.97.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vite": "^8.0.0",
         "vitest": "^4.0.18",
         "wait-on": "^9.0.4",
@@ -69,15 +69,15 @@
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
-    "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
+    "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
 
-    "@actions/exec": ["@actions/exec@1.1.1", "", { "dependencies": { "@actions/io": "^1.0.1" } }, "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w=="],
+    "@actions/exec": ["@actions/exec@3.0.0", "", { "dependencies": { "@actions/io": "^3.0.2" } }, "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw=="],
 
-    "@actions/github": ["@actions/github@6.0.1", "", { "dependencies": { "@actions/http-client": "^2.2.0", "@octokit/core": "^5.0.1", "@octokit/plugin-paginate-rest": "^9.2.2", "@octokit/plugin-rest-endpoint-methods": "^10.4.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "undici": "^5.28.5" } }, "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw=="],
+    "@actions/github": ["@actions/github@9.1.1", "", { "dependencies": { "@actions/http-client": "^3.0.2", "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/request": "^10.0.7", "@octokit/request-error": "^7.1.0", "undici": "^6.23.0" } }, "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA=="],
 
-    "@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
+    "@actions/http-client": ["@actions/http-client@4.0.1", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg=="],
 
-    "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
+    "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -301,9 +301,9 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.1.1", "", {}, "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ=="],
 
-    "@codecov/bundle-analyzer": ["@codecov/bundle-analyzer@1.9.1", "", { "dependencies": { "@codecov/bundler-plugin-core": "^1.9.1", "micromatch": "^4.0.8", "yargs": "^17.7.2" }, "os": [ "linux", "darwin", ], "bin": { "bundle-analyzer": "dist/cli.cjs" } }, "sha512-WVWZIV0v09RueL0L2x8pgaWzGsJsKMsMFjsFgzfjeApq9cE6bZ+0fQC3f/pTQ8h40Y3D5Gk9o4W6jd/if3ohSA=="],
+    "@codecov/bundle-analyzer": ["@codecov/bundle-analyzer@2.0.1", "", { "dependencies": { "@codecov/bundler-plugin-core": "^2.0.1", "micromatch": "^4.0.8", "yargs": "^17.7.2" }, "os": [ "linux", "darwin", ], "bin": { "bundle-analyzer": "dist/cli.cjs" } }, "sha512-SkL0+Ccs6VuHIA9Bxb8/J110CffRXpqtKt7m18FTWC0P6gDKEsoieUerDdcd6K9BFKujj6gaUdTt5i4I/v8GTA=="],
 
-    "@codecov/bundler-plugin-core": ["@codecov/bundler-plugin-core@1.9.1", "", { "dependencies": { "@actions/core": "^1.10.1", "@actions/github": "^6.0.0", "chalk": "4.1.2", "semver": "^7.5.4", "unplugin": "^1.10.1", "zod": "^3.22.4" } }, "sha512-dt3ic7gMswz4p/qdkYPVJwXlLiLsz55rBBn2I7mr0HTG8pCoLRqnANJIwo5WrqGBZgPyVSMPBqBra6VxLWfDyA=="],
+    "@codecov/bundler-plugin-core": ["@codecov/bundler-plugin-core@2.0.1", "", { "dependencies": { "@actions/core": "^3.0.0", "@actions/github": "^9.0.0", "chalk": "4.1.2", "semver": "^7.5.4", "unplugin": "^1.10.1", "zod": "^3.22.4" } }, "sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -323,7 +323,7 @@
 
     "@electron/fuses": ["@electron/fuses@1.8.0", "", { "dependencies": { "chalk": "^4.1.1", "fs-extra": "^9.0.1", "minimist": "^1.2.5" }, "bin": { "electron-fuses": "dist/bin.js" } }, "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw=="],
 
-    "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
+    "@electron/get": ["@electron/get@5.0.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^3.0.0", "graceful-fs": "^4.2.11", "progress": "^2.0.3", "semver": "^7.6.3", "sumchecker": "^3.0.1" }, "optionalDependencies": { "undici": "^7.24.4" } }, "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA=="],
 
     "@electron/notarize": ["@electron/notarize@3.1.1", "", { "dependencies": { "debug": "^4.4.0", "promise-retry": "^2.0.1" } }, "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ=="],
 
@@ -353,61 +353,59 @@
 
     "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
 
@@ -461,29 +459,29 @@
 
     "@messageformat/runtime": ["@messageformat/runtime@3.0.2", "", { "dependencies": { "make-plural": "^7.0.0" } }, "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw=="],
 
-    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.95", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.95", "@napi-rs/canvas-darwin-arm64": "0.1.95", "@napi-rs/canvas-darwin-x64": "0.1.95", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.95", "@napi-rs/canvas-linux-arm64-gnu": "0.1.95", "@napi-rs/canvas-linux-arm64-musl": "0.1.95", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.95", "@napi-rs/canvas-linux-x64-gnu": "0.1.95", "@napi-rs/canvas-linux-x64-musl": "0.1.95", "@napi-rs/canvas-win32-arm64-msvc": "0.1.95", "@napi-rs/canvas-win32-x64-msvc": "0.1.95" } }, "sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w=="],
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
 
-    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.95", "", { "os": "android", "cpu": "arm64" }, "sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA=="],
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
 
-    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.95", "", { "os": "darwin", "cpu": "arm64" }, "sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw=="],
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
 
-    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.95", "", { "os": "darwin", "cpu": "x64" }, "sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw=="],
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
 
-    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.95", "", { "os": "linux", "cpu": "arm" }, "sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q=="],
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
 
-    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.95", "", { "os": "linux", "cpu": "arm64" }, "sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw=="],
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
 
-    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.95", "", { "os": "linux", "cpu": "arm64" }, "sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg=="],
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
 
-    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.95", "", { "os": "linux", "cpu": "none" }, "sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg=="],
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
 
-    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.95", "", { "os": "linux", "cpu": "x64" }, "sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw=="],
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
 
-    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.95", "", { "os": "linux", "cpu": "x64" }, "sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ=="],
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
 
-    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.95", "", { "os": "win32", "cpu": "arm64" }, "sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA=="],
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
 
-    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.95", "", { "os": "win32", "cpu": "x64" }, "sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA=="],
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -491,25 +489,25 @@
 
     "@npmcli/fs": ["@npmcli/fs@4.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q=="],
 
-    "@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
-    "@octokit/core": ["@octokit/core@5.2.2", "", { "dependencies": { "@octokit/auth-token": "^4.0.0", "@octokit/graphql": "^7.1.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.0.0", "before-after-hook": "^2.2.0", "universal-user-agent": "^6.0.0" } }, "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg=="],
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
 
-    "@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
 
-    "@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
 
-    "@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
-    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@9.2.2", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ=="],
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
 
-    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@10.4.1", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg=="],
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
 
-    "@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
 
-    "@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
 
-    "@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
@@ -733,8 +731,6 @@
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.4", "", {}, "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="],
 
-    "@types/http-proxy": ["@types/http-proxy@1.17.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw=="],
-
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
     "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
@@ -783,7 +779,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "a-sync-waterfall": ["a-sync-waterfall@1.0.1", "", {}, "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="],
 
@@ -843,7 +839,7 @@
 
     "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
-    "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
@@ -1041,8 +1037,6 @@
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
-    "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
-
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
@@ -1065,7 +1059,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@41.0.2", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-raotm/aO8kOs1jD8SI8ssJ7EKciQOY295AOOprl1TxW7B0At8m5Ae7qNU1xdMxofiHMR8cNEGi9PKD3U+yT/mA=="],
+    "electron": ["electron@42.0.1", "", { "dependencies": { "@electron/get": "^5.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg=="],
 
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 
@@ -1087,7 +1081,7 @@
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
@@ -1103,7 +1097,7 @@
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1115,8 +1109,6 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
@@ -1126,6 +1118,8 @@
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -1219,15 +1213,15 @@
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
-    "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
-
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "http-proxy-middleware": ["http-proxy-middleware@3.0.5", "", { "dependencies": { "@types/http-proxy": "^1.17.15", "debug": "^4.3.6", "http-proxy": "^1.18.1", "is-glob": "^4.0.3", "is-plain-object": "^5.0.0", "micromatch": "^4.0.8" } }, "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg=="],
+    "http-proxy-middleware": ["http-proxy-middleware@4.0.0", "", { "dependencies": { "debug": "^4.4.3", "httpxy": "^0.5.1", "is-glob": "^4.0.3", "is-plain-obj": "^4.1.0", "micromatch": "^4.0.8" } }, "sha512-wuHwaUtmC0XzJNHqRp41zXtt5ojpHbusXGhq6781VvnjWUYPu7opmOF3eomGNujT07kEOnHWZyV9UZzKimVCKA=="],
 
     "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "httpxy": ["httpxy@0.5.1", "", {}, "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A=="],
 
     "i18n": ["i18n@0.15.3", "", { "dependencies": { "@messageformat/core": "^3.4.0", "debug": "^4.4.3", "fast-printf": "^1.6.10", "make-plural": "^7.4.0", "math-interval-parser": "^2.0.1", "mustache": "^4.2.0" } }, "sha512-tW/AA5R4lJZLnd60Agcd0PfXB1C2G7UqTrdNewuv/SIYdxcHkCE8w4Zx1SgCjJ+2BLuAAGIG/KXb/xNYF1lO5Q=="],
 
@@ -1263,7 +1257,7 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -1306,6 +1300,8 @@
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1465,8 +1461,6 @@
 
     "node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
 
-    "node-readable-to-web-readable-stream": ["node-readable-to-web-readable-stream@0.4.2", "", {}, "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ=="],
-
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
@@ -1511,7 +1505,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pdfjs-dist": ["pdfjs-dist@5.5.207", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.95", "node-readable-to-web-readable-stream": "^0.4.2" } }, "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw=="],
+    "pdfjs-dist": ["pdfjs-dist@5.7.284", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.100" } }, "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw=="],
 
     "pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
 
@@ -1576,8 +1570,6 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "resedit": ["resedit@1.7.2", "", { "dependencies": { "pe-library": "^0.4.1" } }, "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA=="],
 
@@ -1739,7 +1731,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
@@ -1761,7 +1753,7 @@
 
     "unique-slug": ["unique-slug@5.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg=="],
 
-    "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -1775,7 +1767,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
 
@@ -1851,9 +1843,11 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@actions/github/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+    "@actions/github/@actions/http-client": ["@actions/http-client@3.0.2", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA=="],
 
-    "@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+    "@actions/github/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
+
+    "@actions/http-client/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
@@ -1919,7 +1913,7 @@
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+    "@electron/get/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "@electron/osx-sign/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
@@ -1943,10 +1937,6 @@
 
     "@npmcli/fs/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
-
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
-
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "@types/cacheable-request/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
@@ -1955,8 +1945,6 @@
 
     "@types/fs-extra/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@types/http-proxy/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
-
     "@types/jsonfile/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@types/keyv/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
@@ -1964,6 +1952,8 @@
     "@types/plist/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "@types/responselike/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "@types/uuid/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "@types/ws/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
@@ -2085,6 +2075,8 @@
 
     "node-api-version/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
     "node-gyp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "node-gyp/tar": ["tar@7.5.6", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA=="],
@@ -2096,6 +2088,8 @@
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
@@ -2223,10 +2217,6 @@
 
     "@bramus/specificity/css-tree/mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
 
-    "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
     "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -2234,10 +2224,6 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
-
-    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
@@ -2248,8 +2234,6 @@
     "@types/cookie-signature/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/fs-extra/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@types/http-proxy/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/jsonfile/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -2262,6 +2246,8 @@
     "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/yauzl/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "app-builder-lib/@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 

--- a/doc/conventions.md
+++ b/doc/conventions.md
@@ -486,6 +486,82 @@ This transformation ensures that:
 
 ---
 
+## Legacy .elp (v2.x) Import – Identifier Regeneration on Open
+
+### Background
+
+Legacy `.elp` files store page, block, and iDevice identifiers as small sequential strings (e.g. `page-4`, `idevice-2`) baked in at the time the file was last saved by eXeLearning 2.x. These identifiers were stable inside the original Python implementation but are **not unique** across files and would collide if two legacy `.elp` files were merged into the same Y.Doc.
+
+Modern `.elpx` files carry a stable project identity (`odeId`) and ODE-style page/block/iDevice IDs (`YYYYMMDDHHmmss + 6 chars`). See [elpx-format/ids.md](elpx-format/ids.md).
+
+### Transformation Rule
+
+When a legacy `.elp` is opened or imported, the importer **regenerates every identifier**:
+
+1. A new project `odeId` and `odeVersionId` are minted (legacy `.elp` has no equivalent).
+2. Every `<odePageId>`, `<odeBlockId>`, and `<odeIdeviceId>` is replaced with a freshly generated unique ID.
+3. Parent-child page relationships and internal `exe-node:<id>` links are remapped to the new IDs (`remapInternalPageLinks()` in `ElpxImporter.ts`).
+
+This is unconditional: it happens on every open of a legacy `.elp`, including repeated opens of the same file in different sessions.
+
+### User-Visible Consequence
+
+The same `.elp` opened twice produces **two different sets of identifiers**. In particular:
+
+- Open `lesson.elp` → export to SCORM without saving → SCORM manifest contains IDs `A`.
+- Reopen the same `lesson.elp` → export to SCORM again without saving → SCORM manifest contains IDs `B ≠ A`.
+
+For the typical authoring flow this is harmless: the user saves the project once as `.elpx`, and from that point on the identifiers are stable across opens (modern `.elpx` round-trips preserve `odeId`/`odeVersionId` and the importer remap only fires once at the legacy → modern migration boundary).
+
+However, workflows that **use a legacy `.elp` as a source of truth and re-export from it repeatedly** (without ever saving as `.elpx`) will see SCORM/HTML5/EPUB output whose internal identifiers drift between exports. LMS systems that key tracking on these identifiers may treat each re-export as a brand-new package.
+
+### Recommended Workflow
+
+To get stable identifiers across re-exports from a legacy `.elp`:
+
+1. Open the `.elp` once.
+2. **Save as `.elpx`** — this commits the freshly generated `odeId` and `odeVersionId` to the modern format.
+3. From then on, open and re-export the `.elpx`. Identifiers are preserved across the round-trip.
+
+### When This Applies
+
+Identifier regeneration applies **only** when:
+
+- Opening or importing **legacy `.elp` files** (v2.x / `contentv3.xml`, Python pickle-based format).
+- Opening or importing **modern `.elpx` files** into a Y.Doc that already contains content (collision avoidance — same mechanism).
+
+It does **not** apply to:
+
+- Reopening a modern `.elpx` into an empty workspace — `odeId` and `odeVersionId` are restored from `<odeResources>`, so output is byte-stable across saves (see `OdeXmlGenerator.ts:44–45`).
+
+### Implementation Details
+
+- **Generator:** `generateOdeId()` in `src/shared/export/OdeXmlGenerator.ts`
+- **Importer remap:** `buildFlatPageList()`, `convertLegacyPagesToPageData()`, `generateId()`, and `remapInternalPageLinks()` in `src/services/import/ElpxImporter.ts`
+- **Reference docs:** [elpx-format/ids.md](elpx-format/ids.md), [elpx-format/import-pipeline.md](elpx-format/import-pipeline.md)
+
+### Rationale
+
+Legacy `.elp` identifiers are not globally unique and cannot be reused safely. Regeneration on every open guarantees that:
+
+1. **Two different `.elp` files** can be merged into one Y.Doc without identifier collisions.
+2. **Repeated imports** of the same `.elp` into one Y.Doc do not silently overwrite existing pages.
+3. **Internal links** (`exe-node:<id>`) remain valid because the remap walks every component's HTML and JSON properties.
+
+The cost — non-deterministic IDs across reopens of the same `.elp` — is acceptable because the legacy format is a one-way migration source, not a long-term storage format. Users who need stable IDs are expected to save once as `.elpx`.
+
+### Important Notes
+
+- This behavior is **intentional and by design** – it is not a bug.
+- It is the reason why opening the same legacy `.elp` twice yields different SCORM manifests.
+- Do not change this behavior without updating:
+  - The code comments at `ElpxImporter.ts:653` and around `OdeXmlGenerator.ts:44`
+  - This documentation
+  - [elpx-format/ids.md](elpx-format/ids.md)
+  - The test suite
+
+---
+
 ## Adding New Conventions
 
 When adding new conventions to this document:

--- a/doc/elpx-format/ids.md
+++ b/doc/elpx-format/ids.md
@@ -69,7 +69,7 @@ All three forms are accepted by the importer. The modern generator always produc
 | Identifier | Set when | Changes when | Notes |
 |---|---|---|---|
 | `odeId` | Project is created for the first time | Never (stable for the project's lifetime) | Stored in `odeResources`. Retrieved from `meta.odeIdentifier` if already set, otherwise `generateOdeId()` is called once (`OdeXmlGenerator.ts:44`). |
-| `odeVersionId` | Every export / save | Every export / save | Always a freshly generated `generateOdeId()` call (`OdeXmlGenerator.ts:45`). Acts as a change cursor. |
+| `odeVersionId` | Project is created for the first time | Preserved across round-trips | Read from `meta.odeVersionId` when present, otherwise a freshly generated `generateOdeId()` (`OdeXmlGenerator.ts:45`). Imported from `<odeResources>` so an open/save round-trip is byte-stable. |
 | `odePageId` | Page is created | On import (reassigned — see below) | Stable within a project; changes only when the file is re-imported. |
 | `odeBlockId` | Block is created | On import (reassigned) | Stable within a project; changes only when the file is re-imported. |
 | `odeIdeviceId` | iDevice is added | On import (reassigned) | Stable within a project; changes only when the file is re-imported. |

--- a/doc/elpx-format/metadata.md
+++ b/doc/elpx-format/metadata.md
@@ -75,7 +75,7 @@ function generateOdeResourcesXml(odeId: string, versionId: string): string {
 | Key | Description |
 |---|---|
 | `odeId` | Stable project identifier. Retrieved from `meta.odeIdentifier` on export; generated once via `generateOdeId()` if absent. |
-| `odeVersionId` | Regenerated on every export/save via `generateOdeId()`. Acts as a change cursor. |
+| `odeVersionId` | Stable per-version identifier. Read from `meta.odeVersionId` on export; generated once via `generateOdeId()` only when absent. Imported from `<odeResources>` so a round-trip without content changes preserves the value. |
 | `exe_version` | The ODE format version string, currently `'3.0'` (constant `ODE_VERSION` from `constants.ts:1000`). |
 
 **Legacy keys observed in older fixtures:** the v4 generator writes exactly three resources (`odeId`, `odeVersionId`, `exe_version`). Some older fixtures additionally carry `odeVersionName`, `isDownload`, or the misspelling `eXeVersion`. The importer accepts all of these for backward compatibility, but **`generateOdeResourcesXml()` never emits them in v4** — treat them as informational legacy keys when reading older `.elpx` files.

--- a/public/app/rest/apiCallManager.js
+++ b/public/app/rest/apiCallManager.js
@@ -1178,6 +1178,12 @@ export default class ApiCallManager {
                     description: metadata?.get('description') || '',
                     license: metadata?.get('license') || '',
                     theme: metadata?.get('theme') || 'base',
+                    // Stable identifiers (#1786) -- forward so the server-side
+                    // YjsDocumentAdapter can derive a stable SCORM/IMS manifest
+                    // identifier instead of generating a fresh random one.
+                    odeIdentifier: metadata?.get('odeIdentifier') || undefined,
+                    odeVersionId: metadata?.get('odeVersionId') || undefined,
+                    scormIdentifier: metadata?.get('scormIdentifier') || undefined,
                 },
                 pages: [],
                 navigation: [],

--- a/public/app/yjs/ComponentImporter.js
+++ b/public/app/yjs/ComponentImporter.js
@@ -100,11 +100,19 @@ class ComponentImporter {
       blockData.id = newBlockId;
       blockData.blockId = newBlockId;
 
-      // Generate new IDs for components
+      // Generate new IDs for components. When jsonProperties carries an
+      // embedded ideviceId (text/quiz iDevices store it for self-reference),
+      // rewrite it to the fresh id so the Y.Map field and the JSON payload
+      // stay in sync. See #1786.
       for (const comp of blockData.components) {
+        const originalCompId = comp.id;
         const newCompId = this.generateId('idevice');
         comp.id = newCompId;
         comp.ideviceId = newCompId;
+        if (originalCompId && comp.properties && typeof comp.properties === 'object'
+            && comp.properties.ideviceId === originalCompId) {
+          comp.properties.ideviceId = newCompId;
+        }
       }
 
       // Insert block into target page
@@ -466,13 +474,19 @@ class ComponentImporter {
   }
 
   /**
-   * Generate a unique ID
+   * Generate a unique ID.
+   *
+   * Mirrors src/shared/ids.ts::generateId — keep in sync. See issue #1782.
+   *
    * @param {string} prefix - ID prefix
    * @returns {string}
    */
   generateId(prefix) {
+    if (!prefix) {
+      throw new Error('generateId: prefix is required');
+    }
     const timestamp = Date.now().toString(36);
-    const random = Math.random().toString(36).substr(2, 9);
+    const random = Math.random().toString(36).substring(2, 11);
     return `${prefix}-${timestamp}-${random}`;
   }
 }

--- a/public/app/yjs/ComponentImporter.test.js
+++ b/public/app/yjs/ComponentImporter.test.js
@@ -306,6 +306,67 @@ describe('ComponentImporter', () => {
       expect(result.error).toBe('No content.xml found in component file');
     });
 
+    it('should rewrite embedded ideviceId in jsonProperties when component id is regenerated (#1786)', async () => {
+      // Component XML carries an ideviceId inside jsonProperties (text/quiz
+      // iDevices store it for self-reference). ComponentImporter always mints
+      // a fresh component id on import; the embedded value must follow so the
+      // Y.Map field and the JSON payload stay in sync.
+      const COMPONENT_WITH_EMBEDDED_ID = `<?xml version="1.0" encoding="UTF-8"?>
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource>
+    <key>odeComponentsResources</key>
+    <value>true</value>
+  </odeResource>
+</odeResources>
+<odePagStructures>
+  <odePagStructure>
+    <odeBlockId>block-orig-1</odeBlockId>
+    <blockName>Embedded id</blockName>
+    <iconName></iconName>
+    <odePagStructureOrder>0</odePagStructureOrder>
+    <odePagStructureProperties>{}</odePagStructureProperties>
+    <odeComponents>
+      <odeComponent>
+        <odeIdeviceId>idevice-orig-1</odeIdeviceId>
+        <odeIdeviceTypeName>text</odeIdeviceTypeName>
+        <htmlView>&lt;p&gt;hi&lt;/p&gt;</htmlView>
+        <jsonProperties>{"ideviceId":"idevice-orig-1","textTextarea":"&lt;p&gt;hi&lt;/p&gt;"}</jsonProperties>
+        <odeComponentsOrder>0</odeComponentsOrder>
+        <odeComponentsProperties></odeComponentsProperties>
+      </odeComponent>
+    </odeComponents>
+  </odePagStructure>
+</odePagStructures>
+</ode>`;
+
+      const docManager = createMockDocumentManager([{ id: 'page-1', name: 'Test Page' }]);
+      const assetManager = createMockAssetManager();
+      global.window.fflate = createMockFflate(COMPONENT_WITH_EMBEDDED_ID);
+      const importer = new ComponentImporter(docManager, assetManager);
+
+      const file = new File([new Uint8Array([1, 2, 3])], 'test.idevice');
+      const result = await importer.importComponent(file, 'page-1');
+      expect(result.success).toBe(true);
+
+      // Inspect the inserted component on page-1.
+      const navigation = docManager._navigation;
+      const pageMap = navigation.get(0);
+      const blocks = pageMap.get('blocks');
+      const blockMap = blocks.get(blocks.length - 1); // last appended
+      const components = blockMap.get('components');
+      const compMap = components.get(0);
+      const newCompId = compMap.get('id');
+      const jsonStr = compMap.get('jsonProperties');
+      const parsed = JSON.parse(jsonStr);
+
+      // Outer id was regenerated AND the embedded one followed.
+      expect(newCompId).not.toBe('idevice-orig-1');
+      expect(newCompId).toMatch(/^idevice-/);
+      expect(parsed.ideviceId).toBe(newCompId);
+      expect(parsed.ideviceId).not.toBe('idevice-orig-1');
+    });
+
     it('should generate new IDs for imported block and components', async () => {
       const docManager = createMockDocumentManager([{ id: 'page-1', name: 'Test Page' }]);
       const assetManager = createMockAssetManager();
@@ -422,6 +483,13 @@ describe('ComponentImporter', () => {
       expect(id2).toMatch(/^block-/);
       expect(id3).toMatch(/^idevice-/);
       expect(id1).not.toBe(id2); // Should be unique
+    });
+
+    it('should throw on empty prefix (mirrors src/shared/ids.ts)', () => {
+      const docManager = createMockDocumentManager();
+      const importer = new ComponentImporter(docManager, null);
+      expect(() => importer.generateId('')).toThrow('generateId: prefix is required');
+      expect(() => importer.generateId(undefined)).toThrow('generateId: prefix is required');
     });
   });
 

--- a/public/app/yjs/YjsDocumentManager.js
+++ b/public/app/yjs/YjsDocumentManager.js
@@ -656,6 +656,12 @@ class YjsDocumentManager {
       metadata.set('createdAt', Date.now());
       metadata.set('modifiedAt', Date.now());
 
+      // Stable identifiers (odeIdentifier / odeVersionId) are NOT minted on
+      // create -- the first import (v4 <odeResources> or legacy mint at
+      // import time) writes them. Minting here would create CRDT history
+      // that gets superseded by the import and inflate the persisted state.
+      // See #1786.
+
       // Create root page
       const rootPageId = this.generateId();
       const rootPage = new Y.Map();

--- a/public/app/yjs/YjsProjectManagerMixin.js
+++ b/public/app/yjs/YjsProjectManagerMixin.js
@@ -627,6 +627,19 @@ const YjsProjectManagerMixin = {
         return str;
       };
 
+      // Canonical id generator -- mirrors src/shared/ids.ts (Format A: base36
+      // timestamp + 9 base36 random chars). Kept inline because this mixin runs
+      // in the browser before the TS bundle is available. See issue #1782.
+      // Mirrors src/shared/ids.ts::generateId — keep in sync. See issue #1782.
+      const generateCanonicalId = (prefix) => {
+        if (!prefix) {
+          throw new Error('generateId: prefix is required');
+        }
+        const timestamp = Date.now().toString(36);
+        const random = Math.random().toString(36).substring(2, 11);
+        return `${prefix}-${timestamp}-${random}`;
+      };
+
       // 2. Import structure into Yjs
       const documentManager = this._yjsBridge.getDocumentManager();
       const navigation = documentManager.getNavigation();
@@ -673,7 +686,7 @@ const YjsProjectManagerMixin = {
       // Import each page as a flat entry in navigation (NO nested children arrays)
       const importPage = (pageData) => {
         const pageMap = new Y.Map();
-        const pageId = pageData.id || `page-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const pageId = pageData.id || generateCanonicalId('page');
 
         pageMap.set('id', pageId);
         pageMap.set('pageId', pageId);
@@ -687,7 +700,7 @@ const YjsProjectManagerMixin = {
         if (pageData.blocks && Array.isArray(pageData.blocks)) {
           for (const blockData of pageData.blocks) {
             const blockMap = new Y.Map();
-            const blockId = blockData.id || `block-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+            const blockId = blockData.id || generateCanonicalId('block');
 
             blockMap.set('id', blockId);
             blockMap.set('blockId', blockId);
@@ -698,7 +711,7 @@ const YjsProjectManagerMixin = {
             if (blockData.idevices && Array.isArray(blockData.idevices)) {
               for (const ideviceData of blockData.idevices) {
                 const compMap = new Y.Map();
-                const compId = ideviceData.id || `idevice-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+                const compId = ideviceData.id || generateCanonicalId('idevice');
 
                 compMap.set('id', compId);
                 compMap.set('ideviceId', compId);

--- a/public/app/yjs/YjsProjectManagerMixin.test.js
+++ b/public/app/yjs/YjsProjectManagerMixin.test.js
@@ -1189,6 +1189,58 @@ describe('YjsProjectManagerMixin', () => {
       expect(result.components).toBe(1);
     });
 
+    it('generates canonical page, block and iDevice IDs when converted structure has none (#1782)', async () => {
+      const nowSpy = spyOn(Date, 'now').mockReturnValue(1700000000000);
+      window.Y = { Map: global.MockYMap, Array: global.MockYArray };
+      const mockNavigation = new global.MockYArray();
+      mockBridge.getAssetManager = mock(() => null);
+      mockBridge.getDocumentManager = mock(() => ({
+        getNavigation: () => mockNavigation,
+      }));
+
+      await projectManager.enableYjsMode(123, 'token');
+
+      const structure = {
+        pages: [
+          {
+            title: 'Generated IDs',
+            blocks: [
+              {
+                name: 'Generated block',
+                idevices: [
+                  {
+                    type: 'FreeTextIdevice',
+                    htmlView: '<p>Generated component</p>',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      await projectManager.importConvertedStructure(structure, []);
+
+      const page = mockNavigation.get(0);
+      const pageId = page.get('id');
+      const block = page.get('blocks').get(0);
+      const blockId = block.get('id');
+      const component = block.get('components').get(0);
+      const componentId = component.get('id');
+
+      // Canonical Format A: <prefix>-<base36 timestamp>-<9 base36 random chars>
+      expect(pageId).toMatch(/^page-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+      expect(pageId.startsWith(`page-${(1700000000000).toString(36)}-`)).toBe(true);
+      expect(page.get('pageId')).toBe(pageId);
+      expect(blockId).toMatch(/^block-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+      expect(blockId.startsWith(`block-${(1700000000000).toString(36)}-`)).toBe(true);
+      expect(block.get('blockId')).toBe(blockId);
+      expect(componentId).toMatch(/^idevice-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+      expect(componentId.startsWith(`idevice-${(1700000000000).toString(36)}-`)).toBe(true);
+      expect(component.get('ideviceId')).toBe(componentId);
+      nowSpy.mockRestore();
+    });
+
     it('handles empty structure', async () => {
       const mockNavigation = new global.window.Y.Array();
       mockBridge.getAssetManager = mock(() => null);

--- a/public/app/yjs/YjsStructureBinding.js
+++ b/public/app/yjs/YjsStructureBinding.js
@@ -2821,8 +2821,21 @@ class YjsStructureBinding {
     };
   }
 
+  /**
+   * Generate a unique ID.
+   *
+   * Mirrors src/shared/ids.ts::generateId — keep in sync. See issue #1782.
+   *
+   * @param {string} prefix - ID prefix
+   * @returns {string}
+   */
   generateId(prefix) {
-    return `${prefix}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    if (!prefix) {
+      throw new Error('generateId: prefix is required');
+    }
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substring(2, 11);
+    return `${prefix}-${timestamp}-${random}`;
   }
 
   // ===== Import from API Structure =====

--- a/public/app/yjs/YjsStructureBinding.test.js
+++ b/public/app/yjs/YjsStructureBinding.test.js
@@ -566,10 +566,9 @@ describe('YjsStructureBinding', () => {
       expect(id1).toContain('page');
     });
 
-    it('generates IDs without prefix', () => {
-      const id = binding.generateId();
-      expect(typeof id).toBe('string');
-      expect(id.length).toBeGreaterThan(0);
+    it('throws on missing/empty prefix (mirrors src/shared/ids.ts contract)', () => {
+      expect(() => binding.generateId()).toThrow('generateId: prefix is required');
+      expect(() => binding.generateId('')).toThrow('generateId: prefix is required');
     });
   });
 

--- a/src/routes/export.spec.ts
+++ b/src/routes/export.spec.ts
@@ -1118,3 +1118,44 @@ describe('Export Routes', () => {
         });
     });
 });
+
+describe('populateYDocFromStructure - stable identifiers (#1786)', () => {
+    it('forwards odeIdentifier / odeVersionId / scormIdentifier from the client payload', async () => {
+        const Y = await import('yjs');
+        const { populateYDocFromStructure } = await import('./export');
+        const ydoc = new Y.Doc();
+        populateYDocFromStructure(ydoc, {
+            meta: {
+                title: 'Stable identifiers',
+                language: 'en',
+                theme: 'base',
+                odeIdentifier: '20251201123456ABCDEF',
+                odeVersionId: '20251201123456FEDCBA',
+                scormIdentifier: 'CUSTOM-SCORM-ID',
+            },
+            pages: [],
+            navigation: [],
+        });
+        const meta = ydoc.getMap('metadata');
+        expect(meta.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+        expect(meta.get('odeVersionId')).toBe('20251201123456FEDCBA');
+        expect(meta.get('scormIdentifier')).toBe('CUSTOM-SCORM-ID');
+        ydoc.destroy();
+    });
+
+    it('leaves stable identifiers unset when the client omits them (export-side fallback path)', async () => {
+        const Y = await import('yjs');
+        const { populateYDocFromStructure } = await import('./export');
+        const ydoc = new Y.Doc();
+        populateYDocFromStructure(ydoc, {
+            meta: { title: 'No stable ids', language: 'en', theme: 'base' },
+            pages: [],
+            navigation: [],
+        });
+        const meta = ydoc.getMap('metadata');
+        expect(meta.get('odeIdentifier')).toBeUndefined();
+        expect(meta.get('odeVersionId')).toBeUndefined();
+        expect(meta.get('scormIdentifier')).toBeUndefined();
+        ydoc.destroy();
+    });
+});

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -220,6 +220,15 @@ export function populateYDocFromStructure(ydoc: Y.Doc, structure: YjsExportStruc
     if (meta.extraHeadContent) metadata.set('extraHeadContent', meta.extraHeadContent);
     if (meta.footer) metadata.set('footer', meta.footer);
 
+    // Stable identifiers (#1786) -- only write when the client supplied them so
+    // a browser export carrying a stable project identity reaches BaseExporter
+    // with the same odeId/scormId. Without these, the server-side export path
+    // falls back to a fresh generateOdeId() and the LMS sees a new course on
+    // every re-upload.
+    if (meta.odeIdentifier) metadata.set('odeIdentifier', meta.odeIdentifier);
+    if (meta.odeVersionId) metadata.set('odeVersionId', meta.odeVersionId);
+    if (meta.scormIdentifier) metadata.set('scormIdentifier', meta.scormIdentifier);
+
     // Set navigation (pages with blocks)
     const navigation = ydoc.getArray('navigation');
 

--- a/src/routes/types/request-payloads.ts
+++ b/src/routes/types/request-payloads.ts
@@ -133,6 +133,12 @@ export interface YjsExportStructure {
         // Custom content
         extraHeadContent?: string;
         footer?: string;
+        // Stable identifiers (#1786) -- forwarded from the browser Y.Map so the
+        // server-side YjsDocumentAdapter sees the same project identity and
+        // BaseExporter.getManifestIdentifier derives a stable manifest@identifier.
+        odeIdentifier?: string;
+        odeVersionId?: string;
+        scormIdentifier?: string;
     };
     pages: Array<{
         id: string;

--- a/src/services/yjs-initializer.spec.ts
+++ b/src/services/yjs-initializer.spec.ts
@@ -28,6 +28,22 @@ describe('yjs-initializer', () => {
             expect(typeof metadata.get('modifiedAt')).toBe('number');
         });
 
+        it('does NOT mint odeIdentifier/odeVersionId at creation time (#1786)', () => {
+            // Stable identifiers are populated at import time (v4 <odeResources>
+            // or legacy mint in setLegacyMetadata). Minting on create would
+            // get overwritten by the first import and create CRDT history
+            // that the binary-integrity e2e check rejects. Brand-new projects
+            // rely on BaseExporter.getManifestIdentifier fallback for SCORM.
+            const data = createBlankYjsDocument();
+            const ydoc = new Y.Doc();
+            Y.applyUpdate(ydoc, data);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBeUndefined();
+            expect(metadata.get('odeVersionId')).toBeUndefined();
+            ydoc.destroy();
+        });
+
         it('creates document with custom title', () => {
             const data = createBlankYjsDocument({ title: 'My Custom Project' });
 

--- a/src/services/yjs-initializer.ts
+++ b/src/services/yjs-initializer.ts
@@ -51,6 +51,15 @@ export function createBlankYjsDocument(options?: YjsInitOptions): Uint8Array {
         metadata.set('theme', options?.theme || 'base');
         metadata.set('createdAt', Date.now());
         metadata.set('modifiedAt', Date.now());
+        // Stable identifiers (odeIdentifier / odeVersionId) are intentionally
+        // NOT minted at server creation. Minting here would create CRDT history
+        // that gets overwritten by the first import (v4 .elpx carries its own
+        // <odeResources>; legacy v3 .elp generates one at import). The
+        // garbage-collected superseded ops inflate the persisted state and
+        // break the binary-integrity e2e save/load consistency check.
+        // For brand-new projects that are exported without ever being imported
+        // or saved, BaseExporter.getManifestIdentifier falls back to a
+        // memoized fresh id within a single export. See #1786.
 
         // Create root page (matches client-side structure)
         const rootPageId = generateId();

--- a/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.spec.ts
@@ -1154,3 +1154,89 @@ describe('YjsDocumentAdapter', () => {
         });
     });
 });
+
+describe('YjsDocumentAdapter.getMetadata - stable identifiers (#1784)', () => {
+    it('forwards odeIdentifier, odeVersionId and scormIdentifier from the Y.Map (mocked)', () => {
+        const manager = new MockYjsDocumentManager({
+            title: 'Stable IDs',
+            odeIdentifier: '20251201123456ABCDEF',
+            odeVersionId: '20251201123456FEDCBA',
+            scormIdentifier: 'CUSTOM-SCORM-XYZ',
+        });
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const meta = adapter.getMetadata();
+        expect(meta.odeIdentifier).toBe('20251201123456ABCDEF');
+        expect(meta.odeVersionId).toBe('20251201123456FEDCBA');
+        expect(meta.scormIdentifier).toBe('CUSTOM-SCORM-XYZ');
+    });
+
+    it('returns undefined for unset stable identifiers (legacy projects)', () => {
+        const manager = new MockYjsDocumentManager({ title: 'Legacy' });
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const meta = adapter.getMetadata();
+        expect(meta.odeIdentifier).toBeUndefined();
+        expect(meta.odeVersionId).toBeUndefined();
+        expect(meta.scormIdentifier).toBeUndefined();
+    });
+
+    it('returns undefined for stable identifiers on a completely empty real Y.Map', async () => {
+        // Defensive: brand-new project Y.Doc has no metadata at all. The adapter
+        // must not throw and must leave odeIdentifier / odeVersionId / scormIdentifier
+        // unset so the export-side fallback (`BaseExporter.getManifestIdentifier`)
+        // runs instead of inheriting garbage from a partially-initialized map.
+        const Y = await import('yjs');
+        const doc = new Y.Doc();
+        doc.getMap('metadata'); // touch but don't write anything
+        doc.getArray('navigation');
+
+        const manager = {
+            getMetadata: () => doc.getMap('metadata'),
+            getNavigation: () => doc.getArray('navigation'),
+            getDoc: () => doc,
+            projectId: 'empty-yjs-project',
+        };
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const exportMeta = adapter.getMetadata();
+        expect(exportMeta.odeIdentifier).toBeUndefined();
+        expect(exportMeta.odeVersionId).toBeUndefined();
+        expect(exportMeta.scormIdentifier).toBeUndefined();
+        // Sanity: defaults for required fields still apply.
+        expect(exportMeta.title).toBe('eXeLearning');
+        expect(exportMeta.theme).toBe('base');
+
+        doc.destroy();
+    });
+
+    it('reads stable identifiers from a real Y.Doc through YjsDocumentAdapter (no mocks)', async () => {
+        const Y = await import('yjs');
+        const doc = new Y.Doc();
+        const meta = doc.getMap('metadata');
+        meta.set('title', 'Real Y.Doc');
+        meta.set('odeIdentifier', '20251201123456ABCDEF');
+        meta.set('odeVersionId', '20251201123456FEDCBA');
+        // Minimal navigation so the adapter is happy.
+        doc.getArray('navigation');
+
+        const manager = {
+            getMetadata: () => meta,
+            getNavigation: () => doc.getArray('navigation'),
+            getDoc: () => doc,
+            projectId: 'real-yjs-project',
+        };
+        const adapter = new YjsDocumentAdapter(
+            manager as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+
+        const exportMeta = adapter.getMetadata();
+        expect(exportMeta.odeIdentifier).toBe('20251201123456ABCDEF');
+        expect(exportMeta.odeVersionId).toBe('20251201123456FEDCBA');
+
+        doc.destroy();
+    });
+});

--- a/src/shared/export/adapters/YjsDocumentAdapter.ts
+++ b/src/shared/export/adapters/YjsDocumentAdapter.ts
@@ -116,6 +116,12 @@ export class YjsDocumentAdapter implements ExportDocument {
 
             // Project screenshot/thumbnail
             screenshot: (meta.get('screenshot') as string) || undefined,
+
+            // Stable identifiers (#1784, #1785) -- preserved across import/export so
+            // that content.xml diffs stay clean and LMS tracking survives SCORM re-uploads.
+            odeIdentifier: (meta.get('odeIdentifier') as string) || undefined,
+            odeVersionId: (meta.get('odeVersionId') as string) || undefined,
+            scormIdentifier: (meta.get('scormIdentifier') as string) || undefined,
         };
     }
 

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -21,7 +21,7 @@ import type {
 import { IdeviceRenderer } from '../renderers/IdeviceRenderer';
 import { PageRenderer } from '../renderers/PageRenderer';
 import { LibraryDetector } from '../utils/LibraryDetector';
-import { generateOdeXml } from '../generators/OdeXmlGenerator';
+import { generateOdeXml, generateOdeId } from '../generators/OdeXmlGenerator';
 import { formatLicenseText } from '../constants';
 import { deriveFilenameFromMime, getExtensionFromMimeType } from '../../../config';
 
@@ -360,6 +360,65 @@ export abstract class BaseExporter {
         const timestamp = Date.now().toString(36);
         const random = Math.random().toString(36).substring(2, 8);
         return `${prefix}${timestamp}${random}`.toUpperCase();
+    }
+
+    /**
+     * Cached manifest identifier for this exporter instance.
+     * Computed once on the first call and reused so the fallback path
+     * (no scormIdentifier, no odeIdentifier) does not regenerate a new
+     * random id on each subsequent call -- which would desynchronise the
+     * manifest, organization and LOM catalog/entry roots.
+     */
+    private _manifestIdentifier: string | undefined;
+
+    /**
+     * Stable identifier used in SCORM/IMS manifests and LOM catalog/entry.
+     *
+     * Derives from the project's odeIdentifier so the LMS treats updated
+     * re-uploads as the same course (preserving learner tracking). Honours
+     * an explicit `scormIdentifier` override from project metadata.
+     *
+     * Resolution order:
+     * 1. `meta.scormIdentifier` if set (user override -- used verbatim).
+     * 2. `'eXe-MANIFEST-' + meta.odeIdentifier` (default -- shares root with content.xml).
+     * 3. `'eXe-MANIFEST-' + generateOdeId()` (fallback for legacy projects).
+     *
+     * The result is memoized per exporter instance: a single export call must
+     * always observe the same manifest identifier so the manifest, the
+     * organization identifier and the LOM catalog/entry stay consistent.
+     *
+     * The returned string is the FINAL `manifest@identifier` value. Manifest
+     * generators must use it as-is (i.e. they must NOT prepend their own
+     * `eXe-MANIFEST-` prefix).
+     *
+     * Related: exelearning/exelearning#1785.
+     */
+    protected getManifestIdentifier(): string {
+        if (this._manifestIdentifier !== undefined) {
+            return this._manifestIdentifier;
+        }
+        const meta = this.getMetadata();
+        if (meta.scormIdentifier) {
+            this._manifestIdentifier = meta.scormIdentifier;
+        } else if (meta.odeIdentifier) {
+            this._manifestIdentifier = 'eXe-MANIFEST-' + meta.odeIdentifier;
+        } else {
+            this._manifestIdentifier = 'eXe-MANIFEST-' + generateOdeId();
+        }
+        return this._manifestIdentifier;
+    }
+
+    /**
+     * Bare project identifier (without the `eXe-MANIFEST-` prefix).
+     *
+     * Used for the manifest `organization@identifier` (`eXe-<bareId>`) and
+     * for the LOM `catalog/entry` (`ODE-<bareId>`) so a single project
+     * identity flows through every artifact in the export.
+     */
+    protected getBareProjectIdentifier(): string {
+        const fullId = this.getManifestIdentifier();
+        const PREFIX = 'eXe-MANIFEST-';
+        return fullId.startsWith(PREFIX) ? fullId.slice(PREFIX.length) : fullId;
     }
 
     // =========================================================================

--- a/src/shared/export/exporters/ImsExporter.spec.ts
+++ b/src/shared/export/exporters/ImsExporter.spec.ts
@@ -392,12 +392,89 @@ describe('ImsExporter', () => {
     });
 
     describe('Project ID Generation', () => {
-        it('should generate unique project IDs', () => {
+        it('should generate unique low-level project IDs (legacy random helper)', () => {
             const id1 = exporter.generateProjectId();
             const id2 = exporter.generateProjectId();
 
             expect(id1).not.toBe(id2);
             expect(id1.length).toBeGreaterThan(0);
+        });
+
+        it('should produce a STABLE manifest@identifier across exports when odeIdentifier is set (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const zip1 = new MockZipProvider();
+            const exporter1 = new ImsExporter(document, resources, assets, zip1);
+            await exporter1.export();
+            const manifest1 = zip1.files.get('imsmanifest.xml') as string;
+            const idMatch1 = manifest1.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch1).not.toBeNull();
+            const id1 = idMatch1![1];
+
+            const zip2 = new MockZipProvider();
+            const exporter2 = new ImsExporter(document, resources, assets, zip2);
+            await exporter2.export();
+            const manifest2 = zip2.files.get('imsmanifest.xml') as string;
+            const idMatch2 = manifest2.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch2).not.toBeNull();
+            const id2 = idMatch2![1];
+
+            // BUG fix: re-exporting the same project must produce the SAME manifest identifier.
+            expect(id1).toBe(id2);
+            expect(id1).toContain('20251201123456ABCDEF');
+        });
+
+        it('should honour meta.scormIdentifier as a user override (#1785)', async () => {
+            document = new MockDocument(
+                {
+                    odeIdentifier: '20251201123456ABCDEF',
+                    scormIdentifier: 'CUSTOM-OVERRIDE-XYZ',
+                },
+                samplePages,
+            );
+            const localZip = new MockZipProvider();
+            exporter = new ImsExporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            expect(idMatch![1]).toBe('CUSTOM-OVERRIDE-XYZ');
+        });
+
+        it('should fall back to a generated eXe-MANIFEST-* identifier when neither override nor odeIdentifier is set (#1785)', async () => {
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new ImsExporter(document, resources, assets, localZip);
+            const result = await exporter.export();
+            expect(result.success).toBe(true);
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            expect(idMatch![1]).toMatch(/^eXe-MANIFEST-\d{14}[A-Z0-9]{6}$/);
+        });
+
+        it('should derive manifest@identifier and content.xml odeId from the same odeIdentifier (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new ImsExporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const contentXml = localZip.files.get('content.xml') as string;
+            // Both artifacts reference the same project-identity root.
+            expect(manifest).toContain('20251201123456ABCDEF');
+            expect(contentXml).toContain('20251201123456ABCDEF');
+        });
+
+        it('shares a single root id across manifest and organization on the FALLBACK path (#1785)', async () => {
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new ImsExporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const manifestMatch = manifest.match(/<manifest\s+identifier="eXe-MANIFEST-([A-Z0-9]+)"/);
+            const orgMatch = manifest.match(/<organization\s+identifier="eXe-([A-Z0-9]+)"/);
+            expect(manifestMatch).not.toBeNull();
+            expect(orgMatch).not.toBeNull();
+            expect(orgMatch![1]).toBe(manifestMatch![1]);
         });
     });
 

--- a/src/shared/export/exporters/ImsExporter.ts
+++ b/src/shared/export/exporters/ImsExporter.ts
@@ -44,7 +44,12 @@ export class ImsExporter extends Html5Exporter {
             const meta = this.getMetadata();
             // Theme priority: 1º parameter > 2º ELP metadata > 3º default
             const themeName = options?.theme || meta.theme || 'base';
-            const projectId = this.generateProjectId();
+            // Stable manifest identifier (see BaseExporter.getManifestIdentifier and #1785).
+            // `manifestIdentifier` is the final `<manifest identifier="...">` value;
+            // `projectId` is the bare id used for organization and resource ids,
+            // so a single project identity flows through manifest and content.xml.
+            const manifestIdentifier = this.getManifestIdentifier();
+            const projectId = this.getBareProjectIdentifier();
 
             // Pre-process pages: add filenames to asset URLs
             pages = await this.preprocessPagesForExport(pages);
@@ -66,15 +71,20 @@ export class ImsExporter extends Html5Exporter {
             };
 
             // Initialize manifest generator
-            this.manifestGenerator = new ImsManifestGenerator(projectId, pages, {
-                identifier: projectId,
-                pages: pages,
-                title: meta.title || 'eXeLearning',
-                language: meta.language || 'en',
-                author: meta.author || '',
-                description: meta.description || '',
-                license: meta.license || '',
-            });
+            this.manifestGenerator = new ImsManifestGenerator(
+                projectId,
+                pages,
+                {
+                    identifier: manifestIdentifier,
+                    pages: pages,
+                    title: meta.title || 'eXeLearning',
+                    language: meta.language || 'en',
+                    author: meta.author || '',
+                    description: meta.description || '',
+                    license: meta.license || '',
+                },
+                manifestIdentifier,
+            );
 
             // Track files for manifest
             const commonFiles: string[] = [];
@@ -348,7 +358,12 @@ export class ImsExporter extends Html5Exporter {
     }
 
     /**
-     * Generate project ID for IMS package
+     * Generate a random low-level project ID.
+     *
+     * @deprecated Since #1785, the IMS manifest identifier is derived from
+     * the project's odeIdentifier via {@link BaseExporter.getManifestIdentifier}
+     * so LMS tracking survives re-uploads. This helper is kept only for
+     * external callers/tests and is no longer used by the export pipeline.
      */
     generateProjectId(): string {
         return Date.now().toString(36) + Math.random().toString(36).substring(2, 7);

--- a/src/shared/export/exporters/Scorm12Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.spec.ts
@@ -430,12 +430,143 @@ describe('Scorm12Exporter', () => {
     });
 
     describe('Project ID Generation', () => {
-        it('should generate unique project IDs', () => {
+        it('should generate unique low-level project IDs (legacy random helper)', () => {
             const id1 = exporter.generateProjectId();
             const id2 = exporter.generateProjectId();
 
             expect(id1).not.toBe(id2);
             expect(id1.length).toBeGreaterThan(0);
+        });
+
+        it('should produce a STABLE manifest@identifier across exports when odeIdentifier is set (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const zip1 = new MockZipProvider();
+            const exporter1 = new Scorm12Exporter(document, resources, assets, zip1);
+            await exporter1.export();
+            const manifest1 = zip1.files.get('imsmanifest.xml') as string;
+            const idMatch1 = manifest1.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch1).not.toBeNull();
+            const id1 = idMatch1![1];
+
+            const zip2 = new MockZipProvider();
+            const exporter2 = new Scorm12Exporter(document, resources, assets, zip2);
+            await exporter2.export();
+            const manifest2 = zip2.files.get('imsmanifest.xml') as string;
+            const idMatch2 = manifest2.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch2).not.toBeNull();
+            const id2 = idMatch2![1];
+
+            // BUG fix: re-exporting the same project must produce the SAME manifest identifier
+            // so the LMS treats updated re-uploads as the same course.
+            expect(id1).toBe(id2);
+            expect(id1).toContain('20251201123456ABCDEF');
+        });
+
+        it('should honour meta.scormIdentifier as a user override (#1785)', async () => {
+            document = new MockDocument(
+                {
+                    odeIdentifier: '20251201123456ABCDEF',
+                    scormIdentifier: 'CUSTOM-OVERRIDE-XYZ',
+                },
+                samplePages,
+            );
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            // User override wins -- the manifest identifier is exactly the override string.
+            expect(idMatch![1]).toBe('CUSTOM-OVERRIDE-XYZ');
+        });
+
+        it('should fall back to a generated eXe-MANIFEST-* identifier when neither override nor odeIdentifier is set (#1785)', async () => {
+            // No odeIdentifier, no scormIdentifier
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            const result = await exporter.export();
+            expect(result.success).toBe(true);
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            expect(idMatch![1]).toMatch(/^eXe-MANIFEST-\d{14}[A-Z0-9]{6}$/);
+        });
+
+        it('should derive manifest@identifier and LOM catalog/entry from the same odeIdentifier (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+            // Both artifacts must reference the same project-identity root.
+            expect(manifest).toContain('20251201123456ABCDEF');
+            expect(lom).toContain('20251201123456ABCDEF');
+        });
+
+        it('strips the eXe-MANIFEST- prefix when scormIdentifier override already carries it', async () => {
+            // Defensive: if the user types a full eXe-MANIFEST-<X> into the override
+            // field, the organization id and LOM catalog/entry must derive from <X>,
+            // not from the literal "MANIFEST-<X>" tail.
+            document = new MockDocument({ scormIdentifier: 'eXe-MANIFEST-CUSTOM-ROOT' }, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+            expect(manifest).toContain('identifier="eXe-MANIFEST-CUSTOM-ROOT"');
+            expect(manifest).toContain('identifier="eXe-CUSTOM-ROOT"'); // organization
+            expect(lom).toContain('ODE-CUSTOM-ROOT'); // catalog/entry
+            expect(manifest).not.toContain('eXe-MANIFEST-MANIFEST-');
+        });
+
+        it('returns the same manifest root across all references on the FALLBACK path (memoization invariant)', async () => {
+            // With no override and no odeIdentifier, getManifestIdentifier()
+            // falls back to generateOdeId() ONCE per exporter instance.
+            // Manifest, organization id and LOM catalog/entry must all
+            // observe that same random root.
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+            const manifestMatch = manifest.match(/<manifest\s+identifier="eXe-MANIFEST-([A-Z0-9]+)"/);
+            const orgMatch = manifest.match(/<organization\s+identifier="eXe-([A-Z0-9]+)"/);
+            const lomEntryMatch = lom.match(/<entry[^>]*>\s*ODE-([A-Z0-9]+)/);
+            expect(manifestMatch).not.toBeNull();
+            expect(orgMatch).not.toBeNull();
+            expect(lomEntryMatch).not.toBeNull();
+            const root = manifestMatch![1];
+            expect(orgMatch![1]).toBe(root);
+            expect(lomEntryMatch![1]).toBe(root);
+        });
+
+        it('shares a single root id across manifest, organization and LOM entry on the FALLBACK path (#1785)', async () => {
+            // No odeIdentifier, no scormIdentifier -> getManifestIdentifier() falls back
+            // to generateOdeId(). The bug: getBareProjectIdentifier() invokes
+            // getManifestIdentifier() a SECOND time, generating a different random id,
+            // so the manifest, organization and LOM end up referencing unrelated roots.
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm12Exporter(document, resources, assets, localZip);
+            await exporter.export();
+
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+
+            const manifestMatch = manifest.match(/<manifest\s+identifier="eXe-MANIFEST-([A-Z0-9]+)"/);
+            const orgMatch = manifest.match(/<organization\s+identifier="eXe-([A-Z0-9]+)"/);
+            const lomEntryMatch = lom.match(/<entry[^>]*>\s*ODE-([A-Z0-9]+)/);
+
+            expect(manifestMatch).not.toBeNull();
+            expect(orgMatch).not.toBeNull();
+            expect(lomEntryMatch).not.toBeNull();
+
+            const root = manifestMatch![1];
+            expect(orgMatch![1]).toBe(root);
+            expect(lomEntryMatch![1]).toBe(root);
         });
     });
 

--- a/src/shared/export/exporters/Scorm12Exporter.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.ts
@@ -44,7 +44,13 @@ export class Scorm12Exporter extends Html5Exporter {
             const meta = this.getMetadata();
             // Theme priority: 1º parameter > 2º ELP metadata > 3º default
             const themeName = options?.theme || meta.theme || 'base';
-            const projectId = this.generateProjectId();
+            // Stable manifest identifier (see BaseExporter.getManifestIdentifier and #1785).
+            // `manifestIdentifier` is the final `<manifest identifier="...">` value;
+            // `projectId` is the bare id used for organization/resource ids and the
+            // LOM `catalog/entry`, so a single project identity flows through all
+            // artifacts (manifest, organization, LOM, content.xml).
+            const manifestIdentifier = this.getManifestIdentifier();
+            const projectId = this.getBareProjectIdentifier();
 
             // Pre-process pages: add filenames to asset URLs
             pages = await this.preprocessPagesForExport(pages);
@@ -66,16 +72,21 @@ export class Scorm12Exporter extends Html5Exporter {
             };
 
             // Initialize generators
-            this.manifestGenerator = new Scorm12ManifestGenerator(projectId, pages, {
-                identifier: projectId,
-                pages: pages,
-                version: '1.2',
-                title: meta.title || 'eXeLearning',
-                language: meta.language || 'en',
-                author: meta.author || '',
-                description: meta.description || '',
-                license: meta.license || '',
-            });
+            this.manifestGenerator = new Scorm12ManifestGenerator(
+                projectId,
+                pages,
+                {
+                    identifier: manifestIdentifier,
+                    pages: pages,
+                    version: '1.2',
+                    title: meta.title || 'eXeLearning',
+                    language: meta.language || 'en',
+                    author: meta.author || '',
+                    description: meta.description || '',
+                    license: meta.license || '',
+                },
+                manifestIdentifier,
+            );
 
             this.lomGenerator = new LomMetadataGenerator(projectId, {
                 title: meta.title || 'eXeLearning',
@@ -385,7 +396,12 @@ export class Scorm12Exporter extends Html5Exporter {
     }
 
     /**
-     * Generate project ID for SCORM package
+     * Generate a random low-level project ID.
+     *
+     * @deprecated Since #1785, the SCORM manifest identifier is derived from
+     * the project's odeIdentifier via {@link BaseExporter.getManifestIdentifier}
+     * so LMS tracking survives re-uploads. This helper is kept only for
+     * external callers/tests and is no longer used by the export pipeline.
      */
     generateProjectId(): string {
         return Date.now().toString(36) + Math.random().toString(36).substring(2, 7);

--- a/src/shared/export/exporters/Scorm2004Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.spec.ts
@@ -388,11 +388,92 @@ describe('Scorm2004Exporter', () => {
     });
 
     describe('Project ID Generation', () => {
-        it('should generate unique project IDs', () => {
+        it('should generate unique low-level project IDs (legacy random helper)', () => {
             const id1 = exporter.generateProjectId();
             const id2 = exporter.generateProjectId();
 
             expect(id1).not.toBe(id2);
+        });
+
+        it('should produce a STABLE manifest@identifier across exports when odeIdentifier is set (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const zip1 = new MockZipProvider();
+            const exporter1 = new Scorm2004Exporter(document, resources, assets, zip1);
+            await exporter1.export();
+            const manifest1 = zip1.files.get('imsmanifest.xml') as string;
+            const idMatch1 = manifest1.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch1).not.toBeNull();
+            const id1 = idMatch1![1];
+
+            const zip2 = new MockZipProvider();
+            const exporter2 = new Scorm2004Exporter(document, resources, assets, zip2);
+            await exporter2.export();
+            const manifest2 = zip2.files.get('imsmanifest.xml') as string;
+            const idMatch2 = manifest2.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch2).not.toBeNull();
+            const id2 = idMatch2![1];
+
+            // BUG fix: re-exporting the same project must produce the SAME manifest identifier.
+            expect(id1).toBe(id2);
+            expect(id1).toContain('20251201123456ABCDEF');
+        });
+
+        it('should honour meta.scormIdentifier as a user override (#1785)', async () => {
+            document = new MockDocument(
+                {
+                    odeIdentifier: '20251201123456ABCDEF',
+                    scormIdentifier: 'CUSTOM-OVERRIDE-XYZ',
+                },
+                samplePages,
+            );
+            const localZip = new MockZipProvider();
+            exporter = new Scorm2004Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            expect(idMatch![1]).toBe('CUSTOM-OVERRIDE-XYZ');
+        });
+
+        it('should fall back to a generated eXe-MANIFEST-* identifier when neither override nor odeIdentifier is set (#1785)', async () => {
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm2004Exporter(document, resources, assets, localZip);
+            const result = await exporter.export();
+            expect(result.success).toBe(true);
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const idMatch = manifest.match(/<manifest\s+identifier="([^"]+)"/);
+            expect(idMatch).not.toBeNull();
+            expect(idMatch![1]).toMatch(/^eXe-MANIFEST-\d{14}[A-Z0-9]{6}$/);
+        });
+
+        it('should derive manifest@identifier and LOM catalog/entry from the same odeIdentifier (#1785)', async () => {
+            document = new MockDocument({ odeIdentifier: '20251201123456ABCDEF' }, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm2004Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+            expect(manifest).toContain('20251201123456ABCDEF');
+            expect(lom).toContain('20251201123456ABCDEF');
+        });
+
+        it('shares a single root id across manifest, organization and LOM entry on the FALLBACK path (#1785)', async () => {
+            document = new MockDocument({}, samplePages);
+            const localZip = new MockZipProvider();
+            exporter = new Scorm2004Exporter(document, resources, assets, localZip);
+            await exporter.export();
+            const manifest = localZip.files.get('imsmanifest.xml') as string;
+            const lom = localZip.files.get('imslrm.xml') as string;
+            const manifestMatch = manifest.match(/<manifest\s+identifier="eXe-MANIFEST-([A-Z0-9]+)"/);
+            const orgMatch = manifest.match(/<organization\s+identifier="eXe-([A-Z0-9]+)"/);
+            const lomEntryMatch = lom.match(/<entry[^>]*>\s*ODE-([A-Z0-9]+)/);
+            expect(manifestMatch).not.toBeNull();
+            expect(orgMatch).not.toBeNull();
+            expect(lomEntryMatch).not.toBeNull();
+            const root = manifestMatch![1];
+            expect(orgMatch![1]).toBe(root);
+            expect(lomEntryMatch![1]).toBe(root);
         });
     });
 

--- a/src/shared/export/exporters/Scorm2004Exporter.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.ts
@@ -44,7 +44,13 @@ export class Scorm2004Exporter extends Html5Exporter {
             const meta = this.getMetadata();
             // Theme priority: 1º parameter > 2º ELP metadata > 3º default
             const themeName = options?.theme || meta.theme || 'base';
-            const projectId = this.generateProjectId();
+            // Stable manifest identifier (see BaseExporter.getManifestIdentifier and #1785).
+            // `manifestIdentifier` is the final `<manifest identifier="...">` value;
+            // `projectId` is the bare id used for organization/resource ids and the
+            // LOM `catalog/entry`, so a single project identity flows through all
+            // artifacts (manifest, organization, LOM, content.xml).
+            const manifestIdentifier = this.getManifestIdentifier();
+            const projectId = this.getBareProjectIdentifier();
 
             // Pre-process pages: add filenames to asset URLs
             pages = await this.preprocessPagesForExport(pages);
@@ -66,16 +72,21 @@ export class Scorm2004Exporter extends Html5Exporter {
             };
 
             // Initialize generators
-            this.manifestGenerator = new Scorm2004ManifestGenerator(projectId, pages, {
-                identifier: projectId,
-                pages: pages,
-                version: '2004',
-                title: meta.title || 'eXeLearning',
-                language: meta.language || 'en',
-                author: meta.author || '',
-                description: meta.description || '',
-                license: meta.license || '',
-            });
+            this.manifestGenerator = new Scorm2004ManifestGenerator(
+                projectId,
+                pages,
+                {
+                    identifier: manifestIdentifier,
+                    pages: pages,
+                    version: '2004',
+                    title: meta.title || 'eXeLearning',
+                    language: meta.language || 'en',
+                    author: meta.author || '',
+                    description: meta.description || '',
+                    license: meta.license || '',
+                },
+                manifestIdentifier,
+            );
 
             this.lomGenerator = new LomMetadataGenerator(projectId, {
                 title: meta.title || 'eXeLearning',
@@ -373,7 +384,12 @@ export class Scorm2004Exporter extends Html5Exporter {
     }
 
     /**
-     * Generate project ID for SCORM package
+     * Generate a random low-level project ID.
+     *
+     * @deprecated Since #1785, the SCORM manifest identifier is derived from
+     * the project's odeIdentifier via {@link BaseExporter.getManifestIdentifier}
+     * so LMS tracking survives re-uploads. This helper is kept only for
+     * external callers/tests and is no longer used by the export pipeline.
      */
     generateProjectId(): string {
         return Date.now().toString(36) + Math.random().toString(36).substring(2, 7);

--- a/src/shared/export/generators/ImsManifest.ts
+++ b/src/shared/export/generators/ImsManifest.ts
@@ -52,16 +52,27 @@ export class ImsManifestGenerator {
     private projectId: string;
     private pages: ExportPage[];
     private metadata: ImsManifestOptions;
+    private manifestIdentifier: string | null;
 
     /**
-     * @param projectId - Unique project identifier
+     * @param projectId - Bare project identifier (used for organization id and resource ids)
      * @param pages - Pages from navigation structure
      * @param metadata - Project metadata
+     * @param manifestIdentifier - Optional pre-built manifest@identifier. When provided
+     *   it is used verbatim (no `eXe-MANIFEST-` prefix is prepended). Pass this from
+     *   BaseExporter.getManifestIdentifier() so re-exports of the same project produce
+     *   a stable identifier the LMS can track (see exelearning/exelearning#1785).
      */
-    constructor(projectId: string, pages: ExportPage[], metadata: ImsManifestOptions = {}) {
+    constructor(
+        projectId: string,
+        pages: ExportPage[],
+        metadata: ImsManifestOptions = {},
+        manifestIdentifier: string | null = null,
+    ) {
         this.projectId = projectId || this.generateId();
         this.pages = pages || [];
         this.metadata = metadata;
+        this.manifestIdentifier = manifestIdentifier;
     }
 
     /**
@@ -133,7 +144,11 @@ export class ImsManifestGenerator {
      * @returns Manifest opening XML
      */
     generateManifestOpen(): string {
-        return `<manifest identifier="eXe-MANIFEST-${this.escapeXml(this.projectId)}"
+        // When a manifest identifier is supplied (BaseExporter.getManifestIdentifier),
+        // use it verbatim so re-uploads share a stable LMS-tracking identifier.
+        // Otherwise fall back to the legacy `eXe-MANIFEST-<bareId>` shape.
+        const identifier = this.manifestIdentifier ?? `eXe-MANIFEST-${this.projectId}`;
+        return `<manifest identifier="${this.escapeXml(identifier)}"
   xmlns="${IMS_NAMESPACES.imscp}"
   xmlns:imsmd="${IMS_NAMESPACES.imsmd}">
 `;

--- a/src/shared/export/generators/OdeXmlGenerator.spec.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.spec.ts
@@ -331,6 +331,45 @@ describe('OdeXmlGenerator', () => {
             expect(xml).toContain('<value>CUSTOM-VERSION-ID</value>');
         });
 
+        it('should use meta.odeVersionId when options.versionId is not set', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                odeVersionId: '20251201123456FEDCBA',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            expect(xml).toMatch(/<key>odeVersionId<\/key>\s*<value>20251201123456FEDCBA<\/value>/);
+        });
+
+        it('should generate a fresh versionId when neither options.versionId nor meta.odeVersionId is set', () => {
+            const meta: ExportMetadata = { title: 'Test' };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages);
+
+            // Extract the odeVersionId value
+            const match = xml.match(/<key>odeVersionId<\/key>\s*<value>([^<]+)<\/value>/);
+            expect(match).not.toBeNull();
+            expect(match![1]).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+        });
+
+        it('should prefer options.versionId over meta.odeVersionId', () => {
+            const meta: ExportMetadata = {
+                title: 'Test',
+                odeVersionId: '20251201123456FEDCBA',
+            };
+            const pages: ExportPage[] = [];
+
+            const xml = generateOdeXml(meta, pages, {
+                versionId: '20251231235959AAAAAA',
+            });
+
+            expect(xml).toMatch(/<key>odeVersionId<\/key>\s*<value>20251231235959AAAAAA<\/value>/);
+            expect(xml).not.toContain('20251201123456FEDCBA');
+        });
+
         it('should include DOCTYPE by default', () => {
             const meta: ExportMetadata = { title: 'Test' };
             const pages: ExportPage[] = [];
@@ -782,6 +821,47 @@ describe('OdeXmlGenerator', () => {
 
             // Unresolved assets use UUID as filename
             expect(xml).toContain('{{context_path}}/content/resources/12345678-1234-1234-1234-123456789012.jpg');
+        });
+    });
+
+    describe('scormIdentifier round-trip via <odeResources> (#1786)', () => {
+        it('emits scormIdentifier as an odeResource when present in metadata', () => {
+            const meta = {
+                title: 'Stable SCORM ID',
+                author: '',
+                language: 'en',
+                theme: 'base',
+                odeIdentifier: '20251201123456ABCDEF',
+                scormIdentifier: 'LMS-COURSE-XYZ',
+            };
+            const xml = generateOdeXml(meta, []);
+            expect(xml).toContain('<key>scormIdentifier</key>');
+            expect(xml).toContain('<value>LMS-COURSE-XYZ</value>');
+        });
+
+        it('does NOT emit scormIdentifier when the metadata field is absent', () => {
+            const meta = {
+                title: 'No SCORM override',
+                author: '',
+                language: 'en',
+                theme: 'base',
+                odeIdentifier: '20251201123456ABCDEF',
+            };
+            const xml = generateOdeXml(meta, []);
+            expect(xml).not.toContain('<key>scormIdentifier</key>');
+        });
+
+        it('does NOT emit scormIdentifier when the metadata field is empty', () => {
+            const meta = {
+                title: 'Empty SCORM override',
+                author: '',
+                language: 'en',
+                theme: 'base',
+                odeIdentifier: '20251201123456ABCDEF',
+                scormIdentifier: '',
+            };
+            const xml = generateOdeXml(meta, []);
+            expect(xml).not.toContain('<key>scormIdentifier</key>');
         });
     });
 });

--- a/src/shared/export/generators/OdeXmlGenerator.ts
+++ b/src/shared/export/generators/OdeXmlGenerator.ts
@@ -20,6 +20,9 @@
 import type { ExportMetadata, ExportPage, ExportBlock, ExportComponent } from '../interfaces';
 import { ODE_DTD_FILENAME } from '../constants';
 import { isExcludedFromXml, getXmlKeyForProperty, valueToXmlString } from '../metadata-properties';
+import { generateOdeId } from '../utils/odeId';
+
+export { generateOdeId };
 
 /**
  * Options for ODE XML generation
@@ -42,7 +45,7 @@ export interface OdeXmlOptions {
  */
 export function generateOdeXml(meta: ExportMetadata, pages: ExportPage[], options?: OdeXmlOptions): string {
     const odeId = options?.odeId || meta.odeIdentifier || generateOdeId();
-    const versionId = options?.versionId || generateOdeId();
+    const versionId = options?.versionId || meta.odeVersionId || generateOdeId();
     const includeDoctype = options?.includeDoctype ?? true;
 
     let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
@@ -55,7 +58,12 @@ export function generateOdeXml(meta: ExportMetadata, pages: ExportPage[], option
     xml += generateUserPreferencesXml(meta);
 
     // ODE resources (version info, IDs)
-    xml += generateOdeResourcesXml(odeId, versionId, normalizeExeVersion(meta.exelearningVersion));
+    xml += generateOdeResourcesXml(
+        odeId,
+        versionId,
+        normalizeExeVersion(meta.exelearningVersion),
+        meta.scormIdentifier,
+    );
 
     // ODE properties (metadata)
     xml += generateOdePropertiesXml(meta);
@@ -92,13 +100,26 @@ function generateUserPreferenceEntry(key: string, value: string): string {
 }
 
 /**
- * Generate ODE resources section (identifiers, version)
+ * Generate ODE resources section (identifiers, version).
+ *
+ * `scormIdentifier` is the optional LMS-tracking override; it lives in
+ * `<odeResources>` (alongside `odeId`) rather than `<odeProperties>` because
+ * it is a SCORM-specific manifest hint, not user-visible content metadata.
+ * Emitting it here makes the override survive an ELPX round-trip (#1786).
  */
-function generateOdeResourcesXml(odeId: string, versionId: string, exeVersion: string): string {
+function generateOdeResourcesXml(
+    odeId: string,
+    versionId: string,
+    exeVersion: string,
+    scormIdentifier?: string,
+): string {
     let xml = '<odeResources>\n';
     xml += generateOdeResourceEntry('odeId', odeId);
     xml += generateOdeResourceEntry('odeVersionId', versionId);
     xml += generateOdeResourceEntry('exe_version', exeVersion);
+    if (scormIdentifier) {
+        xml += generateOdeResourceEntry('scormIdentifier', scormIdentifier);
+    }
     xml += '</odeResources>\n';
     return xml;
 }
@@ -316,29 +337,6 @@ function generateComponentPropertyEntry(key: string, value: string): string {
               <key>${escapeXml(key)}</key>
               <value>${escapeXml(value)}</value>
             </odeComponentsProperty>\n`;
-}
-
-/**
- * Generate ODE identifier
- * Format: YYYYMMDDHHmmss + 6 random alphanumeric chars
- */
-export function generateOdeId(): string {
-    const now = new Date();
-    const timestamp =
-        now.getFullYear().toString() +
-        String(now.getMonth() + 1).padStart(2, '0') +
-        String(now.getDate()).padStart(2, '0') +
-        String(now.getHours()).padStart(2, '0') +
-        String(now.getMinutes()).padStart(2, '0') +
-        String(now.getSeconds()).padStart(2, '0');
-
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    let random = '';
-    for (let i = 0; i < 6; i++) {
-        random += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-
-    return timestamp + random;
 }
 
 /**

--- a/src/shared/export/generators/Scorm12Manifest.ts
+++ b/src/shared/export/generators/Scorm12Manifest.ts
@@ -56,16 +56,27 @@ export class Scorm12ManifestGenerator {
     private projectId: string;
     private pages: ExportPage[];
     private metadata: ScormManifestOptions;
+    private manifestIdentifier: string | null;
 
     /**
-     * @param projectId - Unique project identifier
+     * @param projectId - Bare project identifier (used for organization id and resource ids)
      * @param pages - Pages from navigation structure
      * @param metadata - Project metadata
+     * @param manifestIdentifier - Optional pre-built manifest@identifier. When provided
+     *   it is used verbatim (no `eXe-MANIFEST-` prefix is prepended). Pass this from
+     *   BaseExporter.getManifestIdentifier() so re-exports of the same project produce
+     *   a stable identifier the LMS can track (see exelearning/exelearning#1785).
      */
-    constructor(projectId: string, pages: ExportPage[], metadata: ScormManifestOptions = {}) {
+    constructor(
+        projectId: string,
+        pages: ExportPage[],
+        metadata: ScormManifestOptions = {},
+        manifestIdentifier: string | null = null,
+    ) {
         this.projectId = projectId || this.generateId();
         this.pages = pages || [];
         this.metadata = metadata;
+        this.manifestIdentifier = manifestIdentifier;
     }
 
     /**
@@ -138,7 +149,11 @@ export class Scorm12ManifestGenerator {
      * @returns Manifest opening XML
      */
     generateManifestOpen(): string {
-        return `<manifest identifier="eXe-MANIFEST-${this.escapeXml(this.projectId)}"
+        // When a manifest identifier is supplied (BaseExporter.getManifestIdentifier),
+        // use it verbatim so re-uploads share a stable LMS-tracking identifier.
+        // Otherwise fall back to the legacy `eXe-MANIFEST-<bareId>` shape.
+        const identifier = this.manifestIdentifier ?? `eXe-MANIFEST-${this.projectId}`;
+        return `<manifest identifier="${this.escapeXml(identifier)}"
   xmlns="${SCORM_12_NAMESPACES.imscp}"
   xmlns:adlcp="${SCORM_12_NAMESPACES.adlcp}"
   xmlns:imsmd="${SCORM_12_NAMESPACES.imsmd}">

--- a/src/shared/export/generators/Scorm2004Manifest.ts
+++ b/src/shared/export/generators/Scorm2004Manifest.ts
@@ -53,16 +53,27 @@ export class Scorm2004ManifestGenerator {
     private projectId: string;
     private pages: ExportPage[];
     private metadata: ScormManifestOptions;
+    private manifestIdentifier: string | null;
 
     /**
-     * @param projectId - Unique project identifier
+     * @param projectId - Bare project identifier (used for organization id and resource ids)
      * @param pages - Pages from navigation structure
      * @param metadata - Project metadata
+     * @param manifestIdentifier - Optional pre-built manifest@identifier. When provided
+     *   it is used verbatim (no `eXe-MANIFEST-` prefix is prepended). Pass this from
+     *   BaseExporter.getManifestIdentifier() so re-exports of the same project produce
+     *   a stable identifier the LMS can track (see exelearning/exelearning#1785).
      */
-    constructor(projectId: string, pages: ExportPage[], metadata: ScormManifestOptions = {}) {
+    constructor(
+        projectId: string,
+        pages: ExportPage[],
+        metadata: ScormManifestOptions = {},
+        manifestIdentifier: string | null = null,
+    ) {
         this.projectId = projectId || this.generateId();
         this.pages = pages || [];
         this.metadata = metadata;
+        this.manifestIdentifier = manifestIdentifier;
     }
 
     /**
@@ -135,7 +146,11 @@ export class Scorm2004ManifestGenerator {
      * @returns Manifest opening XML
      */
     generateManifestOpen(): string {
-        return `<manifest identifier="eXe-MANIFEST-${this.escapeXml(this.projectId)}"
+        // When a manifest identifier is supplied (BaseExporter.getManifestIdentifier),
+        // use it verbatim so re-uploads share a stable LMS-tracking identifier.
+        // Otherwise fall back to the legacy `eXe-MANIFEST-<bareId>` shape.
+        const identifier = this.manifestIdentifier ?? `eXe-MANIFEST-${this.projectId}`;
+        return `<manifest identifier="${this.escapeXml(identifier)}"
   xmlns="${SCORM_2004_NAMESPACES.imscp}"
   xmlns:adlcp="${SCORM_2004_NAMESPACES.adlcp}"
   xmlns:adlseq="${SCORM_2004_NAMESPACES.adlseq}"

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -56,6 +56,7 @@ export interface ExportMetadata {
     // eXeLearning-specific metadata
     exelearningVersion?: string;
     odeIdentifier?: string;
+    odeVersionId?: string;
     createdAt?: string;
     modifiedAt?: string;
 

--- a/src/shared/export/metadata-properties.ts
+++ b/src/shared/export/metadata-properties.ts
@@ -217,6 +217,14 @@ export const METADATA_PROPERTIES: MetadataPropertyConfig[] = [
         category: 'internal',
     },
     {
+        key: 'odeVersionId',
+        xmlKey: 'odeVersionId',
+        type: 'string',
+        defaultValue: '',
+        excludeFromXml: true,
+        category: 'internal',
+    },
+    {
         key: 'createdAt',
         xmlKey: 'createdAt',
         type: 'string',

--- a/src/shared/export/utils/odeId.spec.ts
+++ b/src/shared/export/utils/odeId.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { generateOdeId } from './odeId';
+
+describe('generateOdeId', () => {
+    it('returns a 20-character string', () => {
+        const id = generateOdeId();
+        expect(id).toHaveLength(20);
+    });
+
+    it('matches the YYYYMMDDHHmmss + 6 uppercase alphanumeric pattern', () => {
+        const id = generateOdeId();
+        expect(id).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+    });
+
+    it('produces different identifiers across successive calls', () => {
+        // The previous version of this test asked for 100 unique ids from 100
+        // calls. Mathematically safe (36^6 ~= 2.1B combos -> ~5e-10 collision
+        // probability for two calls) but the assertion technically allowed a
+        // probabilistic flake. The meaningful invariant is just "two
+        // successive calls do not produce the same id".
+        const a = generateOdeId();
+        const b = generateOdeId();
+        expect(a).not.toBe(b);
+    });
+
+    it('encodes the current date in the first 14 chars', () => {
+        const now = new Date();
+        const id = generateOdeId();
+        const year = id.slice(0, 4);
+        const month = id.slice(4, 6);
+        const day = id.slice(6, 8);
+        expect(Number(year)).toBe(now.getFullYear());
+        expect(Number(month)).toBe(now.getMonth() + 1);
+        expect(Number(day)).toBe(now.getDate());
+    });
+});

--- a/src/shared/export/utils/odeId.ts
+++ b/src/shared/export/utils/odeId.ts
@@ -1,0 +1,28 @@
+/**
+ * Stable identifier generator for ODE projects (odeId, odeVersionId).
+ *
+ * Format: `YYYYMMDDHHmmss` + 6 random uppercase alphanumeric chars (20 chars).
+ *
+ * Lives in its own file (no transitive imports) so it can be used from both
+ * the browser-bound importer bundle and the server-side exporters without
+ * pulling Node-only modules (path, fs-extra) into the browser bundle via
+ * `src/shared/export/constants.ts` → `src/services/idevice-config.ts`.
+ */
+export function generateOdeId(): string {
+    const now = new Date();
+    const timestamp =
+        now.getFullYear().toString() +
+        String(now.getMonth() + 1).padStart(2, '0') +
+        String(now.getDate()).padStart(2, '0') +
+        String(now.getHours()).padStart(2, '0') +
+        String(now.getMinutes()).padStart(2, '0') +
+        String(now.getSeconds()).padStart(2, '0');
+
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let random = '';
+    for (let i = 0; i < 6; i++) {
+        random += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+
+    return timestamp + random;
+}

--- a/src/shared/ids.spec.ts
+++ b/src/shared/ids.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for canonical ID generator (src/shared/ids.ts).
+ *
+ * Single source of truth for navigation entity IDs — see issue
+ * exelearning/exelearning#1782.
+ */
+import { describe, it, expect } from 'bun:test';
+import { generateId } from './ids';
+
+describe('generateId', () => {
+    it('returns an ID matching the canonical page format', () => {
+        const id = generateId('page');
+        expect(id).toMatch(/^page-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('returns an ID starting with block- for block prefix', () => {
+        const id = generateId('block');
+        expect(id.startsWith('block-')).toBe(true);
+        expect(id).toMatch(/^block-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('returns an ID starting with idevice- for idevice prefix', () => {
+        const id = generateId('idevice');
+        expect(id.startsWith('idevice-')).toBe(true);
+        expect(id).toMatch(/^idevice-[a-z0-9]{8,}-[a-z0-9]{9}$/);
+    });
+
+    it('produces distinct IDs on consecutive calls', () => {
+        const a = generateId('page');
+        const b = generateId('page');
+        expect(a).not.toBe(b);
+    });
+
+    it('throws when the prefix is empty', () => {
+        expect(() => generateId('')).toThrow();
+    });
+
+    it('throws on a missing prefix argument', () => {
+        // Defensive: the runtime guard catches `undefined` too, not only ''.
+        expect(() => generateId(undefined as unknown as string)).toThrow();
+    });
+});

--- a/src/shared/ids.ts
+++ b/src/shared/ids.ts
@@ -1,0 +1,27 @@
+/**
+ * Canonical ID generator for navigation entities (pages, blocks, iDevices).
+ *
+ * Format: `<prefix>-<base36 timestamp>-<base36 random>` (e.g. `page-mp0fppw7-8djmx3rm8`).
+ * Single source of truth — see issue exelearning/exelearning#1782.
+ *
+ * NOTE: do NOT use this for project/session IDs (use src/utils/id-generator.util.ts)
+ * or SCORM/manifest IDs (use src/shared/export/exporters/BaseExporter.generateId).
+ *
+ * Browser mirrors of this function live in:
+ *   - public/app/yjs/YjsStructureBinding.js
+ *   - public/app/yjs/ComponentImporter.js
+ *   - public/app/yjs/YjsProjectManagerMixin.js (as `generateCanonicalId`)
+ * Keep them byte-equivalent until those files can import this module directly.
+ *
+ * @param prefix Non-empty prefix tag (e.g. `'page'`, `'block'`, `'idevice'`).
+ * @returns Unique string ID combining a base36 timestamp and a 9-char random suffix.
+ * @throws {Error} When `prefix` is empty.
+ */
+export function generateId(prefix: string): string {
+    if (!prefix) {
+        throw new Error('generateId: prefix is required');
+    }
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substring(2, 11);
+    return `${prefix}-${timestamp}-${random}`;
+}

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -1898,7 +1898,7 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
         }
     });
 
-    it('should remap exe-node: cross-page anchor links when importing anchors.zip', async () => {
+    it('should keep exe-node: cross-page anchor links pointing at the imported pages when importing anchors.zip', async () => {
         const elpPath = path.join(process.cwd(), 'test/fixtures/anchors.zip');
         const elpBuffer = await fs.readFile(elpPath);
 
@@ -1911,13 +1911,13 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
         const navigation = ydoc.getArray('navigation');
         expect(navigation.length).toBe(3); // aaa, bbb, ccc
 
-        // Collect new page IDs and the HTML content of components
-        const newPageIds: string[] = [];
+        // Collect imported page IDs and the HTML content of components
+        const importedPageIds: string[] = [];
         const allHtmlContent: string[] = [];
 
         for (let i = 0; i < navigation.length; i++) {
             const page = navigation.get(i) as Y.Map<unknown>;
-            newPageIds.push((page.get('id') as string) || (page.get('pageId') as string));
+            importedPageIds.push((page.get('id') as string) || (page.get('pageId') as string));
 
             const blocks = page.get('blocks') as Y.Array<unknown>;
             for (let j = 0; j < (blocks?.length ?? 0); j++) {
@@ -1931,22 +1931,28 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
             }
         }
 
-        // The original IDs from anchors.zip should NOT appear in any content
-        const originalIds = [
-            '4576a60f-11d1-4414-88f7-6df2d6aaece0',
-            'page-1771919082417-f0hpww2cx',
-            'page-1771919084984-kxe6oqn9a',
-        ];
-
         const combinedHtml = allHtmlContent.join('\n');
 
-        for (const origId of originalIds) {
-            expect(combinedHtml).not.toContain(`exe-node:${origId}`);
-        }
+        // After the v4 ID preservation fix, internal exe-node: links should
+        // continue to point at the (preserved) imported page IDs. At least one
+        // of the imported page IDs must appear as the target of an exe-node link.
+        const hasResolvedLink = importedPageIds.some(id => combinedHtml.includes(`exe-node:${id}`));
+        expect(hasResolvedLink).toBe(true);
 
-        // At least one of the new page IDs should be referenced in the HTML
-        const hasRemappedLink = newPageIds.some(id => combinedHtml.includes(`exe-node:${id}`));
-        expect(hasRemappedLink).toBe(true);
+        // No dangling exe-node: link should reference an ID that is not in
+        // the imported navigation (collision-only remap still applies in
+        // merge-mode imports, but this fixture is a fresh import).
+        // Match every char the importer's boundary considers part of an id
+        // (mirrors the (?![A-Za-z0-9_-]) lookahead in remapInternalPageLinks).
+        const linkPattern = /exe-node:([a-zA-Z0-9_-]+)/g;
+        const referencedIds = new Set<string>();
+        let m: RegExpExecArray | null;
+        while ((m = linkPattern.exec(combinedHtml)) !== null) {
+            referencedIds.add(m[1]);
+        }
+        for (const refId of referencedIds) {
+            expect(importedPageIds).toContain(refId);
+        }
 
         ydoc.destroy();
     });
@@ -2007,7 +2013,9 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
 
         const pageB = navigation.get(1) as Y.Map<unknown>;
         const newPageBId = (pageB.get('id') ?? pageB.get('pageId')) as string;
-        expect(newPageBId).not.toBe('original-page-bbb');
+        // After the v4 ID preservation fix, a fresh import keeps the original
+        // <odePageId> verbatim, so the imported Page B id equals the XML id.
+        expect(newPageBId).toBe('original-page-bbb');
 
         // Get the component HTML from page A
         const pageA = navigation.get(0) as Y.Map<unknown>;
@@ -2017,9 +2025,8 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
         const comp = components.get(0) as Y.Map<unknown>;
         const html = comp.get('htmlView') as string;
 
-        // Link must use new page ID and preserve the fragment
+        // Link must reference the imported page id and preserve the fragment.
         expect(html).toContain(`exe-node:${newPageBId}#my-anchor`);
-        expect(html).not.toContain('exe-node:original-page-bbb');
 
         ydoc.destroy();
     });
@@ -2251,5 +2258,835 @@ describe('ElpxImporter - exe-node link remapping on import', () => {
 
             ydoc.destroy();
         });
+    });
+
+    describe('odeResources preservation', () => {
+        it('should populate metadata.odeIdentifier and metadata.odeVersionId from <odeResources> on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>20251201123456FEDCBA</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>OdeResources Preservation</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+            expect(metadata.get('odeVersionId')).toBe('20251201123456FEDCBA');
+
+            ydoc.destroy();
+        });
+
+        it('should tolerate missing <odeResources> block on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            // v4-style content.xml WITHOUT odeResources
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>No OdeResources</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier');
+            const odeVersionId = metadata.get('odeVersionId');
+            // Either undefined or empty string — export-side fallback will fill them in.
+            expect(odeId === undefined || odeId === '').toBe(true);
+            expect(odeVersionId === undefined || odeVersionId === '').toBe(true);
+
+            ydoc.destroy();
+        });
+
+        it('should still populate metadata.odeIdentifier when <odeProperties> is absent (DTD edge case)', async () => {
+            // The DTD makes <odeProperties> optional. A valid v4 content.xml
+            // may carry <odeResources> alone. Stable identifiers must reach the
+            // Y.Doc metadata regardless of whether <odeProperties> exists.
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>20251201123456FEDCBA</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+            expect(metadata.get('odeVersionId')).toBe('20251201123456FEDCBA');
+
+            ydoc.destroy();
+        });
+
+        it('should round-trip scormIdentifier through <odeResources> (#1786)', async () => {
+            // The user-set SCORM override survives ELPX download-and-reopen so
+            // re-exports keep using the same manifest@identifier the LMS expects.
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>20251201123456FEDCBA</value></odeResource>
+  <odeResource><key>scormIdentifier</key><value>LMS-COURSE-XYZ</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>SCORM ID round-trip</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({ 'content.xml': encoder.encode(contentXml) });
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('scormIdentifier')).toBe('LMS-COURSE-XYZ');
+
+            ydoc.destroy();
+        });
+
+        it('should populate odeIdentifier even when odeVersionId is missing (partial odeResources)', async () => {
+            // Partial resources -- importer keeps odeId, leaves odeVersionId
+            // unset so the exporter's fallback generates a fresh value.
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>20251201123456ABCDEF</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Partial</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({ 'content.xml': encoder.encode(contentXml) });
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            expect(metadata.get('odeIdentifier')).toBe('20251201123456ABCDEF');
+            const versionId = metadata.get('odeVersionId');
+            expect(versionId === undefined || versionId === '').toBe(true);
+
+            ydoc.destroy();
+        });
+
+        it('should tolerate empty <odeResources> block on v4 import', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources></odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Empty OdeResources</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier');
+            const odeVersionId = metadata.get('odeVersionId');
+            expect(odeId === undefined || odeId === '').toBe(true);
+            expect(odeVersionId === undefined || odeVersionId === '').toBe(true);
+
+            ydoc.destroy();
+        });
+
+        it('should generate odeIdentifier and odeVersionId once on legacy v3 import', async () => {
+            const elpPath = path.join(process.cwd(), 'test/fixtures/old_tema-10-ejemplo.elp');
+            const elpBuffer = await fs.readFile(elpPath);
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(new Uint8Array(elpBuffer));
+
+            const metadata = ydoc.getMap('metadata');
+            const odeId = metadata.get('odeIdentifier') as string;
+            const odeVersionId = metadata.get('odeVersionId') as string;
+            expect(typeof odeId).toBe('string');
+            expect(typeof odeVersionId).toBe('string');
+            expect(odeId).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+            expect(odeVersionId).toMatch(/^\d{14}[A-Z0-9]{6}$/);
+
+            ydoc.destroy();
+        });
+
+        it('should round-trip odeId and odeVersionId through import -> generateOdeXml -> re-parse', async () => {
+            const fflate = await import('fflate');
+            const encoder = new TextEncoder();
+            const { generateOdeXml } = await import('../export/generators/OdeXmlGenerator');
+
+            const inputOdeId = '20251201123456ABCDEF';
+            const inputOdeVersionId = '20251201123456FEDCBA';
+
+            const contentXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>${inputOdeId}</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>${inputOdeVersionId}</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Round Trip</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-a</odePageId>
+  <pageName>Page A</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+            const zipData = fflate.zipSync({
+                'content.xml': encoder.encode(contentXml),
+            });
+
+            const ydoc = new Y.Doc();
+            const importer = new ElpxImporter(ydoc, null, silentLogger);
+            await importer.importFromBuffer(zipData);
+
+            const metadata = ydoc.getMap('metadata');
+            const exportedXml = generateOdeXml(
+                {
+                    title: 'Round Trip',
+                    author: '',
+                    language: 'en',
+                    theme: 'base',
+                    odeIdentifier: metadata.get('odeIdentifier') as string,
+                    odeVersionId: metadata.get('odeVersionId') as string,
+                },
+                [],
+            );
+
+            const odeIdMatch = exportedXml.match(/<key>odeId<\/key>\s*<value>([^<]+)<\/value>/);
+            const odeVersionIdMatch = exportedXml.match(/<key>odeVersionId<\/key>\s*<value>([^<]+)<\/value>/);
+            expect(odeIdMatch).not.toBeNull();
+            expect(odeVersionIdMatch).not.toBeNull();
+            expect(odeIdMatch![1]).toBe(inputOdeId);
+            expect(odeVersionIdMatch![1]).toBe(inputOdeVersionId);
+
+            ydoc.destroy();
+        });
+    });
+});
+
+describe('ElpxImporter - id preservation across v4 import', () => {
+    // Minimal v4 content.xml with two sibling root pages, each with one block + one iDevice.
+    // IDs use the canonical "Format A" shape produced by the workarea.
+    const PAGE_A = 'page-mp0fppwf-71v64kl4r';
+    const PAGE_B = 'page-mp0fppwf-71v64kl4s';
+    const BLOCK_A = 'block-mp0fppwf-blkaaaaaa';
+    const BLOCK_B = 'block-mp0fppwf-blkbbbbbb';
+    const IDEVICE_A = 'idevice-mp0fppwf-idvaaaaaa';
+    const IDEVICE_B = 'idevice-mp0fppwf-idvbbbbbb';
+
+    const buildV4ContentXml = (pageAId = PAGE_A, pageBId = PAGE_B): string => `<?xml version="1.0" encoding="UTF-8"?>
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>ID Preservation Test</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+  <odeNavStructure>
+    <odePageId>${pageAId}</odePageId>
+    <odeParentPageId></odeParentPageId>
+    <pageName>Page A</pageName>
+    <odeNavStructureOrder>0</odeNavStructureOrder>
+    <odePagStructures>
+      <odePagStructure>
+        <odePageId>${pageAId}</odePageId>
+        <odeBlockId>${BLOCK_A}</odeBlockId>
+        <blockName>BlockA</blockName>
+        <iconName></iconName>
+        <odePagStructureOrder>0</odePagStructureOrder>
+        <odeComponents>
+          <odeComponent>
+            <odePageId>${pageAId}</odePageId>
+            <odeBlockId>${BLOCK_A}</odeBlockId>
+            <odeIdeviceId>${IDEVICE_A}</odeIdeviceId>
+            <odeIdeviceTypeName>text</odeIdeviceTypeName>
+            <htmlView><![CDATA[<p>Hello A with <a href="exe-node:${pageBId}">link</a></p>]]></htmlView>
+            <jsonProperties><![CDATA[{"ideviceId":"${IDEVICE_A}","textTextarea":"<p>Hello A</p>"}]]></jsonProperties>
+            <odeComponentsOrder>0</odeComponentsOrder>
+          </odeComponent>
+        </odeComponents>
+      </odePagStructure>
+    </odePagStructures>
+  </odeNavStructure>
+  <odeNavStructure>
+    <odePageId>${pageBId}</odePageId>
+    <odeParentPageId></odeParentPageId>
+    <pageName>Page B</pageName>
+    <odeNavStructureOrder>1</odeNavStructureOrder>
+    <odePagStructures>
+      <odePagStructure>
+        <odePageId>${pageBId}</odePageId>
+        <odeBlockId>${BLOCK_B}</odeBlockId>
+        <blockName>BlockB</blockName>
+        <iconName></iconName>
+        <odePagStructureOrder>0</odePagStructureOrder>
+        <odeComponents>
+          <odeComponent>
+            <odePageId>${pageBId}</odePageId>
+            <odeBlockId>${BLOCK_B}</odeBlockId>
+            <odeIdeviceId>${IDEVICE_B}</odeIdeviceId>
+            <odeIdeviceTypeName>text</odeIdeviceTypeName>
+            <htmlView><![CDATA[<p>Hello B</p>]]></htmlView>
+            <jsonProperties><![CDATA[{"ideviceId":"${IDEVICE_B}","textTextarea":"<p>Hello B</p>"}]]></jsonProperties>
+            <odeComponentsOrder>0</odeComponentsOrder>
+          </odeComponent>
+        </odeComponents>
+      </odePagStructure>
+    </odePagStructures>
+  </odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+    it('fresh-import preserves <odePageId> values verbatim', async () => {
+        const zipContents: Record<string, Uint8Array> = {
+            'content.xml': new TextEncoder().encode(buildV4ContentXml()),
+        };
+
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+
+        await importer.importFromZipContents(zipContents, { clearExisting: true });
+
+        const navigation = ydoc.getArray('navigation');
+        expect(navigation.length).toBe(2);
+
+        const importedIds = new Set<string>();
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            importedIds.add(page.get('id') as string);
+            // pageId mirror field must also match
+            expect(page.get('pageId')).toBe(page.get('id'));
+        }
+        expect(importedIds.has(PAGE_A)).toBe(true);
+        expect(importedIds.has(PAGE_B)).toBe(true);
+
+        ydoc.destroy();
+    });
+
+    it('fresh-import preserves <odeBlockId> and <odeIdeviceId> values verbatim', async () => {
+        const zipContents: Record<string, Uint8Array> = {
+            'content.xml': new TextEncoder().encode(buildV4ContentXml()),
+        };
+
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+
+        await importer.importFromZipContents(zipContents, { clearExisting: true });
+
+        const navigation = ydoc.getArray('navigation');
+        // Locate Page A by its preserved id
+        let pageA: Y.Map<unknown> | null = null;
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            if (page.get('id') === PAGE_A) {
+                pageA = page;
+                break;
+            }
+        }
+        expect(pageA).not.toBeNull();
+
+        const blocks = pageA!.get('blocks') as Y.Array<unknown>;
+        expect(blocks.length).toBe(1);
+        const block = blocks.get(0) as Y.Map<unknown>;
+        expect(block.get('id')).toBe(BLOCK_A);
+        expect(block.get('blockId')).toBe(BLOCK_A);
+
+        const components = block.get('components') as Y.Array<unknown>;
+        expect(components.length).toBe(1);
+        const component = components.get(0) as Y.Map<unknown>;
+        expect(component.get('id')).toBe(IDEVICE_A);
+        expect(component.get('ideviceId')).toBe(IDEVICE_A);
+
+        ydoc.destroy();
+    });
+
+    it('merge-mode collision remaps the page id and updates exe-node: links', async () => {
+        const ydoc = new Y.Doc();
+        const navigation = ydoc.getArray('navigation');
+
+        // Pre-populate the navigation with a page that collides with PAGE_B
+        ydoc.transact(() => {
+            const existing = new Y.Map();
+            existing.set('id', PAGE_B);
+            existing.set('pageId', PAGE_B);
+            existing.set('pageName', 'Pre-existing');
+            existing.set('title', 'Pre-existing');
+            existing.set('parentId', null);
+            existing.set('order', 0);
+            existing.set('blocks', new Y.Array());
+            navigation.push([existing]);
+        });
+
+        const zipContents: Record<string, Uint8Array> = {
+            'content.xml': new TextEncoder().encode(buildV4ContentXml()),
+        };
+
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+        await importer.importFromZipContents(zipContents, { clearExisting: false });
+
+        // navigation now has: pre-existing page + 2 imported pages
+        expect(navigation.length).toBe(3);
+
+        // Find the imported pages (skip the pre-existing one at index 0)
+        const importedAId = (navigation.get(1) as Y.Map<unknown>).get('id') as string;
+        const importedBId = (navigation.get(2) as Y.Map<unknown>).get('id') as string;
+
+        // Page A had no collision -> preserved verbatim
+        expect(importedAId).toBe(PAGE_A);
+
+        // Page B collided -> must have been regenerated
+        expect(importedBId).not.toBe(PAGE_B);
+        expect(importedBId.startsWith('page-')).toBe(true);
+
+        // The internal link inside Page A's iDevice that pointed at PAGE_B must
+        // have been rewritten to the new imported B id (not the pre-existing one).
+        const importedA = navigation.get(1) as Y.Map<unknown>;
+        const blocks = importedA.get('blocks') as Y.Array<unknown>;
+        const block = blocks.get(0) as Y.Map<unknown>;
+        const components = block.get('components') as Y.Array<unknown>;
+        const component = components.get(0) as Y.Map<unknown>;
+        const htmlView = component.get('htmlView') as string;
+
+        expect(htmlView).toContain(`exe-node:${importedBId}`);
+        expect(htmlView).not.toContain(`exe-node:${PAGE_B}"`);
+
+        ydoc.destroy();
+    });
+
+    it('legacy v3 contentv3.xml path still regenerates page IDs', async () => {
+        // Legacy IDs are short non-namespaced strings; they collide trivially across
+        // documents, so the v3 path must keep regenerating. This pins the v3/v4 boundary.
+        const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Legacy"/>
+    <string role="key" value="_lang"/>
+    <unicode value="en"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Root"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="idevices"/>
+        <list/>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+        const zipContents: Record<string, Uint8Array> = {
+            'contentv3.xml': new TextEncoder().encode(legacyXml),
+        };
+
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+        await importer.importFromZipContents(zipContents, { clearExisting: true });
+
+        const navigation = ydoc.getArray('navigation');
+        expect(navigation.length).toBeGreaterThan(0);
+        const page = navigation.get(0) as Y.Map<unknown>;
+        const id = page.get('id') as string;
+
+        // The legacy parser uses ids like "page-1" / "node-..." internally;
+        // the importer must replace them with freshly generated namespaced ids.
+        expect(id.startsWith('page-')).toBe(true);
+        // Generated ids include the timestamp segment, so the id is longer than "page-1".
+        expect(id.length).toBeGreaterThan('page-1'.length + 4);
+
+        ydoc.destroy();
+    });
+});
+
+describe('ElpxImporter - remapInternalPageLinks prefix-collision safety', () => {
+    it('does not partially remap when one page id is a prefix of another (page-1 vs page-10)', async () => {
+        const fflate = await import('fflate');
+        const encoder = new TextEncoder();
+
+        // Two pages with prefix-colliding short ids; page-1 carries a link to page-10.
+        // After a merge-mode collision both ids get remapped via idRemap. The link
+        // must remap to the new <page-10> id verbatim -- not to the new <page-1> id
+        // plus a trailing "0", which is what a naive alternation regex produces.
+        const buildContent = () => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Prefix collision</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-1</odePageId>
+  <pageName>Page 1</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+  <odePagStructures>
+    <odePagStructure>
+      <odeBlockId>block-1</odeBlockId>
+      <blockName>Text</blockName>
+      <odeBlockOrder>0</odeBlockOrder>
+      <odeComponents>
+        <odeComponent>
+          <odeIdeviceId>idevice-1</odeIdeviceId>
+          <odeIdeviceTypeName>text</odeIdeviceTypeName>
+          <htmlView>&lt;p&gt;&lt;a href="exe-node:page-10"&gt;Go to page 10&lt;/a&gt;&lt;/p&gt;</htmlView>
+          <odeComponentOrder>0</odeComponentOrder>
+        </odeComponent>
+      </odeComponents>
+    </odePagStructure>
+  </odePagStructures>
+</odeNavStructure>
+<odeNavStructure>
+  <odePageId>page-10</odePageId>
+  <pageName>Page 10</pageName>
+  <odeNavStructureOrder>1</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+        const zipData = fflate.zipSync({ 'content.xml': encoder.encode(buildContent()) });
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+
+        // First import preserves page-1 and page-10 verbatim (fresh doc, no collision).
+        await importer.importFromBuffer(zipData, { clearExisting: true });
+        // Second import collides on both ids -> both get remapped, link must follow.
+        await importer.importFromBuffer(zipData, { clearExisting: false });
+
+        const navigation = ydoc.getArray('navigation');
+        const idsByName = new Map<string, string>();
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            idsByName.set((page.get('pageName') ?? page.get('title')) as string, page.get('id') as string);
+        }
+        // Sanity: first import kept the originals, second created two new ids -> 4 pages.
+        expect(navigation.length).toBe(4);
+
+        // Find the htmlView that originated from the SECOND import (its links must
+        // have been remapped). It's on the remapped "Page 1" -- not on the original.
+        let remappedLink: string | null = null;
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            const pageId = page.get('id') as string;
+            if (pageId === 'page-1') continue; // skip the originals from first import
+            const blocks = page.get('blocks') as Y.Array<unknown>;
+            for (let j = 0; j < (blocks?.length ?? 0); j++) {
+                const block = blocks.get(j) as Y.Map<unknown>;
+                const components = block.get('components') as Y.Array<unknown>;
+                for (let k = 0; k < (components?.length ?? 0); k++) {
+                    const comp = components.get(k) as Y.Map<unknown>;
+                    const html = comp.get('htmlView') as string | undefined;
+                    if (html?.includes('exe-node:')) {
+                        remappedLink = html;
+                    }
+                }
+            }
+        }
+        expect(remappedLink).not.toBeNull();
+
+        // Find the second-import id for page-10 (not equal to the original "page-10").
+        const newPage10Ids: string[] = [];
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            const id = page.get('id') as string;
+            const name = page.get('pageName') as string;
+            if (name === 'Page 10' && id !== 'page-10') newPage10Ids.push(id);
+        }
+        expect(newPage10Ids.length).toBe(1);
+        const newPage10 = newPage10Ids[0];
+
+        // Bug pinned: the link must point at the new page-10 id, exactly.
+        expect(remappedLink).toContain(`exe-node:${newPage10}`);
+        // ...and must NOT contain a partial remap leaving a stray "0" tail.
+        // A naive alternation regex would produce e.g. exe-node:<new-page-1>0.
+        const stray = /exe-node:[a-z0-9-]+0(?![a-z0-9-])/i;
+        const matches = remappedLink!.match(stray);
+        if (matches) {
+            const m = matches[0];
+            // Acceptable only if it equals the legitimate newPage10 link itself.
+            expect(m).toBe(`exe-node:${newPage10}`);
+        }
+
+        ydoc.destroy();
+    });
+
+    it('rewrites embedded ideviceId in jsonProperties when the component is regenerated on collision', async () => {
+        // Many iDevices serialise their own id inside jsonProperties (text/quiz
+        // self-reference). When merge-mode forces the component to regenerate
+        // its id, the JSON payload must follow -- otherwise the workarea would
+        // try to resolve the old id and silently fail.
+        const fflate = await import('fflate');
+        const encoder = new TextEncoder();
+
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>JSON remap</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-jp-1</odePageId>
+  <pageName>Page</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+  <odePagStructures>
+    <odePagStructure>
+      <odeBlockId>block-jp-1</odeBlockId>
+      <blockName>Block</blockName>
+      <odeBlockOrder>0</odeBlockOrder>
+      <odeComponents>
+        <odeComponent>
+          <odeIdeviceId>idevice-jp-1</odeIdeviceId>
+          <odeIdeviceTypeName>text</odeIdeviceTypeName>
+          <htmlView>&lt;p&gt;hi&lt;/p&gt;</htmlView>
+          <jsonProperties>{"ideviceId":"idevice-jp-1","textTextarea":"&lt;p&gt;hi&lt;/p&gt;"}</jsonProperties>
+          <odeComponentOrder>0</odeComponentOrder>
+        </odeComponent>
+      </odeComponents>
+    </odePagStructure>
+  </odePagStructures>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+        const zip = fflate.zipSync({ 'content.xml': encoder.encode(xml) });
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+
+        // First import keeps idevice-jp-1 verbatim (fresh doc, no collision).
+        await importer.importFromBuffer(zip, { clearExisting: true });
+        // Second import collides on idevice-jp-1 -> regenerate.
+        await importer.importFromBuffer(zip, { clearExisting: false });
+
+        const nav = ydoc.getArray('navigation');
+        // Locate the second-import copy of the component (its outer id is NOT
+        // 'idevice-jp-1' because it was regenerated).
+        let newCompId: string | null = null;
+        let jsonProps: string | null = null;
+        for (let i = 0; i < nav.length; i++) {
+            const page = nav.get(i) as Y.Map<unknown>;
+            if (page.get('id') === 'page-jp-1') continue; // skip first-import originals
+            const blocks = page.get('blocks') as Y.Array<unknown>;
+            if (!blocks?.length) continue;
+            const block = blocks.get(0) as Y.Map<unknown>;
+            const comps = block.get('components') as Y.Array<unknown>;
+            const comp = comps.get(0) as Y.Map<unknown>;
+            const compId = comp.get('id') as string;
+            if (compId !== 'idevice-jp-1') {
+                newCompId = compId;
+                jsonProps = comp.get('jsonProperties') as string;
+            }
+        }
+        expect(newCompId).not.toBeNull();
+        expect(jsonProps).not.toBeNull();
+        const parsed = JSON.parse(jsonProps as string);
+        // Embedded ideviceId now points at the FRESH id, not the stale XML one.
+        expect(parsed.ideviceId).toBe(newCompId);
+        expect(parsed.ideviceId).not.toBe('idevice-jp-1');
+
+        ydoc.destroy();
+    });
+
+    it('handles multi-level prefix nesting (page-1, page-10, page-100) without stray remaps', async () => {
+        // Three ids where each is a prefix of the next. Belt-and-suspenders:
+        // descending-length sort puts page-100 before page-10 before page-1 in
+        // the alternation; the (?![A-Za-z0-9_-]) lookahead would still reject a
+        // shorter match inside a longer id even if the sort regressed.
+        const fflate = await import('fflate');
+        const encoder = new TextEncoder();
+
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Triple prefix</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-1</odePageId>
+  <pageName>Page 1</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+  <odePagStructures>
+    <odePagStructure>
+      <odeBlockId>block-multi-1</odeBlockId>
+      <blockName>Text</blockName>
+      <odeBlockOrder>0</odeBlockOrder>
+      <odeComponents>
+        <odeComponent>
+          <odeIdeviceId>idevice-multi-1</odeIdeviceId>
+          <odeIdeviceTypeName>text</odeIdeviceTypeName>
+          <htmlView>&lt;p&gt;&lt;a href="exe-node:page-100"&gt;to 100&lt;/a&gt; &lt;a href="exe-node:page-10"&gt;to 10&lt;/a&gt;&lt;/p&gt;</htmlView>
+          <odeComponentOrder>0</odeComponentOrder>
+        </odeComponent>
+      </odeComponents>
+    </odePagStructure>
+  </odePagStructures>
+</odeNavStructure>
+<odeNavStructure>
+  <odePageId>page-10</odePageId>
+  <pageName>Page 10</pageName>
+  <odeNavStructureOrder>1</odeNavStructureOrder>
+</odeNavStructure>
+<odeNavStructure>
+  <odePageId>page-100</odePageId>
+  <pageName>Page 100</pageName>
+  <odeNavStructureOrder>2</odeNavStructureOrder>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+        const zip = fflate.zipSync({ 'content.xml': encoder.encode(xml) });
+        const ydoc = new Y.Doc();
+        const importer = new ElpxImporter(ydoc, null, silentLogger);
+        await importer.importFromBuffer(zip, { clearExisting: true });
+        // Second import forces full remap of all three ids.
+        await importer.importFromBuffer(zip, { clearExisting: false });
+
+        const nav = ydoc.getArray('navigation');
+        // Map "Page N" -> the FRESH id (the one that's not equal to the original).
+        const fresh = new Map<string, string>();
+        for (let i = 0; i < nav.length; i++) {
+            const page = nav.get(i) as Y.Map<unknown>;
+            const id = page.get('id') as string;
+            const name = page.get('pageName') as string;
+            if (id !== `page-${name.replace('Page ', '')}`) fresh.set(name, id);
+        }
+        expect(fresh.size).toBe(3);
+
+        // Find the remapped htmlView on the second-import copy of page-1.
+        let remapped: string | null = null;
+        for (let i = 0; i < nav.length; i++) {
+            const page = nav.get(i) as Y.Map<unknown>;
+            if (page.get('pageName') !== 'Page 1') continue;
+            if (page.get('id') === 'page-1') continue; // skip the original (first import)
+            const blocks = page.get('blocks') as Y.Array<unknown>;
+            const block = blocks.get(0) as Y.Map<unknown>;
+            const comps = block.get('components') as Y.Array<unknown>;
+            const html = (comps.get(0) as Y.Map<unknown>).get('htmlView') as string;
+            remapped = html;
+        }
+        expect(remapped).not.toBeNull();
+
+        // Each link must point at the EXACT fresh id of its target page --
+        // no stray "0" or "00" tail from a shorter-prefix partial match.
+        expect(remapped).toContain(`exe-node:${fresh.get('Page 100')}`);
+        expect(remapped).toContain(`exe-node:${fresh.get('Page 10')}`);
+        expect(remapped).not.toContain(`exe-node:${fresh.get('Page 1')}0`);
+        expect(remapped).not.toContain(`exe-node:${fresh.get('Page 10')}0`);
+
+        ydoc.destroy();
     });
 });

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -48,7 +48,9 @@ import {
 import { stripLegacyExeTextWrapper } from './legacyExeTextWrapper';
 
 import { LegacyXmlParser } from './LegacyXmlParser';
+import { generateId } from '../ids';
 import type { LegacyParseResult, LegacyPage, LegacyBlock, LegacyIdevice, LegacyMetadata } from './LegacyXmlParser';
+import { generateOdeId } from '../export/utils/odeId';
 
 /**
  * ElpxImporter class
@@ -419,6 +421,20 @@ export class ElpxImporter {
         const odeProperties = this.getElement(xmlDoc, 'odeProperties');
         const metadataValues = this.extractMetadata(xmlDoc, odeProperties);
 
+        // Preserve stable identifiers from <odeResources> (odeId, odeVersionId).
+        // Without this, every round-trip generates a fresh pair, defeating
+        // diff stability and SCORM manifest identity. See #1784.
+        const odeResources = this.extractOdeResources(xmlDoc);
+        if (odeResources.odeId) {
+            metadataValues.odeIdentifier = odeResources.odeId;
+        }
+        if (odeResources.odeVersionId) {
+            metadataValues.odeVersionId = odeResources.odeVersionId;
+        }
+        if (odeResources.scormIdentifier) {
+            metadataValues.scormIdentifier = odeResources.scormIdentifier;
+        }
+
         // Extract screenshot.png from archive root if present
         const screenshot = this.extractScreenshotFromZip(zip);
         if (screenshot) {
@@ -435,6 +451,11 @@ export class ElpxImporter {
         // Build all page structures as a FLAT list
         const pageStructures: PageData[] = [];
         const idRemap = new Map<string, string>();
+        // Pre-seed the set of "ids already taken" with whatever lives in the
+        // target Y.Doc navigation when merging. On a fresh import (clearExisting)
+        // the navigation will be wiped inside the transaction below, so we start
+        // empty and let the original ids from content.xml flow through verbatim.
+        const usedIds = clearExisting ? new Set<string>() : this.collectExistingIds();
         this.buildFlatPageList(
             rootNavStructures,
             zip,
@@ -444,6 +465,7 @@ export class ElpxImporter {
             orderOffset,
             idRemap,
             true,
+            usedIds,
         );
         this.logger.log(
             '[ElpxImporter] Built flat page list:',
@@ -475,8 +497,13 @@ export class ElpxImporter {
                     this.logger.log('[ElpxImporter] Navigation cleared');
                 }
 
-                // Set metadata only if clearing (replacing) the document
-                if (odeProperties && clearExisting) {
+                // Set metadata only if clearing (replacing) the document.
+                // <odeProperties> is optional per the DTD, so we also write
+                // when <odeResources> alone carried stable identifiers --
+                // otherwise odeIdentifier / odeVersionId would never reach
+                // the Y.Doc on those minimal documents.
+                const hasStableIdentifiers = Boolean(metadataValues.odeIdentifier || metadataValues.odeVersionId);
+                if (clearExisting && (odeProperties || hasStableIdentifiers)) {
                     this.logger.log('[ElpxImporter] Setting metadata...');
                     this.setMetadata(metadata, metadataValues);
                     this.logger.log('[ElpxImporter] Metadata set');
@@ -652,11 +679,11 @@ export class ElpxImporter {
         // Legacy IDs are stable inside .elp files (e.g. page-4, idevice-2).
         // On repeated imports into the same Y.Doc we must remap to unique IDs to avoid collisions.
         for (const legacyPage of legacyPages) {
-            pageIdRemap.set(legacyPage.id, this.generateId('page'));
+            pageIdRemap.set(legacyPage.id, generateId('page'));
         }
 
         for (const legacyPage of legacyPages) {
-            const pageId = pageIdRemap.get(legacyPage.id) || this.generateId('page');
+            const pageId = pageIdRemap.get(legacyPage.id) || generateId('page');
             const parentId =
                 legacyPage.parent_id === null ? rootParentId : (pageIdRemap.get(legacyPage.parent_id) ?? rootParentId);
             const order = legacyPage.parent_id === null ? rootOrderOffset + legacyPage.position : legacyPage.position;
@@ -692,7 +719,7 @@ export class ElpxImporter {
      * Convert legacy block to BlockData format
      */
     private convertLegacyBlockToBlockData(legacyBlock: LegacyBlock): BlockData {
-        const blockId = this.generateId('block');
+        const blockId = generateId('block');
 
         const blockData: BlockData = {
             id: blockId,
@@ -718,7 +745,7 @@ export class ElpxImporter {
      * Convert legacy iDevice to ComponentData format
      */
     private convertLegacyIdeviceToComponentData(legacyIdevice: LegacyIdevice): ComponentData {
-        const componentId = this.generateId('idevice');
+        const componentId = generateId('idevice');
 
         // Build HTML view with feedback if present
         let htmlView = legacyIdevice.htmlView || '';
@@ -812,6 +839,12 @@ export class ElpxImporter {
 
         metadata.set('extraHeadContent', legacyMeta.extraHeadContent);
         metadata.set('footer', legacyMeta.footer);
+
+        // Legacy contentv3.xml has no <odeResources>. Generate fresh stable
+        // identifiers once at import time so subsequent re-exports of the
+        // converted project keep the same odeId / odeVersionId. See #1784.
+        metadata.set('odeIdentifier', generateOdeId());
+        metadata.set('odeVersionId', generateOdeId());
     }
 
     /**
@@ -873,6 +906,28 @@ export class ElpxImporter {
             this.logger.warn('[ElpxImporter] Failed to read screenshot.png:', error);
             return undefined;
         }
+    }
+
+    /**
+     * Extract <odeResources> entries from a v4 content.xml document.
+     * Returns an empty object when the section is missing or empty so callers
+     * can fall back to fresh identifiers without crashing.
+     */
+    private extractOdeResources(xmlDoc: Document): Partial<Record<string, string>> {
+        const result: Partial<Record<string, string>> = {};
+        const container = this.getElement(xmlDoc, 'odeResources');
+        if (!container) return result;
+        const resources = this.getElements(container, 'odeResource');
+        for (const res of resources) {
+            const keyEl = this.getElement(res, 'key');
+            const valEl = this.getElement(res, 'value');
+            const key = keyEl?.textContent?.trim();
+            const value = valEl?.textContent?.trim();
+            if (key && value) {
+                result[key] = value;
+            }
+        }
+        return result;
     }
 
     /**
@@ -947,6 +1002,17 @@ export class ElpxImporter {
         if (values.screenshot) {
             metadata.set('screenshot', values.screenshot);
         }
+        // Stable identifiers preserved from <odeResources>. Only set when present —
+        // export-side fallback (OdeXmlGenerator) generates fresh values otherwise.
+        if (values.odeIdentifier) {
+            metadata.set('odeIdentifier', values.odeIdentifier);
+        }
+        if (values.odeVersionId) {
+            metadata.set('odeVersionId', values.odeVersionId);
+        }
+        if (values.scormIdentifier) {
+            metadata.set('scormIdentifier', values.scormIdentifier);
+        }
     }
 
     /**
@@ -961,19 +1027,27 @@ export class ElpxImporter {
         orderOffset: number,
         idRemap: Map<string, string>,
         isRootLevel: boolean,
+        usedIds: Set<string>,
     ): void {
         let siblingOrder = 0;
 
         for (const navNode of navNodes) {
             const originalPageId = this.getPageId(navNode);
-            const newPageId = this.generateId('page');
+            // Preserve the original <odePageId> verbatim when it is present and
+            // does not collide with an id already used in the target Y.Doc or
+            // assigned earlier in this same import. Collisions only happen in
+            // merge-mode imports (clearExisting=false); when they do, we
+            // regenerate and the remap is later used to rewrite internal
+            // exe-node: links.
+            const newPageId = originalPageId && !usedIds.has(originalPageId) ? originalPageId : generateId('page');
+            usedIds.add(newPageId);
 
-            if (originalPageId) {
+            if (originalPageId && newPageId !== originalPageId) {
                 idRemap.set(originalPageId, newPageId);
             }
 
             const calculatedOrder = isRootLevel ? orderOffset + siblingOrder : siblingOrder;
-            const pageData = this.buildPageData(navNode, zip, parentId, newPageId, calculatedOrder);
+            const pageData = this.buildPageData(navNode, zip, parentId, newPageId, calculatedOrder, usedIds);
 
             if (pageData) {
                 flatList.push(pageData);
@@ -1000,6 +1074,7 @@ export class ElpxImporter {
                         0,
                         idRemap,
                         false,
+                        usedIds,
                     );
                 }
             }
@@ -1015,6 +1090,7 @@ export class ElpxImporter {
         parentId: string | null,
         newPageId: string,
         calculatedOrder: number,
+        usedIds: Set<string>,
     ): PageData {
         const pageId = newPageId;
         const pageName = this.getPageName(navNode);
@@ -1040,7 +1116,7 @@ export class ElpxImporter {
         });
 
         for (const pagNode of sortedPagStructures) {
-            const blockData = this.buildBlockData(pagNode, zip);
+            const blockData = this.buildBlockData(pagNode, zip, usedIds);
             if (blockData) {
                 pageData.blocks.push(blockData);
             }
@@ -1052,11 +1128,14 @@ export class ElpxImporter {
     /**
      * Build plain JavaScript data structure for a block
      */
-    private buildBlockData(pagNode: Element, zip: Record<string, Uint8Array>): BlockData {
-        const blockId =
-            pagNode.getAttribute('odePagStructureId') ||
-            this.getTextContent(pagNode, 'odeBlockId') ||
-            this.generateId('block');
+    private buildBlockData(pagNode: Element, zip: Record<string, Uint8Array>, usedIds: Set<string>): BlockData {
+        // Preserve the original block id from XML when present and not colliding
+        // with an id already used in this import or in the target Y.Doc.
+        // Otherwise generate a fresh id.
+        const originalBlockId =
+            pagNode.getAttribute('odePagStructureId') || this.getTextContent(pagNode, 'odeBlockId') || null;
+        const blockId = originalBlockId && !usedIds.has(originalBlockId) ? originalBlockId : generateId('block');
+        usedIds.add(blockId);
         const blockName = pagNode.getAttribute('blockName') || this.getTextContent(pagNode, 'blockName') || '';
         const order = this.getPagOrder(pagNode);
         const iconName = pagNode.getAttribute('iconName') || this.getTextContent(pagNode, 'iconName') || '';
@@ -1080,7 +1159,7 @@ export class ElpxImporter {
         });
 
         for (const compNode of sortedComponents) {
-            const compData = this.buildComponentData(compNode, zip);
+            const compData = this.buildComponentData(compNode, zip, usedIds);
             if (compData) {
                 blockData.components.push(compData);
             }
@@ -1092,11 +1171,19 @@ export class ElpxImporter {
     /**
      * Build plain JavaScript data structure for a component
      */
-    private buildComponentData(compNode: Element, _zip: Record<string, Uint8Array>): ComponentData {
+    private buildComponentData(
+        compNode: Element,
+        _zip: Record<string, Uint8Array>,
+        usedIds: Set<string>,
+    ): ComponentData {
+        // Preserve the original iDevice id from XML when present and not colliding
+        // with an id already used in this import or in the target Y.Doc.
+        // Otherwise generate a fresh id.
+        const originalComponentId =
+            compNode.getAttribute('odeComponentId') || this.getTextContent(compNode, 'odeIdeviceId') || null;
         const componentId =
-            compNode.getAttribute('odeComponentId') ||
-            this.getTextContent(compNode, 'odeIdeviceId') ||
-            this.generateId('idevice');
+            originalComponentId && !usedIds.has(originalComponentId) ? originalComponentId : generateId('idevice');
+        usedIds.add(componentId);
 
         let ideviceType =
             compNode.getAttribute('odeIdeviceTypeDirName') ||
@@ -1189,6 +1276,20 @@ export class ElpxImporter {
 
                 if (typeof props.htmlView === 'string') {
                     props.htmlView = stripLegacyExeTextWrapper(props.htmlView);
+                }
+
+                // When merge-mode collision regenerated the component id, an embedded
+                // `ideviceId` inside jsonProperties (commonly stored by text/quiz
+                // iDevices and used by the workarea for self-reference) would still
+                // point at the old XML id. Rewrite it so the Yjs field and the JSON
+                // payload stay in sync.
+                if (
+                    originalComponentId &&
+                    originalComponentId !== componentId &&
+                    typeof props.ideviceId === 'string' &&
+                    props.ideviceId === originalComponentId
+                ) {
+                    props.ideviceId = componentId;
                 }
 
                 compData.properties = props;
@@ -1453,9 +1554,14 @@ export class ElpxImporter {
     private remapInternalPageLinks(pageStructures: PageData[], idRemap: Map<string, string>): void {
         if (idRemap.size === 0) return;
 
-        // Build regex that matches any of the old page IDs
-        const escapedIds = Array.from(idRemap.keys()).map(id => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-        const pattern = new RegExp(`(exe-node:)(${escapedIds.join('|')})(#[^"'\\s]*)?`, 'g');
+        // Sort keys by descending length so longer ids (e.g. "page-10") are tried
+        // before shorter prefixes (e.g. "page-1") in the regex alternation.
+        // Combined with the (?![A-Za-z0-9_-]) boundary lookahead below, this
+        // prevents partial-prefix remaps that would otherwise rewrite
+        // "exe-node:page-10" using the mapping for "page-1" and leave a stray "0".
+        const sortedKeys = Array.from(idRemap.keys()).sort((a, b) => b.length - a.length);
+        const escapedIds = sortedKeys.map(id => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+        const pattern = new RegExp(`(exe-node:)(${escapedIds.join('|')})(?![A-Za-z0-9_-])(#[^"'\\s]*)?`, 'g');
 
         const replacer = (_m: string, prefix: string, oldId: string, fragment: string | undefined) => {
             const newId = idRemap.get(oldId) ?? oldId;
@@ -1819,12 +1925,48 @@ export class ElpxImporter {
     }
 
     /**
-     * Generate a unique ID
+     * Collect every page, block and component (iDevice) id currently present in
+     * the Y.Doc navigation. Used by merge-mode v4 imports to detect collisions
+     * with the existing document before deciding to preserve or regenerate ids.
+     *
+     * On a clean v4 import (clearExisting=true) the navigation will be wiped
+     * inside the import transaction, so the caller starts with an empty Set
+     * instead of invoking this scan.
      */
-    private generateId(prefix: string): string {
-        const timestamp = Date.now().toString(36);
-        const random = Math.random().toString(36).substring(2, 11);
-        return `${prefix}-${timestamp}-${random}`;
+    private collectExistingIds(): Set<string> {
+        const ids = new Set<string>();
+        const navigation = this.getNavigation();
+        for (let i = 0; i < navigation.length; i++) {
+            const page = navigation.get(i) as Y.Map<unknown>;
+            if (!page) continue;
+            const pageIdValue = page.get('id');
+            if (typeof pageIdValue === 'string') ids.add(pageIdValue);
+            const pageIdMirror = page.get('pageId');
+            if (typeof pageIdMirror === 'string') ids.add(pageIdMirror);
+
+            const blocks = page.get('blocks') as Y.Array<unknown> | undefined;
+            if (!blocks || typeof blocks.length !== 'number') continue;
+            for (let j = 0; j < blocks.length; j++) {
+                const block = blocks.get(j) as Y.Map<unknown>;
+                if (!block) continue;
+                const blockIdValue = block.get('id');
+                if (typeof blockIdValue === 'string') ids.add(blockIdValue);
+                const blockIdMirror = block.get('blockId');
+                if (typeof blockIdMirror === 'string') ids.add(blockIdMirror);
+
+                const components = block.get('components') as Y.Array<unknown> | undefined;
+                if (!components || typeof components.length !== 'number') continue;
+                for (let k = 0; k < components.length; k++) {
+                    const comp = components.get(k) as Y.Map<unknown>;
+                    if (!comp) continue;
+                    const compIdValue = comp.get('id');
+                    if (typeof compIdValue === 'string') ids.add(compIdValue);
+                    const compIdMirror = comp.get('ideviceId');
+                    if (typeof compIdMirror === 'string') ids.add(compIdMirror);
+                }
+            }
+        }
+        return ids;
     }
 
     /**

--- a/src/shared/import/interfaces.ts
+++ b/src/shared/import/interfaces.ts
@@ -286,4 +286,10 @@ export interface OdeMetadata {
     globalFont: string;
     /** Project screenshot/thumbnail as base64 data URL (optional) */
     screenshot?: string;
+    /** Stable ODE identifier preserved from <odeResources><odeId> (optional) */
+    odeIdentifier?: string;
+    /** Stable ODE version identifier preserved from <odeResources><odeVersionId> (optional) */
+    odeVersionId?: string;
+    /** SCORM manifest identifier override preserved from <odeResources><scormIdentifier> (optional) */
+    scormIdentifier?: string;
 }

--- a/src/yjs/structure-binding.ts
+++ b/src/yjs/structure-binding.ts
@@ -12,6 +12,7 @@
  * called within a transaction (via doc-manager.withDocument).
  */
 import * as Y from 'yjs';
+import { generateId } from '../shared/ids';
 import type {
     PageData,
     CreatePageInput,
@@ -32,14 +33,12 @@ import type {
 // ============================================================================
 
 /**
- * Generate a unique ID with prefix
- * Same algorithm as client-side for consistency
+ * Generate a unique ID with prefix.
+ *
+ * Re-exported from the canonical module so existing imports across
+ * `src/*` keep working — see issue exelearning/exelearning#1782.
  */
-export function generateId(prefix: string): string {
-    const timestamp = Date.now().toString(36);
-    const random = Math.random().toString(36).substring(2, 11);
-    return `${prefix}-${timestamp}-${random}`;
-}
+export { generateId };
 
 /**
  * Get the navigation array from a Y.Doc

--- a/test/integration/stable-identifiers.spec.ts
+++ b/test/integration/stable-identifiers.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration: stable identifiers end-to-end (#1782, #1783, #1784, #1785, #1786).
+ *
+ * Exercises the chain the unit tests cannot cover in isolation:
+ *   v4 .elpx (with <odeResources>)
+ *     → ElpxImporter → Y.Doc metadata + navigation
+ *     → YjsDocumentAdapter → ExportMetadata
+ *
+ * Once `ExportMetadata.odeIdentifier` is set, the per-exporter unit tests
+ * (Scorm12 / Scorm2004 / IMS spec files) already prove that the manifest,
+ * organization and LOM/content.xml roots are derived consistently from it
+ * (see #1785). This test pins the bridge from XML through Yjs to that
+ * boundary so a regression in import or adapter cannot silently disable
+ * stable LMS tracking.
+ */
+import { describe, it, expect } from 'bun:test';
+import * as Y from 'yjs';
+import { zipSync } from 'fflate';
+import { ElpxImporter } from '../../src/shared/import/ElpxImporter';
+import { YjsDocumentAdapter } from '../../src/shared/export/adapters/YjsDocumentAdapter';
+
+const silentLogger = {
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+const ODE_ID = '20251201123456ABCDEF';
+const ODE_VERSION_ID = '20251201123456FEDCBA';
+
+const buildContentXml = (): string => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ode SYSTEM "content.dtd">
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource><key>odeId</key><value>${ODE_ID}</value></odeResource>
+  <odeResource><key>odeVersionId</key><value>${ODE_VERSION_ID}</value></odeResource>
+  <odeResource><key>exe_version</key><value>4.0.0</value></odeResource>
+</odeResources>
+<odeProperties>
+  <odeProperty><key>pp_title</key><value>Integration Stable Identifiers</value></odeProperty>
+  <odeProperty><key>pp_lang</key><value>en</value></odeProperty>
+</odeProperties>
+<odeNavStructures>
+<odeNavStructure>
+  <odePageId>page-mp0fppwf-71v64kl4r</odePageId>
+  <pageName>Introduction</pageName>
+  <odeNavStructureOrder>0</odeNavStructureOrder>
+  <odePagStructures>
+    <odePagStructure>
+      <odeBlockId>block-mp0fppwf-aaaaaaaaa</odeBlockId>
+      <blockName>Text</blockName>
+      <odeBlockOrder>0</odeBlockOrder>
+      <odeComponents>
+        <odeComponent>
+          <odeIdeviceId>idevice-mp0fppwf-bbbbbbbbb</odeIdeviceId>
+          <odeIdeviceTypeName>text</odeIdeviceTypeName>
+          <htmlView>&lt;p&gt;Hello LMS&lt;/p&gt;</htmlView>
+          <odeComponentOrder>0</odeComponentOrder>
+        </odeComponent>
+      </odeComponents>
+    </odePagStructure>
+  </odePagStructures>
+</odeNavStructure>
+</odeNavStructures>
+</ode>`;
+
+async function importV4ContentIntoYDoc(contentXml: string): Promise<Y.Doc> {
+    const ydoc = new Y.Doc();
+    const importer = new ElpxImporter(ydoc, null, silentLogger);
+    const zip = zipSync({ 'content.xml': new TextEncoder().encode(contentXml) });
+    await importer.importFromBuffer(zip, { clearExisting: true });
+    return ydoc;
+}
+
+function makeYjsManagerFromDoc(ydoc: Y.Doc) {
+    return {
+        getDoc: () => ydoc,
+        getMetadata: () => ydoc.getMap('metadata'),
+        getNavigation: () => ydoc.getArray('navigation'),
+        projectId: 'stable-id-integration-test',
+    };
+}
+
+describe('stable identifiers end-to-end (#1786)', () => {
+    it('preserves odeId/odeVersionId from content.xml all the way into Y.Doc metadata', async () => {
+        const ydoc = await importV4ContentIntoYDoc(buildContentXml());
+        const meta = ydoc.getMap('metadata');
+        expect(meta.get('odeIdentifier')).toBe(ODE_ID);
+        expect(meta.get('odeVersionId')).toBe(ODE_VERSION_ID);
+        ydoc.destroy();
+    });
+
+    it('preserves page/block/iDevice ids verbatim through Yjs navigation', async () => {
+        const ydoc = await importV4ContentIntoYDoc(buildContentXml());
+        const nav = ydoc.getArray('navigation');
+        expect(nav.length).toBe(1);
+        const page = nav.get(0) as Y.Map<unknown>;
+        expect(page.get('id')).toBe('page-mp0fppwf-71v64kl4r');
+        const block = (page.get('blocks') as Y.Array<unknown>).get(0) as Y.Map<unknown>;
+        expect(block.get('id')).toBe('block-mp0fppwf-aaaaaaaaa');
+        const component = (block.get('components') as Y.Array<unknown>).get(0) as Y.Map<unknown>;
+        expect(component.get('id')).toBe('idevice-mp0fppwf-bbbbbbbbb');
+        ydoc.destroy();
+    });
+
+    it('YjsDocumentAdapter forwards stable identifiers to ExportMetadata (#1784 review)', async () => {
+        const ydoc = await importV4ContentIntoYDoc(buildContentXml());
+        const adapter = new YjsDocumentAdapter(
+            makeYjsManagerFromDoc(ydoc) as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const exportMeta = adapter.getMetadata();
+        // The fields the SCORM/IMS exporter unit tests then consume via
+        // BaseExporter.getManifestIdentifier() -- see #1785 specs.
+        expect(exportMeta.odeIdentifier).toBe(ODE_ID);
+        expect(exportMeta.odeVersionId).toBe(ODE_VERSION_ID);
+        ydoc.destroy();
+    });
+
+    it('survives a full XML round-trip: import -> generateOdeXml -> re-import keeps every identifier (#1786)', async () => {
+        // The strongest invariant: take an imported project, re-emit content.xml
+        // through the real export-side generator, then re-import that emitted
+        // XML into a fresh Y.Doc. All identifiers (project + page/block/idevice)
+        // must survive both legs untouched.
+        const { generateOdeXml } = await import('../../src/shared/export/generators/OdeXmlGenerator');
+
+        const ydocA = await importV4ContentIntoYDoc(buildContentXml());
+        const adapterA = new YjsDocumentAdapter(
+            makeYjsManagerFromDoc(ydocA) as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        );
+        const metaA = adapterA.getMetadata();
+        const pagesA = adapterA.getNavigation();
+
+        const exportedXml = generateOdeXml(metaA, pagesA);
+
+        // Re-import the just-emitted XML and read everything back.
+        const ydocB = await importV4ContentIntoYDoc(exportedXml);
+        const metaB = ydocB.getMap('metadata');
+        expect(metaB.get('odeIdentifier')).toBe(ODE_ID);
+        expect(metaB.get('odeVersionId')).toBe(ODE_VERSION_ID);
+
+        const navB = ydocB.getArray('navigation');
+        expect(navB.length).toBe(1);
+        const pageB = navB.get(0) as Y.Map<unknown>;
+        expect(pageB.get('id')).toBe('page-mp0fppwf-71v64kl4r');
+        const blockB = (pageB.get('blocks') as Y.Array<unknown>).get(0) as Y.Map<unknown>;
+        expect(blockB.get('id')).toBe('block-mp0fppwf-aaaaaaaaa');
+        const compB = (blockB.get('components') as Y.Array<unknown>).get(0) as Y.Map<unknown>;
+        expect(compB.get('id')).toBe('idevice-mp0fppwf-bbbbbbbbb');
+
+        ydocA.destroy();
+        ydocB.destroy();
+    });
+
+    it('two consecutive imports of the same XML keep identifiers stable across the chain', async () => {
+        const xml = buildContentXml();
+        const ydocA = await importV4ContentIntoYDoc(xml);
+        const ydocB = await importV4ContentIntoYDoc(xml);
+        const metaA = new YjsDocumentAdapter(
+            makeYjsManagerFromDoc(ydocA) as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        ).getMetadata();
+        const metaB = new YjsDocumentAdapter(
+            makeYjsManagerFromDoc(ydocB) as unknown as ConstructorParameters<typeof YjsDocumentAdapter>[0],
+        ).getMetadata();
+        // odeId / odeVersionId stay identical -- no LMS-tracking break on re-upload.
+        expect(metaA.odeIdentifier).toBe(metaB.odeIdentifier);
+        expect(metaA.odeVersionId).toBe(metaB.odeVersionId);
+        ydocA.destroy();
+        ydocB.destroy();
+    });
+});


### PR DESCRIPTION
## Summary

Single landable bundle for the four parallel fixes that close issue #1786 (and its four sub-issues #1782–#1785). Replaces the four open PRs #1787–#1790 with one self-contained branch, plus the coverage gaps each PR could not test in isolation.

The original bug, end-to-end: opening and re-downloading a `.elpx` rewrote every page/block/iDevice id and the SCORM `manifest@identifier`, so LMS course-tracking broke on every re-upload and content.xml diffs were unusable.

## What this PR contains

### Bundled fixes (one commit per upstream PR)

| Closes | Area | Fix |
|---|---|---|
| #1782 | `src/shared/ids.ts` (new), `structure-binding.ts`, `ElpxImporter.ts`, `ComponentImporter.js`, `YjsStructureBinding.js` | Single canonical `generateId(prefix)`. Two browser sites keep byte-equivalent mirror copies tagged `// keep in sync`. Deprecated `.substr` replaced with `.substring(2, 11)`. |
| #1783 | `ElpxImporter.buildFlatPageList`, `remapInternalPageLinks` | Preserve `<odePageId>` / `<odeBlockId>` / `<odeIdeviceId>` verbatim when no collision. Merge-mode remaps only on real collisions. Boundary lookahead `(?![A-Za-z0-9_-])` + descending-length sort fix the `page-1` / `page-10` partial-prefix remap. |
| #1784 | `ElpxImporter.extractOdeResources` (new), `metadata-properties.ts`, `OdeXmlGenerator.ts`, `YjsDocumentAdapter.getMetadata`, doc updates | Read `<odeResources>` on import; forward `odeIdentifier` / `odeVersionId` / `scormIdentifier` from the Yjs metadata Y.Map; legacy v3 generates the pair once; `versionId` fallback chain mirrors `odeId`. Gate also fires when `<odeProperties>` is absent (valid per DTD). |
| #1785 | `BaseExporter.getManifestIdentifier` (memoized), `Scorm12 / Scorm2004 / Ims` exporters + generators | `manifest@identifier` derives deterministically from `meta.scormIdentifier` > `'eXe-MANIFEST-' + meta.odeIdentifier` > `'eXe-MANIFEST-' + generateOdeId()`. The same root flows into `organization@identifier` (`eXe-<root>`) and the LOM `catalog/entry` (`ODE-<root>`). Memoization prevents the fallback path from generating three unrelated roots. |

Each merge commit (`Merge #1787…#1790`) preserves the original commit history so review attribution stays intact.

### Coverage gaps closed in this bundle

The four parallel PRs covered their own files but could not test the chain between them. This PR adds:

1. **`public/app/yjs/YjsProjectManagerMixin.js`** — three additional sites that minted ids in Format B (decimal timestamp + deprecated `.substr`) discovered while diffing against the existing `hotfix/id-mismatch-issues` branch. Routed through a canonical helper that mirrors `src/shared/ids.ts`. Test added in `YjsProjectManagerMixin.test.js`.

2. **`test/integration/stable-identifiers.spec.ts`** — end-to-end bridge test (XML → `ElpxImporter` → Y.Doc metadata + navigation → `YjsDocumentAdapter` → `ExportMetadata`). This is the gap the reviewer flagged on #1789 / #1790: a regression in import or adapter previously made the per-exporter unit tests pass while the real Yjs export path silently fell back to a random id.

## Verification

- `make test-unit-ci` → **6956 pass / 0 fail**
- `bun test test/integration/` → **704 pass / 0 fail** (4 new bridge tests included)
- Frontend `YjsProjectManagerMixin.test.js` → **107 / 107 pass**
- `make fix` / `make lint` → clean

## End-to-end invariant after merge

1. Round-trip a `.elpx` twice without changes → diff of `content.xml` is empty (modulo legitimate timestamps).
2. Two SCORM 1.2 / 2004 / IMS exports of the same project → byte-identical `imsmanifest.xml`.
3. Re-uploading the updated SCORM package to Moodle / Canvas preserves learner tracking.
4. Mixed-format ids in already-saved projects continue to work; new ids are uniform.

## Out of scope

- Migrating existing saved projects to UUIDv7 or any other scheme.
- Bumping `odeVersionId` automatically when content changes (separate follow-up).
- Rewriting legacy `.elp` v3 ids — short collision-prone, still regenerated on import.

Closes #1782
Closes #1783
Closes #1784
Closes #1785
Closes #1786

Supersedes #1787
Supersedes #1788
Supersedes #1789
Supersedes #1790