### PR TITLE
fix(test): make migration 005 spec compatible with SQLite 3.53 (Bun 1.3.14)

### DIFF
--- a/src/db/migrations/005_user_id_nullable.spec.ts
+++ b/src/db/migrations/005_user_id_nullable.spec.ts
@@ -202,33 +202,57 @@ describe('005_user_id_nullable migration', () => {
         });
     });
 
+    // Verifies the dialect branch by capturing dispatched SQL through a
+    // getExecutor wrapper. The previous approach relied on SQLite rejecting
+    // non-SQLite syntax with a parse error, which broke on Bun 1.3.14 when
+    // SQLite 3.53 added native support for `ALTER COLUMN ... DROP/SET NOT NULL`.
+    // See issue #1794.
+    function spyOnExecutedSql(): { executed: string[]; restore: () => void } {
+        const executed: string[] = [];
+        const originalGetExecutor = db.getExecutor.bind(db);
+        (db as { getExecutor: typeof db.getExecutor }).getExecutor = () => {
+            const executor = originalGetExecutor();
+            const originalExecuteQuery = executor.executeQuery.bind(executor);
+            (executor as { executeQuery: typeof executor.executeQuery }).executeQuery = async (
+                compiled: Parameters<typeof executor.executeQuery>[0],
+                queryId?: Parameters<typeof executor.executeQuery>[1],
+            ) => {
+                executed.push(compiled.sql);
+                return originalExecuteQuery(compiled, queryId as never);
+            };
+            return executor;
+        };
+        return {
+            executed,
+            restore: () => {
+                (db as { getExecutor: typeof db.getExecutor }).getExecutor = originalGetExecutor;
+            },
+        };
+    }
+
     describe('MySQL dialect', () => {
         beforeEach(() => {
             configure({ getDialect: () => 'mysql' });
         });
 
-        it('should attempt to run MySQL ALTER TABLE syntax for up()', async () => {
-            // SQLite will fail to parse MySQL syntax, but we verify the code path is taken
-            let errorThrown = false;
+        it('should dispatch MySQL MODIFY COLUMN syntax for up()', async () => {
+            const spy = spyOnExecutedSql();
             try {
-                await up(db);
-            } catch (err: any) {
-                // Expected: SQLite doesn't understand MySQL MODIFY COLUMN syntax
-                errorThrown = true;
-                expect(err.message).toMatch(/MODIFY|syntax/i);
+                await up(db).catch(() => {}); // engine may reject MySQL syntax — branch verification only
+            } finally {
+                spy.restore();
             }
-            expect(errorThrown).toBe(true);
+            expect(spy.executed.some(s => /ALTER TABLE users MODIFY COLUMN user_id .* NULL/i.test(s))).toBe(true);
         });
 
-        it('should attempt to run MySQL ALTER TABLE syntax for down()', async () => {
-            let errorThrown = false;
+        it('should dispatch MySQL MODIFY COLUMN syntax for down()', async () => {
+            const spy = spyOnExecutedSql();
             try {
-                await down(db);
-            } catch (err: any) {
-                errorThrown = true;
-                expect(err.message).toMatch(/MODIFY|syntax/i);
+                await down(db).catch(() => {});
+            } finally {
+                spy.restore();
             }
-            expect(errorThrown).toBe(true);
+            expect(spy.executed.some(s => /ALTER TABLE users MODIFY COLUMN user_id .* NOT NULL/i.test(s))).toBe(true);
         });
     });
 
@@ -237,28 +261,24 @@ describe('005_user_id_nullable migration', () => {
             configure({ getDialect: () => 'postgres' });
         });
 
-        it('should attempt to run PostgreSQL ALTER TABLE syntax for up()', async () => {
-            // SQLite will fail to parse PostgreSQL syntax, but we verify the code path is taken
-            let errorThrown = false;
+        it('should dispatch PostgreSQL ALTER COLUMN ... DROP NOT NULL for up()', async () => {
+            const spy = spyOnExecutedSql();
             try {
-                await up(db);
-            } catch (err: any) {
-                // Expected: SQLite doesn't understand PostgreSQL DROP NOT NULL syntax
-                errorThrown = true;
-                expect(err.message).toMatch(/DROP|NOT NULL|syntax/i);
+                await up(db).catch(() => {}); // SQLite ≤3.51 rejects, SQLite ≥3.53 accepts — both are fine
+            } finally {
+                spy.restore();
             }
-            expect(errorThrown).toBe(true);
+            expect(spy.executed.some(s => /ALTER TABLE users ALTER COLUMN user_id DROP NOT NULL/i.test(s))).toBe(true);
         });
 
-        it('should attempt to run PostgreSQL ALTER TABLE syntax for down()', async () => {
-            let errorThrown = false;
+        it('should dispatch PostgreSQL ALTER COLUMN ... SET NOT NULL for down()', async () => {
+            const spy = spyOnExecutedSql();
             try {
-                await down(db);
-            } catch (err: any) {
-                errorThrown = true;
-                expect(err.message).toMatch(/SET|NOT NULL|syntax/i);
+                await down(db).catch(() => {});
+            } finally {
+                spy.restore();
             }
-            expect(errorThrown).toBe(true);
+            expect(spy.executed.some(s => /ALTER TABLE users ALTER COLUMN user_id SET NOT NULL/i.test(s))).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary

Two tests in `src/db/migrations/005_user_id_nullable.spec.ts` regressed the moment CI picked up [Bun v1.3.14](https://bun.com/blog/bun-v1.3.14) (released 2026-05-13). Its Linux build ships SQLite **3.53.0** (up from 3.51.2), and [3.53.0 added](https://sqlite.org/releaselog/3_53_0.html):

> Enhance ALTER TABLE to permit adding and removing NOT NULL and CHECK constraints.

i.e. SQLite now accepts the Postgres syntax `ALTER TABLE t ALTER COLUMN c [DROP|SET] NOT NULL`. The PostgreSQL describe block previously used SQLite's parse error as a proxy for "the postgres branch was taken" — that proxy stopped working.

## Failing tests on `main`

```
(fail) 005_user_id_nullable migration > PostgreSQL dialect > should attempt to run PostgreSQL ALTER TABLE syntax for up()
(fail) 005_user_id_nullable migration > PostgreSQL dialect > should attempt to run PostgreSQL ALTER TABLE syntax for down()
```

## Fix

Replace the syntax-error proxy with a `getExecutor` wrapper that captures the SQL dispatched by Kysely. The assertion checks the captured SQL string regardless of whether the engine accepts or rejects it — stable across SQLite versions. Applied the same pattern to the MySQL block (still passing today, but had the same latent fragility for any future SQLite that adds `MODIFY COLUMN`).

Closes #1794

## Test plan

- [x] `make fix` — clean
- [x] `bun test src/db/migrations/005_user_id_nullable.spec.ts` on local Bun 1.3.14 (macOS, bundled SQLite 3.51.0) → 15/15 pass
- [x] `bun test src/db/migrations` (full migration suite) → 144/144 pass
- [x] CI (Linux Bun 1.3.14, bundled SQLite 3.53.0) → expected to pass; the spy captures SQL before the underlying `executeQuery` is awaited, so the test is decoupled from whether the engine throws

## Notes

Discovered while working on #1793 (CAS demo URL hotfix). That PR's CI was failing on this exact pair of tests — once this lands, #1793 should go green on rebase.