### PR TITLE
fix(auth): update CAS demo server URL to casserverpac4j.dev

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -61,8 +61,8 @@ AUTH_CREATE_USERS=true
 AUTH_TEMP_EMAIL_DOMAIN=domain.local
 
 ###> CAS Configuration (required if using CAS) ###
-# Test server: https://casserverpac4j.herokuapp.com
-CAS_URL=https://casserverpac4j.herokuapp.com
+# Test server: https://www.casserverpac4j.dev
+CAS_URL=https://www.casserverpac4j.dev
 CAS_VALIDATE_PATH=/p3/serviceValidate
 CAS_LOGIN_PATH=/login
 CAS_LOGOUT_PATH=/logout

--- a/doc/development/authentication.md
+++ b/doc/development/authentication.md
@@ -32,7 +32,7 @@ APP_AUTH_METHODS=password,cas,openid,guest
 AUTH_CREATE_USERS=true
 
 # CAS
-CAS_URL=https://casserverpac4j.herokuapp.com
+CAS_URL=https://www.casserverpac4j.dev
 CAS_VALIDATE_PATH=/p3/serviceValidate
 CAS_LOGIN_PATH=/login
 CAS_LOGOUT_PATH=/logout
@@ -149,7 +149,7 @@ OIDC_CLIENT_SECRET=secret
 Use these variables (example with a public test server):
 
 ```
-CAS_URL=https://casserverpac4j.herokuapp.com
+CAS_URL=https://www.casserverpac4j.dev
 CAS_VALIDATE_PATH=/p3/serviceValidate
 CAS_LOGIN_PATH=/login
 CAS_LOGOUT_PATH=/logout

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -607,7 +607,7 @@ const ADMIN_SETTINGS_DEFAULTS: Record<
         type: 'number',
     },
     AUTOSAVE_ODE_FILES_FUNCTION: { value: process.env.AUTOSAVE_ODE_FILES_FUNCTION ?? 'true', type: 'boolean' },
-    CAS_URL: { value: process.env.CAS_URL || 'https://casserverpac4j.herokuapp.com', type: 'string' },
+    CAS_URL: { value: process.env.CAS_URL || 'https://www.casserverpac4j.dev', type: 'string' },
     CAS_VALIDATE_PATH: { value: process.env.CAS_VALIDATE_PATH || '/p3/serviceValidate', type: 'string' },
     CAS_LOGIN_PATH: { value: process.env.CAS_LOGIN_PATH || '/login', type: 'string' },
     CAS_LOGOUT_PATH: { value: process.env.CAS_LOGOUT_PATH || '/logout', type: 'string' },

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -1153,7 +1153,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                         autosave_ode_files_function: parseBoolean(process.env.AUTOSAVE_ODE_FILES_FUNCTION, true),
                     },
                     cas: {
-                        url: process.env.CAS_URL || 'https://casserverpac4j.herokuapp.com',
+                        url: process.env.CAS_URL || 'https://www.casserverpac4j.dev',
                         validate_path: process.env.CAS_VALIDATE_PATH || '/p3/serviceValidate',
                         login_path: process.env.CAS_LOGIN_PATH || '/login',
                         logout_path: process.env.CAS_LOGOUT_PATH || '/logout',


### PR DESCRIPTION
## Summary

- The default CAS demo server `https://casserverpac4j.herokuapp.com` now returns *"Application Moved — This application has been migrated to a new address."*
- New URL: <https://www.casserverpac4j.dev>
- Replaces the URL in `.env.dist`, the two hardcoded fallbacks in the backend (`src/routes/pages.ts`, `src/routes/admin.ts`), and the authentication docs so out-of-the-box CAS login works without overrides.

Closes #1792

## Test plan

- [ ] `make fix` passes (already clean)
- [ ] With no `CAS_URL` override, the admin panel shows the new default
- [ ] Login via `/login/cas` reaches `https://www.casserverpac4j.dev/login`