### PR TITLE
fix(static): preset tinymce.baseURL so srcdoc-embedded editor works on Firefox

### DIFF
--- a/scripts/static-bundle/static-index.html
+++ b/scripts/static-bundle/static-index.html
@@ -359,6 +359,40 @@
     <script src="./libs/abcjs/exe_abc_music.js?v={{BUILD_VERSION}}"></script>
 
     <!-- TinyMCE -->
+    <script>
+        // TinyMCE 5 autodetects its baseURL by scanning <script> tags for one
+        // whose src ends in tinymce.min.js. When this document is embedded by
+        // a host app via `<iframe srcdoc=…>` (the pattern documented in the
+        // embedding protocol, with a `<base href>` pointing at the deployed
+        // editor folder), Firefox's autodetection ends up with an undefined
+        // base. The first time a plugin script's onload fires inside
+        // tinymce.init(), URI.toAbsPath(undefined, …) then throws
+        // "can't access property 'split', e is undefined" and TinyMCE never
+        // registers — every text iDevice becomes un-editable. See
+        // https://github.com/exelearning/exelearning/issues/1799.
+        //
+        // Preset window.tinymce.baseURL and window.tinyMCEPreInit ourselves
+        // (derived from document.baseURI, which is the <base href> under
+        // srcdoc and the document URL otherwise). This bypasses autodetection
+        // entirely in every embedding context.
+        (function () {
+            try {
+                var tinymceBase = new URL('./libs/tinymce_5/js/tinymce', document.baseURI)
+                    .toString()
+                    .replace(/\/$/, '');
+                window.tinymce = window.tinymce || {};
+                window.tinymce.baseURL = tinymceBase;
+                window.tinymce.suffix = '.min';
+                window.tinyMCEPreInit = window.tinyMCEPreInit || {
+                    base: tinymceBase,
+                    suffix: '.min',
+                    query: ''
+                };
+            } catch (e) {
+                // Fall back to TinyMCE's autodetection if URL resolution fails.
+            }
+        })();
+    </script>
     <script src="./libs/tinymce_5/js/tinymce/tinymce.min.js?v={{BUILD_VERSION}}"></script>
     <script src="./app/editor/tinymce_5_settings.js?v={{BUILD_VERSION}}"></script>
 


### PR DESCRIPTION
## Summary
Preset `window.tinymce.baseURL` and `window.tinyMCEPreInit` from the static template, derived from `document.baseURI`, so TinyMCE 5 never has to autodetect its base URL by scanning `<script>` tags.

Fixes the Firefox-only crash for any embedder that follows the documented `<iframe srcdoc=…>` + `__EXE_EMBEDDING_CONFIG__` pattern.

## Context
Filed alongside #1799. Short version: when the static bundle is loaded inside `iframe srcdoc` on Firefox, `document.location.href === 'about:srcdoc'` and the TinyMCE 5 autodetection (which iterates `document.getElementsByTagName('script')` looking for `tinymce.min.js`) ends up with an undefined base. The first time a plugin script's `onload` fires inside `tinymce.init()`, `URI.toAbsPath(undefined, …)` throws `TypeError: can't access property "split", e is undefined` and TinyMCE never registers — every text iDevice becomes un-editable until reload.

Chromium does not trigger this code path, so the issue is invisible to the standalone static deployment and to most existing E2E coverage.

The repro is from the `gdrive-exelearning` Drive embedder: erseco/gdrive-exelearning#8 has the full Firefox console trace and the consumer-side workaround (which is the same preset, but applied from the embedder's injected `srcdoc` HTML). That workaround should not be necessary — embedders following the official protocol should just work.

## Change
One small inline `<script>` immediately before `<script src="./libs/tinymce_5/js/tinymce/tinymce.min.js">` in `scripts/static-bundle/static-index.html`:

```js
var tinymceBase = new URL('./libs/tinymce_5/js/tinymce', document.baseURI)
    .toString().replace(/\/$/, '');
window.tinymce = window.tinymce || {};
window.tinymce.baseURL = tinymceBase;
window.tinymce.suffix = '.min';
window.tinyMCEPreInit = window.tinyMCEPreInit || {
    base: tinymceBase, suffix: '.min', query: ''
};
```

- `document.baseURI` resolves to the `<base href>` under `srcdoc`, and to the document URL otherwise. The expression `new URL('./libs/tinymce_5/js/tinymce', document.baseURI)` therefore yields the right absolute URL in every deployment topology.
- Wrapped in a `try/catch` so we silently fall back to TinyMCE's own autodetection if URL resolution ever fails — the change cannot break anything that worked before.
- No-op for standalone deployments (the values match what TinyMCE would have autodetected on its own).
- This is the same fix TinyMCE's own docs document for embedders that don't want autodetection.

## Test plan
- [x] `make fix` is clean (the lint chain doesn't touch `scripts/`, but ran end-to-end to confirm no incidental breakage).
- [x] The bundle template still parses (the inline IIFE only adds a new `<script>` block before the existing TinyMCE tag).
- [ ] Manual Firefox smoke test via `gdrive-exelearning` Drive embedder — owner of the bug confirms whether removing the consumer-side workaround reproduces the crash before this fix and resolves after.
- [ ] Suggested for reviewers: `make test-e2e-static` and `make test-e2e-firefox`. I did not add a new Playwright spec because the existing E2E suite runs against the standalone static bundle (no srcdoc embedder), so it does not exercise the failing path. If you'd like, I can follow up with a fixture that loads the static build inside `iframe srcdoc` and asserts TinyMCE registers in a Firefox project — happy to do this if you want it in the same PR.

## Out of scope (filed separately for follow-up)
The issue #1799 also flags two adjacent fragilities — hardcoded `baseURL: '.'` / `fullURL: '.'` defaults and hardcoded `edicuatex_url: '/app/common/…'` absolute paths. Both deserve a fix but neither is needed to unblock Firefox; happy to send separate PRs for them once this lands.
