### PR TITLE
fix(deploy): prepend BASE_PATH to icon, codemagic and exemindmap URLs (#1802)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -23,6 +23,13 @@ APP_PORT=8080
 #   BASE_PATH=/web/exelearning
 BASE_PATH=
 
+# When STRICT_BASE_PATH_ROUTES=true AND BASE_PATH is set, routes are
+# registered ONLY under BASE_PATH (no dual-mount at root). This makes
+# `bun run dev` behave like a real production reverse proxy that only
+# forwards the BASE_PATH namespace, surfacing client-side BASE_PATH bugs
+# (issue #1802) instead of masking them. Default: false (compat mode on).
+STRICT_BASE_PATH_ROUTES=false
+
 # Allow users to import/install styles
 ONLINE_THEMES_INSTALL=0
 

--- a/public/libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic-plugin.test.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic-plugin.test.js
@@ -8,150 +8,107 @@
 
 describe('codemagic plugin - Path Handling', () => {
     describe('Dialog URL selection', () => {
-        // Extract the logic from plugin.min.js lines 69-102
-        function getCodemagicUrl(config, capabilities, staticModeGlobal) {
-            const basePath = (config && config.basePath) || '';
-
-            // Check if we're in static mode
+        // Mirror plugin.min.js: in server mode, route through composeUrl() so that
+        // BASE_PATH is prepended (issue #1802). Static mode still wins when its
+        // flags are set. Reading basePath directly from config is gone — composeUrl
+        // is the single source of truth, identical to the rest of the client.
+        function getCodemagicUrl(config, capabilities, staticModeGlobal, app) {
             let isStaticMode = config?.isStaticMode || config?.isOfflineInstallation;
             if (!isStaticMode) {
                 isStaticMode = capabilities ? !capabilities.storage.remote : staticModeGlobal;
             }
 
-            // In static mode, use relative file path
-            // In server mode, use API endpoint
             if (isStaticMode) {
                 return './libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html';
-            } else {
-                return basePath + '/api/codemagic-editor/codemagic.html';
             }
+            return app && typeof app.composeUrl === 'function'
+                ? app.composeUrl('/api/codemagic-editor/codemagic.html')
+                : '/api/codemagic-editor/codemagic.html';
         }
 
-        describe('Online mode (server available)', () => {
-            it('should return API URL with no basePath', () => {
-                const result = getCodemagicUrl({ basePath: '' }, null, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
+        // Mirror window.eXeLearning.app.composeUrl from public/app/app.js:849-858
+        function makeApp(basePath) {
+            return {
+                composeUrl(p) {
+                    const normalized = !basePath || basePath === '/' ? '' : basePath.replace(/\/+$/, '');
+                    const path = p.startsWith('/') ? p : `/${p}`;
+                    return `${normalized}${path}`;
+                },
+            };
+        }
+
+        describe('Server mode', () => {
+            it('returns bare API URL when no host app is available (back-compat)', () => {
+                expect(getCodemagicUrl(null, null, false)).toBe('/api/codemagic-editor/codemagic.html');
+                expect(getCodemagicUrl(undefined, null, false)).toBe('/api/codemagic-editor/codemagic.html');
+                expect(getCodemagicUrl({}, null, false)).toBe('/api/codemagic-editor/codemagic.html');
             });
 
-            it('should return API URL with basePath prefix', () => {
-                const result = getCodemagicUrl({ basePath: '/web/exe' }, null, false);
-                expect(result).toBe('/web/exe/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should return API URL with deep basePath prefix', () => {
-                const result = getCodemagicUrl({ basePath: '/deep/nested/path' }, null, false);
-                expect(result).toBe('/deep/nested/path/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should return API URL when config is null', () => {
-                const result = getCodemagicUrl(null, null, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should return API URL when config is undefined', () => {
-                const result = getCodemagicUrl(undefined, null, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should return API URL when config is empty object', () => {
-                const result = getCodemagicUrl({}, null, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-        });
-
-        describe('Static mode via config flags', () => {
-            it('should return relative URL when isStaticMode is true', () => {
-                const result = getCodemagicUrl({ isStaticMode: true }, null, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-
-            it('should return relative URL when isOfflineInstallation is true', () => {
-                const result = getCodemagicUrl({ isOfflineInstallation: true }, null, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-
-            it('should return relative URL when both flags are true', () => {
-                const result = getCodemagicUrl({ isStaticMode: true, isOfflineInstallation: true }, null, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-
-            it('should ignore basePath in static mode', () => {
-                const result = getCodemagicUrl({ basePath: '/web/exe', isStaticMode: true }, null, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-        });
-
-        describe('Static mode via capabilities fallback', () => {
-            it('should return relative URL when capabilities.storage.remote is false', () => {
-                const capabilities = { storage: { remote: false } };
-                const result = getCodemagicUrl({}, capabilities, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-
-            it('should return API URL when capabilities.storage.remote is true', () => {
-                const capabilities = { storage: { remote: true } };
-                const result = getCodemagicUrl({}, capabilities, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should respect basePath when capabilities indicate online mode', () => {
-                const capabilities = { storage: { remote: true } };
-                const result = getCodemagicUrl({ basePath: '/web/exe' }, capabilities, false);
-                expect(result).toBe('/web/exe/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should prioritize config flags over capabilities', () => {
-                const capabilities = { storage: { remote: true } };
-                const result = getCodemagicUrl({ isStaticMode: true }, capabilities, false);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-        });
-
-        describe('Static mode via global flag fallback', () => {
-            it('should return relative URL when global static mode flag is true', () => {
-                const result = getCodemagicUrl({}, null, true);
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-
-            it('should return API URL when global static mode flag is false', () => {
-                const result = getCodemagicUrl({}, null, false);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should prioritize capabilities over global flag', () => {
-                const capabilities = { storage: { remote: true } };
-                const result = getCodemagicUrl({}, capabilities, true);
-                expect(result).toBe('/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should prioritize config flags over global flag', () => {
-                const result = getCodemagicUrl({ isStaticMode: false }, null, true);
-                // When isStaticMode is explicitly false, fallback to global flag
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
-            });
-        });
-
-        describe('Edge cases', () => {
-            it('should handle basePath with trailing slash', () => {
-                // The plugin doesn't normalize trailing slashes, so this would create a double slash
-                // This tests current behavior - consider normalizing in the plugin if this is undesirable
-                const result = getCodemagicUrl({ basePath: '/web/exe/' }, null, false);
-                expect(result).toBe('/web/exe//api/codemagic-editor/codemagic.html');
-            });
-
-            it('should handle basePath without leading slash', () => {
-                const result = getCodemagicUrl({ basePath: 'web/exe' }, null, false);
-                expect(result).toBe('web/exe/api/codemagic-editor/codemagic.html');
-            });
-
-            it('should handle all detection methods at once (config wins)', () => {
-                const capabilities = { storage: { remote: true } };
-                const result = getCodemagicUrl(
-                    { isStaticMode: true, basePath: '/ignored' },
-                    capabilities,
-                    false
+            it('prefixes BASE_PATH via composeUrl when host app is wired (issue #1802)', () => {
+                const app = makeApp('/aplicaciones/medusa/exelearning');
+                expect(getCodemagicUrl({}, null, false, app)).toBe(
+                    '/aplicaciones/medusa/exelearning/api/codemagic-editor/codemagic.html',
                 );
-                expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html');
+                expect(getCodemagicUrl(null, null, false, app)).toBe(
+                    '/aplicaciones/medusa/exelearning/api/codemagic-editor/codemagic.html',
+                );
+            });
+
+            it('handles deep BASE_PATH', () => {
+                const app = makeApp('/deep/nested/path');
+                expect(getCodemagicUrl({}, null, false, app)).toBe(
+                    '/deep/nested/path/api/codemagic-editor/codemagic.html',
+                );
+            });
+
+            it('falls through to bare URL when BASE_PATH is empty', () => {
+                const app = makeApp('');
+                expect(getCodemagicUrl({}, null, false, app)).toBe('/api/codemagic-editor/codemagic.html');
+            });
+
+            it('respects composeUrl regardless of any (now-ignored) config.basePath', () => {
+                // The plugin no longer reads config.basePath - composeUrl wins.
+                const app = makeApp('/aplicaciones/medusa/exelearning');
+                expect(getCodemagicUrl({ basePath: '/ignored' }, null, false, app)).toBe(
+                    '/aplicaciones/medusa/exelearning/api/codemagic-editor/codemagic.html',
+                );
+            });
+        });
+
+        describe('Static mode (always wins over composeUrl)', () => {
+            const expected = './libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html';
+            const app = makeApp('/aplicaciones/medusa/exelearning');
+
+            it('honours config.isStaticMode', () => {
+                expect(getCodemagicUrl({ isStaticMode: true }, null, false)).toBe(expected);
+                expect(getCodemagicUrl({ isStaticMode: true }, null, false, app)).toBe(expected);
+            });
+
+            it('honours config.isOfflineInstallation', () => {
+                expect(getCodemagicUrl({ isOfflineInstallation: true }, null, false, app)).toBe(expected);
+            });
+
+            it('falls back to capabilities.storage.remote === false', () => {
+                const capabilities = { storage: { remote: false } };
+                expect(getCodemagicUrl({}, capabilities, false)).toBe(expected);
+                expect(getCodemagicUrl({}, capabilities, false, app)).toBe(expected);
+            });
+
+            it('falls back to global staticMode flag', () => {
+                expect(getCodemagicUrl({}, null, true)).toBe(expected);
+                expect(getCodemagicUrl({}, null, true, app)).toBe(expected);
+            });
+
+            it('config flag takes priority over capabilities', () => {
+                const capabilities = { storage: { remote: true } };
+                expect(getCodemagicUrl({ isStaticMode: true }, capabilities, false, app)).toBe(expected);
+            });
+
+            it('capabilities take priority over global flag', () => {
+                const capabilities = { storage: { remote: true } };
+                expect(getCodemagicUrl({}, capabilities, true, app)).toBe(
+                    '/aplicaciones/medusa/exelearning/api/codemagic-editor/codemagic.html',
+                );
             });
         });
     });

--- a/public/libs/tinymce_5/js/tinymce/plugins/codemagic/plugin.min.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/codemagic/plugin.min.js
@@ -75,8 +75,6 @@ jQuery(document).ready(function ($) {
 				try { config = JSON.parse(config); } catch(e) { config = null; }
 			}
 
-			var basePath = (config && config.basePath) || '';
-
 			// Check if we're in static mode (no server available)
 			// Use config flags first, fall back to capabilities, then __EXE_STATIC_MODE__
 			var isStaticMode = config?.isStaticMode || config?.isOfflineInstallation;
@@ -85,12 +83,17 @@ jQuery(document).ready(function ($) {
 				isStaticMode = capabilities ? !capabilities.storage.remote : window.__EXE_STATIC_MODE__;
 			}
 
-			// In static mode, use relative file path (no API server available)
-			// In server mode, use API endpoint to bypass Bun's HTML bundler
+			// In static mode, use relative file path (no API server available).
+			// In server mode, route through composeUrl() so BASE_PATH is prepended;
+			// emitting a bare "/api/..." URL 404s behind any reverse proxy that only
+			// mounts the BASE_PATH namespace (issue #1802). composeUrl is the single
+			// source of truth for BASE_PATH on the client.
 			if (isStaticMode) {
 				codemagicUrl = './libs/tinymce_5/js/tinymce/plugins/codemagic/codemagic.html';
 			} else {
-				codemagicUrl = basePath + '/api/codemagic-editor/codemagic.html';
+				codemagicUrl = (window.eXeLearning && window.eXeLearning.app && typeof window.eXeLearning.app.composeUrl === 'function')
+					? window.eXeLearning.app.composeUrl('/api/codemagic-editor/codemagic.html')
+					: '/api/codemagic-editor/codemagic.html';
 			}
 
 			codemagicDialog = editor.windowManager.openUrl({

--- a/public/libs/tinymce_5/js/tinymce/plugins/exemindmap/exemindmap-plugin.test.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/exemindmap/exemindmap-plugin.test.js
@@ -8,53 +8,64 @@
 
 describe('exemindmap plugin - Path Handling', () => {
     describe('Editor URL selection', () => {
-        // Extract the logic from plugin.min.js lines 264-276
-        function getEditorUrl(config) {
-            let editorUrl = '/api/exemindmap-editor/index.html';
+        // Mirror plugin.min.js: in server mode, route through composeUrl() so
+        // BASE_PATH is prepended (issue #1802). Fall back to a bare path only
+        // when the eXeLearning app/composeUrl helper isn't available (early init,
+        // or environments without the host app).
+        function getEditorUrl(config, app) {
+            let editorUrl =
+                app && typeof app.composeUrl === 'function'
+                    ? app.composeUrl('/api/exemindmap-editor/index.html')
+                    : '/api/exemindmap-editor/index.html';
             if (config?.isStaticMode || config?.isOfflineInstallation) {
                 editorUrl = './libs/tinymce_5/js/tinymce/plugins/exemindmap/editor/index.html';
             }
             return editorUrl;
         }
 
-        it('should return API URL when config is null', () => {
-            const result = getEditorUrl(null);
-            expect(result).toBe('/api/exemindmap-editor/index.html');
+        // Mirror window.eXeLearning.app.composeUrl from public/app/app.js:849-858
+        function makeApp(basePath) {
+            return {
+                composeUrl(p) {
+                    const normalized = !basePath || basePath === '/' ? '' : basePath.replace(/\/+$/, '');
+                    const path = p.startsWith('/') ? p : `/${p}`;
+                    return `${normalized}${path}`;
+                },
+            };
+        }
+
+        it('should return bare API URL when no host app is available (back-compat fallback)', () => {
+            expect(getEditorUrl(null)).toBe('/api/exemindmap-editor/index.html');
+            expect(getEditorUrl(undefined)).toBe('/api/exemindmap-editor/index.html');
+            expect(getEditorUrl({})).toBe('/api/exemindmap-editor/index.html');
+            expect(getEditorUrl({ isStaticMode: false })).toBe('/api/exemindmap-editor/index.html');
         });
 
-        it('should return API URL when config is undefined', () => {
-            const result = getEditorUrl(undefined);
-            expect(result).toBe('/api/exemindmap-editor/index.html');
+        it('should prefix BASE_PATH via composeUrl in server mode (issue #1802)', () => {
+            const app = makeApp('/aplicaciones/medusa/exelearning');
+            expect(getEditorUrl(null, app)).toBe(
+                '/aplicaciones/medusa/exelearning/api/exemindmap-editor/index.html',
+            );
+            expect(getEditorUrl({}, app)).toBe(
+                '/aplicaciones/medusa/exelearning/api/exemindmap-editor/index.html',
+            );
+            expect(getEditorUrl({ isStaticMode: false }, app)).toBe(
+                '/aplicaciones/medusa/exelearning/api/exemindmap-editor/index.html',
+            );
         });
 
-        it('should return API URL in online mode (isStaticMode: false)', () => {
-            const result = getEditorUrl({ isStaticMode: false });
-            expect(result).toBe('/api/exemindmap-editor/index.html');
+        it('should fall through to bare URL when BASE_PATH is empty', () => {
+            const app = makeApp('');
+            expect(getEditorUrl(null, app)).toBe('/api/exemindmap-editor/index.html');
         });
 
-        it('should return relative URL in static mode (isStaticMode: true)', () => {
-            const result = getEditorUrl({ isStaticMode: true });
-            expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/exemindmap/editor/index.html');
-        });
-
-        it('should return relative URL for offline installation (isOfflineInstallation: true)', () => {
-            const result = getEditorUrl({ isOfflineInstallation: true });
-            expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/exemindmap/editor/index.html');
-        });
-
-        it('should return relative URL when both flags are true', () => {
-            const result = getEditorUrl({ isStaticMode: true, isOfflineInstallation: true });
-            expect(result).toBe('./libs/tinymce_5/js/tinymce/plugins/exemindmap/editor/index.html');
-        });
-
-        it('should return API URL when config has other properties but not mode flags', () => {
-            const result = getEditorUrl({ basePath: '/web/exe', version: 'v3.0' });
-            expect(result).toBe('/api/exemindmap-editor/index.html');
-        });
-
-        it('should handle config as empty object', () => {
-            const result = getEditorUrl({});
-            expect(result).toBe('/api/exemindmap-editor/index.html');
+        it('should return relative URL in static mode regardless of composeUrl', () => {
+            const expected = './libs/tinymce_5/js/tinymce/plugins/exemindmap/editor/index.html';
+            const app = makeApp('/aplicaciones/medusa/exelearning');
+            expect(getEditorUrl({ isStaticMode: true })).toBe(expected);
+            expect(getEditorUrl({ isStaticMode: true }, app)).toBe(expected);
+            expect(getEditorUrl({ isOfflineInstallation: true }, app)).toBe(expected);
+            expect(getEditorUrl({ isStaticMode: true, isOfflineInstallation: true }, app)).toBe(expected);
         });
     });
 

--- a/public/libs/tinymce_5/js/tinymce/plugins/exemindmap/plugin.min.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/exemindmap/plugin.min.js
@@ -261,8 +261,13 @@ tinymce.PluginManager.add('exemindmap', function (editor, url) {
                 initialData: eXeMediaPluginDialog.getInitialData(),
                 onAction: function (api, details) {
                     if (details.name === 'mindmapEditorButton') {
-                        // Determine URL based on mode: static vs server
-                        var editorUrl = "/api/exemindmap-editor/index.html";
+                        // Determine URL based on mode: static vs server.
+                        // In server mode we MUST go through composeUrl() so that BASE_PATH
+                        // is prepended; emitting a bare "/api/..." URL 404s behind any
+                        // reverse proxy that only mounts the BASE_PATH namespace (issue #1802).
+                        var editorUrl = (window.eXeLearning && window.eXeLearning.app && typeof window.eXeLearning.app.composeUrl === 'function')
+                            ? window.eXeLearning.app.composeUrl('/api/exemindmap-editor/index.html')
+                            : '/api/exemindmap-editor/index.html';
                         var config = window.eXeLearning?.config;
                         if (typeof config === 'string') {
                             try { config = JSON.parse(config); } catch(e) { config = null; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,44 +571,56 @@ const app = new Elysia()
         }),
     );
 
-// Get BASE_PATH for route registration and add routes
-// Routes are always added at root, PLUS at BASE_PATH if configured
-// This allows frontend code that doesn't use BASE_PATH to still work
+// Get BASE_PATH for route registration and add routes.
+//
+// Default behaviour: routes are added at root AND at BASE_PATH (if configured).
+// This dual-mount lets frontend code that emits unprefixed URLs still work in a
+// flat `bun run dev`, but it ALSO masks BASE_PATH client bugs (issue #1802):
+// every URL emitted without BASE_PATH would 404 behind a real reverse proxy
+// that only mounts the BASE_PATH namespace.
+//
+// Set STRICT_BASE_PATH_ROUTES=true to disable the root mount when BASE_PATH
+// is configured, so dev/CI behaves like a production proxy and surfaces those
+// bugs immediately. Default is false (compat preserved).
 const routePrefix = getBasePath();
+const strictBasePathRoutes = process.env.STRICT_BASE_PATH_ROUTES === 'true';
+const registerRootRoutes = !routePrefix || !strictBasePathRoutes;
 
-// Always register routes at root
-app.use(healthRoutes)
-    .use(healthCheckAlias)
-    .use(authRoutes)
-    .use(platformIntegrationRoutes)
-    .use(pagesRoutes)
-    .use(projectRoutes)
-    .use(symfonyCompatProjectRoutes)
-    .use(assetsRoutes)
-    .use(fileManagerRoutes)
-    .use(exportRoutes)
-    .use(convertRoutes)
-    .use(configRoutes)
-    .use(idevicesRoutes)
-    .use(gamesRoutes)
-    .use(themesRoutes)
-    .use(resourcesRoutes)
-    .use(userRoutes)
-    .use(adminRoutes)
-    .use(adminThemesRoutes)
-    .use(adminTemplatesRoutes)
-    .use(yjsRoutes)
-    .use(apiV1Routes)
-    .use(uploadSessionRoutes)
-    .use(createWebSocketRoutes())
-    .get('/api', () => ({
-        name: 'eXeLearning API',
-        version: '4.0.0-elysia',
-        framework: 'Elysia',
-        runtime: 'Bun',
-    }))
-    .get('/api/websocket/info', () => getServerInfo())
-    .get('/api/websocket/rooms', () => ({ rooms: getActiveRooms() }));
+// Register routes at root (skipped when STRICT_BASE_PATH_ROUTES=true AND BASE_PATH is set)
+if (registerRootRoutes) {
+    app.use(healthRoutes)
+        .use(healthCheckAlias)
+        .use(authRoutes)
+        .use(platformIntegrationRoutes)
+        .use(pagesRoutes)
+        .use(projectRoutes)
+        .use(symfonyCompatProjectRoutes)
+        .use(assetsRoutes)
+        .use(fileManagerRoutes)
+        .use(exportRoutes)
+        .use(convertRoutes)
+        .use(configRoutes)
+        .use(idevicesRoutes)
+        .use(gamesRoutes)
+        .use(themesRoutes)
+        .use(resourcesRoutes)
+        .use(userRoutes)
+        .use(adminRoutes)
+        .use(adminThemesRoutes)
+        .use(adminTemplatesRoutes)
+        .use(yjsRoutes)
+        .use(apiV1Routes)
+        .use(uploadSessionRoutes)
+        .use(createWebSocketRoutes())
+        .get('/api', () => ({
+            name: 'eXeLearning API',
+            version: '4.0.0-elysia',
+            framework: 'Elysia',
+            runtime: 'Bun',
+        }))
+        .get('/api/websocket/info', () => getServerInfo())
+        .get('/api/websocket/rooms', () => ({ rooms: getActiveRooms() }));
+}
 
 // Also register routes at BASE_PATH if configured
 if (routePrefix) {

--- a/src/routes/themes.spec.ts
+++ b/src/routes/themes.spec.ts
@@ -5,7 +5,7 @@
  * Only base and site themes are served from the server.
  * User themes from .elpx files are stored client-side in Yjs.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
 import { themesRoutes, configure, resetDependencies } from './themes';
 import * as fs from 'fs';
@@ -15,8 +15,26 @@ import { migrateToLatest } from '../db/migrations';
 
 describe('Themes Routes', () => {
     let app: Elysia;
+    let originalBasePath: string | undefined;
+
+    beforeAll(() => {
+        // Tests must be deterministic regardless of the developer's local .env.
+        // Snapshot BASE_PATH so we can restore it on suite teardown.
+        originalBasePath = process.env.BASE_PATH;
+    });
+
+    afterAll(() => {
+        if (originalBasePath !== undefined) {
+            process.env.BASE_PATH = originalBasePath;
+        } else {
+            delete process.env.BASE_PATH;
+        }
+    });
 
     beforeEach(() => {
+        // Default each test to a root deployment (BASE_PATH cleared). Tests that
+        // exercise BASE_PATH set it explicitly inside their own describe block.
+        delete process.env.BASE_PATH;
         resetDependencies();
         app = new Elysia().use(themesRoutes);
     });
@@ -1132,6 +1150,91 @@ describe('Themes Routes', () => {
             const body = await res.json();
             // Falls back to themeId when name cannot be extracted from config.xml
             expect(body.zipFileName).toBe('base.zip');
+        });
+    });
+
+    describe('BASE_PATH handling (regression for issue #1802)', () => {
+        // When eXeLearning is deployed in a subdirectory, every URL the server
+        // emits must include BASE_PATH; otherwise the reverse proxy in front of
+        // Bun (which only mounts the BASE_PATH namespace) returns 404 for the
+        // bare-rooted URLs and the icon picker / TinyMCE plugins break.
+        let savedBasePath: string | undefined;
+
+        beforeEach(() => {
+            savedBasePath = process.env.BASE_PATH;
+            resetDependencies();
+            app = new Elysia().use(themesRoutes);
+        });
+
+        afterEach(() => {
+            if (savedBasePath !== undefined) {
+                process.env.BASE_PATH = savedBasePath;
+            } else {
+                delete process.env.BASE_PATH;
+            }
+            resetDependencies();
+        });
+
+        it('emits unprefixed URLs when BASE_PATH is empty', async () => {
+            delete process.env.BASE_PATH;
+            const localApp = new Elysia().use(themesRoutes);
+            const res = await localApp.handle(new Request('http://localhost/api/themes/installed'));
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            const themeWithIcons = body.themes.find(
+                (t: { icons?: Record<string, unknown> }) => Object.keys(t.icons || {}).length > 0,
+            );
+            expect(themeWithIcons).toBeDefined();
+
+            // Every URL stays at root (no /aplicaciones/... prefix)
+            expect(themeWithIcons.url.startsWith('/aplicaciones/')).toBe(false);
+            expect(themeWithIcons.preview.startsWith('/aplicaciones/')).toBe(false);
+            for (const icon of Object.values(themeWithIcons.icons) as Array<{ value: string }>) {
+                expect(icon.value.startsWith('/aplicaciones/')).toBe(false);
+                expect(icon.value).toMatch(/\/files\/perm\/themes\/.+\/icons\//);
+            }
+        });
+
+        it('prefixes every emitted URL with BASE_PATH when configured', async () => {
+            process.env.BASE_PATH = '/aplicaciones/medusa/exelearning';
+            const localApp = new Elysia().use(themesRoutes);
+            const res = await localApp.handle(new Request('http://localhost/api/themes/installed'));
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            const themeWithIcons = body.themes.find(
+                (t: { icons?: Record<string, unknown> }) => Object.keys(t.icons || {}).length > 0,
+            );
+            expect(themeWithIcons).toBeDefined();
+
+            // Theme's own URLs prefixed
+            expect(themeWithIcons.url.startsWith('/aplicaciones/medusa/exelearning/')).toBe(true);
+            expect(themeWithIcons.preview.startsWith('/aplicaciones/medusa/exelearning/')).toBe(true);
+
+            // Every icon URL prefixed - this is the regression test for the icon picker bug.
+            const iconValues = Object.values(themeWithIcons.icons) as Array<{ value: string }>;
+            expect(iconValues.length).toBeGreaterThan(0);
+            for (const icon of iconValues) {
+                expect(icon.value.startsWith('/aplicaciones/medusa/exelearning/')).toBe(true);
+            }
+        });
+
+        it('normalizes trailing slash on BASE_PATH (no double-slash in URLs)', async () => {
+            process.env.BASE_PATH = '/exe/';
+            const localApp = new Elysia().use(themesRoutes);
+            const res = await localApp.handle(new Request('http://localhost/api/themes/installed'));
+
+            const body = await res.json();
+            const themeWithIcons = body.themes.find(
+                (t: { icons?: Record<string, unknown> }) => Object.keys(t.icons || {}).length > 0,
+            );
+            for (const icon of Object.values(themeWithIcons.icons) as Array<{ value: string }>) {
+                expect(icon.value.startsWith('/exe/')).toBe(true);
+                expect(icon.value).not.toContain('/exe//');
+            }
+            expect(themeWithIcons.url.startsWith('/exe/')).toBe(true);
+            expect(themeWithIcons.url).not.toContain('/exe//');
         });
     });
 });

--- a/src/routes/themes.ts
+++ b/src/routes/themes.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { db } from '../db/client';
 import { getEnabledSiteThemes, getDefaultTheme, getBaseThemes } from '../db/queries/themes';
 import type { Theme } from '../db/types';
+import { prefixPath } from '../utils/basepath.util';
 
 // Base path for themes (bundled with the app)
 const THEMES_BASE_PATH = 'public/files/perm/themes/base';
@@ -204,16 +205,19 @@ function parseThemeConfig(
 
         const version = getAppVersion();
 
-        // Build URL paths with version for cache busting
+        // Build URL paths with version for cache busting.
+        // prefixPath() ensures BASE_PATH is prepended when configured, so URLs
+        // are correct behind a reverse proxy that only mounts the BASE_PATH
+        // namespace (see issue #1802).
         let themeBasePath: string;
         if (customUrlPrefix) {
-            themeBasePath = `/${version}${customUrlPrefix}/${themeId}`;
+            themeBasePath = prefixPath(`/${version}${customUrlPrefix}/${themeId}`);
         } else {
-            themeBasePath = `/${version}/files/perm/themes/base/${themeId}`;
+            themeBasePath = prefixPath(`/${version}/files/perm/themes/base/${themeId}`);
         }
 
         const previewPath =
-            type === 'base' ? `/${version}/style/${themeId}/preview.png` : `${themeBasePath}/preview.png`;
+            type === 'base' ? prefixPath(`/${version}/style/${themeId}/preview.png`) : `${themeBasePath}/preview.png`;
 
         // Scan for CSS files
         const cssFiles = scanThemeFiles(themePath, '.css');
@@ -296,8 +300,9 @@ function siteThemeToConfig(siteTheme: Theme): ThemeConfig {
     const siteThemesPath = getSiteThemesPath();
     const themePath = path.join(siteThemesPath, siteTheme.dir_name);
 
-    // Build URL paths - site themes are served from FILES_DIR
-    const themeUrl = `/${version}/site-files/themes/${siteTheme.dir_name}`;
+    // Build URL paths - site themes are served from FILES_DIR.
+    // prefixPath() prepends BASE_PATH so URLs are valid behind a subdirectory proxy.
+    const themeUrl = prefixPath(`/${version}/site-files/themes/${siteTheme.dir_name}`);
 
     // Scan for CSS, JS, and icons
     const cssFiles = deps.fs.existsSync(themePath) ? scanThemeFiles(themePath, '.css') : ['style.css'];


### PR DESCRIPTION
## Summary

Fixes the BASE_PATH 404s documented in #1802. When eXeLearning is deployed in a subdirectory behind a reverse proxy that only forwards the BASE_PATH namespace (the realistic production shape), three client-facing surfaces emitted URLs without BASE_PATH and 404'd:

- **iDevice icon picker** (~40 broken icons) — `src/routes/themes.ts` emitted bare `/${version}/files/perm/themes/.../icons/*.png`. Fixed by routing every emitted URL through `prefixPath()` from `src/utils/basepath.util.ts`.
- **codemagic TinyMCE plugin** (HTML source editor iframe 404) — read `basePath` from a runtime-stale config field; on the affected deployment it ended up empty even though `eXeLearning.config.basePath` was correctly populated. Fixed by routing through `window.eXeLearning.app.composeUrl(...)` (the canonical client helper, defined in `public/app/app.js`).
- **exemindmap TinyMCE plugin** (mind-map iframe 404) — hardcoded `/api/exemindmap-editor/index.html`. Fixed the same way.

Plus a new `STRICT_BASE_PATH_ROUTES` env (default off, opt-in) that disables the root dual-mount in `src/index.ts` when `BASE_PATH` is set, so `bun run dev` / CI behaves like a real proxy and surfaces these regressions instead of masking them. Documented in `.env.dist`.

## Why this was invisible in dev (and how this PR prevents regressions)

The Bun server registered every route at root AND under `BASE_PATH`, so a flat `bun run dev` answered either URL shape. Client-side BASE_PATH bugs only surfaced behind a real proxy. Every fix in this PR ships with a regression test:

- `src/routes/themes.spec.ts` — new `BASE_PATH handling (regression for issue #1802)` describe block with 3 specs that toggle `process.env.BASE_PATH` and assert URLs are (or aren't) prefixed accordingly. Outer `beforeEach` now clears `process.env.BASE_PATH` so the rest of the suite is deterministic regardless of the developer's local `.env`.
- `codemagic-plugin.test.js` and `exemindmap-plugin.test.js` rewritten to mirror the new `composeUrl` contract: server mode with the host app present → prefixed URL; without → bare fallback; static-mode override still wins.

With `STRICT_BASE_PATH_ROUTES=true` set in CI, any future regression of this class would 404 immediately in unit/integration test fixtures that issue HTTP requests against the embedded server.

## How to test this works locally (behind a real reverse proxy)

A flat `bun run dev` will not catch this — the server's dual-mount answers both URL shapes. To reproduce the production failure mode, put a real reverse proxy in front that only forwards the BASE_PATH namespace. The minimum viable nginx-in-Docker recipe (3 files):

**`docker-compose.yml`**

```yaml
services:
  nginx:
    build: .
    ports: ["80:80"]
    extra_hosts:
      - "host.docker.internal:host-gateway"
```

**`Dockerfile`**

```dockerfile
FROM alpine:3.20
RUN apk add --no-cache nginx \
    && mkdir -p /run/nginx \
    && rm -f /etc/nginx/http.d/default.conf
COPY nginx.conf /etc/nginx/http.d/exelearning.conf
EXPOSE 80
CMD ["nginx", "-g", "daemon off;"]
```

**`nginx.conf`** (only forwards the BASE_PATH namespace; everything else 404s — same boundary the production proxy enforces)

```nginx
server {
    listen 80 default_server;
    server_name _;
    location /subfolder1/subfolder2/exelearning/ {
        proxy_pass http://host.docker.internal:81/subfolder1/subfolder2/exelearning/;
        proxy_set_header Host $host;
    }
}
```

Steps:

1. Add `127.0.0.1 machine.local` to `/etc/hosts` (or use any local hostname you prefer; just keep it consistent below).
2. Set `BASE_PATH=/subfolder1/subfolder2/exelearning` in `.env` (any path works; just keep both sides consistent).
3. Start eXeLearning on the host at port `81` (`make up` or `make up-local`).
4. Save the three files above in a folder, then `docker compose up -d --build`.

Sanity probes:

```sh
# bare-root: nginx 404s (the bug pattern)
curl -I http://machine.local/v0.0.0-alpha/files/perm/themes/base/base/icons/objectives.png   # -> 404

# BASE_PATH-prefixed: nginx forwards to Bun -> 200 (what the client should be emitting)
curl -I http://machine.local/subfolder1/subfolder2/exelearning/v0.0.0-alpha/files/perm/themes/base/base/icons/objectives.png   # -> 200 image/png
```

Then open `http://machine.local/subfolder1/subfolder2/exelearning/workarea` in a browser, log in, and paste this in DevTools:

```js
const t = window.eXeLearning?.app?.themes?.selected;
const allIcons = Object.values(t?.icons || {});
({
    total: allIcons.length,
    withBasePath: allIcons.filter(i =>
        i.value.startsWith('/subfolder1/subfolder2/exelearning/'),
    ).length,
    codemagicUrl: window.eXeLearning?.app?.composeUrl?.(
        '/api/codemagic-editor/codemagic.html',
    ),
    exemindmapUrl: window.eXeLearning?.app?.composeUrl?.(
        '/api/exemindmap-editor/index.html',
    ),
})
```

On `main` (without this PR): `withBasePath` is `0`, codemagic / exemindmap URLs are bare, and the icon picker / both iframes 404. After this PR: `withBasePath === total`, both URLs are BASE_PATH-prefixed, all three flows work.

## Test plan

- [x] `make fix` clean.
- [x] `bun test src/routes/themes.spec.ts` → 44/44 pass (3 new BASE_PATH specs).
- [x] `bun test public/libs/tinymce_5/js/tinymce/plugins/{codemagic,exemindmap}/*-plugin.test.js` → 35/35 pass.
- [x] Full `bun test` → same pre-existing 21 fails as `main` (env / DB_PATH issues from local `.env`, not introduced by this PR — verified via stash + diff).
- [x] End-to-end against the local nginx proxy recipe above: 50/50 icons load, codemagic + exemindmap iframes return 200 (verified live).
- [ ] `make test-e2e` — to be run by reviewer; my changes don't touch any flow not already exercised by existing E2E.

Closes #1802
