### PR TITLE
feat(mermaid): Allow setting maximum Mermaid diagram width/height

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "mime-types": "^3.0.2",
         "mysql2": "^3.18.2",
         "nunjucks": "^3.2.4",
-        "pdfjs-dist": "5.7.284",
+        "pdfjs-dist": "6.0.227",
         "uuid": "^14.0.0",
         "ws": "^8.19.0",
         "y-websocket": "^3.0.0",
@@ -461,29 +461,29 @@
 
     "@messageformat/runtime": ["@messageformat/runtime@3.0.2", "", { "dependencies": { "make-plural": "^7.0.0" } }, "sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw=="],
 
-    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
+    "@napi-rs/canvas": ["@napi-rs/canvas@1.0.0", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.0", "@napi-rs/canvas-darwin-arm64": "1.0.0", "@napi-rs/canvas-darwin-x64": "1.0.0", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0", "@napi-rs/canvas-linux-arm64-gnu": "1.0.0", "@napi-rs/canvas-linux-arm64-musl": "1.0.0", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-gnu": "1.0.0", "@napi-rs/canvas-linux-x64-musl": "1.0.0", "@napi-rs/canvas-win32-arm64-msvc": "1.0.0", "@napi-rs/canvas-win32-x64-msvc": "1.0.0" } }, "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg=="],
 
-    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw=="],
 
-    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA=="],
 
-    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@1.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ=="],
 
-    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@1.0.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA=="],
 
-    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA=="],
 
-    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg=="],
 
-    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@1.0.0", "", { "os": "linux", "cpu": "none" }, "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA=="],
 
-    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA=="],
 
-    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA=="],
 
-    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@1.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ=="],
 
-    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -1529,7 +1529,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pdfjs-dist": ["pdfjs-dist@5.7.284", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.100" } }, "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw=="],
+    "pdfjs-dist": ["pdfjs-dist@6.0.227", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg=="],
 
     "pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -33,9 +33,12 @@ window.UnsavedChangesHelper = UnsavedChangesHelper;
 import BlobPasteGuard from './common/blobPasteGuard.js';
 // Drag-and-drop to open project files
 import FileDropHandler from './common/fileDropHandler.js';
+// Mermaid max-size utilities — exposed on window.eXeLearning for TinyMCE plugins
+import * as mermaidMaxSize from './common/mermaidMaxSize.js';
 
 export default class App {
     constructor(eXeLearning) {
+        eXeLearning.mermaidMaxSize = mermaidMaxSize;
         this.eXeLearning = eXeLearning;
         this.parseExelearningConfig();
 

--- a/public/app/common/mermaidMaxSize.js
+++ b/public/app/common/mermaidMaxSize.js
@@ -1,0 +1,50 @@
+/**
+ * Utility functions for Mermaid diagram max-width / max-height handling.
+ *
+ * Consumed by the exemermaid TinyMCE plugin via window.eXeLearning.mermaidMaxSize,
+ * which is set up by the App constructor before any editor is opened.
+ */
+
+export function normalizeDimension(value) {
+    if (typeof value !== 'string') return '';
+    return value.trim();
+}
+
+export function isValidDimension(value) {
+    if (value === '') return true;
+    const matches = /^(\d+(?:\.\d+)?)(px|em|rem|%)$/i.exec(value);
+    if (!matches) return false;
+    return Number(matches[1]) > 0;
+}
+
+export function getStyleValue(value) {
+    const normalized = normalizeDimension(value);
+    return isValidDimension(normalized) ? normalized : '';
+}
+
+export function buildMaxSizeStyle(maxWidth, maxHeight) {
+    const styles = [];
+    const safeMaxWidth = getStyleValue(maxWidth);
+    const safeMaxHeight = getStyleValue(maxHeight);
+    if (safeMaxWidth !== '') styles.push('max-width:' + safeMaxWidth);
+    if (safeMaxHeight !== '') styles.push('max-height:' + safeMaxHeight);
+    return styles.join(';');
+}
+
+export function validateMaxSizeFields(maxWidth, maxHeight) {
+    const normalizedMaxWidth = normalizeDimension(maxWidth);
+    const normalizedMaxHeight = normalizeDimension(maxHeight);
+    const errors = [];
+    if (normalizedMaxWidth !== '' && !isValidDimension(normalizedMaxWidth)) {
+        errors.push('invalid-max-width');
+    }
+    if (normalizedMaxHeight !== '' && !isValidDimension(normalizedMaxHeight)) {
+        errors.push('invalid-max-height');
+    }
+    return {
+        isValid: errors.length === 0,
+        errors,
+        maxWidth: normalizedMaxWidth,
+        maxHeight: normalizedMaxHeight,
+    };
+}

--- a/public/app/common/mermaidMaxSize.test.js
+++ b/public/app/common/mermaidMaxSize.test.js
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for Mermaid max-size utility functions.
+ */
+import {
+    normalizeDimension,
+    isValidDimension,
+    getStyleValue,
+    buildMaxSizeStyle,
+    validateMaxSizeFields,
+} from './mermaidMaxSize.js';
+
+describe('normalizeDimension', () => {
+    it('trims leading and trailing whitespace', () => {
+        expect(normalizeDimension(' 800px ')).toBe('800px');
+        expect(normalizeDimension('  40em  ')).toBe('40em');
+    });
+
+    it('returns empty string for non-string input', () => {
+        expect(normalizeDimension(null)).toBe('');
+        expect(normalizeDimension(undefined)).toBe('');
+        expect(normalizeDimension(800)).toBe('');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(normalizeDimension('')).toBe('');
+    });
+
+    it('leaves already-trimmed values unchanged', () => {
+        expect(normalizeDimension('50%')).toBe('50%');
+    });
+});
+
+describe('isValidDimension', () => {
+    it('accepts empty string (optional field)', () => {
+        expect(isValidDimension('')).toBe(true);
+    });
+
+    it('accepts valid px value', () => {
+        expect(isValidDimension('800px')).toBe(true);
+    });
+
+    it('accepts valid percentage value', () => {
+        expect(isValidDimension('50%')).toBe(true);
+    });
+
+    it('accepts valid em value', () => {
+        expect(isValidDimension('40em')).toBe(true);
+    });
+
+    it('accepts valid rem value', () => {
+        expect(isValidDimension('30rem')).toBe(true);
+    });
+
+    it('accepts decimal values', () => {
+        expect(isValidDimension('12.5em')).toBe(true);
+        expect(isValidDimension('33.3%')).toBe(true);
+    });
+
+    it('rejects zero values', () => {
+        expect(isValidDimension('0px')).toBe(false);
+        expect(isValidDimension('0.0em')).toBe(false);
+        expect(isValidDimension('0%')).toBe(false);
+    });
+
+    it('rejects unsupported units', () => {
+        expect(isValidDimension('200vh')).toBe(false);
+        expect(isValidDimension('100vw')).toBe(false);
+        expect(isValidDimension('50dvw')).toBe(false);
+    });
+
+    it('rejects bare numbers without units', () => {
+        expect(isValidDimension('800')).toBe(false);
+    });
+
+    it('rejects CSS injection attempts', () => {
+        expect(isValidDimension('800px;color:red')).toBe(false);
+    });
+});
+
+describe('getStyleValue', () => {
+    it('returns normalized value for valid input', () => {
+        expect(getStyleValue(' 800px ')).toBe('800px');
+        expect(getStyleValue('50%')).toBe('50%');
+    });
+
+    it('returns empty string for invalid input', () => {
+        expect(getStyleValue('800')).toBe('');
+        expect(getStyleValue('200vh')).toBe('');
+        expect(getStyleValue('0px')).toBe('');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(getStyleValue('')).toBe('');
+    });
+});
+
+describe('buildMaxSizeStyle', () => {
+    it('generates both max-width and max-height', () => {
+        expect(buildMaxSizeStyle('800px', '60%')).toBe('max-width:800px;max-height:60%');
+    });
+
+    it('supports em units', () => {
+        expect(buildMaxSizeStyle('40em', '25em')).toBe('max-width:40em;max-height:25em');
+    });
+
+    it('supports rem units', () => {
+        expect(buildMaxSizeStyle('30rem', '20rem')).toBe('max-width:30rem;max-height:20rem');
+    });
+
+    it('trims values before generating style', () => {
+        expect(buildMaxSizeStyle(' 800px ', ' 60% ')).toBe('max-width:800px;max-height:60%');
+    });
+
+    it('ignores invalid units', () => {
+        expect(buildMaxSizeStyle('800', '200vh')).toBe('');
+    });
+
+    it('ignores CSS injection attempts', () => {
+        expect(buildMaxSizeStyle('800px;color:red', '50%')).toBe('max-height:50%');
+    });
+
+    it('allows decimal values', () => {
+        expect(buildMaxSizeStyle('12.5em', '33.3%')).toBe('max-width:12.5em;max-height:33.3%');
+    });
+
+    it('returns only max-width when max-height is empty', () => {
+        expect(buildMaxSizeStyle('800px', '')).toBe('max-width:800px');
+    });
+
+    it('returns only max-height when max-width is empty', () => {
+        expect(buildMaxSizeStyle('', '60%')).toBe('max-height:60%');
+    });
+
+    it('returns empty string when both values are empty', () => {
+        expect(buildMaxSizeStyle('', '')).toBe('');
+    });
+
+    it('ignores zero values', () => {
+        expect(buildMaxSizeStyle('0px', '0%')).toBe('');
+        expect(buildMaxSizeStyle('0.0em', '50%')).toBe('max-height:50%');
+    });
+});
+
+describe('validateMaxSizeFields', () => {
+    it('accepts valid values', () => {
+        const result = validateMaxSizeFields('800px', '50%');
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    it('trims values and returns normalized result', () => {
+        const result = validateMaxSizeFields(' 40em ', ' 33.3% ');
+        expect(result.isValid).toBe(true);
+        expect(result.maxWidth).toBe('40em');
+        expect(result.maxHeight).toBe('33.3%');
+    });
+
+    it('accepts rem values', () => {
+        const result = validateMaxSizeFields('30rem', '20rem');
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    it('accepts empty values (both fields are optional)', () => {
+        const result = validateMaxSizeFields('', '');
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    it('rejects invalid max-width', () => {
+        const result = validateMaxSizeFields('800', '50%');
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('invalid-max-width');
+    });
+
+    it('rejects invalid max-height', () => {
+        const result = validateMaxSizeFields('800px', '10vh');
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('invalid-max-height');
+    });
+
+    it('rejects both invalid values', () => {
+        const result = validateMaxSizeFields('abc', 'def');
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(['invalid-max-width', 'invalid-max-height']);
+    });
+
+    it('rejects zero values', () => {
+        const result = validateMaxSizeFields('0px', '0%');
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(['invalid-max-width', 'invalid-max-height']);
+    });
+});

--- a/public/libs/tinymce_5/js/tinymce/plugins/exemermaid/plugin.min.js
+++ b/public/libs/tinymce_5/js/tinymce/plugins/exemermaid/plugin.min.js
@@ -12,6 +12,7 @@
  */
 tinymce.PluginManager.add('exemermaid', function (editor, url) {
 
+    var mms = window.eXeLearning?.mermaidMaxSize;
     let $ = tinymce.dom.DomQuery;
 
     function setHTMLAttribs() {
@@ -23,12 +24,18 @@ tinymce.PluginManager.add('exemermaid', function (editor, url) {
 
     PasteMermaidDialog = {
         actualHtmlSource: '',
+        actualMaxWidth: '',
+        actualMaxHeight: '',
         setDefaultData: function() {
             PasteMermaidDialog.actualHtmlSource = '';
+            PasteMermaidDialog.actualMaxWidth = '';
+            PasteMermaidDialog.actualMaxHeight = '';
         },
         getInitialData:function () {
             return {
-                htmlSource: PasteMermaidDialog.actualHtmlSource
+                htmlSource: PasteMermaidDialog.actualHtmlSource,
+                maxWidth: PasteMermaidDialog.actualMaxWidth,
+                maxHeight: PasteMermaidDialog.actualMaxHeight
             };
         },
         activateButton: function (node) {
@@ -42,33 +49,39 @@ tinymce.PluginManager.add('exemermaid', function (editor, url) {
 
             this.initialValue = v;
             this.isUpdating = false;
+            PasteMermaidDialog.actualMaxWidth = '';
+            PasteMermaidDialog.actualMaxHeight = '';
 
             if (node.nodeName === "PRE") {
                 var c = node.innerHTML;
                 c = c.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
                 v = c;
                 this.isUpdating = true;
+                PasteMermaidDialog.actualMaxWidth = mms.normalizeDimension(node.style.maxWidth || '');
+                PasteMermaidDialog.actualMaxHeight = mms.normalizeDimension(node.style.maxHeight || '');
             }
             PasteMermaidDialog.actualHtmlSource = v;
         },
         // Create or update the content
-        insert: function (content) {
+        insert: function (content, maxWidth, maxHeight) {
             var editor = tinyMCE.activeEditor;
 
             // Code (the content)
             var t = content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            var c = "<pre class=\"mermaid\">" + t + "</pre>";
-            if (content === "") c = "";
 
             // Insert the content
             if (this.isUpdating === false) {
-                // New content
+                var style = mms.buildMaxSizeStyle(maxWidth, maxHeight);
+                var styleAttr = style === '' ? '' : ' style="' + style + '"';
+                var c = content === "" ? "" : '<pre class="mermaid"' + styleAttr + '>' + t + '</pre>';
                 editor.insertContent(c);
             } else {
-                // Update the selected content
+                // Update the selected content, preserving any unrelated inline styles
                 var ed = editor;
                 var node = ed.selection.getNode();
                 ed.dom.setHTML(node, t);
+                ed.dom.setStyle(node, 'max-width', mms.getStyleValue(maxWidth) || null);
+                ed.dom.setStyle(node, 'max-height', mms.getStyleValue(maxHeight) || null);
             }
             // Close the editor
             editor.windowManager.close();
@@ -96,6 +109,27 @@ tinymce.PluginManager.add('exemermaid', function (editor, url) {
                             label: _('Need help? Visit %s').replace('%s', '<a href="https://mermaid.js.org/" target="_blank" rel="noopener">mermaid.js.org</a>'),
                             items: []
                         },
+                        {
+                            type: 'grid',
+                            columns: 2,
+                            items: [
+                                {
+                                    type: 'input',
+                                    name: 'maxWidth',
+                                    label: _('Max. width (optional)'),
+                                },
+                                {
+                                    type: 'input',
+                                    name: 'maxHeight',
+                                    label: _('Max. height (optional)'),
+                                },
+                            ]
+                        },
+                        {
+                            type: 'label',
+                            label: _('e.g. 800px, 50%, 40em, 30rem'),
+                            items: []
+                        },
                     ]
                 },
                 buttons: [
@@ -113,12 +147,32 @@ tinymce.PluginManager.add('exemermaid', function (editor, url) {
                 ],
                 initialData: PasteMermaidDialog.getInitialData(),
                 onSubmit: function (api) {
-                    PasteMermaidDialog.actualHtmlSource = api.getData().htmlSource;
-                    PasteMermaidDialog.insert(PasteMermaidDialog.actualHtmlSource);
+                    var data = api.getData();
+                    var validation = mms.validateMaxSizeFields(data.maxWidth, data.maxHeight);
+
+                    if (!validation.isValid) {
+                        var messages = validation.errors.map(function (code) {
+                            if (code === 'invalid-max-width') {
+                                return _('Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).');
+                            }
+                            return _('Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).');
+                        });
+                        editor.windowManager.alert(messages.join('\n'));
+                        return false;
+                    }
+
+                    PasteMermaidDialog.actualHtmlSource = data.htmlSource;
+                    PasteMermaidDialog.actualMaxWidth = validation.maxWidth;
+                    PasteMermaidDialog.actualMaxHeight = validation.maxHeight;
+                    PasteMermaidDialog.insert(
+                        PasteMermaidDialog.actualHtmlSource,
+                        PasteMermaidDialog.actualMaxWidth,
+                        PasteMermaidDialog.actualMaxHeight
+                    );
                     return false;
                 },
                 onClose: function () {
-                    PasteCodeDialog.setDefaultData();
+                    PasteMermaidDialog.setDefaultData();
                 }
             });
 
@@ -128,11 +182,11 @@ tinymce.PluginManager.add('exemermaid', function (editor, url) {
             tinymce.DOM.setStyle(divDialog, 'height', 400);
         }
 
-    } // PasteCodeDialog
+    } // PasteMermaidDialog
 
     editor.ui.registry.addIcon('exemermaid', `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" height="24px" clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" version="1.1" viewBox="0 0 491 491" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
-    
+
     <path d="m407.48 111.18c-71.893-3.077-137.91 41.158-162.4 108.82-24.493-67.662-90.507-111.9-162.4-108.82-2.395 57.049 24.897 111.45 72.06 143.64 24.168 16.599 38.61 44.131 38.53 73.45v50.86h103.63v-50.86c-0.084-29.317 14.355-56.85 38.52-73.45 47.176-32.176 74.472-86.587 72.06-143.64z" fill-rule="nonzero"/>
 </svg>`);
 

--- a/test/e2e/playwright/specs/idevices/text.spec.ts
+++ b/test/e2e/playwright/specs/idevices/text.spec.ts
@@ -917,6 +917,110 @@ test.describe('Text iDevice', () => {
                 // Library exclusion optimization may vary by export type.
             }
         });
+
+        test('should preserve unrelated inline styles when updating max-size', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Mermaid Style Survival Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addTextIdevice(page);
+
+            const block = page.locator('#node-content article .idevice_node.text').last();
+            await block.waitFor({ timeout: 10000 });
+
+            const tinyMceMenubar = page.locator('.tox-menubar');
+            const isTinyMceVisible = await tinyMceMenubar.isVisible().catch(() => false);
+
+            if (!isTinyMceVisible) {
+                const editBtn = block.locator('.btn-edit-idevice');
+                if ((await editBtn.count()) > 0) {
+                    await editBtn.waitFor({ state: 'visible', timeout: 10000 });
+                    await editBtn.click();
+                }
+            }
+
+            await page.waitForSelector('.tox-menubar', { timeout: 15000 });
+
+            const toggleToolbarsButton = page
+                .locator(
+                    '.tox-tbtn[aria-label*="Toggle"], .tox-tbtn[aria-label*="Alternar"], .tox-tbtn[title*="Toggle"], .tox-tbtn[title*="Alternar"]',
+                )
+                .first();
+            if ((await toggleToolbarsButton.count()) > 0 && (await toggleToolbarsButton.isVisible())) {
+                await toggleToolbarsButton.click();
+                await page.waitForTimeout(500);
+            }
+
+            const mermaidButton = page
+                .locator(
+                    '.tox-tbtn[aria-label*="Mermaid"], .tox-tbtn[aria-label*="mermaid"], .tox-tbtn[title*="Mermaid"]',
+                )
+                .first();
+            await expect(mermaidButton).toBeVisible({ timeout: 10000 });
+
+            // Insert initial diagram with no max-size
+            await mermaidButton.click();
+            const dialog = page.locator('.tox-dialog');
+            await expect(dialog).toBeVisible({ timeout: 10000 });
+            await dialog.locator('textarea').fill('graph LR\n    A[Style Test] --> B[Node]');
+            await dialog
+                .locator('button')
+                .filter({ hasText: /Save|Guardar/i })
+                .click();
+            await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+            // Wait for the <pre class="mermaid"> to exist in the editor body, then inject
+            // an unrelated inline style that must survive the upcoming max-size update.
+            await page.waitForFunction(
+                () => (window as any).tinymce?.activeEditor?.getBody()?.querySelector('pre.mermaid') != null,
+                undefined,
+                { timeout: 5000 },
+            );
+            await page.evaluate(() => {
+                const editor = (window as any).tinymce.activeEditor;
+                const pre = editor.getBody().querySelector('pre.mermaid');
+                editor.dom.setStyle(pre, 'color', 'red');
+            });
+
+            // Select the mermaid node so the plugin enters the update branch
+            const tinyMceFrame = block.locator('iframe.tox-edit-area__iframe').first();
+            const frameEl = await tinyMceFrame.elementHandle();
+            const frame = await frameEl?.contentFrame();
+            if (frame) {
+                await frame.click('pre.mermaid');
+                await page.waitForTimeout(300);
+            }
+
+            // Re-open the dialog and set max-width — this exercises the update branch.
+            // TinyMCE 5 does not emit HTML name= attributes; max-width is the first <input>.
+            await mermaidButton.click();
+            const updateDialog = page.locator('.tox-dialog');
+            await expect(updateDialog).toBeVisible({ timeout: 10000 });
+            await updateDialog.locator('input').first().fill('600px');
+            await updateDialog
+                .locator('button')
+                .filter({ hasText: /Save|Guardar/i })
+                .click();
+            await expect(updateDialog).not.toBeVisible({ timeout: 5000 });
+
+            // Both the newly set max-width and the pre-existing color must be present
+            const styles = await page.evaluate(() => {
+                const editor = (window as any).tinymce?.activeEditor;
+                const pre = editor?.getBody()?.querySelector('pre.mermaid');
+                if (!pre) return null;
+                return { color: pre.style.color, maxWidth: pre.style.maxWidth };
+            });
+
+            expect(styles).not.toBeNull();
+            expect(styles!.color).toBe('red');
+            expect(styles!.maxWidth).toBe('600px');
+        });
     });
 
     test.describe('TinyMCE Audio Recorder (exeaudio)', () => {


### PR DESCRIPTION
# Allow setting maximum Mermaid diagram width/height

## Description

  This PR adds optional `max-width` and `max-height` constraints to the Mermaid
  diagram editor dialog. Previously, a Mermaid diagram inserted via the TinyMCE
  plugin always rendered at its natural size, which could overflow its container
  or occupy excessive vertical space in the page layout.

  Users can now enter an optional maximum width and/or height directly in the
  insert/edit dialog. Both fields accept the standard CSS length units used
  elsewhere in the editor (`px`, `em`, `rem`, `%`), must be greater than zero,
  and are fully optional — leaving them blank preserves the existing
  unconstrained behaviour.

  ## Architectural Decisions & Changes

  1. **Dialog layout (`plugin.min.js`)**:
     - Added `maxWidth` and `maxHeight` input fields to the Mermaid dialog,
  displayed side by side in a two-column `grid` layout.
     - A shared label below the inputs shows a translated usage example (`e.g.
  800px, 50%, 40em, 30rem`).
     - Validation follows the pattern of all other `exe*` plugins: errors are
  reported via `editor.windowManager.alert()`, keeping UX consistent across the editor.
  2. **Style injection**:
     - On insert, the validated values are written as an inline
  `style="max-width:…;max-height:…"` attribute on the `<pre class="mermaid">`
  element.
     - On update, `null` is passed to `setAttrib` when both fields are empty,
  cleanly removing a previously set style.
     - When a diagram is reopened for editing, existing
  `node.style.maxWidth/maxHeight` values are read back and pre-populated in the
  fields.
  3. **Utility functions extracted to module scope**:
     - `normalizeDimension`, `isValidDimension`, `getStyleValue`,
  `buildMaxSizeStyle`, and `validateMaxSizeFields` have been moved outside the
  `PluginManager.add` callback. This makes them available as top-level
  declarations, enabling the test suite to load and exercise the real production
  code via indirect `eval`.
     - `validateMaxSizeFields` returns error codes (`invalid-max-width`,
  `invalid-max-height`) rather than translated strings, keeping the validation
  logic i18n-agnostic.
  4. **Internationalisation**:
     - Six new strings added and translated into 11 languages (ca, de, en, eo,
  es, eu, gl, it, pt, ro, va): two validation error messages, two field labels,
  one example hint, and the `e.g.` abbreviation localised per language.

  ## Automated Testing

  - **Frontend (`vitest`)**: Refactored `exemermaid-plugin.test.js` to load
  `plugin.min.js` via `readFileSync` + indirect `eval` (following the pattern
  used by other lib tests in the project). The `buildMaxSizeStyle` and
  `validateMaxSizeFields` suites now exercise the actual production functions
  rather than local copies, eliminating the code-duplication risk. All 42 tests
  pass.
  - **Linting**: `make fix` passes clean (Biome).

  ## Manual Testing Required

  1. **Insert a new diagram**:
     - Open the Mermaid dialog. Verify two side-by-side inputs labelled *Max. 
  width (optional)* and *Max. height (optional)* appear, with the translated
  hint label beneath them.
     - Insert a diagram leaving both fields empty — confirm no `style` attribute
  is added to the `<pre>` element.
     - Insert again with `800px` in *Max. width* — confirm
  `style="max-width:800px"` is present in the source.
  2. **Validation**:
     - Enter an invalid value such as `200vh` or `abc`. Click *Save* — a single
  `windowManager.alert` should appear listing all invalid fields; the dialog
  should remain open.
     - Confirm zero values (`0px`, `0%`) are also rejected.
  3. **Edit an existing diagram**:
     - Open a diagram that has `style="max-width:600px;max-height:400px"`.
  Verify the fields are pre-populated with `600px` and `400px`.
     - Clear one field and save — confirm the removed dimension disappears from
  the inline style.
