### PR TITLE
Fixes #1911 - "Creado con eXeLearning" always in Spanish

### DIFF
--- a/src/cli/commands/translations-format.spec.ts
+++ b/src/cli/commands/translations-format.spec.ts
@@ -34,6 +34,66 @@ function makeXlf(targetLang: string, units: { id: string; resname: string; sourc
 }
 
 // ---------------------------------------------------------------------------
+// Unit tests — fixAttributeQuotes
+// ---------------------------------------------------------------------------
+
+describe('fixAttributeQuotes', () => {
+    let fixAttributeQuotes: (content: string) => string;
+
+    beforeEach(async () => {
+        ({ fixAttributeQuotes } = await import('./translations-format'));
+    });
+
+    it('replaces left/right curly double-quote attribute delimiters with straight quotes', () => {
+        const input = '      <trans-unit id=“MwExe01” resname=“Made with eXeLearning”>';
+        const expected = '      <trans-unit id="MwExe01" resname="Made with eXeLearning">';
+        expect(fixAttributeQuotes(input)).toBe(expected);
+    });
+
+    it('leaves straight-quote attributes unchanged', () => {
+        const input = '      <trans-unit id="safe" resname="Also safe">';
+        expect(fixAttributeQuotes(input)).toBe(input);
+    });
+
+    it('does not touch curly quotes inside element text content (e.g. Romanian typography)', () => {
+        // Romanian uses „ (U+201E) as opening quote — different character, not affected
+        const input = '        <target>Faceți clic pe „Salvează” pentru a salva.</target>';
+        expect(fixAttributeQuotes(input)).toBe(input);
+    });
+
+    it('handles multiple attributes with curly quotes on the same line', () => {
+        const input = '<file source-language=“en” target-language=“ro” datatype=“plaintext”>';
+        const expected = '<file source-language="en" target-language="ro" datatype="plaintext">';
+        expect(fixAttributeQuotes(input)).toBe(expected);
+    });
+
+    it('replaces U+201D used as both opening and closing delimiter (real-world ro.xlf case)', () => {
+        // messages.ro.xlf uses U+201D (“) for both opening and closing attr delimiters.
+        // String.fromCharCode() is used for all special chars to prevent editor conversion.
+        const U201D = String.fromCharCode(0x201d);
+        const Q = String.fromCharCode(0x22); // straight double quote
+        const input = `      <trans-unit id=${U201D}MwExe01${U201D} resname=${U201D}Made with eXeLearning${U201D}>`;
+        const expected = `      <trans-unit id=${Q}MwExe01${Q} resname=${Q}Made with eXeLearning${Q}>`;
+        expect(fixAttributeQuotes(input)).toBe(expected);
+    });
+
+    it('is idempotent — running twice produces the same output', () => {
+        const U = String.fromCharCode(0x201c);
+        const input = `      <trans-unit id=${U}MwExe01${String.fromCharCode(0x201d)} resname=${U}Made with eXeLearning${String.fromCharCode(0x201d)}>`;
+        const once = fixAttributeQuotes(input);
+        const twice = fixAttributeQuotes(once);
+        expect(twice).toBe(once);
+    });
+
+    it('preserves attribute values that contain curly quotes as typographic content', () => {
+        // A resname whose value uses curly quotes as part of the text
+        // (the value is delimited by straight quotes, so this is untouched)
+        const input = '      <trans-unit id="abc" resname="Click “OK” button">';
+        expect(fixAttributeQuotes(input)).toBe(input);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Unit tests — needsCDATA
 // ---------------------------------------------------------------------------
 
@@ -417,6 +477,50 @@ describe('runMain', () => {
 // ---------------------------------------------------------------------------
 // Unit tests — formatXlfContent edge cases
 // ---------------------------------------------------------------------------
+
+describe('formatXlfContent — curly-quote attribute fix', () => {
+    let formatXlfContent: (content: string) => string;
+
+    beforeEach(async () => {
+        ({ formatXlfContent } = await import('./translations-format'));
+    });
+
+    it('fixes curly-quote attribute delimiters in a trans-unit opening tag', () => {
+        const content =
+            `<?xml version="1.0" encoding="utf-8"?>\n` +
+            `<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">\n` +
+            `  <file source-language="en" target-language="ro">\n` +
+            `    <body>\n` +
+            `      <trans-unit id="MwExe01" resname="Made with eXeLearning">\n` +
+            `        <source>Made with eXeLearning</source>\n` +
+            `        <target>Realizat cu eXeLearning</target>\n` +
+            `      </trans-unit>\n` +
+            `    </body>\n` +
+            `  </file>\n` +
+            `</xliff>`;
+        const result = formatXlfContent(content);
+        expect(result).toContain('id="MwExe01"');
+        expect(result).toContain('resname="Made with eXeLearning"');
+        expect(result).not.toContain('id=“MwExe01”');
+        expect(result).not.toContain('resname=“Made with eXeLearning”');
+    });
+
+    it('preserves Romanian typographic quotes inside target content', () => {
+        const content =
+            `<?xml version="1.0"?>\n` +
+            `<xliff>\n` +
+            `    <body>\n` +
+            `      <trans-unit id="x" resname="y">\n` +
+            `        <source>y</source>\n` +
+            `        <target>Faceți clic pe „Salvează”.</target>\n` +
+            `      </trans-unit>\n` +
+            `    </body>\n` +
+            `</xliff>`;
+        const result = formatXlfContent(content);
+        // Romanian „ (U+201E) + " (U+201D) inside target must be untouched
+        expect(result).toContain('„Salvează”');
+    });
+});
 
 describe('formatXlfContent — edge cases', () => {
     let formatXlfContent: (content: string) => string;

--- a/src/cli/commands/translations-format.ts
+++ b/src/cli/commands/translations-format.ts
@@ -1,6 +1,8 @@
 /**
  * Translations Format Command
  * Normalizes XLF translation files:
+ *   - Fixes curly/smart quote characters used as XML attribute delimiters
+ *     (e.g. id="…" → id="…").
  *   - Wraps <target> content in <![CDATA[...]]> when the text contains characters
  *     that are invalid as raw XML (unrecognised entity references or bare `<`).
  *   - Normalises indentation: 6 spaces before <trans-unit>, 8 spaces before
@@ -92,11 +94,40 @@ export function formatTargetContent(rawContent: string): string {
 }
 
 /**
+ * Replaces curly/smart quote characters used as XML attribute delimiters with
+ * straight ASCII double quotes. Attribute values are preserved verbatim.
+ *
+ * Curly quotes inside element text content (e.g. the body of a `<target>`) are
+ * intentional typographic choices (common in Romanian „…", German „…", etc.)
+ * and are not affected: Romanian content uses U+201E „ as opening, whereas the
+ * broken attribute delimiter is always U+201C " (left double quotation mark).
+ */
+export function fixAttributeQuotes(content: string): string {
+    // Curly/smart double-quote variants sometimes misused as XML attribute delimiters:
+    //   U+201C left double quotation mark
+    //   U+201D right double quotation mark
+    //   U+201E double low-9 quotation mark
+    // String.fromCharCode() is used for all special characters to prevent editors
+    // from silently normalising character literals to unexpected codepoints.
+    //
+    // The `=` prefix makes the pattern unambiguous: identical characters inside
+    // element text content are not preceded by `=` and are therefore not touched
+    // (e.g. Romanian and German typographic quotes inside <target>).
+    const CURLY = String.fromCharCode(0x201c, 0x201d, 0x201e);
+    const Q = String.fromCharCode(0x22); // ASCII straight double quote
+    const re = new RegExp(`=[${CURLY}]([^${CURLY}\\r\\n]*)[${CURLY}]`, 'g');
+    return content.replace(re, (_: string, val: string) => `=${Q}${val}${Q}`);
+}
+
+/**
  * Apply formatting to the full content of an XLF file.
  *
- * Two independent passes — neither ever parses or reconstructs attribute values
- * from `<trans-unit>` opening tags, so those are guaranteed to be preserved
- * exactly as-is:
+ * Three independent passes — none ever reconstructs attribute values from
+ * scratch, so all attribute content is guaranteed to be preserved exactly:
+ *
+ *   Pass 0 — Attribute quote fix:
+ *     · Replaces curly/smart quotes used as XML attribute delimiters with
+ *       straight ASCII double quotes.
  *
  *   Pass 1 — Indentation (line-by-line, no attribute parsing):
  *     · `<trans-unit …>` and `</trans-unit>` lines → 6 leading spaces
@@ -111,8 +142,11 @@ export function formatXlfContent(content: string): string {
     // Detect original line-ending style so we can preserve it.
     const eol = content.includes('\r\n') ? '\r\n' : '\n';
 
+    // Pass 0: fix curly/smart quote characters used as XML attribute delimiters.
+    const withFixedQuotes = fixAttributeQuotes(content);
+
     // Pass 1: reindent line by line.
-    const lines = content.split(/\r?\n/);
+    const lines = withFixedQuotes.split(/\r?\n/);
     const reindented = lines
         .map(line => {
             // <trans-unit …> opening tag — only strip/add leading whitespace;
@@ -212,11 +246,13 @@ ${colors.cyan('Options:')}
 
 ${colors.cyan('What it does:')}
   1. Reads each target-language XLF file in translations/.
-  2. Wraps any <target> element whose text contains characters invalid as raw
+  2. Fixes curly/smart quote characters used as XML attribute delimiters:
+       id=“MwExe01”  →  id="MwExe01"
+  3. Wraps any <target> element whose text contains characters invalid as raw
      XML (e.g. &percnt;, bare <) inside a CDATA section:
        <target><![CDATA[...]]></target>
-  3. Leaves already-wrapped CDATA sections and valid plain-text targets untouched.
-  4. Normalises indentation: 6 spaces before <trans-unit>, 8 spaces before
+  4. Leaves already-wrapped CDATA sections and valid plain-text targets untouched.
+  5. Normalises indentation: 6 spaces before <trans-unit>, 8 spaces before
      <source> and <target>.
 
 ${colors.cyan('Available Locales:')}

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -154,7 +154,15 @@ export abstract class BaseExporter {
     protected async fetchNavLabels(
         language: string,
         license?: string,
-    ): Promise<{ previous: string; next: string; page: string; license?: string }> {
+    ): Promise<{
+        previous: string;
+        next: string;
+        page: string;
+        license?: string;
+        licenseLabel: string;
+        madeWith: string;
+        newWindow: string;
+    }> {
         const translations = await this.resources.fetchI18nTranslations(language);
         let translatedLicense = license;
 
@@ -168,6 +176,9 @@ export abstract class BaseExporter {
             next: translations.get('Next') || 'Next',
             page: translations.get('Page') || 'Page',
             license: translatedLicense,
+            licenseLabel: translations.get('License') || 'License',
+            madeWith: translations.get('Made with eXeLearning') || 'Made with eXeLearning',
+            newWindow: translations.get('New window') || 'New window',
         };
     }
 

--- a/src/shared/export/interfaces.ts
+++ b/src/shared/export/interfaces.ts
@@ -644,7 +644,15 @@ export interface PageRenderOptions {
     isEpub?: boolean;
 
     /** Translated labels for navigation buttons (resolved at export time from XLF) */
-    navLabels?: { previous: string; next: string; page: string; license?: string };
+    navLabels?: {
+        previous: string;
+        next: string;
+        page: string;
+        license?: string;
+        licenseLabel?: string;
+        madeWith?: string;
+        newWindow?: string;
+    };
 
     // Detected library names from content scanning (MathJax, Mermaid, etc.)
     detectedLibraries?: string[];

--- a/src/shared/export/renderers/PageRenderer.spec.ts
+++ b/src/shared/export/renderers/PageRenderer.spec.ts
@@ -589,7 +589,7 @@ describe('PageRenderer', () => {
     });
 
     describe('renderFooterSection', () => {
-        it('should render footer with license', () => {
+        it('should render footer with license using English label by default', () => {
             const html = renderer.renderFooterSection({
                 license: 'creative commons: attribution - share alike 4.0',
                 licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
@@ -598,10 +598,20 @@ describe('PageRenderer', () => {
             expect(html).toContain('<footer id="siteFooter">');
             expect(html).toContain('<div id="siteFooterContent">');
             expect(html).toContain('id="packageLicense"');
-            expect(html).toContain('class="license-label">Licencia: </span>');
+            expect(html).toContain('class="license-label">License: </span>');
             // formatLicenseText returns the lowercase key for CC licenses (used as translation key)
             expect(html).toContain('class="license">creative commons: attribution - share alike 4.0</a>');
             expect(html).toContain('href="https://creativecommons.org/licenses/by-sa/4.0/"');
+        });
+
+        it('should use navLabels.licenseLabel when provided', () => {
+            const html = renderer.renderFooterSection({
+                license: 'creative commons: attribution - share alike 4.0',
+                licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+                navLabels: { licenseLabel: 'Licencia' },
+            });
+
+            expect(html).toContain('class="license-label">Licencia: </span>');
         });
 
         it('should render correct license class for different licenses', () => {
@@ -699,14 +709,33 @@ describe('PageRenderer', () => {
     });
 
     describe('renderMadeWithEXe', () => {
-        it('should render made-with-eXe credit', () => {
+        it('should render made-with-eXe credit with English defaults', () => {
             const html = renderer.renderMadeWithEXe();
 
             expect(html).toContain('id="made-with-eXe"');
             expect(html).toContain('href="https://exelearning.net/"');
-            expect(html).toContain('Creado con eXeLearning');
+            expect(html).toContain('Made with eXeLearning');
+            expect(html).toContain('(New window)');
             expect(html).toContain('target="_blank"');
             expect(html).toContain('rel="noopener"');
+        });
+
+        it('should use navLabels translations when provided', () => {
+            const html = renderer.renderMadeWithEXe('es', {
+                madeWith: 'Creado con eXeLearning',
+                newWindow: 'Ventana nueva',
+            });
+
+            expect(html).toContain('Creado con eXeLearning');
+            expect(html).toContain('(Ventana nueva)');
+            expect(html).not.toContain('Made with eXeLearning');
+        });
+
+        it('should use trans() fallback when navLabels are not provided', () => {
+            const html = renderer.renderMadeWithEXe('en');
+
+            expect(html).toContain('Made with eXeLearning');
+            expect(html).toContain('(New window)');
         });
     });
 

--- a/src/shared/export/renderers/PageRenderer.ts
+++ b/src/shared/export/renderers/PageRenderer.ts
@@ -160,7 +160,7 @@ export class PageRenderer {
             : '';
 
         // Build "Made with eXeLearning" link (only if enabled)
-        const madeWithExeHtml = addExeLink ? this.renderMadeWithEXe() : '';
+        const madeWithExeHtml = addExeLink ? this.renderMadeWithEXe(language, options.navLabels) : '';
 
         // Extract page filename map for navigation links (handles title collisions)
         const pageFilenameMap = options.pageFilenameMap;
@@ -820,7 +820,7 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         licenseUrl?: string;
         userFooterContent?: string;
         language?: string;
-        navLabels?: { license?: string };
+        navLabels?: { license?: string; licenseLabel?: string };
     }): string {
         const { license, licenseUrl = '', userFooterContent, language = 'en', navLabels } = options;
 
@@ -839,23 +839,28 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         const licenseText = formatLicenseText(license);
         const translatedLicenseText = navLabels?.license || trans(licenseText, {}, language);
         const licenseClass = getLicenseClass(license);
+        const licenseLabel = navLabels?.licenseLabel || trans('License', {}, language);
 
         // If there's a license URL, create a link; otherwise, just show the text
         const licenseContent = licenseUrl
             ? `<a href="${licenseUrl}" class="license">${translatedLicenseText}</a>`
             : `<span class="license">${translatedLicenseText}</span>`;
 
-        return `<footer id="siteFooter"><div id="siteFooterContent"> <div id="packageLicense" class="${licenseClass}"> <p> <span class="license-label">Licencia: </span>${licenseContent}</p>
+        return `<footer id="siteFooter"><div id="siteFooterContent"> <div id="packageLicense" class="${licenseClass}"> <p> <span class="license-label">${licenseLabel}: </span>${licenseContent}</p>
 </div>
 ${userFooterHtml}</div></footer>`;
     }
 
     /**
-     * Render "Made with eXeLearning" credit
+     * Render "Made with eXeLearning" credit in the document language.
+     * @param language - Document language code (e.g. 'es', 'en')
+     * @param navLabels - Pre-translated labels (browser-side exports supply these via fetchNavLabels)
      * @returns Made with eXe HTML
      */
-    renderMadeWithEXe(): string {
-        return `<p id="made-with-eXe"> <a href="https://exelearning.net/" target="_blank" rel="noopener"> <span>Creado con eXeLearning <span>(nueva ventana)</span></span></a></p>`;
+    renderMadeWithEXe(language: string = 'en', navLabels?: { madeWith?: string; newWindow?: string }): string {
+        const madeWithText = navLabels?.madeWith || trans('Made with eXeLearning', {}, language);
+        const newWindowText = navLabels?.newWindow || trans('New window', {}, language);
+        return `<p id="made-with-eXe"> <a href="https://exelearning.net/" target="_blank" rel="noopener"> <span>${madeWithText} <span>(${newWindowText})</span></span></a></p>`;
     }
 
     /**
@@ -1096,9 +1101,9 @@ ${addMathJax ? `<script src="libs/exe_math/tex-mml-svg.js"> </script>` : ''}
 <header class="package-header"><p class="package-title">${this.escapeHtml(projectTitle)}</p>${projectSubtitle ? `\n<p class="package-subtitle">${this.escapeHtml(projectSubtitle)}</p>` : ''}</header>
 ${contentHtml}
 </main>
-${this.renderFooterSection({ license, licenseUrl, userFooterContent, navLabels })}
+${this.renderFooterSection({ license, licenseUrl, userFooterContent, language, navLabels })}
 </div>
-${addExeLink ? this.renderMadeWithEXe() : ''}
+${addExeLink ? this.renderMadeWithEXe(language, navLabels) : ''}
 </body>
 </html>`;
     }

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -10929,6 +10929,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Ajudeu-nos a difondre eXeLearning. En seleccionar aquesta opció, s'afegirà  l'enllaç "Creat amb eXeLearning" a les vostres pàgines.</target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>Creat amb eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>Comptador de pàgines</target>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -10927,11 +10927,15 @@
       </trans-unit>
       <trans-unit id="H3EiJ5m" resname="&quot;Made with eXeLearning&quot; link">
         <source>"Made with eXeLearning" link</source>
-        <target>~"Mit eXeLearning erstellt" Link</target>
+        <target>~"Erstellt mit eXeLearning" Link</target>
       </trans-unit>
       <trans-unit id="OToz6k0" resname="Help us spreading eXeLearning. Checking this option, a &quot;Made with eXeLearning&quot; link will be displayed in your pages.">
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>~Helfen Sie uns, eXeLearning zu verbreiten. Wenn Sie diese Option aktivieren, wird in Ihren Seiten ein Link "Mit eXeLearning erstellt" angezeigt.</target>
+      </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>~Erstellt mit eXeLearning</target>
       </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -10933,6 +10933,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target></target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target></target>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -10929,6 +10929,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>~Helpu nin disvastigi eXeLearning. Se vi markos ĉi tiun opcion, "Farita kun eXeLearning" ligilo aperos en viaj paĝoj.</target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>~Farita kun eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>~Paĝa kalkulilo</target>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -10933,6 +10933,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Ayúdanos a difundir eXeLearning. Si marcas esta opción se incluirá un "Hecho con eXeLearning" en tus páginas.</target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>Creado con eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>Contador de páginas</target>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -10923,11 +10923,15 @@
       </trans-unit>
       <trans-unit id="H3EiJ5m" resname="&quot;Made with eXeLearning&quot; link">
         <source>"Made with eXeLearning" link</source>
-        <target>"eXeLearning-ekin egidako" esteka</target>
+        <target>"eXeLearning-ekin egina" esteka</target>
       </trans-unit>
       <trans-unit id="OToz6k0" resname="Help us spreading eXeLearning. Checking this option, a &quot;Made with eXeLearning&quot; link will be displayed in your pages.">
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Lagundu eXeLearning zabaltzen. Aukera hau markatuz gero, "eXeLearning-ekin egidako" esteka agertuko da zure orrietan.</target>
+      </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>eXeLearning-ekin egina</target>
       </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -4951,7 +4951,7 @@
       </trans-unit>
       <trans-unit id="uNPuyer" resname="Click here to toggle between Word starts with... and Word contains...">
         <source>Click here to toggle between Word starts with... and Word contains...</source>
-        <target>Preme aquí para alternar entre "Palabra que comeza con..." e "Palabra que contén...”</target>
+        <target>Preme aquí para alternar entre "Palabra que comeza con..." e "Palabra que contén..."</target>
       </trans-unit>
       <trans-unit id="ronRdQx" resname="The word starts with...">
         <source>The word starts with...</source>
@@ -10923,11 +10923,15 @@
       </trans-unit>
       <trans-unit id="H3EiJ5m" resname="&quot;Made with eXeLearning&quot; link">
         <source>"Made with eXeLearning" link</source>
-        <target>Ligazón "Feito con eXeLearning”</target>
+        <target>Ligazón "Feito con eXeLearning"</target>
       </trans-unit>
       <trans-unit id="OToz6k0" resname="Help us spreading eXeLearning. Checking this option, a &quot;Made with eXeLearning&quot; link will be displayed in your pages.">
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Axúdanos a difundir eXeLearning. Ao marcar esta opción, amosarase unha ligazón "Feito con eXeLearning" nas túas páxinas.</target>
+      </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>Feito con eXeLearning</target>
       </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -10933,6 +10933,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Includere una copia del file sorgente</target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>Realizzato con eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>Contatore di pagine</target>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -10929,6 +10929,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>~Ajude a divulgar o eXeLearning. Ao marcar esta opção, um link "Feito com eXeLearning" será exibido em suas páginas.  </target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>~Feito com eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>~Contador de páginas  </target>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -10929,7 +10929,11 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Ajută-ne să răspândim eXeLearning. Bifând această opțiune, va fi afișat un link „Realizat cu eXeLearning” pe paginile tale.</target>
       </trans-unit>
-      <trans-unit id="AK7eXCi" resname="Page counter">
+      <trans-unit id=”MwExe01” resname=”Made with eXeLearning”>
+        <source>Made with eXeLearning</source>
+        <target>Realizat cu eXeLearning</target>
+      </trans-unit>
+      <trans-unit id=”AK7eXCi” resname=”Page counter”>
         <source>Page counter</source>
         <target>Contor de pagini</target>
       </trans-unit>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -10929,11 +10929,11 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Ajută-ne să răspândim eXeLearning. Bifând această opțiune, va fi afișat un link „Realizat cu eXeLearning” pe paginile tale.</target>
       </trans-unit>
-      <trans-unit id=”MwExe01” resname=”Made with eXeLearning”>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
         <source>Made with eXeLearning</source>
         <target>Realizat cu eXeLearning</target>
       </trans-unit>
-      <trans-unit id=”AK7eXCi” resname=”Page counter”>
+      <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>Contor de pagini</target>
       </trans-unit>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -10929,6 +10929,10 @@
         <source>Help us spreading eXeLearning. Checking this option, a "Made with eXeLearning" link will be displayed in your pages.</source>
         <target>Ajuda'ns a difondre eXeLearning. En seleccionar aquesta opció, s'afegirà un enllaç "Creat amb eXeLearning" a les teues pàgines.</target>
       </trans-unit>
+      <trans-unit id="MwExe01" resname="Made with eXeLearning">
+        <source>Made with eXeLearning</source>
+        <target>Creat amb eXeLearning</target>
+      </trans-unit>
       <trans-unit id="AK7eXCi" resname="Page counter">
         <source>Page counter</source>
         <target>Comptador de pàgines</target>


### PR DESCRIPTION
The “Made with eXeLearning” link was always in Spanish ("Creado con eXeLearning") because it was hardcoded in `src/shared/export/renderers/PageRenderer.ts`. 

It is now displayed in the content language (not necessarily the application language).
