### PR TITLE
fix(desktop): single save dialog for blob file downloads in Electron (#1875)

### DIFF
--- a/public/app/common/asset_url_resolver.js
+++ b/public/app/common/asset_url_resolver.js
@@ -783,6 +783,52 @@
         return 'HTML websites from the Resources folder cannot be navigated in preview. Please export the project to view this content correctly.';
     }
 
+    /**
+     * Resolve the Electron API from this window or its parent (iframe contexts).
+     * @returns {Object|null} electronAPI bridge or null when not in Electron.
+     */
+    function getElectronAPI() {
+        if (typeof window === 'undefined') return null;
+        try {
+            if (window.electronAPI) return window.electronAPI;
+            if (window.parent && window.parent !== window && window.parent.electronAPI) {
+                return window.parent.electronAPI;
+            }
+        } catch (_e) {
+            // Cross-origin parent access blocked
+        }
+        return null;
+    }
+
+    /**
+     * Save a blob: asset through the Electron saveBufferAs IPC channel.
+     *
+     * Bypasses the will-download path in app/main.js, whose async handler
+     * shows a native save dialog on top of our own promptSave(), producing
+     * two simultaneous dialogs (issue #1875). Fetching the blob bytes and
+     * handing them to saveBufferAs keeps a single dialog per user action.
+     *
+     * @param {string} blobUrl - The blob: URL to save.
+     * @param {string} filename - Suggested file name.
+     * @returns {boolean} True if the Electron save path was used (caller must
+     *   then prevent the default navigation); false in non-Electron contexts.
+     */
+    function saveBlobViaElectron(blobUrl, filename) {
+        const electronAPI = getElectronAPI();
+        if (!electronAPI || typeof electronAPI.saveBufferAs !== 'function') {
+            return false;
+        }
+        const projectKey = (typeof window !== 'undefined' && window.__currentProjectId) || 'asset-download';
+        Promise.resolve()
+            .then(() => fetch(blobUrl))
+            .then((response) => response.arrayBuffer())
+            .then((buffer) => electronAPI.saveBufferAs(new Uint8Array(buffer), projectKey, filename))
+            .catch((err) => {
+                console.error('[AssetResolver] Electron saveBufferAs failed:', err);
+            });
+        return true;
+    }
+
     document.addEventListener('click', function(e) {
         const link = e.target.closest('a[href]');
         if (!link) return;
@@ -827,6 +873,22 @@
                         }
                     }
                 }
+            }
+
+            // In Electron, letting an <a download> with a blob: URL navigate
+            // triggers the will-download handler in app/main.js. That handler
+            // is async and shows our custom promptSave() dialog while Electron
+            // also shows its own default save dialog, so two dialogs appear at
+            // once (issue #1875). Route non-image blob downloads through the
+            // saveBufferAs IPC channel instead: will-download never fires and a
+            // single native dialog is shown. Images keep opening in the
+            // lightbox / new tab. This mirrors the bypass documented for the
+            // gamification iDevices in common_edition.js (downloadBlob).
+            const downloadFilename = href.startsWith('blob:') ? link.getAttribute('download') : null;
+            if (downloadFilename && saveBlobViaElectron(href, downloadFilename)) {
+                e.preventDefault();
+                e.stopPropagation();
+                return;
             }
 
             link.setAttribute('target', '_blank');

--- a/public/app/common/asset_url_resolver.test.js
+++ b/public/app/common/asset_url_resolver.test.js
@@ -2252,6 +2252,124 @@ describe('AssetUrlResolver', () => {
       document.body.removeChild(link);
     });
 
+    describe('Electron blob download (single save dialog, issue #1875)', () => {
+      let fetchMock;
+
+      afterEach(() => {
+        delete window.electronAPI;
+        delete global.fetch;
+        delete window.fetch;
+      });
+
+      function setupElectron(saveBufferAs) {
+        window.electronAPI = { saveBufferAs };
+        const buffer = new Uint8Array([1, 2, 3, 4]).buffer;
+        fetchMock = vi.fn(() =>
+          Promise.resolve({ arrayBuffer: () => Promise.resolve(buffer) }),
+        );
+        global.fetch = fetchMock;
+        window.fetch = fetchMock;
+      }
+
+      it('routes non-image blob downloads through saveBufferAs to avoid the double dialog', async () => {
+        const blobUrl = 'blob:app://localhost/a61add6d-a090-4e22-883e-2da07a032e50';
+        const assetId = 'rar12345-def6-7890-abcd-ef1234567890';
+        const saveBufferAs = vi.fn(() => Promise.resolve('/tmp/archive.rar'));
+        setupElectron(saveBufferAs);
+        window.__currentProjectId = 'project-xyz';
+
+        const assetManager = window.eXeLearning.app.project._yjsBridge.assetManager;
+        assetManager.reverseBlobCache = new Map([[blobUrl, assetId]]);
+        assetManager.getAssetMetadata = vi.fn(() => ({
+          filename: 'archive.rar',
+          mime: 'application/vnd.rar',
+        }));
+
+        const link = document.createElement('a');
+        link.setAttribute('href', blobUrl);
+        document.body.appendChild(link);
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        link.dispatchEvent(event);
+
+        // The default <a download> navigation is suppressed so Electron's
+        // will-download handler never fires a second native dialog.
+        expect(event.defaultPrevented).toBe(true);
+
+        // Note: each test re-imports the module, accumulating click listeners
+        // on the shared document, so we assert "called" rather than an exact
+        // count. In the real app the IIFE registers a single listener.
+        await vi.waitFor(() => expect(saveBufferAs).toHaveBeenCalled());
+        expect(fetchMock).toHaveBeenCalledWith(blobUrl);
+        const [bytes, projectKey, filename] = saveBufferAs.mock.calls[0];
+        expect(bytes).toBeInstanceOf(Uint8Array);
+        expect(projectKey).toBe('project-xyz');
+        expect(filename).toBe('archive.rar');
+
+        document.body.removeChild(link);
+        delete window.__currentProjectId;
+      });
+
+      it('falls back to a default project key when none is set and logs save failures', async () => {
+        const blobUrl = 'blob:app://localhost/b71add6d-a090-4e22-883e-2da07a032e51';
+        const assetId = 'rar67890-def6-7890-abcd-ef1234567890';
+        const saveBufferAs = vi.fn(() => Promise.reject(new Error('user cancelled')));
+        setupElectron(saveBufferAs);
+        delete window.__currentProjectId;
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const assetManager = window.eXeLearning.app.project._yjsBridge.assetManager;
+        assetManager.reverseBlobCache = new Map([[blobUrl, assetId]]);
+        assetManager.getAssetMetadata = vi.fn(() => ({
+          filename: 'data.zip',
+          mime: 'application/zip',
+        }));
+
+        const link = document.createElement('a');
+        link.setAttribute('href', blobUrl);
+        document.body.appendChild(link);
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        link.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        await vi.waitFor(() => expect(saveBufferAs).toHaveBeenCalled());
+        expect(saveBufferAs.mock.calls[0][1]).toBe('asset-download');
+        await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+        expect(errorSpy.mock.calls[0][0]).toContain('saveBufferAs failed');
+
+        errorSpy.mockRestore();
+        document.body.removeChild(link);
+      });
+
+      it('does not route image blob links through saveBufferAs (lightbox/new tab)', () => {
+        const blobUrl = 'blob:app://localhost/99cf3174-a4ae-4c3b-9f2b-0972b94b8f03';
+        const assetId = 'img12345-def6-7890-abcd-ef1234567890';
+        const saveBufferAs = vi.fn(() => Promise.resolve('/tmp/photo.jpg'));
+        setupElectron(saveBufferAs);
+
+        const assetManager = window.eXeLearning.app.project._yjsBridge.assetManager;
+        assetManager.reverseBlobCache = new Map([[blobUrl, assetId]]);
+        assetManager.getAssetMetadata = vi.fn(() => ({
+          filename: 'photo.jpg',
+          mime: 'image/jpeg',
+        }));
+
+        const link = document.createElement('a');
+        link.setAttribute('href', blobUrl);
+        document.body.appendChild(link);
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        link.dispatchEvent(event);
+
+        expect(saveBufferAs).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+        expect(link.getAttribute('target')).toBe('_blank');
+
+        document.body.removeChild(link);
+      });
+    });
+
     it('skips links inside TinyMCE editors', () => {
       const tinymceContainer = document.createElement('div');
       tinymceContainer.classList.add('tox-tinymce');


### PR DESCRIPTION
## Summary
Fixes #1875. In the Electron desktop app, clicking a content link to a downloadable file asset (e.g. a `.rar`/`.zip`) in the **editor** or **live preview** opened **two** save dialogs at once.

## Root cause
The editor click handler in `public/app/common/asset_url_resolver.js` set a `download` attribute on the resolved `blob:` link and let the default navigation proceed. In Electron, navigating an `<a download>` with a `blob:` URL fires the async `will-download` handler in `app/main.js`, which shows our custom `promptSave()` dialog while Electron **also** shows its own default native save dialog — hence two dialogs (one titled `blob:app://localhost/…`).

## Fix
Route non-image `blob:` downloads through the `saveBufferAs` IPC channel (the same bypass already documented for the gamification iDevices in `common_edition.js`). `will-download` never fires, so a single native dialog is shown.

- Browser (non-Electron) behaviour is unchanged: links still download via `<a download>` + `target="_blank"`.
- Image / lightbox links are unchanged (they continue to open in the lightbox / new tab).

## Relation to #1818 / #1819
PR #1819 fixed the same *class* of double-dialog bug, but only for the **ELPx source-file** link (`exe-package:elp`), which now routes through the workarea export flow. Arbitrary file-download links inserted into content went through a **different** path (`asset_url_resolver.js`) that was still affected. This PR covers that path.

## Tests
Added colocated Vitest coverage in `asset_url_resolver.test.js` (TDD — written failing first):
- non-image `blob:` download routes through `saveBufferAs` (bytes + project key + filename) and suppresses default navigation (no second dialog);
- default project key fallback + `saveBufferAs` rejection is logged;
- image `blob:` links are **not** routed through `saveBufferAs`.

`make fix` clean; full `asset_url_resolver.test.js` suite green (124 tests).