### PR TITLE
fix(filedrop): hide open-overlay while a side panel is open and accept .zip

### DIFF
--- a/public/app/common/fileDropHandler.js
+++ b/public/app/common/fileDropHandler.js
@@ -24,13 +24,15 @@
 
 /**
  * Whether a filename is an openable eXeLearning project file.
+ * Accepts `.elpx`/`.elp` projects and `.zip` archives (an `.elpx` is a ZIP),
+ * matching the extensions the File menu open/import pickers already allow.
  * @param {string} name
  * @returns {boolean}
  */
 export function isOpenableProjectFile(name) {
     if (typeof name !== 'string') return false;
     const lower = name.toLowerCase();
-    return lower.endsWith('.elpx') || lower.endsWith('.elp');
+    return lower.endsWith('.elpx') || lower.endsWith('.elp') || lower.endsWith('.zip');
 }
 
 export default class FileDropHandler {
@@ -86,8 +88,11 @@ export default class FileDropHandler {
 
     /**
      * True when the drop should be left to another component instead of opening
-     * a project — currently any open modal (e.g. the File Manager has its own
-     * file dropzone for uploading assets).
+     * a project. This is the case when:
+     *   - any modal is open (e.g. the File Manager has its own file dropzone for
+     *     uploading assets), or
+     *   - the Styles or Preview side panel is open — those have their own UI and
+     *     the full-window "drop to open" overlay must not cover them.
      * @param {EventTarget} target
      * @returns {boolean}
      */
@@ -95,7 +100,20 @@ export default class FileDropHandler {
         if (target && typeof target.closest === 'function' && target.closest('.modal.show')) {
             return true;
         }
-        return !!document.querySelector('.modal.show');
+        if (document.querySelector('.modal.show')) return true;
+        return this._isPanelOpen();
+    }
+
+    /**
+     * True when the Styles or Preview side panel is currently open.
+     * @returns {boolean}
+     */
+    _isPanelOpen() {
+        if (typeof document === 'undefined') return false;
+        if (document.getElementById('stylessidenav')?.classList.contains('active')) return true;
+        if (document.getElementById('previewsidenav')?.classList.contains('active')) return true;
+        if (document.getElementById('workarea')?.getAttribute('data-preview-pinned') === 'true') return true;
+        return false;
     }
 
     /**
@@ -201,7 +219,7 @@ export default class FileDropHandler {
     _showInvalidAlert() {
         this.app?.modals?.alert?.show?.({
             title: _('Open project'),
-            body: _('Only .elpx or .elp project files can be opened by dragging them here.'),
+            body: _('Only .elpx, .elp or .zip project files can be opened by dragging them here.'),
             contentId: 'error',
         });
     }

--- a/public/app/common/fileDropHandler.test.js
+++ b/public/app/common/fileDropHandler.test.js
@@ -37,17 +37,19 @@ function makeDragEvent({ files = [], hasFiles = true } = {}) {
 
 afterEach(() => {
     delete window.electronAPI;
+    document.body.innerHTML = '';
 });
 
 describe('isOpenableProjectFile', () => {
-    it('accepts .elpx and .elp regardless of case', () => {
+    it('accepts .elpx, .elp and .zip regardless of case', () => {
         expect(isOpenableProjectFile('project.elpx')).toBe(true);
         expect(isOpenableProjectFile('project.elp')).toBe(true);
+        expect(isOpenableProjectFile('project.zip')).toBe(true);
         expect(isOpenableProjectFile('PROJECT.ELPX')).toBe(true);
+        expect(isOpenableProjectFile('PROJECT.ZIP')).toBe(true);
     });
 
     it('rejects other extensions and non-strings', () => {
-        expect(isOpenableProjectFile('project.zip')).toBe(false);
         expect(isOpenableProjectFile('project.pdf')).toBe(false);
         expect(isOpenableProjectFile('elpx')).toBe(false);
         expect(isOpenableProjectFile(null)).toBe(false);
@@ -177,6 +179,58 @@ describe('FileDropHandler drag events', () => {
         handler._onDrop(drop);
         expect(drop.preventDefault).toHaveBeenCalled();
         expect(app.modals.openuserodefiles.largeFilesUpload).not.toHaveBeenCalled();
+    });
+});
+
+describe('FileDropHandler defers while a side panel is open', () => {
+    /** Inject an element with the given id and the `active` class. */
+    function openPanel(id) {
+        const el = document.createElement('div');
+        el.id = id;
+        el.classList.add('active');
+        document.body.appendChild(el);
+        return el;
+    }
+
+    it.each([
+        ['styles panel', () => openPanel('stylessidenav')],
+        ['preview slide-out panel', () => openPanel('previewsidenav')],
+        [
+            'pinned preview panel',
+            () => {
+                const workarea = document.createElement('div');
+                workarea.id = 'workarea';
+                workarea.setAttribute('data-preview-pinned', 'true');
+                document.body.appendChild(workarea);
+            },
+        ],
+    ])('shows no overlay and does not open on drop when the %s is open', (_label, setup) => {
+        setup();
+        const app = makeApp();
+        const handler = new FileDropHandler({ app });
+
+        const enter = makeDragEvent();
+        handler._onDragEnter(enter);
+        // Native open is still prevented, but the overlay never appears.
+        expect(enter.preventDefault).toHaveBeenCalled();
+        expect(document.querySelector('.exe-file-drop-overlay')).toBeFalsy();
+
+        const drop = makeDragEvent({ files: [{ name: 'demo.elpx' }] });
+        handler._onDrop(drop);
+        expect(drop.preventDefault).toHaveBeenCalled();
+        expect(app.modals.openuserodefiles.largeFilesUpload).not.toHaveBeenCalled();
+    });
+
+    it('shows the overlay again once the panel is closed', () => {
+        const panel = openPanel('stylessidenav');
+        const handler = new FileDropHandler({ app: makeApp() });
+
+        handler._onDragEnter(makeDragEvent());
+        expect(document.querySelector('.exe-file-drop-overlay')).toBeFalsy();
+
+        panel.classList.remove('active');
+        handler._onDragEnter(makeDragEvent());
+        expect(document.querySelector('.exe-file-drop-overlay')).toBeTruthy();
     });
 });
 


### PR DESCRIPTION
## Summary

The drag-and-drop "drop a project file to open it" overlay (`public/app/common/fileDropHandler.js`) had two problems:

1. It appeared even when the **Styles** or **Preview** side panel was open, covering their UI and risking an accidental project replacement.
2. It only accepted `.elpx` / `.elp`, while the File menu open/import pickers already accept `.zip` (an `.elpx` is a ZIP archive).

Fixes #1879.

## Changes

- **Suppress the overlay (and the open) while a side panel is open** — `_isHandledElsewhere()` now also returns `true` when the Styles panel (`#stylessidenav.active`), the Preview slide-out (`#previewsidenav.active`), or the pinned preview (`#workarea[data-preview-pinned="true"]`) is active. Same semantics as the existing modal guard: overlay not shown, native open still prevented, file not handled.
- **Accept `.zip`** in `isOpenableProjectFile`, matching `navbarFile.js` (`accept = '.elpx,.elp,.zip'`).
- Updated the invalid-file alert text accordingly.

## Tests

- New unit cases in `fileDropHandler.test.js`: `.zip` acceptance; overlay suppressed + drop ignored for each panel state (styles, preview slide-out, pinned); overlay reappears once the panel closes. All 23 tests pass (`vitest`).
- Verified live in the browser (`make up-local`): `_isPanelOpen()` returns correctly for each panel state against the real workarea DOM, the overlay shows at baseline and is suppressed with a panel open, and the served module accepts `.zip`.

Reported by @montesdeocaleocadia-sys.
