### PR TITLE
fix(deploy): prepend BASE_PATH on codemagic editor sub-asset URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { renderTemplate, setRenderLocale } from './services/template';
 import { getSettingNumber } from './services/app-settings';
 import { isMaintenanceMode, shouldBypassMaintenance, isAdminRequest } from './services/maintenance';
 import { getBasePath } from './utils/basepath.util';
+import { rewriteCodemagicAssetPaths } from './utils/editor-html.util';
 import { HttpException, TranslatableException, getStatusText } from './exceptions';
 import { MIME_TYPES } from './utils/mime-types';
 import { isRedisEnabled, connectRedis, disconnectRedis } from './redis/client';
@@ -134,14 +135,10 @@ const codemagicEditorHandler = ({
         const ext = path.extname(filePath).toLowerCase();
         const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
-        // For HTML files, rewrite relative paths to absolute paths
+        // For HTML files, rewrite document-relative asset paths to BASE_PATH-aware
+        // absolute paths so they resolve behind a subdirectory reverse proxy (#1806).
         if (ext === '.html' || ext === '.htm') {
-            let html = content.toString('utf-8');
-            // Fix includes/ paths -> /api/codemagic-editor/includes/
-            html = html.replace(/src="includes\//g, 'src="/api/codemagic-editor/includes/');
-            html = html.replace(/href="includes\//g, 'href="/api/codemagic-editor/includes/');
-            // Fix images/icons/ paths -> /api/codemagic-editor/images/
-            html = html.replace(/src="images\//g, 'src="/api/codemagic-editor/images/');
+            const html = rewriteCodemagicAssetPaths(content.toString('utf-8'));
             content = Buffer.from(html, 'utf-8');
         }
 

--- a/src/utils/editor-html.util.spec.ts
+++ b/src/utils/editor-html.util.spec.ts
@@ -1,0 +1,76 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { rewriteCodemagicAssetPaths } from './editor-html.util';
+
+// Minimal slice of codemagic.html: the document-relative tags the handler rewrites.
+const SAMPLE_HTML = [
+    '<link rel="stylesheet" href="includes/codemagic.css" />',
+    '<link rel="stylesheet" href="includes/codemirror/codemirror.css" />',
+    '<script type="text/javascript" src="includes/codemirror/codemirror.js"></script>',
+    '<script type="text/javascript" src="includes/codemagic.js"></script>',
+    '<img src="images/icons/undo.png" alt="Undo" />',
+].join('\n');
+
+describe('rewriteCodemagicAssetPaths', () => {
+    let originalBasePath: string | undefined;
+
+    beforeAll(() => {
+        originalBasePath = process.env.BASE_PATH;
+    });
+
+    afterAll(() => {
+        if (originalBasePath !== undefined) {
+            process.env.BASE_PATH = originalBasePath;
+        } else {
+            delete process.env.BASE_PATH;
+        }
+    });
+
+    beforeEach(() => {
+        delete process.env.BASE_PATH;
+    });
+
+    afterEach(() => {
+        delete process.env.BASE_PATH;
+    });
+
+    describe('with BASE_PATH set (subdirectory deploy behind a reverse proxy)', () => {
+        const BASE = '/aplicaciones/medusa/exelearning';
+
+        beforeEach(() => {
+            process.env.BASE_PATH = BASE;
+        });
+
+        it('prefixes includes/ asset paths with BASE_PATH', () => {
+            const out = rewriteCodemagicAssetPaths(SAMPLE_HTML);
+            expect(out).toContain(`href="${BASE}/api/codemagic-editor/includes/codemagic.css"`);
+            expect(out).toContain(`href="${BASE}/api/codemagic-editor/includes/codemirror/codemirror.css"`);
+            expect(out).toContain(`src="${BASE}/api/codemagic-editor/includes/codemirror/codemirror.js"`);
+            expect(out).toContain(`src="${BASE}/api/codemagic-editor/includes/codemagic.js"`);
+        });
+
+        it('prefixes images/ asset paths with BASE_PATH', () => {
+            const out = rewriteCodemagicAssetPaths(SAMPLE_HTML);
+            expect(out).toContain(`src="${BASE}/api/codemagic-editor/images/icons/undo.png"`);
+        });
+
+        it('never emits a bare-absolute /api/codemagic-editor path', () => {
+            const out = rewriteCodemagicAssetPaths(SAMPLE_HTML);
+            expect(out).not.toMatch(/(?:src|href)="\/api\/codemagic-editor\//);
+        });
+    });
+
+    describe('without BASE_PATH (flat dev / root deploy)', () => {
+        it('rewrites to bare-absolute paths (back-compat)', () => {
+            const out = rewriteCodemagicAssetPaths(SAMPLE_HTML);
+            expect(out).toContain('href="/api/codemagic-editor/includes/codemagic.css"');
+            expect(out).toContain('src="/api/codemagic-editor/includes/codemagic.js"');
+            expect(out).toContain('src="/api/codemagic-editor/images/icons/undo.png"');
+        });
+
+        it('leaves no unresolved document-relative includes/ or images/ references', () => {
+            const out = rewriteCodemagicAssetPaths(SAMPLE_HTML);
+            expect(out).not.toMatch(/(?:src|href)="includes\//);
+            expect(out).not.toMatch(/src="images\//);
+        });
+    });
+});

--- a/src/utils/editor-html.util.ts
+++ b/src/utils/editor-html.util.ts
@@ -1,0 +1,21 @@
+import { prefixPath } from './basepath.util';
+
+/**
+ * Rewrite the document-relative asset paths inside the codemagic editor HTML into
+ * absolute paths that include BASE_PATH.
+ *
+ * The codemagic editor is served as a static HTML page whose <link>/<script>/<img>
+ * tags reference assets relative to the document (`includes/...`, `images/...`).
+ * Behind a reverse proxy that only mounts the BASE_PATH namespace, emitting these as
+ * bare-absolute paths (`/api/codemagic-editor/...`) makes the browser resolve them at
+ * the origin root, bypassing BASE_PATH, so they 404/502 (see #1802, #1806). Routing
+ * the rewrite through prefixPath() keeps them inside the mounted namespace. In flat
+ * dev (no BASE_PATH) prefixPath() is a no-op, so the paths stay bare.
+ */
+export function rewriteCodemagicAssetPaths(html: string): string {
+    const base = prefixPath('/api/codemagic-editor');
+    return html
+        .replace(/src="includes\//g, `src="${base}/includes/`)
+        .replace(/href="includes\//g, `href="${base}/includes/`)
+        .replace(/src="images\//g, `src="${base}/images/`);
+}


### PR DESCRIPTION
## Summary

Fixes #1833. Behind a reverse proxy that only forwards the BASE_PATH namespace (the production shape from #1802), the **codemagic** TinyMCE source-code editor iframe loads — its `src` was fixed in #1804 — but every asset referenced inside that iframe's HTML (`includes/*.css`, `includes/*.js`, `images/icons/*.png`) is requested at bare root without BASE_PATH and 502s.

## Root cause

`src/index.ts` `codemagicEditorHandler` serves `codemagic.html` and rewrites its document-relative asset paths into **bare-absolute** paths that omit BASE_PATH:

```
src="includes/..."  ->  /api/codemagic-editor/includes/...
src="images/..."    ->  /api/codemagic-editor/images/...
```

A leading-slash absolute URL ignores the iframe's own location (which IS under BASE_PATH) and resolves at the origin root. The rewrite to bare-absolute is what breaks it.

## Fix

Extract a pure helper `rewriteCodemagicAssetPaths()` into `src/utils/editor-html.util.ts` that routes every rewritten path through `prefixPath()` (from `src/utils/basepath.util.ts`) — the same helper #1804 used for theme URLs. `codemagicEditorHandler` now calls it instead of inlining the regexes. In flat dev (no BASE_PATH) `prefixPath()` is a no-op, so paths stay bare and the dual-mount still answers both URL shapes.

## Why exemindmap is NOT touched

exemindmap is unaffected and intentionally left alone. It builds its asset base at runtime inside the iframe from `window.parent.eXeLearning.symfony.fullURL` (`editor/index.html:44`); `public/app/app.js:664` sets a compat shim `eXeLearning.symfony = { …, fullURL: config.fullURL }`, and `config.fullURL === basePath` (`src/routes/pages.ts:940`). So its `editorBase`, `/app/common/mindmaps/…` CSS and `script.js` are already BASE_PATH-prefixed. Verified loading behind the proxy.

## Tests

`src/utils/editor-html.util.spec.ts` (new, colocated `bun test`): with `BASE_PATH` set, asserts every `includes/`/`images/` path is prefixed and no bare-absolute `/api/codemagic-editor/` path survives; with `BASE_PATH` unset, asserts bare-absolute paths (back-compat) and that no document-relative `includes/`/`images/` reference is left. `beforeEach`/`afterEach` save+clear+restore `process.env.BASE_PATH` (same determinism guard #1804 added to `themes.spec.ts`).

## Test plan

- [x] `make fix` clean (Biome).
- [x] `bun test src/utils/editor-html.util.spec.ts` → 5/5 pass.
- [x] Live behind the local nginx proxy (BASE_PATH=/aplicaciones/medusa/exelearning): all `…/api/codemagic-editor/{includes,images}/…` now return 200 (were 502); bare-root still 502; exemindmap still loads.
- [ ] `make test-e2e` — to be run by reviewer; no E2E flow changes.

Closes #1833
Refs #1802 #1804 #1807
