### PR TITLE
fix(security): harden ZIP extraction against path traversal

### DIFF
--- a/src/services/admin-upload-validator.spec.ts
+++ b/src/services/admin-upload-validator.spec.ts
@@ -346,6 +346,37 @@ describe('Admin Upload Validator', () => {
             expect(extractedFiles).toContain('icons/logo.png');
             expect(await fs.pathExists(path.join(testDir, 'icons'))).toBe(true);
         });
+
+        test('should reject entries that traverse out of the target directory', async () => {
+            const zipData = fflate.zipSync({
+                '../escape.txt': fflate.strToU8('pwned'),
+            });
+
+            await expect(validator.extractTheme(Buffer.from(zipData), testDir)).rejects.toThrow();
+
+            const escapedPath = path.join(path.dirname(testDir), 'escape.txt');
+            expect(await fs.pathExists(escapedPath)).toBe(false);
+        });
+
+        test('should reject entries with absolute paths', async () => {
+            const zipData = fflate.zipSync({
+                '/tmp/admin-validator-zipslip-absolute.txt': fflate.strToU8('pwned'),
+            });
+
+            await expect(validator.extractTheme(Buffer.from(zipData), testDir)).rejects.toThrow();
+            expect(await fs.pathExists('/tmp/admin-validator-zipslip-absolute.txt')).toBe(false);
+        });
+
+        test('should reject entries that use backslash separators to escape', async () => {
+            const zipData = fflate.zipSync({
+                '..\\escape-backslash.txt': fflate.strToU8('pwned'),
+            });
+
+            await expect(validator.extractTheme(Buffer.from(zipData), testDir)).rejects.toThrow();
+
+            const escapedPath = path.join(path.dirname(testDir), 'escape-backslash.txt');
+            expect(await fs.pathExists(escapedPath)).toBe(false);
+        });
     });
 
     describe('extractTemplate', () => {

--- a/src/services/admin-upload-validator.ts
+++ b/src/services/admin-upload-validator.ts
@@ -234,31 +234,36 @@ export function createAdminUploadValidator(deps: AdminUploadValidatorDeps = {}):
     };
 
     /**
-     * Extract theme to target directory
+     * Extract theme to target directory.
+     *
+     * Defends against Zip Slip: every ZIP entry path is normalized (backslashes
+     * to forward slashes, since on POSIX `\` is a valid filename character that
+     * archive crafters can abuse) and resolved against the target directory.
+     * Any entry whose resolved path falls outside the target directory is
+     * rejected before any write happens.
      */
     const extractTheme = async (buffer: Buffer, targetDir: string): Promise<string[]> => {
         const uint8Data = new Uint8Array(buffer);
         const unzipped = fflate.unzipSync(uint8Data);
         const extractedFiles: string[] = [];
 
-        // Ensure target directory exists
         await fs.ensureDir(targetDir);
+        const resolvedTargetDir = path.resolve(targetDir);
 
-        // Extract all files
         for (const [relativePath, data] of Object.entries(unzipped)) {
-            // Skip directories (they end with /)
+            const safeRelativePath = relativePath.replace(/\\/g, '/');
+            const targetPath = path.resolve(resolvedTargetDir, safeRelativePath);
+
+            if (targetPath !== resolvedTargetDir && !targetPath.startsWith(resolvedTargetDir + path.sep)) {
+                throw new Error(`Security error: theme entry escapes target directory: ${relativePath}`);
+            }
+
             if (relativePath.endsWith('/')) {
-                await fs.ensureDir(path.join(targetDir, relativePath));
+                await fs.ensureDir(targetPath);
                 continue;
             }
 
-            // Build target path
-            const targetPath = path.join(targetDir, relativePath);
-
-            // Ensure parent directory exists
             await fs.ensureDir(path.dirname(targetPath));
-
-            // Write file
             await fs.writeFile(targetPath, Buffer.from(data));
             extractedFiles.push(relativePath);
         }

--- a/src/shared/import/FileSystemAssetHandler.spec.ts
+++ b/src/shared/import/FileSystemAssetHandler.spec.ts
@@ -68,6 +68,35 @@ describe('FileSystemAssetHandler', () => {
             expect(existsSync(resourcesDir)).toBe(true);
         });
 
+        it('should reject folderPath that escapes the extract directory', async () => {
+            const handler = new FileSystemAssetHandler(testDir);
+
+            await expect(
+                handler.storeAsset('id', new Uint8Array([1]), {
+                    filename: 'evil.txt',
+                    mimeType: 'text/plain',
+                    folderPath: '../escape',
+                }),
+            ).rejects.toThrow();
+
+            const escapedPath = path.join(path.dirname(testDir), 'escape', 'evil.txt');
+            expect(existsSync(escapedPath)).toBe(false);
+        });
+
+        it('should reject filenames that escape the asset directory', async () => {
+            const handler = new FileSystemAssetHandler(testDir);
+
+            await expect(
+                handler.storeAsset('id', new Uint8Array([1]), {
+                    filename: '../escape.txt',
+                    mimeType: 'text/plain',
+                }),
+            ).rejects.toThrow();
+
+            const escapedPath = path.join(testDir, 'escape.txt');
+            expect(existsSync(escapedPath)).toBe(false);
+        });
+
         it('should handle duplicate filenames', async () => {
             const handler = new FileSystemAssetHandler(testDir);
 
@@ -325,6 +354,21 @@ describe('FileSystemAssetHandler', () => {
 
             // Don't create any assets
             await expect(handler.clear()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('extractThemeFromZip', () => {
+        it('should reject theme entries that escape the theme directory', async () => {
+            const handler = new FileSystemAssetHandler(testDir);
+
+            const malicious: Record<string, Uint8Array> = {
+                'theme/../escape.txt': new Uint8Array([1, 2, 3]),
+            };
+
+            await expect(handler.extractThemeFromZip(malicious)).rejects.toThrow();
+
+            const escapedPath = path.join(testDir, 'escape.txt');
+            expect(existsSync(escapedPath)).toBe(false);
         });
     });
 });

--- a/src/shared/import/FileSystemAssetHandler.ts
+++ b/src/shared/import/FileSystemAssetHandler.ts
@@ -201,21 +201,28 @@ export class FileSystemAssetHandler implements AssetHandler {
      * @returns Asset ID
      */
     async storeAsset(id: string, data: Uint8Array, metadata: AssetMetadata): Promise<string> {
-        // Determine the full directory path including any subfolders
-        let assetDir: string;
-        if (metadata.folderPath) {
-            assetDir = path.join(this.extractPath, metadata.folderPath);
-        } else {
-            assetDir = path.join(this.extractPath, 'resources');
+        // Both folderPath and filename can originate from untrusted ZIP entry
+        // names. Normalize backslashes (valid filename chars on POSIX) and
+        // resolve against the extract root so any traversal attempt is caught
+        // before any directory or file is written.
+        const resolvedExtractPath = path.resolve(this.extractPath);
+        const safeFolderPath = (metadata.folderPath ?? 'resources').replace(/\\/g, '/');
+        const assetDir = path.resolve(resolvedExtractPath, safeFolderPath);
+
+        if (assetDir !== resolvedExtractPath && !assetDir.startsWith(resolvedExtractPath + path.sep)) {
+            throw new Error(`Security error: asset folderPath escapes extract directory: ${metadata.folderPath}`);
         }
 
         if (!existsSync(assetDir)) {
             mkdirSync(assetDir, { recursive: true });
         }
 
-        // Store the file with its original filename (preserving extension)
-        const filename = metadata.filename;
-        const filePath = path.join(assetDir, filename);
+        const filename = metadata.filename.replace(/\\/g, '/');
+        const filePath = path.resolve(assetDir, filename);
+
+        if (!filePath.startsWith(assetDir + path.sep)) {
+            throw new Error(`Security error: asset filename escapes asset directory: ${metadata.filename}`);
+        }
 
         // Handle duplicate filenames by appending a number
         let finalPath = filePath;
@@ -415,7 +422,7 @@ export class FileSystemAssetHandler implements AssetHandler {
         themeDir: string | null;
         downloadable: boolean;
     }> {
-        const themeDir = path.join(this.extractPath, THEME_DIRECTORY);
+        const themeDir = path.resolve(this.extractPath, THEME_DIRECTORY);
         let themeName: string | null = null;
         let downloadable = false;
         let hasThemeFiles = false;
@@ -428,9 +435,16 @@ export class FileSystemAssetHandler implements AssetHandler {
 
             hasThemeFiles = true;
 
-            // Get relative path within theme directory
+            // Get relative path within theme directory. Normalize backslashes
+            // and resolve against themeDir to block Zip Slip via crafted entries
+            // such as `theme/../escape.txt`.
             const relativePath = zipPath.substring(THEME_DIRECTORY.length + 1);
-            const fullPath = path.join(themeDir, relativePath);
+            const safeRelativePath = relativePath.replace(/\\/g, '/');
+            const fullPath = path.resolve(themeDir, safeRelativePath);
+
+            if (!fullPath.startsWith(themeDir + path.sep)) {
+                throw new Error(`Security error: theme entry escapes theme directory: ${zipPath}`);
+            }
 
             // Create directory if needed
             const fileDir = path.dirname(fullPath);


### PR DESCRIPTION
## Summary

Three archive-extraction code paths build target paths from untrusted ZIP entry names with `path.join` and no containment check, so a crafted archive with entries like `../escape.txt`, `/abs/escape.txt`, or `..\escape.txt` can write files anywhere the server process can write.

The affected paths are:

- `extractTheme` in `src/services/admin-upload-validator.ts` (admin theme upload)
- `storeAsset` in `src/shared/import/FileSystemAssetHandler.ts` (asset extraction during ELP import — both `folderPath` and `filename` come from ZIP entries)
- `extractThemeFromZip` in `src/shared/import/FileSystemAssetHandler.ts` (theme extraction during ELP import)

`validatePathSecurity` already screens entry names in the normal admin theme flow before `extractTheme` runs, but `extractTheme` is also exported as a public factory function and is reachable without that pre-check. The FileSystemAssetHandler paths have no pre-check at all.

## Fix

For each entry, normalize backslashes to forward slashes (on POSIX `\` is a valid filename character, so it can be used to bypass naive `..` checks), resolve the path against the target root, and reject anything that does not stay strictly inside the root (`startsWith(root + path.sep)`, or equal to the root for the root entry).

No new dependencies. No behavior change for valid archives.

## Tests

TDD: tests were written first, observed failing against the unfixed code (the malicious archives successfully wrote files outside the target directory), then the fix was applied. New tests:

- `extractTheme` rejects `../escape.txt`, absolute paths, and `..\escape.txt`
- `storeAsset` rejects `metadata.folderPath = '../escape'` and `metadata.filename = '../escape.txt'`
- `extractThemeFromZip` rejects `theme/../escape.txt`

Each test also asserts that no file was written outside the intended directory.

## Test plan

- [x] `make fix` clean
- [x] `bun test src/services/admin-upload-validator.spec.ts src/shared/import/FileSystemAssetHandler.spec.ts` — 77 pass, 0 fail
- [x] `bun test` on adjacent affected files (`src/routes/admin.spec.ts`, `src/services/file-helper.spec.ts`) — 238 pass, 0 fail
- [x] Tests verified failing before fix (RED), passing after (GREEN)