### PR TITLE
fix(ci): harden Windows installer test against silent NSIS install failures

### DIFF
--- a/.github/workflows/build-electron-installers.yml
+++ b/.github/workflows/build-electron-installers.yml
@@ -280,48 +280,147 @@ jobs:
           $installTimeout = [int]($env:INSTALL_POLL_TIMEOUT ?? 240)
           $installPoll    = [int]($env:INSTALL_POLL_INTERVAL ?? 2)
 
-          # -------- Find installer and install silently --------
+          # -------- Find installer --------
           $installer = Get-ChildItem installers\*Setup*.exe -ErrorAction SilentlyContinue | Select-Object -First 1
           if (-not $installer) { throw "No Windows installer found in 'installers'." }
 
-          # /S = silent for NSIS oneClick; avoids UI + autolaunch races.
-          # NOTE: electron-builder's NSIS installer extracts the app in a child
-          # process that can outlive the launcher it spawns, so -Wait sometimes
-          # returns before eXeLearning.exe exists on disk. Checking for the EXE
-          # only once right after this call is the root cause of the flaky
-          # "Installed EXE not found to launch." failures, so we poll below.
-          Start-Process $installer.FullName -ArgumentList '/S' -Wait -NoNewWindow
+          # Deterministic per-user install dir (NSIS perMachine:false default base).
+          $installDir = Join-Path $env:LOCALAPPDATA 'Programs\eXeLearning'
 
-          # -------- Locate installed EXE (poll to absorb the NSIS extraction race) --------
           $candidatePaths = @(
-            (Join-Path $env:LOCALAPPDATA 'Programs\eXeLearning\eXeLearning.exe'),
+            (Join-Path $installDir 'eXeLearning.exe'),
             (Join-Path ${env:ProgramFiles} 'eXeLearning\eXeLearning.exe'),
             (Join-Path ${env:ProgramFiles(x86)} 'eXeLearning\eXeLearning.exe')
-          )
+          ) | Select-Object -Unique
 
-          $exePath = $null
-          $installDeadline = (Get-Date).AddSeconds($installTimeout)
-          do {
-            $exePath = $candidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
-
-            if (-not $exePath) {
-              $exePath = Get-ChildItem -Path (Join-Path $env:LOCALAPPDATA 'Programs') -Recurse -Depth 3 -Filter 'eXeLearning.exe' -ErrorAction SilentlyContinue |
-                Select-Object -First 1 | ForEach-Object FullName
-            }
-
-            if ($exePath) { break }
-
-            # Installer still extracting; wait for any lingering Setup processes
-            # then retry until the EXE shows up or we hit the install timeout.
-            Get-Process -Name '*Setup*' -ErrorAction SilentlyContinue | ForEach-Object {
-              try { $_.WaitForExit($installPoll * 1000) | Out-Null } catch {}
-            }
-            Start-Sleep -Seconds $installPoll
-          } until ((Get-Date) -ge $installDeadline)
-
-          if (-not $exePath) {
-            throw "Installed EXE not found to launch after $installTimeout s (NSIS silent install never produced eXeLearning.exe)."
+          # -------- Defender exclusions (best-effort) --------
+          # The 240s poll added in #1894 assumed a slow "NSIS extraction race",
+          # but the step kept failing on main *after the full timeout* - the EXE
+          # never appears at all on some runs, so the silent install is genuinely
+          # failing, not racing. The most likely cause on windows-latest is
+          # Windows Defender real-time scanning quarantining/locking the freshly
+          # extracted Electron binary mid-install, which NSIS silent mode swallows.
+          # Exclude the install/temp dirs before installing to rule it out.
+          foreach ($p in @($installDir, (Join-Path $env:LOCALAPPDATA 'Programs'), $env:TEMP, $installer.DirectoryName)) {
+            try { Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue } catch {}
           }
+          try { Add-MpPreference -ExclusionProcess 'eXeLearning.exe' -ErrorAction SilentlyContinue } catch {}
+
+          function Test-ExeInstalled {
+            param([string[]]$Paths)
+            $hit = $Paths | Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (-not $hit) {
+              $hit = Get-ChildItem -Path (Join-Path $env:LOCALAPPDATA 'Programs') -Recurse -Depth 3 `
+                       -Filter 'eXeLearning.exe' -ErrorAction SilentlyContinue |
+                     Select-Object -First 1 | ForEach-Object FullName
+            }
+            return $hit
+          }
+
+          function Invoke-SilentInstall {
+            param([string]$Installer, [string]$Dir)
+            # /S = silent (NSIS oneClick). /D=<dir> MUST be the last arg and UNQUOTED.
+            $exeArgs = "/S", "/D=$Dir"
+            Write-Host "Running installer: $Installer $($exeArgs -join ' ')"
+            $proc = Start-Process -FilePath $Installer -ArgumentList $exeArgs -Wait -NoNewWindow -PassThru
+            Write-Host "Installer exit code: $($proc.ExitCode)"
+            return $proc.ExitCode
+          }
+
+          function Wait-ForExe {
+            param([string[]]$Paths, [int]$TimeoutSec, [int]$PollSec)
+            $deadline = (Get-Date).AddSeconds($TimeoutSec)
+            do {
+              $exe = Test-ExeInstalled -Paths $Paths
+              if ($exe) { return $exe }
+              # Wait for any lingering Setup processes, then retry until the EXE
+              # shows up or we hit the install timeout.
+              Get-Process -Name '*Setup*' -ErrorAction SilentlyContinue | ForEach-Object {
+                try { $_.WaitForExit($PollSec * 1000) | Out-Null } catch {}
+              }
+              Start-Sleep -Seconds $PollSec
+            } until ((Get-Date) -ge $deadline)
+            return $null
+          }
+
+          # -------- Install (1 attempt + 1 automatic retry) --------
+          $exePath      = $null
+          $maxAttempts  = 2
+          $lastExitCode = $null
+          for ($attempt = 1; $attempt -le $maxAttempts -and -not $exePath; $attempt++) {
+            Write-Host "=== Install attempt $attempt of $maxAttempts ==="
+
+            $lastExitCode = Invoke-SilentInstall -Installer $installer.FullName -Dir $installDir
+
+            # Neutralize runAfterFinish:true - kill any app the installer auto-launched
+            # (CI-only; package.json keeps runAfterFinish for the shipped installer).
+            Get-Process -Name 'eXeLearning' -ErrorAction SilentlyContinue |
+              ForEach-Object { try { $_.Kill() } catch {} }
+
+            $exePath = Wait-ForExe -Paths $candidatePaths -TimeoutSec $installTimeout -PollSec $installPoll
+            if (-not $exePath) {
+              Write-Warning "Attempt $attempt produced no eXeLearning.exe (installer exit=$lastExitCode)."
+            }
+          }
+
+          # -------- Diagnostics dump on total failure (best-effort, never throws) --------
+          if (-not $exePath) {
+            Write-Host "##[group]Windows install failure diagnostics"
+            Write-Host "Installer: $($installer.FullName)  size=$($installer.Length)  lastExitCode=$lastExitCode"
+
+            try {
+              Write-Host "--- Recursive listing: %LOCALAPPDATA%\Programs ---"
+              Get-ChildItem -Path (Join-Path $env:LOCALAPPDATA 'Programs') -Recurse -Depth 4 -ErrorAction SilentlyContinue |
+                Select-Object FullName, Length, LastWriteTime | Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+            } catch { Write-Host "Programs listing failed: $_" }
+
+            try {
+              Write-Host "--- Top-level listing: %LOCALAPPDATA% ---"
+              Get-ChildItem -Path $env:LOCALAPPDATA -ErrorAction SilentlyContinue |
+                Select-Object Name, LastWriteTime | Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+            } catch { Write-Host "LOCALAPPDATA listing failed: $_" }
+
+            try {
+              Write-Host "--- eXeLearning* under Program Files / Program Files(x86) ---"
+              @(${env:ProgramFiles}, ${env:ProgramFiles(x86)}) | Where-Object { $_ } | ForEach-Object {
+                Get-ChildItem -Path $_ -Filter 'eXeLearning*' -ErrorAction SilentlyContinue |
+                  Select-Object FullName | Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+              }
+            } catch { Write-Host "Program Files listing failed: $_" }
+
+            try {
+              Write-Host "--- NSIS install log (if any) ---"
+              Get-ChildItem -Path $installDir -Filter '*.log' -Recurse -ErrorAction SilentlyContinue |
+                ForEach-Object { Write-Host "### $($_.FullName)"; Get-Content $_.FullName -Tail 200 -ErrorAction SilentlyContinue }
+            } catch { Write-Host "NSIS log read failed: $_" }
+
+            try {
+              Write-Host "--- Running processes matching eXeLearning|Setup ---"
+              Get-Process -ErrorAction SilentlyContinue |
+                Where-Object { $_.ProcessName -match 'eXeLearning|Setup' } |
+                Select-Object Id, ProcessName, StartTime | Format-Table -AutoSize | Out-String -Width 4096 | Write-Host
+            } catch { Write-Host "Process listing failed: $_" }
+
+            try {
+              Write-Host "--- Windows Defender threat detections ---"
+              Get-MpThreatDetection -ErrorAction SilentlyContinue |
+                Select-Object ThreatID, ActionSuccess, InitialDetectionTime, Resources |
+                Format-List | Out-String -Width 4096 | Write-Host
+            } catch { Write-Host "Get-MpThreatDetection failed: $_" }
+
+            try {
+              Write-Host "--- Defender Operational event log (last 25) ---"
+              Get-WinEvent -FilterHashtable @{
+                LogName = 'Microsoft-Windows-Windows Defender/Operational'
+              } -MaxEvents 25 -ErrorAction SilentlyContinue |
+                Select-Object TimeCreated, Id, LevelDisplayName, Message |
+                Format-List | Out-String -Width 4096 | Write-Host
+            } catch { Write-Host "Get-WinEvent (Defender) failed: $_" }
+
+            Write-Host "##[endgroup]"
+            throw "Installed EXE not found after $maxAttempts attempt(s); install timeout ${installTimeout}s each. Last installer exit code: $lastExitCode. See diagnostics above."
+          }
+
           Write-Host "Found installed EXE: $exePath"
 
           # -------- Launch with deterministic env for CI --------


### PR DESCRIPTION
## Follow-up to #1894

#1894 tried to stop the flaky Windows `test-install` step by adding a **240s poll**
for the installed `eXeLearning.exe`, on the theory that electron-builder's NSIS
installer extracts the app in a child process that can outlive the launcher
(a slow "extraction race").

That hypothesis turned out to be wrong — or at least incomplete. After #1894
merged, the step **still failed on `main`**, and now it fails *after the full
240s elapse* (job ~4m17s):

```
Installed EXE not found to launch after 240 s (NSIS silent install never produced eXeLearning.exe).
```

A full 240s timeout means the EXE **never appears at all** on those runs — the
silent install is genuinely **failing**, not racing. And the step captured zero
signal about why: the installer's exit code was discarded (`Start-Process -Wait`
without `-PassThru`) and nothing was dumped on failure, so every failure looked
like a blind timeout.

Flake rate on `main`: ~10% (26 success / 3 failure over the last 30 runs).

## Most likely root cause

On `windows-latest`, **Windows Defender** real-time scanning quarantines/locks
the freshly extracted Electron binary mid-install — the classic Electron-on-CI
flake. NSIS silent mode swallows the resulting file-copy error, leaving no EXE.

## Changes

Hardens only the Windows install portion of the `Test install on Windows
(deterministic)` step:

- **Capture the installer exit code** — `Start-Process … -PassThru`, logged.
- **Windows Defender exclusions** for the install dir + temp **before**
  installing (best-effort, `try/catch`) to rule out the AV quarantine.
- **Force the install dir** with NSIS `/D=` for a deterministic location.
- **One automatic retry** of the whole install if the first attempt produces no
  EXE.
- **Kill any app auto-launched** by `runAfterFinish:true` between attempts
  (CI-only; `package.json` keeps `runAfterFinish` so shipped installs still
  auto-open).
- **Rich diagnostics on total failure** (best-effort, never throws): recursive
  listing of `%LOCALAPPDATA%\Programs`, `eXeLearning*` under Program Files,
  any NSIS log, processes matching `eXeLearning|Setup`, `Get-MpThreatDetection`
  and the Defender Operational event log — so the next failure is debuggable
  instead of a blind timeout.

No `package.json` / build-config change. The Windows test stays a **required**
check on `main` (the `fail-fast: false` from #1894 is preserved, so a flake on
one OS still doesn't cancel the others).

## Notes

- `/D=` is passed last and unquoted (NSIS requirement); the install path has no
  spaces. `Add-MpPreference` needs admin + the Defender module, both present on
  `windows-latest` today, and is wrapped in `try/catch` so a restricted future
  image degrades gracefully.
- Worst case before failing is now 2 × `INSTALL_POLL_TIMEOUT`; if the Defender
  exclusion proves to be the fix, `INSTALL_POLL_TIMEOUT` (currently 240s) can be
  lowered in a follow-up since a successful install lands the EXE within seconds.

## Verification

- `workflow_dispatch` run on this branch with `test-install (windows-latest)`
  green; log shows `Installer exit code: …` and `Found installed EXE: …`.
- Other OS matrix legs unaffected.
