### PR TITLE
Update third-party licenses for 3Dmol and electrical-circuits iDevices

### DIFF
--- a/public/files/perm/idevices/base/electrical-circuits/edition/fonts/LICENCE_BAKOMA.txt
+++ b/public/files/perm/idevices/base/electrical-circuits/edition/fonts/LICENCE_BAKOMA.txt
@@ -1,0 +1,34 @@
+BaKoMa Fonts Licence
+--------------------
+
+This licence covers two font packs (known as BaKoMa Fonts Colelction,
+which is available at `CTAN:fonts/cm/ps-type1/bakoma/'):
+  1) BaKoMa-CM (1.1/12-Nov-94)
+     Computer Modern Fonts in PostScript Type 1 and TrueType font formats.
+
+  2) BaKoMa-AMS (1.2/19-Jan-95)
+     AMS TeX fonts in PostScript Type 1 and TrueType font formats.
+
+Copyright (C) 1994, 1995, Basil K. Malyshev. All Rights Reserved.
+Permission to copy and distribute these fonts for any purpose is
+hereby granted without fee, provided that the above copyright notice,
+author statement and this permission notice appear in all copies of
+these fonts and related documentation.
+Permission to modify and distribute modified fonts for any purpose is
+hereby granted without fee, provided that the copyright notice,
+author statement, this permission notice and location of original
+fonts (http://www.ctan.org/tex-archive/fonts/cm/ps-type1/bakoma)
+appear in all copies of modified fonts and related documentation.
+Permission to use these fonts (embedding into PostScript, PDF, SVG
+and printing by using any software) is hereby granted without fee.
+It is not required to provide any notices about using these fonts.
+
+Basil K. Malyshev
+INSTITUTE FOR HIGH ENERGY PHYSICS
+IHEP, OMVT
+Moscow Region
+142281 PROTVINO
+RUSSIA
+
+E-Mail: bakoma@mail.ru
+     or malyshev@mail.ihep.ru

--- a/public/files/perm/idevices/base/electrical-circuits/export/fonts/LICENCE_BAKOMA.txt
+++ b/public/files/perm/idevices/base/electrical-circuits/export/fonts/LICENCE_BAKOMA.txt
@@ -1,0 +1,34 @@
+BaKoMa Fonts Licence
+--------------------
+
+This licence covers two font packs (known as BaKoMa Fonts Colelction,
+which is available at `CTAN:fonts/cm/ps-type1/bakoma/'):
+  1) BaKoMa-CM (1.1/12-Nov-94)
+     Computer Modern Fonts in PostScript Type 1 and TrueType font formats.
+
+  2) BaKoMa-AMS (1.2/19-Jan-95)
+     AMS TeX fonts in PostScript Type 1 and TrueType font formats.
+
+Copyright (C) 1994, 1995, Basil K. Malyshev. All Rights Reserved.
+Permission to copy and distribute these fonts for any purpose is
+hereby granted without fee, provided that the above copyright notice,
+author statement and this permission notice appear in all copies of
+these fonts and related documentation.
+Permission to modify and distribute modified fonts for any purpose is
+hereby granted without fee, provided that the copyright notice,
+author statement, this permission notice and location of original
+fonts (http://www.ctan.org/tex-archive/fonts/cm/ps-type1/bakoma)
+appear in all copies of modified fonts and related documentation.
+Permission to use these fonts (embedding into PostScript, PDF, SVG
+and printing by using any software) is hereby granted without fee.
+It is not required to provide any notices about using these fonts.
+
+Basil K. Malyshev
+INSTITUTE FOR HIGH ENERGY PHYSICS
+IHEP, OMVT
+Moscow Region
+142281 PROTVINO
+RUSSIA
+
+E-Mail: bakoma@mail.ru
+     or malyshev@mail.ihep.ru

--- a/public/libs/LICENSES.md
+++ b/public/libs/LICENSES.md
@@ -11,6 +11,8 @@
 *   License: LGPL-2.1
     *   On Debian systems and derivatives, the full text of the GNU Lesser General Public License version 2.1 can be found in the file '/common-licenses/LGPL-2.1'.
     *   For the rest of the systems, it is available online at [https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+*   License: LPPL-1.3c
+    *   The text of the LaTeX Project Public License version 1.3c can be found at [https://www.latex-project.org/lppl/lppl-1-3c/](https://www.latex-project.org/lppl/lppl-1-3c/)
 *   License: MIT
     *   A template for the MIT license can be found at the OSI's site [https://opensource.org/license/mit](https://opensource.org/license/mit)
 *   License: Apache License 2.0
@@ -23,7 +25,9 @@
     *   The text of the Modified BSD License can be found at [The 3-Clause BSD License](https://opensource.org/license/BSD-3-clause)
 *   License: SIL Open Font License
     *   The text of the SIL Open Font License can be found at [https://openfontlicense.org/](https://openfontlicense.org/)
+*   License: BaKoMa Fonts Licence
+    *   The text of the BaKoMa Fonts Licence is included next to the bundled BaKoMa font files.
 *   License: ISC License
-    *   The text of the ISC License can be found at [https://opensource.org/license/isc)
+    *   The text of the ISC License can be found at [https://opensource.org/license/isc](https://opensource.org/license/isc)
 *   License: Public Domain
     *   Read more about Public Domain at [https://creativecommons.org/public-domain/](https://creativecommons.org/public-domain/)

--- a/public/libs/README.md
+++ b/public/libs/README.md
@@ -158,9 +158,6 @@
 *   Package: sass
     *   Copyright: Natalie Weizenbaum
     *   License: MIT
-*   Package: tikzjax
-    *   Copyright: Jim Fowler (kisonecat)
-    *   License: LPPL-1.3c
 *   Package: typescript
     *   Copyright: Microsoft Corp.
     *   License: Apache-2.0
@@ -345,6 +342,21 @@
 *   Files: /public/style/workarea/fonts/\Inter*
     *   Copyright: The Inter Project Authors. Designed by Rasmus Andersson
     *   License: SIL Open Font License version 1.1
-*   Files: /public/files/perm/idevices/base/3dmol/export/3Dmol-min.js and /public/files/perm/idevices/base/3dmol/edition/3Dmol-min.js
+*   File: /public/files/perm/idevices/base/3dmol/export/3Dmol-min.js (3Dmol.js)
     *   Copyright: 2014, University of Pittsburgh and contributors
-    *   License: BSD-3-Clause (https://github.com/3dmol/3Dmol.js/blob/master/LICENSE)
+    *   License: BSD-3-Clause
+*   Files: /public/files/perm/idevices/base/electrical-circuits/edition/tikzjax.js and /public/files/perm/idevices/base/electrical-circuits/export/tikzjax.js
+    *   Copyright: Jim Fowler (kisonecat)
+    *   License: LPPL-1.3c
+*   Files: /public/files/perm/idevices/base/electrical-circuits/edition/fonts/*.ttf and /public/files/perm/idevices/base/electrical-circuits/export/fonts/*.ttf (BaKoMa Fonts Collection)
+    *   Copyright: 1994, 1995, Basil K. Malyshev
+    *   License: BaKoMa Fonts Licence
+*   Package: circuitikz
+    *   Copyright: Massimo Redaelli, Stefan Erhardt, Stefan Lindner, Romano Giannetti
+    *   License: LPPL / GPL
+*   Package: amsmath
+    *   Copyright: American Mathematical Society and LaTeX3 Project
+    *   License: LPPL-1.3c
+*   Package: amssymb / amsfonts
+    *   Copyright: American Mathematical Society
+    *   License: SIL Open Font License


### PR DESCRIPTION
## Summary

Updates the third-party license documentation for the 3Dmol and electrical-circuits iDevices.

## Changes

- Adds missing license references for 3Dmol, TikZJax, LaTeX packages, and BaKoMa fonts.
- Adds BaKoMa font license files next to the bundled electrical-circuits fonts.
- Fixes incorrect license references in the shared third-party license documentation.

