### PR TITLE
fix(build): exclude node_modules and dev files from static build

### DIFF
--- a/scripts/build-static-bundle.ts
+++ b/scripts/build-static-bundle.ts
@@ -1205,7 +1205,7 @@ async function buildStaticBundle() {
     console.log('  Copied bundles/');
 
     // Copy files/perm (themes, iDevices, favicon)
-    copyDirRecursive(path.join(projectRoot, 'public/files/perm'), path.join(outputDir, 'files/perm'));
+    copyDirRecursive(path.join(projectRoot, 'public/files/perm'), path.join(outputDir, 'files/perm'),['src', 'node_modules','bun.lock','package.json']);
     console.log('  Copied files/perm/');
 
     // Copy images folder (default-avatar.svg, logo.svg, etc.)


### PR DESCRIPTION
## Description
This PR fixes the issue where unnecessary files, such as `node_modules`, were being included in the static editor build. 

Now, the build process filters the contents to ensure only production-ready files are included in the final artifact.

## Related Issue
Fixes #1848 

## Changes Made
* Updated the `build-static-bundle.ts` script to implement a filtering mechanism.

## How to Test
1. Run the static build command: make build-static