### PR TITLE
feat(preview): mobile/desktop viewport toggle in the preview panel (#1837)

### DIFF
--- a/assets/styles/layout/_previewpanel.scss
+++ b/assets/styles/layout/_previewpanel.scss
@@ -253,6 +253,75 @@ $preview-transition: 0.3s ease;
     font-family: var(--icons-ff);
 }
 
+.mobile-icon::before {
+    content: "smartphone";
+    font-family: var(--icons-ff);
+}
+
+// Estado activo (modo móvil): el botón se queda claramente "pulsado".
+// Especificidad doble (id + clase + atributo) para superar a `.button-tertiary`.
+#preview-mobile-button.is-active,
+#preview-mobile-button[aria-pressed="true"],
+#preview-pinned-mobile-button.is-active,
+#preview-pinned-mobile-button[aria-pressed="true"] {
+    color: var(--brand-primary);
+    background-color: var(--gray-100);
+    box-shadow: inset 0 0 0 1px var(--brand-primary);
+}
+
+// Marco de dispositivo: en escritorio es transparente y deja el iframe a tamaño
+// completo; en modo móvil simula un teléfono (bisel + notch) centrado.
+.preview-device-frame {
+    width: 100%;
+    height: 100%;
+}
+
+// Vista móvil. Los selectores se anclan a los contenedores con id para superar
+// la especificidad de la regla `.preview-iframe { width: 100% }` existente.
+#previewsidenav-content .preview-sidenav .preview-panel-body.preview-mobile-viewport,
+#preview-pinned-container .preview-pinned-body.preview-mobile-viewport {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: auto;
+    padding: 16px;
+    background-color: var(--gray-100, #f0f1f3);
+
+    .preview-device-frame {
+        position: relative;
+        flex: 0 0 auto;
+        width: 375px;
+        max-width: 100%;
+        height: 760px;
+        max-height: 100%;
+        padding: 30px 12px 14px;
+        background: #1a1a1a;
+        border-radius: 36px;
+        box-shadow: 0 10px 30px rgba(16, 24, 40, 0.25);
+
+        // Notch del teléfono
+        &::before {
+            content: "";
+            position: absolute;
+            top: 11px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 90px;
+            height: 14px;
+            background: #000;
+            border-radius: 999px;
+            z-index: 2;
+        }
+
+        .preview-iframe {
+            width: 100%;
+            height: 100%;
+            border-radius: 20px;
+            background-color: #fff;
+        }
+    }
+}
+
 // Responsive
 @media (max-width: 1200px) {
     #previewsidenav-content .preview-sidenav {

--- a/public/app/workarea/interface/elements/previewPanel.js
+++ b/public/app/workarea/interface/elements/previewPanel.js
@@ -19,6 +19,7 @@ export default class PreviewPanelManager {
         this.extractButton = document.getElementById('preview-extract-button');
         this.pinButton = document.getElementById('preview-pin-button');
         this.refreshButton = document.getElementById('preview-refresh-button');
+        this.mobileButton = document.getElementById('preview-mobile-button');
         this.iframe = document.getElementById('preview-iframe');
 
         // DOM Elements - Pinned mode
@@ -27,11 +28,13 @@ export default class PreviewPanelManager {
         this.pinnedExtractButton = document.getElementById('preview-pinned-extract-button');
         this.unpinButton = document.getElementById('preview-unpin-button');
         this.pinnedRefreshButton = document.getElementById('preview-pinned-refresh-button');
+        this.pinnedMobileButton = document.getElementById('preview-pinned-mobile-button');
 
         // State
         this.isOpen = false;
         this.isPinned = false;
         this.isLoading = false;
+        this.isMobileViewport = this._readStoredViewport() === 'mobile';
         this.autoRefreshEnabled = true;
         this.refreshDebounceTimer = null;
         this.refreshDebounceDelay = 500; // 500ms debounce for responsive updates
@@ -55,6 +58,7 @@ export default class PreviewPanelManager {
      */
     init() {
         this.bindEvents();
+        this.applyViewport();
         this.subscribeToChanges();
         this.resetToDefaultState();
         this._setupVisibilityHandler();
@@ -79,6 +83,58 @@ export default class PreviewPanelManager {
 
         const workarea = document.getElementById('workarea');
         workarea?.setAttribute('data-preview-pinned', 'false');
+    }
+
+    /** sessionStorage key used to persist the viewport choice for the session */
+    static VIEWPORT_STORAGE_KEY = 'exe-preview-viewport';
+
+    /**
+     * Read the stored viewport preference for the session.
+     * @returns {string|null} 'mobile', 'desktop', or null when unavailable
+     */
+    _readStoredViewport() {
+        try {
+            return window.sessionStorage?.getItem(PreviewPanelManager.VIEWPORT_STORAGE_KEY) ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Toggle the preview iframe between desktop (full width) and mobile
+     * (phone-sized, centered) viewports. The choice persists for the session.
+     */
+    toggleViewport() {
+        this.isMobileViewport = !this.isMobileViewport;
+        try {
+            window.sessionStorage?.setItem(
+                PreviewPanelManager.VIEWPORT_STORAGE_KEY,
+                this.isMobileViewport ? 'mobile' : 'desktop',
+            );
+        } catch {
+            // sessionStorage may be unavailable (private mode); ignore.
+        }
+        this.applyViewport();
+    }
+
+    /**
+     * Apply the current viewport state to the preview bodies and toolbar
+     * buttons in both slide-out and pinned modes.
+     */
+    applyViewport() {
+        const bodies = [
+            this.iframe?.closest('.preview-panel-body'),
+            this.pinnedIframe?.closest('.preview-pinned-body'),
+        ];
+        for (const body of bodies) {
+            body?.classList.toggle('preview-mobile-viewport', this.isMobileViewport);
+        }
+
+        const buttons = [this.mobileButton, this.pinnedMobileButton];
+        for (const button of buttons) {
+            button?.setAttribute('aria-pressed', this.isMobileViewport ? 'true' : 'false');
+            button?.classList.toggle('is-active', this.isMobileViewport);
+        }
     }
 
     /**
@@ -265,6 +321,7 @@ export default class PreviewPanelManager {
         this.extractButton?.addEventListener('click', () => this.extractToNewTab());
         this.pinButton?.addEventListener('click', () => this.pin());
         this.refreshButton?.addEventListener('click', () => this.refresh());
+        this.mobileButton?.addEventListener('click', () => this.toggleViewport());
 
         // Keyboard on close button
         this.closeButton?.addEventListener('keydown', (e) => {
@@ -278,6 +335,7 @@ export default class PreviewPanelManager {
         this.pinnedExtractButton?.addEventListener('click', () => this.extractToNewTab());
         this.unpinButton?.addEventListener('click', () => this.unpin());
         this.pinnedRefreshButton?.addEventListener('click', () => this.refresh());
+        this.pinnedMobileButton?.addEventListener('click', () => this.toggleViewport());
 
         // Keyboard shortcuts
         document.addEventListener('keydown', (e) => {

--- a/public/app/workarea/interface/elements/previewPanel.test.js
+++ b/public/app/workarea/interface/elements/previewPanel.test.js
@@ -57,22 +57,27 @@ describe('PreviewPanelManager', () => {
       'preview-extract-button': document.createElement('button'),
       'preview-pin-button': document.createElement('button'),
       'preview-refresh-button': document.createElement('button'),
+      'preview-mobile-button': document.createElement('button'),
       'preview-iframe': document.createElement('iframe'),
       'preview-pinned-container': document.createElement('div'),
       'preview-pinned-iframe': document.createElement('iframe'),
       'preview-pinned-extract-button': document.createElement('button'),
       'preview-unpin-button': document.createElement('button'),
       'preview-pinned-refresh-button': document.createElement('button'),
+      'preview-pinned-mobile-button': document.createElement('button'),
       workarea: document.createElement('div'),
     };
 
-    // Add nested elements for loading states
+    // Add nested elements for loading states; place the iframes inside the
+    // bodies so parentElement matches the real DOM (used by viewport toggling).
     const panelBody = document.createElement('div');
     panelBody.className = 'preview-panel-body';
+    panelBody.appendChild(mockElements['preview-iframe']);
     mockElements.previewsidenav.appendChild(panelBody);
 
     const pinnedBody = document.createElement('div');
     pinnedBody.className = 'preview-pinned-body';
+    pinnedBody.appendChild(mockElements['preview-pinned-iframe']);
     mockElements['preview-pinned-container'].appendChild(pinnedBody);
 
     vi.spyOn(document, 'getElementById').mockImplementation(id => mockElements[id] || null);
@@ -139,6 +144,70 @@ describe('PreviewPanelManager', () => {
       expect(manager.isOpen).toBe(false);
       expect(manager.isPinned).toBe(false);
       expect(manager.panel).toBe(mockElements.previewsidenav);
+    });
+  });
+
+  describe('viewport toggle', () => {
+    beforeEach(() => {
+      try {
+        window.sessionStorage.clear();
+      } catch {
+        // ignore
+      }
+    });
+
+    it('should default to desktop viewport', () => {
+      expect(manager.isMobileViewport).toBe(false);
+    });
+
+    it('should toggle to mobile and back on toggleViewport()', () => {
+      const body = mockElements['preview-iframe'].parentElement;
+      const pinnedBody = mockElements['preview-pinned-iframe'].parentElement;
+
+      manager.toggleViewport();
+      expect(manager.isMobileViewport).toBe(true);
+      expect(body.classList.contains('preview-mobile-viewport')).toBe(true);
+      expect(pinnedBody.classList.contains('preview-mobile-viewport')).toBe(true);
+      expect(mockElements['preview-mobile-button'].getAttribute('aria-pressed')).toBe('true');
+      expect(mockElements['preview-pinned-mobile-button'].getAttribute('aria-pressed')).toBe('true');
+
+      manager.toggleViewport();
+      expect(manager.isMobileViewport).toBe(false);
+      expect(body.classList.contains('preview-mobile-viewport')).toBe(false);
+      expect(mockElements['preview-mobile-button'].getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('should persist the viewport choice to sessionStorage', () => {
+      manager.toggleViewport();
+      expect(window.sessionStorage.getItem('exe-preview-viewport')).toBe('mobile');
+      manager.toggleViewport();
+      expect(window.sessionStorage.getItem('exe-preview-viewport')).toBe('desktop');
+    });
+
+    it('should restore a persisted mobile choice on construction and apply it', () => {
+      window.sessionStorage.setItem('exe-preview-viewport', 'mobile');
+      const restored = new PreviewPanelManager();
+      expect(restored.isMobileViewport).toBe(true);
+
+      restored.applyViewport();
+      expect(mockElements['preview-iframe'].parentElement.classList.contains('preview-mobile-viewport')).toBe(true);
+    });
+
+    it('should not throw when sessionStorage is unavailable', () => {
+      const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+      Object.defineProperty(window, 'sessionStorage', {
+        configurable: true,
+        get() {
+          throw new Error('blocked');
+        },
+      });
+      try {
+        expect(() => new PreviewPanelManager().toggleViewport()).not.toThrow();
+      } finally {
+        if (original) {
+          Object.defineProperty(window, 'sessionStorage', original);
+        }
+      }
     });
   });
 

--- a/scripts/static-bundle/static-index.html
+++ b/scripts/static-bundle/static-index.html
@@ -233,14 +233,19 @@
                             <button id="preview-unpin-button" class="btn button-square button-tertiary" title="Unpin preview" data-i18n-title="Unpin preview">
                                 <span class="small-icon unpin-icon"></span>
                             </button>
+                            <button id="preview-pinned-mobile-button" class="btn button-square button-tertiary" aria-pressed="false" title="Toggle mobile preview" data-i18n-title="Toggle mobile preview" data-i18n-aria-label="Toggle mobile preview" aria-label="Toggle mobile preview">
+                                <span class="small-icon mobile-icon"></span>
+                            </button>
                             <button id="preview-pinned-refresh-button" class="btn button-square button-tertiary" title="Refresh preview" data-i18n-title="Refresh preview">
                                 <span class="small-icon refresh-icon"></span>
                             </button>
                         </div>
                     </div>
                     <div class="preview-pinned-body">
-                        <iframe id="preview-pinned-iframe" class="preview-iframe" title="Content preview" data-i18n-title="Content preview"
-                                sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                        <div class="preview-device-frame">
+                            <iframe id="preview-pinned-iframe" class="preview-iframe" title="Content preview" data-i18n-title="Content preview"
+                                    sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                        </div>
                     </div>
                 </aside>
             </div>
@@ -260,6 +265,9 @@
                     <button id="preview-pin-button" class="btn button-square button-tertiary" title="Pin preview" data-i18n-title="Pin preview">
                         <span class="small-icon pin-icon"></span>
                     </button>
+                    <button id="preview-mobile-button" class="btn button-square button-tertiary" aria-pressed="false" title="Toggle mobile preview" data-i18n-title="Toggle mobile preview" data-i18n-aria-label="Toggle mobile preview" aria-label="Toggle mobile preview">
+                        <span class="small-icon mobile-icon"></span>
+                    </button>
                     <button id="preview-refresh-button" class="btn button-square button-tertiary" title="Refresh preview" data-i18n-title="Refresh preview">
                         <span class="small-icon refresh-icon"></span>
                     </button>
@@ -271,8 +279,10 @@
                 </div>
             </div>
             <div class="preview-panel-body">
-                <iframe id="preview-iframe" class="preview-iframe" title="Content preview" data-i18n-title="Content preview"
-                        sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                <div class="preview-device-frame">
+                    <iframe id="preview-iframe" class="preview-iframe" title="Content preview" data-i18n-title="Content preview"
+                            sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                </div>
             </div>
         </aside>
     </div>

--- a/test/e2e/playwright/specs/preview-viewport-toggle.spec.ts
+++ b/test/e2e/playwright/specs/preview-viewport-toggle.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { waitForAppReady, gotoWorkarea } from '../helpers/workarea-helpers';
+
+/**
+ * E2E Tests for the preview viewport toggle (issue #1837).
+ *
+ * The preview toolbar has a mobile/desktop toggle button. Clicking it should
+ * constrain the preview iframe to a phone-sized width (centered) and mark the
+ * button as active; clicking again restores the full-width desktop view.
+ */
+
+test.describe('Preview viewport toggle', () => {
+    test('should toggle the preview between mobile and desktop viewports', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+
+        const projectUuid = await createProject(page, 'Preview Viewport Toggle Test');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        // Open the preview panel and wait until it is actually slid in (active),
+        // otherwise its toolbar sits off-screen behind the translateX transform.
+        const panel = page.locator('#previewsidenav');
+        await page.locator('#head-bottom-preview').click();
+        await expect(panel).toHaveClass(/active/, { timeout: 15000 });
+        await page.locator('#preview-iframe').waitFor({ state: 'attached', timeout: 10000 });
+
+        const mobileButton = page.locator('#preview-mobile-button');
+        const panelBody = page.locator('#previewsidenav .preview-panel-body');
+
+        // Default: desktop viewport.
+        await expect(mobileButton).toHaveAttribute('aria-pressed', 'false');
+        await expect(panelBody).not.toHaveClass(/preview-mobile-viewport/);
+
+        // Switch to mobile.
+        await mobileButton.click();
+        await expect(mobileButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(panelBody).toHaveClass(/preview-mobile-viewport/);
+
+        // Iframe is constrained to a phone-sized width.
+        const iframeWidth = await page.locator('#preview-iframe').evaluate(el => el.getBoundingClientRect().width);
+        expect(iframeWidth).toBeLessThanOrEqual(420);
+
+        // Switch back to desktop.
+        await mobileButton.click();
+        await expect(mobileButton).toHaveAttribute('aria-pressed', 'false');
+        await expect(panelBody).not.toHaveClass(/preview-mobile-viewport/);
+    });
+});

--- a/views/workarea/workarea.njk
+++ b/views/workarea/workarea.njk
@@ -124,13 +124,18 @@
                             <button id="preview-unpin-button" class="btn button-square button-tertiary" title="{{ t.unpin_preview or 'Unpin preview' }}" aria-label="{{ t.unpin_preview or 'Unpin preview' }}">
                                 <span class="small-icon unpin-icon"></span>
                             </button>
+                            <button id="preview-pinned-mobile-button" class="btn button-square button-tertiary" aria-pressed="false" title="{{ 'Toggle mobile preview' | trans }}" aria-label="{{ 'Toggle mobile preview' | trans }}">
+                                <span class="small-icon mobile-icon"></span>
+                            </button>
                             <button id="preview-pinned-refresh-button" class="btn button-square button-tertiary" title="{{ t.refresh_preview or 'Refresh preview' }}" aria-label="{{ t.refresh_preview or 'Refresh preview' }}">
                                 <span class="small-icon refresh-icon"></span>
                             </button>
                         </div>
                     </div>
                     <div class="preview-pinned-body">
-                        <iframe id="preview-pinned-iframe" class="preview-iframe" title="{{ t.content_preview or 'Content preview' }}" sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                        <div class="preview-device-frame">
+                            <iframe id="preview-pinned-iframe" class="preview-iframe" title="{{ t.content_preview or 'Content preview' }}" sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                        </div>
                     </div>
                 </aside>
             </div>
@@ -185,6 +190,9 @@
                     <button id="preview-pin-button" class="btn button-square button-tertiary" title="{{ t.pin_preview or 'Pin preview' }}" aria-label="{{ t.pin_preview or 'Pin preview to layout' }}">
                         <span class="small-icon pin-icon"></span>
                     </button>
+                    <button id="preview-mobile-button" class="btn button-square button-tertiary" aria-pressed="false" title="{{ 'Toggle mobile preview' | trans }}" aria-label="{{ 'Toggle mobile preview' | trans }}">
+                        <span class="small-icon mobile-icon"></span>
+                    </button>
                     <button id="preview-refresh-button" class="btn button-square button-tertiary" title="{{ t.refresh_preview or 'Refresh preview' }}" aria-label="{{ t.refresh_preview or 'Refresh preview' }}">
                         <span class="small-icon refresh-icon"></span>
                     </button>
@@ -196,7 +204,9 @@
                 </div>
             </div>
             <div class="preview-panel-body">
-                <iframe id="preview-iframe" class="preview-iframe" title="{{ t.content_preview or 'Content preview' }}" sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                <div class="preview-device-frame">
+                    <iframe id="preview-iframe" class="preview-iframe" title="{{ t.content_preview or 'Content preview' }}" sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-downloads allow-popups allow-presentation"></iframe>
+                </div>
             </div>
         </aside>
     </div>


### PR DESCRIPTION
## Why

Closes #1837. Authors had no quick way to check how their content looks on a phone without exporting and opening it on a real device. This adds a viewport toggle to the preview panel so responsive review is part of the normal authoring loop.

## What

A phone-icon toggle button is added to **both** preview toolbars (slide-out and pinned). Toggling switches the preview into a centered **phone mockup** (device bezel + notch, 375px screen) so the result reads like a real device; toggling again restores the full-width desktop view.

- The active button stays clearly **pressed** (highlighted background + border).
- The choice **persists for the session** (`sessionStorage`) and is mirrored across both toolbars.
- Only the *display* of the existing iframe changes — generated content and the export pipeline are untouched.

## Preview

<img width="1467" height="835" alt="Captura de pantalla 2026-05-21 a las 14 49 52" src="https://github.com/user-attachments/assets/41f70752-9d3f-4f6a-9527-f5cc8e2fd17b" />


## How

- `views/workarea/workarea.njk` — toggle button + a `.preview-device-frame` wrapper around each iframe.
- `public/app/workarea/interface/elements/previewPanel.js` — `toggleViewport()` / `applyViewport()`, session persistence, state restored on init and mirrored on both buttons.
- `assets/styles/layout/_previewpanel.scss` — phone mockup (bezel/notch/rounded screen, centered) and the visible pressed-button state. Selectors are anchored to the panel container ids to beat the existing `.preview-iframe { width: 100% }` specificity.

The toggle button label uses `| trans` (translatable, no hardcoded English); no new translation strings are committed.

## Testing

- `make fix` clean.
- Unit (Vitest): `previewPanel.test.js` — toggle flips state, adds/removes the class on both bodies, sets `aria-pressed`, persists to and restores from `sessionStorage`, and degrades gracefully when storage is unavailable. **165 passing.**
- E2E (Playwright): `preview-viewport-toggle.spec.ts` — opens the preview, toggles to mobile (asserts `aria-pressed`, the body class, and the constrained iframe width), toggles back. **Passing on chromium.**