### PR TITLE
fix(tests): repair main pipeline broken by Adaptative Quiz merge (#1798)

### DIFF
--- a/public/app/common/common_edition.test.js
+++ b/public/app/common/common_edition.test.js
@@ -1159,9 +1159,9 @@ describe('common_edition.js', () => {
         expect(text).toContain('easiest');
         // Each level must mix the three question types
         expect(text).toContain('all three types');
-        expect(text).toContain('selecciona');
-        expect(text).toContain('ordena');
-        expect(text).toContain('palabra/definici');
+        expect(text).toContain('select/multiple-choice');
+        expect(text).toContain('sort/order');
+        expect(text).toContain('word/definition');
         // Must NOT contain a literal backslash-n sequence
         expect(text.indexOf('\\n')).toBe(-1);
         // Must split into multiple actual lines


### PR DESCRIPTION
## Problem

The `main` pipeline has been red since the merge of **feat(idevices): add new Adaptative Quiz iDevice (#1798)** (`5ace5b71`).

The failure is in the **Frontend Tests + Coverage** step of the **Build & Test Docker Images** workflow ([failed run](https://github.com/exelearning/exelearning/actions/runs/26935736996)):

```
FAIL  public/app/common/common_edition.test.js > common_edition.js > gamification.share
      > adaptative quiz (gameId 10) > buildIAPromptText(10) joins lines with real newlines (no literal \n)

AssertionError: expected 'Act as a highly experienced teacher.\…' to contain 'selecciona'

 ❯ public/app/common/common_edition.test.js:1162:22
    1161|  expect(text).toContain('all three types');
    1162|  expect(text).toContain('selecciona');
    1163|  expect(text).toContain('ordena');
    1164|  expect(text).toContain('palabra/definici');

 Test Files  1 failed | 235 passed (236)
      Tests  1 failed | 13005 passed (13006)
```

## Root cause

During the development of #1798 the AI prompt for the Adaptative Quiz (gameId 10) was finalized in **English**, but three assertions in `common_edition.test.js` still expected the **Spanish** draft wording. The merge dragged these stale assertions into `main`.

The prompt source in `public/app/common/common_edition.js` emits English:

> `…each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2).`

There are no `selecciona` / `ordena` / `palabra/definici` strings anywhere in the source — every other assertion in the same test already checks English text (`Act as a highly experienced teacher.`, `Formats`, `Examples`, `all three types`). The three Spanish ones were simply leftovers from an earlier draft.

## Fix

Align the three assertions with the canonical English prompt wording, preserving the original test intent ("each level must mix the three question types"):

| Before (stale ES) | After (matches source EN) |
|---|---|
| `selecciona` | `select/multiple-choice` |
| `ordena` | `sort/order` |
| `palabra/definici` | `word/definition` |

No production code changed — this is a test-only correction that makes the suite match the shipped English prompt.

## Verification

```
$ npx vitest run public/app/common/common_edition.test.js
 ✓ public/app/common/common_edition.test.js (156 tests) 292ms
 Test Files  1 passed (1)
      Tests  156 passed (156)
```

- `make fix` — clean (the single pre-existing `any` warning in `src/` is unrelated).