### PR TITLE
i18n: add automated translations for empty targets (#1921)

### DIFF
--- a/src/services/admin-upload-validator.spec.ts
+++ b/src/services/admin-upload-validator.spec.ts
@@ -177,6 +177,7 @@ describe('Admin Upload Validator', () => {
             expect(SUPPORTED_LOCALES).toContain('es');
             expect(SUPPORTED_LOCALES).toContain('fr');
             expect(SUPPORTED_LOCALES).toContain('de');
+            expect(SUPPORTED_LOCALES).toContain('ro');
         });
 
         test('BASE_THEME_NAMES should include default themes', () => {

--- a/src/services/admin-upload-validator.ts
+++ b/src/services/admin-upload-validator.ts
@@ -74,6 +74,7 @@ export const SUPPORTED_LOCALES = [
     'eo',
     'nl',
     'pl',
+    'ro',
     'ru',
     'zh',
     'ja',

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="46ilu2z" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà), 2 (alt), 3 (expert) o 4 (mestre).</target>
       </trans-unit>
       <trans-unit id="ijh8lt9" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà), 2 (alt) o 3 (expert).</target>
       </trans-unit>
       <trans-unit id="i8ihb14" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà) o 2 (alt).</target>
       </trans-unit>
       <trans-unit id="bbpljee" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpcióE</target>
       </trans-unit>
       <trans-unit id="vtnu45s" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpcióF</target>
       </trans-unit>
       <trans-unit id="xz34iyo" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Quins dels següents són nombres primers?</target>
       </trans-unit>
       <trans-unit id="u5zqieu" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordena de major a menor</target>
       </trans-unit>
       <trans-unit id="fb1eniw" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefant</target>
       </trans-unit>
       <trans-unit id="x29bi0i" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Ratolí</target>
       </trans-unit>
       <trans-unit id="ckrttw0" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Quins d'aquests són nombres transcendents?</target>
       </trans-unit>
       <trans-unit id="u9jgsip" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Constant de Liouville</target>
       </trans-unit>
       <trans-unit id="g3opkvq" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Constant de Champernowne</target>
       </trans-unit>
       <trans-unit id="qvlxuga" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordena aquests elements químics de menor a major nombre atòmic</target>
       </trans-unit>
       <trans-unit id="mgvvb8z" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~S'accepten tres tipus de preguntes. Cada línia ha de començar amb el número de tipus, seguit de @, el nivell i la resta de camps separats amb #:</target>
       </trans-unit>
       <trans-unit id="kelu6px" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipus 0 (opció múltiple): 0@Nivell#Solució#Pregunta#OpcióA#OpcióB[#OpcióC][#OpcióD][#OpcióE][#OpcióF]. La solució és una combinació en majúscules d'A, B, C, D, E, F que identifica les opcions correctes (p. ex. A, AB, ACD, ABCDEF). Usa fins a 6 lletres i mai més que el nombre d'opcions. Deixa Solució buida si cap opció no és correcta.</target>
       </trans-unit>
       <trans-unit id="8nwqdvz" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipus 1 (ordenar): 1@Nivell#Pregunta#Element1#Element2#Element3[#Element4][#Element5][#Element6]. Proporciona entre 3 i 6 elements ja llistats en l'ordre correcte segons el criteri de la pregunta.</target>
       </trans-unit>
       <trans-unit id="mj2lg7q" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipus 2 (paraula/definició): 2@Nivell#Paraula#Definició.</target>
       </trans-unit>
       <trans-unit id="l1w5ihn" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~No incloguis el caràcter # dins de cap camp.</target>
       </trans-unit>
       <trans-unit id="d2eumxj" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuïdes entre els 5 nivells (0=baix, 1=mitjà, 2=alt, 3=expert, 4=mestre)</target>
       </trans-unit>
       <trans-unit id="4uj6sgy" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuïdes entre els 4 nivells (0=baix, 1=mitjà, 2=alt, 3=expert)</target>
       </trans-unit>
       <trans-unit id="vefnuk5" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuïdes entre els 3 nivells (0=baix, 1=mitjà, 2=alt)</target>
       </trans-unit>
       <trans-unit id="4cd95ns" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contenir les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 4 (mestre) ha de contenir les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="g2bqaj7" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contenir les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 3 (expert) ha de contenir les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="idt0qsj" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contenir les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 2 (alt) ha de contenir les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="dqcyy7e" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~El teu navegador no és compatible amb aquest tipus d'activitat.</target>
       </trans-unit>
       <trans-unit id="1bvhar4" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Has d'afegir almenys una pregunta.</target>
       </trans-unit>
       <trans-unit id="bizh92a" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Has de tenir almenys una pregunta.</target>
       </trans-unit>
       <trans-unit id="bbdfhay" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Pregunta %s: el text de la pregunta no pot estar buit.</target>
       </trans-unit>
       <trans-unit id="pysxjdh" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Pregunta %s: omple totes les opcions de resposta.</target>
       </trans-unit>
       <trans-unit id="e6i0l51" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: indica quina opció és la resposta correcta.</target>
       </trans-unit>
       <trans-unit id="24gqibf" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Has d'afegir almenys %s preguntes.</target>
       </trans-unit>
       <trans-unit id="0zyyjfg" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Avís: el nivell inicial seleccionat no té preguntes. El qüestionari començarà usant el nivell de reserva.</target>
       </trans-unit>
       <trans-unit id="5bcbb3i" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indica un nom per a cada nivell.</target>
       </trans-unit>
       <trans-unit id="4xcljhy" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~El nivell «%s» ha de tenir almenys 2 preguntes.</target>
       </trans-unit>
       <trans-unit id="bivulu9" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indica el temps que es mostrarà la solució.</target>
       </trans-unit>
       <trans-unit id="l6ue8yh" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: marca almenys una resposta correcta.</target>
       </trans-unit>
       <trans-unit id="egbn5j9" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona la paraula o frase solució.</target>
       </trans-unit>
       <trans-unit id="x655xgj" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona la definició.</target>
       </trans-unit>
       <trans-unit id="m3n8lhm" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Pregunta %s: assigna un ordre únic de l'1 al %n a cada opció.</target>
       </trans-unit>
       <trans-unit id="kthem7s" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL d'àudio</target>
       </trans-unit>
       <trans-unit id="dn3c8nk" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Mostra les opcions d'àudio</target>
       </trans-unit>
       <trans-unit id="5p33q3e" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Crea un qüestionari d'opció múltiple la dificultat del qual s'adapta a l'alumne. Tria el nombre de nivells de dificultat (3, 4 o 5) i assigna'n un a cada pregunta; el qüestionari puja un nivell després de dues respostes correctes seguides i baixa després de dues incorrectes seguides.</target>
       </trans-unit>
       <trans-unit id="qes4rjh" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Nombre de nivells</target>
       </trans-unit>
       <trans-unit id="cmpkgrb" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nom del nivell 1</target>
       </trans-unit>
       <trans-unit id="yct6t37" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Fàcil</target>
       </trans-unit>
       <trans-unit id="kyv4dgw" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nom del nivell 2</target>
       </trans-unit>
       <trans-unit id="r41yptz" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nom del nivell 3</target>
       </trans-unit>
       <trans-unit id="byf2jqz" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Difícil</target>
       </trans-unit>
       <trans-unit id="l6oyk1n" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nom del nivell 4</target>
       </trans-unit>
       <trans-unit id="84rp47o" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Expert</target>
       </trans-unit>
       <trans-unit id="losg1o0" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nom del nivell 5</target>
       </trans-unit>
       <trans-unit id="9yo8onl" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Mestre</target>
       </trans-unit>
       <trans-unit id="e107hs5" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Nivell inicial</target>
       </trans-unit>
       <trans-unit id="3t3qak5" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Posa 0 per desactivar el límit de temps.</target>
       </trans-unit>
       <trans-unit id="5amojxn" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Barreja les opcions de resposta durant l'execució</target>
       </trans-unit>
       <trans-unit id="8hptn1z" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Distingeix majúscules i minúscules (tipus paraula)</target>
       </trans-unit>
       <trans-unit id="k0ty05j" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Exigeix accents correctes (tipus paraula)</target>
       </trans-unit>
       <trans-unit id="bv7wd6n" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtre de nivell</target>
       </trans-unit>
       <trans-unit id="mg3lzgg" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Torna a carregar la imatge</target>
       </trans-unit>
       <trans-unit id="v5iwlnm" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Qüestionari adaptatiu</target>
       </trans-unit>
       <trans-unit id="akuzeko" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Fes clic en una opció per triar la teva resposta.</target>
       </trans-unit>
       <trans-unit id="qxy5u4c" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Nivell més alt assolit</target>
       </trans-unit>
       <trans-unit id="03i7o4k" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Puges de nivell!</target>
       </trans-unit>
       <trans-unit id="2m7rys4" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Baixes de nivell</target>
       </trans-unit>
       <trans-unit id="852pb3d" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Informe final</target>
       </trans-unit>
       <trans-unit id="if6iczi" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Excel·lent. Domines els continguts de més alt nivell.</target>
       </trans-unit>
       <trans-unit id="pp715tz" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bona feina. Has assolit el nivell intermedi.</target>
       </trans-unit>
       <trans-unit id="twbqvib" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Necessites una mica més de pràctica. Repassa els continguts bàsics.</target>
       </trans-unit>
       <trans-unit id="jckvs5f" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pausa l'àudio</target>
       </trans-unit>
       <trans-unit id="u2ztnn8" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Il·lustració</target>
       </trans-unit>
       <trans-unit id="xqdg3p8" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Tria la resposta correcta per a cada pregunta. Per pujar al següent nivell has de respondre correctament dues preguntes seguides. Si falles dues seguides, baixaràs al nivell anterior.</target>
       </trans-unit>
       <trans-unit id="5yysqlm" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~S'ha acabat el temps!</target>
       </trans-unit>
       <trans-unit id="mvddxf3" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Crea %total% preguntes mixtes de qüestionari adaptatiu %distribution% i dels tres tipus de pregunta admesos. Cada línia ha de començar amb el número de tipus seguit de @, després el nivell i després la resta de camps separats amb #. Mai posis # dins d'un camp. Les tres formes de línia admeses són: Tipus 0 (opció múltiple): 0@Nivell#Solució#Pregunta#OpcióA#OpcióB[#OpcióC][#OpcióD][#OpcióE][#OpcióF] — La solució és una combinació en majúscules de les lletres A, B, C, D, E, F que identifica les opcions correctes (p. ex. A, AB, ACD, ABCDEF); usa fins a 6 lletres i mai més que el nombre d'opcions; deixa la solució buida si cap opció no és correcta. Tipus 1 (ordenar): 1@Nivell#Pregunta#Element1#Element2#Element3[#Element4][#Element5][#Element6] — proporciona entre 3 i 6 elements ja llistats en l'ordre correcte segons el criteri de la pregunta. Tipus 2 (paraula/definició): 2@Nivell#Paraula#Definició. La dificultat ha d'augmentar amb el nivell: %ladder% Dins de cada nivell has d'incloure preguntes dels tres tipus (Tipus 0, Tipus 1 i Tipus 2): genera al voltant de %perLevel% preguntes per nivell i assegura't que cada nivell combini seleccionar (Tipus 0), ordenar (Tipus 1) i paraula/definició (Tipus 2). No posis totes del mateix tipus juntes; intercala els tres tipus dins de cada nivell.</target>
       </trans-unit>
       <trans-unit id="mhmzu4t" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Genera la vista prèvia del circuit abans de desar</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="h5b9u6k" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Stufe: 0 (niedrig), 1 (mittel), 2 (hoch), 3 (Experte) oder 4 (Meister).</target>
       </trans-unit>
       <trans-unit id="lf9egpf" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Stufe: 0 (niedrig), 1 (mittel), 2 (hoch) oder 3 (Experte).</target>
       </trans-unit>
       <trans-unit id="la1rebv" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Stufe: 0 (niedrig), 1 (mittel) oder 2 (hoch).</target>
       </trans-unit>
       <trans-unit id="i2w0bv3" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OptionE</target>
       </trans-unit>
       <trans-unit id="oyxe9w6" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OptionF</target>
       </trans-unit>
       <trans-unit id="q9wc7gz" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Welche der folgenden Zahlen sind Primzahlen?</target>
       </trans-unit>
       <trans-unit id="2kf1xwx" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Vom größten zum kleinsten sortieren</target>
       </trans-unit>
       <trans-unit id="0809mlx" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefant</target>
       </trans-unit>
       <trans-unit id="6mofnio" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Maus</target>
       </trans-unit>
       <trans-unit id="ftc71yx" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Welche dieser Zahlen sind transzendente Zahlen?</target>
       </trans-unit>
       <trans-unit id="a9n6i5i" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Liouville-Konstante</target>
       </trans-unit>
       <trans-unit id="jjkjp0h" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Champernowne-Konstante</target>
       </trans-unit>
       <trans-unit id="6r5q0nx" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordne diese chemischen Elemente von der niedrigsten zur höchsten Ordnungszahl</target>
       </trans-unit>
       <trans-unit id="p7viqu2" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Es werden drei Fragetypen akzeptiert. Jede Zeile muss mit der Typnummer beginnen, gefolgt von @, der Stufe und den restlichen Feldern, die mit # getrennt werden:</target>
       </trans-unit>
       <trans-unit id="g9y6viq" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Typ 0 (Multiple-Choice): 0@Stufe#Lösung#Frage#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Die Lösung ist eine Großbuchstabenkombination aus A, B, C, D, E, F, die die richtigen Optionen angibt (z. B. A, AB, ACD, ABCDEF). Verwende bis zu 6 Buchstaben und nie mehr als die Anzahl der Optionen. Lass die Lösung leer, wenn keine Option richtig ist.</target>
       </trans-unit>
       <trans-unit id="cx4vf30" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Typ 1 (sortieren): 1@Stufe#Frage#Element1#Element2#Element3[#Element4][#Element5][#Element6]. Gib zwischen 3 und 6 Elemente an, die bereits in der richtigen Reihenfolge gemäß dem Fragekriterium aufgelistet sind.</target>
       </trans-unit>
       <trans-unit id="sgm7w0d" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Typ 2 (Wort/Definition): 2@Stufe#Wort#Definition.</target>
       </trans-unit>
       <trans-unit id="cb5bc4s" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Füge das Zeichen # in keinem Feld ein.</target>
       </trans-unit>
       <trans-unit id="nhgs7ig" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~ausgewogen verteilt auf die 5 Stufen (0=niedrig, 1=mittel, 2=hoch, 3=Experte, 4=Meister)</target>
       </trans-unit>
       <trans-unit id="6zeevfi" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~ausgewogen verteilt auf die 4 Stufen (0=niedrig, 1=mittel, 2=hoch, 3=Experte)</target>
       </trans-unit>
       <trans-unit id="pay38uh" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~ausgewogen verteilt auf die 3 Stufen (0=niedrig, 1=mittel, 2=hoch)</target>
       </trans-unit>
       <trans-unit id="jjz2x9s" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Stufe 0 muss die einfachsten Fragen enthalten (grundlegende Fakten und einfaches Abrufen); jede folgende Stufe muss strikt anspruchsvoller sein als die vorherige (mehr Schlussfolgern, längere oder kniffligere Optionen, abstrakteres Vokabular), und Stufe 4 (Meister) muss die schwierigsten Fragen enthalten.</target>
       </trans-unit>
       <trans-unit id="f8dpgx8" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Stufe 0 muss die einfachsten Fragen enthalten (grundlegende Fakten und einfaches Abrufen); jede folgende Stufe muss strikt anspruchsvoller sein als die vorherige (mehr Schlussfolgern, längere oder kniffligere Optionen, abstrakteres Vokabular), und Stufe 3 (Experte) muss die schwierigsten Fragen enthalten.</target>
       </trans-unit>
       <trans-unit id="eotnfnh" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Stufe 0 muss die einfachsten Fragen enthalten (grundlegende Fakten und einfaches Abrufen); jede folgende Stufe muss strikt anspruchsvoller sein als die vorherige (mehr Schlussfolgern, längere oder kniffligere Optionen, abstrakteres Vokabular), und Stufe 2 (hoch) muss die schwierigsten Fragen enthalten.</target>
       </trans-unit>
       <trans-unit id="k2t8003" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~Dein Browser ist mit dieser Art von Aktivität nicht kompatibel.</target>
       </trans-unit>
       <trans-unit id="u6zcxlv" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Du musst mindestens eine Frage hinzufügen.</target>
       </trans-unit>
       <trans-unit id="mtizgbj" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Du musst mindestens eine Frage haben.</target>
       </trans-unit>
       <trans-unit id="hxussqb" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Frage %s: Der Fragetext darf nicht leer sein.</target>
       </trans-unit>
       <trans-unit id="uqsc9lk" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Frage %s: Bitte fülle alle Antwortoptionen aus.</target>
       </trans-unit>
       <trans-unit id="q36owh8" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Frage %s: Bitte markiere, welche Option die richtige Antwort ist.</target>
       </trans-unit>
       <trans-unit id="2kxn5sw" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Du musst mindestens %s Fragen hinzufügen.</target>
       </trans-unit>
       <trans-unit id="00r0da3" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Warnung: Die ausgewählte Anfangsstufe hat keine Fragen. Das Quiz startet mit der Ausweichstufe.</target>
       </trans-unit>
       <trans-unit id="d2o1q7x" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Bitte gib für jede Stufe einen Namen an.</target>
       </trans-unit>
       <trans-unit id="7w6gur3" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~Die Stufe „%s“ muss mindestens 2 Fragen haben.</target>
       </trans-unit>
       <trans-unit id="l2f9hz6" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Bitte gib an, wie lange die Lösung angezeigt wird.</target>
       </trans-unit>
       <trans-unit id="oigamsu" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Frage %s: Bitte markiere mindestens eine richtige Antwort.</target>
       </trans-unit>
       <trans-unit id="iayh6vu" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Frage %s: Bitte gib das Lösungswort oder den Lösungssatz an.</target>
       </trans-unit>
       <trans-unit id="gx83wmd" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Frage %s: Bitte gib die Definition an.</target>
       </trans-unit>
       <trans-unit id="2uqsj92" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Frage %s: Bitte lege für jede Option eine eindeutige Reihenfolge von 1 bis %n fest.</target>
       </trans-unit>
       <trans-unit id="j0z2i0t" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~Audio-URL</target>
       </trans-unit>
       <trans-unit id="p4v2nd6" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Audiooptionen anzeigen</target>
       </trans-unit>
       <trans-unit id="ffcnpmw" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Erstelle ein Multiple-Choice-Quiz, dessen Schwierigkeit sich an den Lernenden anpasst. Wähle die Anzahl der Schwierigkeitsstufen (3, 4 oder 5) und weise jeder Frage eine zu; das Quiz steigt nach zwei richtigen Antworten in Folge eine Stufe auf und sinkt nach zwei falschen Antworten in Folge eine Stufe ab.</target>
       </trans-unit>
       <trans-unit id="oc22e1p" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Anzahl der Stufen</target>
       </trans-unit>
       <trans-unit id="wy2s3a7" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Name der Stufe 1</target>
       </trans-unit>
       <trans-unit id="3h5n412" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Einfach</target>
       </trans-unit>
       <trans-unit id="dvulu27" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Name der Stufe 2</target>
       </trans-unit>
       <trans-unit id="xi2x4jg" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Name der Stufe 3</target>
       </trans-unit>
       <trans-unit id="prq1nzk" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Schwer</target>
       </trans-unit>
       <trans-unit id="i7fa4kc" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Name der Stufe 4</target>
       </trans-unit>
       <trans-unit id="ug4gvh9" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Experte</target>
       </trans-unit>
       <trans-unit id="7hq0pm7" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Name der Stufe 5</target>
       </trans-unit>
       <trans-unit id="l9268tt" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Meister</target>
       </trans-unit>
       <trans-unit id="4o9v2fe" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Anfangsstufe</target>
       </trans-unit>
       <trans-unit id="46zje5a" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Auf 0 setzen, um das Zeitlimit zu deaktivieren.</target>
       </trans-unit>
       <trans-unit id="j34riut" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Antwortoptionen zur Laufzeit mischen</target>
       </trans-unit>
       <trans-unit id="yrpprce" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Antwortabgleich unter Berücksichtigung der Groß-/Kleinschreibung (Worttyp)</target>
       </trans-unit>
       <trans-unit id="0f81lat" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Korrekte Akzente verlangen (Worttyp)</target>
       </trans-unit>
       <trans-unit id="mcjpnes" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Stufenfilter</target>
       </trans-unit>
       <trans-unit id="wxl8gff" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Bild neu laden</target>
       </trans-unit>
       <trans-unit id="dk9w0zd" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Adaptives Quiz</target>
       </trans-unit>
       <trans-unit id="qnw14sc" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Klicke auf eine Option, um deine Antwort auszuwählen.</target>
       </trans-unit>
       <trans-unit id="v2k6bgv" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Höchste erreichte Stufe</target>
       </trans-unit>
       <trans-unit id="81gu9a1" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Stufe aufgestiegen!</target>
       </trans-unit>
       <trans-unit id="jfvgup1" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Stufe abgestiegen</target>
       </trans-unit>
       <trans-unit id="m3ndl16" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Abschlussbericht</target>
       </trans-unit>
       <trans-unit id="6rawsh9" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Ausgezeichnet. Du beherrschst die Inhalte der höchsten Stufe.</target>
       </trans-unit>
       <trans-unit id="dq3okly" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Gute Arbeit. Du hast die mittlere Stufe erreicht.</target>
       </trans-unit>
       <trans-unit id="xnqpwxw" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Du brauchst noch etwas Übung. Wiederhole die grundlegenden Inhalte.</target>
       </trans-unit>
       <trans-unit id="9usqern" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Audio pausieren</target>
       </trans-unit>
       <trans-unit id="yb85cnl" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Illustration</target>
       </trans-unit>
       <trans-unit id="vrmhzj5" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Wähle für jede Frage die richtige Antwort. Um in die nächste Stufe aufzusteigen, musst du zwei Fragen in Folge richtig beantworten. Wenn du zwei Fragen in Folge falsch beantwortest, steigst du in die vorherige Stufe ab.</target>
       </trans-unit>
       <trans-unit id="qz1kypz" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Die Zeit ist um!</target>
       </trans-unit>
       <trans-unit id="h61vg8x" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Erstelle %total% gemischte Fragen für ein adaptives Quiz %distribution% und aus den drei unterstützten Fragetypen. Jede Zeile muss mit der Typnummer beginnen, gefolgt von @, dann der Stufe und dann den restlichen Feldern, die mit # getrennt werden. Setze niemals # in ein Feld. Die drei zulässigen Zeilenformen sind: Typ 0 (Multiple-Choice): 0@Stufe#Lösung#Frage#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Die Lösung ist eine Großbuchstabenkombination aus den Buchstaben A, B, C, D, E, F, die die richtigen Optionen angibt (z. B. A, AB, ACD, ABCDEF); verwende bis zu 6 Buchstaben und nie mehr als die Anzahl der Optionen; lass die Lösung leer, wenn keine Option richtig ist. Typ 1 (sortieren): 1@Stufe#Frage#Element1#Element2#Element3[#Element4][#Element5][#Element6] — gib zwischen 3 und 6 Elemente an, die bereits in der richtigen Reihenfolge gemäß dem Fragekriterium aufgelistet sind. Typ 2 (Wort/Definition): 2@Stufe#Wort#Definition. Die Schwierigkeit muss mit der Stufe zunehmen: %ladder% Innerhalb jeder einzelnen Stufe musst du Fragen aller drei Typen aufnehmen (Typ 0, Typ 1 und Typ 2): erstelle etwa %perLevel% Fragen pro Stufe und stelle sicher, dass jede Stufe Multiple-Choice (Typ 0), Sortieren (Typ 1) und Wort/Definition (Typ 2) mischt. Setze nicht alle gleichen Typen zusammen; verschachtle die drei Typen innerhalb jeder Stufe.</target>
       </trans-unit>
       <trans-unit id="y8d5q93" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Bitte erzeuge die Schaltungsvorschau vor dem Speichern</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="s4q4729" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nivelo: 0 (malalta), 1 (meza), 2 (alta), 3 (spertulo) aŭ 4 (majstro).</target>
       </trans-unit>
       <trans-unit id="7wuyn6r" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nivelo: 0 (malalta), 1 (meza), 2 (alta) aŭ 3 (spertulo).</target>
       </trans-unit>
       <trans-unit id="q4wupex" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nivelo: 0 (malalta), 1 (meza) aŭ 2 (alta).</target>
       </trans-unit>
       <trans-unit id="8de24hs" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpcioE</target>
       </trans-unit>
       <trans-unit id="8m9rm96" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpcioF</target>
       </trans-unit>
       <trans-unit id="m5c1n1u" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Kiuj el la jenaj estas primoj?</target>
       </trans-unit>
       <trans-unit id="x7jrypc" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordigu de plej granda al plej malgranda</target>
       </trans-unit>
       <trans-unit id="i4sdmwf" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefanto</target>
       </trans-unit>
       <trans-unit id="kp4t0c8" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Muso</target>
       </trans-unit>
       <trans-unit id="vkouumy" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Kiuj el ĉi tiuj estas transcendaj nombroj?</target>
       </trans-unit>
       <trans-unit id="f1w39zp" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Konstanto de Liouville</target>
       </trans-unit>
       <trans-unit id="4uau8e4" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Konstanto de Champernowne</target>
       </trans-unit>
       <trans-unit id="stmm32q" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordigu ĉi tiujn kemiajn elementojn de la plej malalta al la plej alta atomnumero</target>
       </trans-unit>
       <trans-unit id="9t42e80" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Tri demandtipoj estas akceptataj. Ĉiu linio devas komenci per la tipnumero, sekvata de @, la nivelo kaj la ceteraj kampoj apartigitaj per #:</target>
       </trans-unit>
       <trans-unit id="mm7ciof" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipo 0 (plurelekta): 0@Nivelo#Solvo#Demando#OpcioA#OpcioB[#OpcioC][#OpcioD][#OpcioE][#OpcioF]. La solvo estas majuskla kombinaĵo de A, B, C, D, E, F kiu identigas la ĝustajn opciojn (ekz. A, AB, ACD, ABCDEF). Uzu ĝis 6 literojn kaj neniam pli ol la nombro da opcioj. Lasu Solvon malplena se neniu opcio estas ĝusta.</target>
       </trans-unit>
       <trans-unit id="54j7zi1" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipo 1 (ordigi): 1@Nivelo#Demando#Ero1#Ero2#Ero3[#Ero4][#Ero5][#Ero6]. Provizu inter 3 kaj 6 erojn jam listigitajn en la ĝusta ordo laŭ la kriterio de la demando.</target>
       </trans-unit>
       <trans-unit id="vvmcuez" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipo 2 (vorto/difino): 2@Nivelo#Vorto#Difino.</target>
       </trans-unit>
       <trans-unit id="00o2hy2" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Ne inkluzivu la signon # ene de iu ajn kampo.</target>
       </trans-unit>
       <trans-unit id="fttvne2" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~egale distribuitaj inter la 5 niveloj (0=malalta, 1=meza, 2=alta, 3=spertulo, 4=majstro)</target>
       </trans-unit>
       <trans-unit id="z45bnhl" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~egale distribuitaj inter la 4 niveloj (0=malalta, 1=meza, 2=alta, 3=spertulo)</target>
       </trans-unit>
       <trans-unit id="z6qy2h5" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~egale distribuitaj inter la 3 niveloj (0=malalta, 1=meza, 2=alta)</target>
       </trans-unit>
       <trans-unit id="xm6elne" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelo 0 devas enhavi la plej facilajn demandojn (bazaj faktoj kaj simpla rememorado); ĉiu sekva nivelo devas esti strikte pli malfacila ol la antaŭa (pli da rezonado, pli longaj aŭ pli ruzaj opcioj, pli abstrakta vortprovizo), kaj nivelo 4 (majstro) devas enhavi la plej malfacilajn demandojn.</target>
       </trans-unit>
       <trans-unit id="tqdf6r5" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelo 0 devas enhavi la plej facilajn demandojn (bazaj faktoj kaj simpla rememorado); ĉiu sekva nivelo devas esti strikte pli malfacila ol la antaŭa (pli da rezonado, pli longaj aŭ pli ruzaj opcioj, pli abstrakta vortprovizo), kaj nivelo 3 (spertulo) devas enhavi la plej malfacilajn demandojn.</target>
       </trans-unit>
       <trans-unit id="neahg43" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelo 0 devas enhavi la plej facilajn demandojn (bazaj faktoj kaj simpla rememorado); ĉiu sekva nivelo devas esti strikte pli malfacila ol la antaŭa (pli da rezonado, pli longaj aŭ pli ruzaj opcioj, pli abstrakta vortprovizo), kaj nivelo 2 (alta) devas enhavi la plej malfacilajn demandojn.</target>
       </trans-unit>
       <trans-unit id="ndzqm25" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~Via retumilo ne kongruas kun ĉi tiu tipo de agado.</target>
       </trans-unit>
       <trans-unit id="1mpkyj3" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Vi devas aldoni almenaŭ unu demandon.</target>
       </trans-unit>
       <trans-unit id="nbf4air" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Vi devas havi almenaŭ unu demandon.</target>
       </trans-unit>
       <trans-unit id="byj8s8x" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Demando %s: la teksto de la demando ne povas esti malplena.</target>
       </trans-unit>
       <trans-unit id="zgmwwq7" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu plenigi ĉiujn respondajn opciojn.</target>
       </trans-unit>
       <trans-unit id="ciym7ab" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu marki kiu opcio estas la ĝusta respondo.</target>
       </trans-unit>
       <trans-unit id="jaxeu4c" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Vi devas aldoni almenaŭ %s demandojn.</target>
       </trans-unit>
       <trans-unit id="34oskgf" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Averto: la elektita komenca nivelo ne havas demandojn. La kvizo komenciĝos uzante la rezervan nivelon.</target>
       </trans-unit>
       <trans-unit id="h0h1ia1" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Bonvolu provizi nomon por ĉiu nivelo.</target>
       </trans-unit>
       <trans-unit id="l1fpjm6" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~La nivelo «%s» devas havi almenaŭ 2 demandojn.</target>
       </trans-unit>
       <trans-unit id="1y93sry" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Bonvolu indiki la tempon dum kiu la solvo estos montrata.</target>
       </trans-unit>
       <trans-unit id="ohfjf0s" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu marki almenaŭ unu ĝustan respondon.</target>
       </trans-unit>
       <trans-unit id="670parr" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu provizi la solvan vorton aŭ frazon.</target>
       </trans-unit>
       <trans-unit id="ghdw590" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu provizi la difinon.</target>
       </trans-unit>
       <trans-unit id="tjg6rbf" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Demando %s: bonvolu specifi unikan ordon de 1 ĝis %n por ĉiu opcio.</target>
       </trans-unit>
       <trans-unit id="6lot0xo" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~Aŭdio-URL</target>
       </trans-unit>
       <trans-unit id="szh4xug" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Montri aŭdajn opciojn</target>
       </trans-unit>
       <trans-unit id="kee8n3r" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Kreu plurelektan kvizon, kies malfacileco adaptiĝas al la lernanto. Elektu la nombron da malfacilecaj niveloj (3, 4 aŭ 5) kaj atribuu unu al ĉiu demando; la kvizo supreniras unu nivelon post du ĝustaj respondoj sinsekve kaj malsupreniras post du malĝustaj respondoj sinsekve.</target>
       </trans-unit>
       <trans-unit id="2hu0r7z" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Nombro da niveloj</target>
       </trans-unit>
       <trans-unit id="c42j9lu" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nomo de nivelo 1</target>
       </trans-unit>
       <trans-unit id="zxtvixa" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Facila</target>
       </trans-unit>
       <trans-unit id="eze7cwy" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nomo de nivelo 2</target>
       </trans-unit>
       <trans-unit id="v17txvx" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nomo de nivelo 3</target>
       </trans-unit>
       <trans-unit id="xkd9ip7" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Malfacila</target>
       </trans-unit>
       <trans-unit id="uhnbtgy" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nomo de nivelo 4</target>
       </trans-unit>
       <trans-unit id="ufjlxyh" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Spertulo</target>
       </trans-unit>
       <trans-unit id="5hmrb1h" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nomo de nivelo 5</target>
       </trans-unit>
       <trans-unit id="3kkfxiy" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Majstro</target>
       </trans-unit>
       <trans-unit id="l2w5rn2" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Komenca nivelo</target>
       </trans-unit>
       <trans-unit id="hhg0n7d" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Agordu al 0 por malŝalti la tempolimon.</target>
       </trans-unit>
       <trans-unit id="rgukwpc" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Miksi respondajn opciojn dum la rulado</target>
       </trans-unit>
       <trans-unit id="zcj6s17" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Uskleca komparo de respondoj (vorta tipo)</target>
       </trans-unit>
       <trans-unit id="v087cv1" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Postuli ĝustajn supersignojn (vorta tipo)</target>
       </trans-unit>
       <trans-unit id="nra2y6n" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Nivela filtrilo</target>
       </trans-unit>
       <trans-unit id="8qcuhan" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Reŝargi la bildon</target>
       </trans-unit>
       <trans-unit id="a8zmkhu" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Adaptiĝema kvizo</target>
       </trans-unit>
       <trans-unit id="6240n3r" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Klaku opcion por elekti vian respondon.</target>
       </trans-unit>
       <trans-unit id="wesp0ul" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Plej alta atingita nivelo</target>
       </trans-unit>
       <trans-unit id="vachwiy" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Vi supreniras nivelon!</target>
       </trans-unit>
       <trans-unit id="jt1zj5a" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Vi malsupreniras nivelon</target>
       </trans-unit>
       <trans-unit id="4qgd1jd" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Fina raporto</target>
       </trans-unit>
       <trans-unit id="verqjd5" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Bonege. Vi regas la enhavojn de la plej alta nivelo.</target>
       </trans-unit>
       <trans-unit id="bim8k85" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bona laboro. Vi atingis la mezan nivelon.</target>
       </trans-unit>
       <trans-unit id="jgwsnab" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Vi bezonas iom pli da praktiko. Revizu la bazajn enhavojn.</target>
       </trans-unit>
       <trans-unit id="qfjevpc" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Paŭzigi aŭdion</target>
       </trans-unit>
       <trans-unit id="qacbfe9" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Ilustraĵo</target>
       </trans-unit>
       <trans-unit id="x9rfzw6" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Elektu la ĝustan respondon por ĉiu demando. Por supreniri al la sekva nivelo, vi devas respondi du demandojn ĝuste sinsekve. Se vi malĝustas du sinsekve, vi malsupreniros al la antaŭa nivelo.</target>
       </trans-unit>
       <trans-unit id="f9ots6y" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~La tempo finiĝis!</target>
       </trans-unit>
       <trans-unit id="nzr5nvw" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Kreu %total% miksitajn demandojn de adaptiĝema kvizo %distribution% kaj el la tri subtenataj demandtipoj. Ĉiu linio devas komenci per la tipnumero sekvata de @, poste la nivelo kaj poste la ceteraj kampoj apartigitaj per #. Neniam metu # ene de kampo. La tri akceptataj linioformoj estas: Tipo 0 (plurelekta): 0@Nivelo#Solvo#Demando#OpcioA#OpcioB[#OpcioC][#OpcioD][#OpcioE][#OpcioF] — La solvo estas majuskla kombinaĵo de la literoj A, B, C, D, E, F kiu identigas la ĝustajn opciojn (ekz. A, AB, ACD, ABCDEF); uzu ĝis 6 literojn kaj neniam pli ol la nombro da opcioj; lasu la solvon malplena se neniu opcio estas ĝusta. Tipo 1 (ordigi): 1@Nivelo#Demando#Ero1#Ero2#Ero3[#Ero4][#Ero5][#Ero6] — provizu inter 3 kaj 6 erojn jam listigitajn en la ĝusta ordo laŭ la kriterio de la demando. Tipo 2 (vorto/difino): 2@Nivelo#Vorto#Difino. La malfacileco devas pliiĝi kun la nivelo: %ladder% Ene de ĉiu unuopa nivelo vi devas inkluzivi demandojn de ĉiuj tri tipoj (Tipo 0, Tipo 1 kaj Tipo 2): produktu ĉirkaŭ %perLevel% demandojn po nivelo kaj certigu ke ĉiu nivelo miksas plurelektajn (Tipo 0), ordigajn (Tipo 1) kaj vorto/difinajn (Tipo 2). Ne metu ĉiujn samtipajn kune; interplektu la tri tipojn ene de ĉiu nivelo.</target>
       </trans-unit>
       <trans-unit id="y6inhkv" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Bonvolu generi la antaŭrigardon de la cirkvito antaŭ ol konservi</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="dh46kpt" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Maila: 0 (baxua), 1 (ertaina), 2 (altua), 3 (aditua) edo 4 (maisua).</target>
       </trans-unit>
       <trans-unit id="cautdf2" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Maila: 0 (baxua), 1 (ertaina), 2 (altua) edo 3 (aditua).</target>
       </trans-unit>
       <trans-unit id="1x2yu53" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Maila: 0 (baxua), 1 (ertaina) edo 2 (altua).</target>
       </trans-unit>
       <trans-unit id="nnc4mjs" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~EAukera</target>
       </trans-unit>
       <trans-unit id="vyvdwuc" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~FAukera</target>
       </trans-unit>
       <trans-unit id="6uoxfty" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Hauetako zein dira zenbaki lehenak?</target>
       </trans-unit>
       <trans-unit id="jxf5hrb" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordenatu handienetik txikienera</target>
       </trans-unit>
       <trans-unit id="4wktc5z" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefantea</target>
       </trans-unit>
       <trans-unit id="oqlg7ud" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Sagua</target>
       </trans-unit>
       <trans-unit id="nyelv16" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Hauetako zein dira zenbaki transzendenteak?</target>
       </trans-unit>
       <trans-unit id="zhpo309" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Liouvilleren konstantea</target>
       </trans-unit>
       <trans-unit id="24o6j35" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Champernowneren konstantea</target>
       </trans-unit>
       <trans-unit id="4e2s70n" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordenatu elementu kimiko hauek zenbaki atomiko txikienetik handienera</target>
       </trans-unit>
       <trans-unit id="98ld8fm" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Hiru galdera mota onartzen dira. Lerro bakoitzak mota-zenbakiarekin hasi behar du, ondoren @, maila eta gainerako eremuak #-rekin bereizita:</target>
       </trans-unit>
       <trans-unit id="ewlcb8f" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~0 mota (aukera anitzekoa): 0@Maila#Soluzioa#Galdera#AAukera#BAukera[#CAukera][#DAukera][#EAukera][#FAukera]. Soluzioa A, B, C, D, E, F letren maiuskula-konbinazioa da, aukera zuzenak adierazten dituena (adib. A, AB, ACD, ABCDEF). Erabili gehienez 6 letra eta inoiz ez aukera kopurua baino gehiago. Utzi Soluzioa hutsik aukera bat ere zuzena ez bada.</target>
       </trans-unit>
       <trans-unit id="rxctuop" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~1 mota (ordenatu): 1@Maila#Galdera#1Elementua#2Elementua#3Elementua[#4Elementua][#5Elementua][#6Elementua]. Eman 3 eta 6 elementu artean, galderaren irizpidearen arabera ordena zuzenean zerrendatuta.</target>
       </trans-unit>
       <trans-unit id="mchlxa1" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~2 mota (hitza/definizioa): 2@Maila#Hitza#Definizioa.</target>
       </trans-unit>
       <trans-unit id="4o6wouk" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Ez sartu # karakterea inongo eremutan.</target>
       </trans-unit>
       <trans-unit id="cu8mnd9" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~5 mailetan banatuta (0=baxua, 1=ertaina, 2=altua, 3=aditua, 4=maisua)</target>
       </trans-unit>
       <trans-unit id="138ydah" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~4 mailetan banatuta (0=baxua, 1=ertaina, 2=altua, 3=aditua)</target>
       </trans-unit>
       <trans-unit id="ky6rhl3" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~3 mailetan banatuta (0=baxua, 1=ertaina, 2=altua)</target>
       </trans-unit>
       <trans-unit id="k7e8ktp" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~0 mailak galdera errazenak izan behar ditu (oinarrizko datuak eta gogoratze sinplea); hurrengo maila bakoitza aurrekoa baino zorrotzago zailagoa izan behar da (arrazoiketa gehiago, aukera luzeagoak edo korapilatsuagoak, hiztegi abstraktuagoa), eta 4. mailak (maisua) galderarik zailenak izan behar ditu.</target>
       </trans-unit>
       <trans-unit id="r7iw7mc" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~0 mailak galdera errazenak izan behar ditu (oinarrizko datuak eta gogoratze sinplea); hurrengo maila bakoitza aurrekoa baino zorrotzago zailagoa izan behar da (arrazoiketa gehiago, aukera luzeagoak edo korapilatsuagoak, hiztegi abstraktuagoa), eta 3. mailak (aditua) galderarik zailenak izan behar ditu.</target>
       </trans-unit>
       <trans-unit id="2h2x68t" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~0 mailak galdera errazenak izan behar ditu (oinarrizko datuak eta gogoratze sinplea); hurrengo maila bakoitza aurrekoa baino zorrotzago zailagoa izan behar da (arrazoiketa gehiago, aukera luzeagoak edo korapilatsuagoak, hiztegi abstraktuagoa), eta 2. mailak (altua) galderarik zailenak izan behar ditu.</target>
       </trans-unit>
       <trans-unit id="4ovmm0n" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~Zure nabigatzailea ez da bateragarria jarduera mota honekin.</target>
       </trans-unit>
       <trans-unit id="9gm2xul" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Gutxienez galdera bat gehitu behar duzu.</target>
       </trans-unit>
       <trans-unit id="wsyv236" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Gutxienez galdera bat izan behar duzu.</target>
       </trans-unit>
       <trans-unit id="d5lazt4" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~%s galdera: galderaren testua ezin da hutsik egon.</target>
       </trans-unit>
       <trans-unit id="fveejdx" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~%s galdera: bete erantzun-aukera guztiak.</target>
       </trans-unit>
       <trans-unit id="acjl06k" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~%s galdera: adierazi zein aukera den erantzun zuzena.</target>
       </trans-unit>
       <trans-unit id="96tfcof" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Gutxienez %s galdera gehitu behar dituzu.</target>
       </trans-unit>
       <trans-unit id="8hg8n4l" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Abisua: hautatutako hasierako mailak ez du galderarik. Galdetegia ordezko maila erabiliz hasiko da.</target>
       </trans-unit>
       <trans-unit id="1kjjhkn" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Eman izen bat maila bakoitzarentzat.</target>
       </trans-unit>
       <trans-unit id="1ewwkqd" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~«%s» mailak gutxienez 2 galdera izan behar ditu.</target>
       </trans-unit>
       <trans-unit id="ofuuzyd" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Adierazi soluzioa zenbat denboraz erakutsiko den.</target>
       </trans-unit>
       <trans-unit id="nlrj7xd" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~%s galdera: markatu gutxienez erantzun zuzen bat.</target>
       </trans-unit>
       <trans-unit id="ft9t470" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~%s galdera: eman soluzioaren hitza edo esaldia.</target>
       </trans-unit>
       <trans-unit id="72pf70z" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~%s galdera: eman definizioa.</target>
       </trans-unit>
       <trans-unit id="nweglt5" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~%s galdera: esleitu 1etik %n-ra bitarteko ordena bakar bat aukera bakoitzari.</target>
       </trans-unit>
       <trans-unit id="mavrntg" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~Audioaren URLa</target>
       </trans-unit>
       <trans-unit id="k4sz5uu" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Erakutsi audio-aukerak</target>
       </trans-unit>
       <trans-unit id="hnzht4z" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Sortu zailtasuna ikaslearentzat egokitzen den aukera anitzeko galdetegi bat. Aukeratu zailtasun-mailen kopurua (3, 4 edo 5) eta esleitu bat galdera bakoitzari; galdetegia maila bat igotzen da segidan bi erantzun zuzen emanda, eta jaisten da segidan bi erantzun oker emanda.</target>
       </trans-unit>
       <trans-unit id="ivw2c4c" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Maila kopurua</target>
       </trans-unit>
       <trans-unit id="75b0jbi" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~1. mailaren izena</target>
       </trans-unit>
       <trans-unit id="poa6lpp" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Erraza</target>
       </trans-unit>
       <trans-unit id="wckpyat" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~2. mailaren izena</target>
       </trans-unit>
       <trans-unit id="gis0khe" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~3. mailaren izena</target>
       </trans-unit>
       <trans-unit id="8u35fl5" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Zaila</target>
       </trans-unit>
       <trans-unit id="fdxjqnv" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~4. mailaren izena</target>
       </trans-unit>
       <trans-unit id="t70iuq1" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Aditua</target>
       </trans-unit>
       <trans-unit id="2fy5ztm" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~5. mailaren izena</target>
       </trans-unit>
       <trans-unit id="zvlympa" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Maisua</target>
       </trans-unit>
       <trans-unit id="qhc0d0u" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Hasierako maila</target>
       </trans-unit>
       <trans-unit id="zrwc2wp" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Jarri 0 denbora-muga desgaitzeko.</target>
       </trans-unit>
       <trans-unit id="1begbuv" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Nahastu erantzun-aukerak exekuzioan</target>
       </trans-unit>
       <trans-unit id="d6ct6jz" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Maiuskulak eta minuskulak bereiztea (hitz mota)</target>
       </trans-unit>
       <trans-unit id="5u01ehg" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Eskatu azentu zuzenak (hitz mota)</target>
       </trans-unit>
       <trans-unit id="sjek1xz" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Maila-iragazkia</target>
       </trans-unit>
       <trans-unit id="ko50yub" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Birkargatu irudia</target>
       </trans-unit>
       <trans-unit id="kuzzlf4" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Galdetegi moldagarria</target>
       </trans-unit>
       <trans-unit id="ye96oy0" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Egin klik aukera batean zure erantzuna aukeratzeko.</target>
       </trans-unit>
       <trans-unit id="khez84r" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Lortutako mailarik altuena</target>
       </trans-unit>
       <trans-unit id="408eb2h" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Maila igo duzu!</target>
       </trans-unit>
       <trans-unit id="66oh6mx" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Maila jaitsi duzu</target>
       </trans-unit>
       <trans-unit id="4srmipn" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Azken txostena</target>
       </trans-unit>
       <trans-unit id="ej86qwb" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Bikain. Mailarik altueneko edukiak menderatzen dituzu.</target>
       </trans-unit>
       <trans-unit id="68z00go" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Lan ona. Bitarteko maila lortu duzu.</target>
       </trans-unit>
       <trans-unit id="evy3u4v" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Praktika pixka bat gehiago behar duzu. Berrikusi oinarrizko edukiak.</target>
       </trans-unit>
       <trans-unit id="bjhgp7h" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pausatu audioa</target>
       </trans-unit>
       <trans-unit id="1hthjtq" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Ilustrazioa</target>
       </trans-unit>
       <trans-unit id="uh7cnvf" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Aukeratu erantzun zuzena galdera bakoitzerako. Hurrengo mailara igotzeko, segidan bi galdera zuzen erantzun behar dituzu. Segidan bi huts egiten badituzu, aurreko mailara jaitsiko zara.</target>
       </trans-unit>
       <trans-unit id="ghw7ndw" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Denbora agortu da!</target>
       </trans-unit>
       <trans-unit id="l132pgi" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Sortu %total% galdetegi moldagarriko galdera mistoak %distribution% eta onartzen diren hiru galdera moten artean. Lerro bakoitzak mota-zenbakiarekin hasi behar du, ondoren @, gero maila eta gero gainerako eremuak #-rekin bereizita. Inoiz ez jarri # eremu baten barruan. Onartzen diren hiru lerro-formak hauek dira: 0 mota (aukera anitzekoa): 0@Maila#Soluzioa#Galdera#AAukera#BAukera[#CAukera][#DAukera][#EAukera][#FAukera] — Soluzioa A, B, C, D, E, F letren maiuskula-konbinazioa da, aukera zuzenak adierazten dituena (adib. A, AB, ACD, ABCDEF); erabili gehienez 6 letra eta inoiz ez aukera kopurua baino gehiago; utzi soluzioa hutsik aukera bat ere zuzena ez bada. 1 mota (ordenatu): 1@Maila#Galdera#1Elementua#2Elementua#3Elementua[#4Elementua][#5Elementua][#6Elementua] — eman 3 eta 6 elementu artean, galderaren irizpidearen arabera ordena zuzenean zerrendatuta. 2 mota (hitza/definizioa): 2@Maila#Hitza#Definizioa. Zailtasunak mailarekin handitu behar du: %ladder% Maila bakoitzaren barruan hiru moten galderak sartu behar dituzu (0 mota, 1 mota eta 2 mota): sortu %perLevel% galdera inguru maila bakoitzeko eta ziurtatu maila bakoitzak hautaketa (0 mota), ordenatzea (1 mota) eta hitza/definizioa (2 mota) nahasten dituela. Ez jarri mota bereko guztiak elkarrekin; txandakatu hiru motak maila bakoitzaren barruan.</target>
       </trans-unit>
       <trans-unit id="9n0ymdt" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Sortu zirkuituaren aurrebista gorde aurretik</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="u7zw9yb" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nivel: 0 (baixo), 1 (medio), 2 (alto), 3 (experto) ou 4 (mestre).</target>
       </trans-unit>
       <trans-unit id="bxshrwt" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nivel: 0 (baixo), 1 (medio), 2 (alto) ou 3 (experto).</target>
       </trans-unit>
       <trans-unit id="cb9t41l" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nivel: 0 (baixo), 1 (medio) ou 2 (alto).</target>
       </trans-unit>
       <trans-unit id="tey6gez" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpciónE</target>
       </trans-unit>
       <trans-unit id="bjhf111" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpciónF</target>
       </trans-unit>
       <trans-unit id="620g1ax" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Cales dos seguintes son números primos?</target>
       </trans-unit>
       <trans-unit id="ajl9b18" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordena de maior a menor</target>
       </trans-unit>
       <trans-unit id="ew5q9fx" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefante</target>
       </trans-unit>
       <trans-unit id="ujhq6hc" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Rato</target>
       </trans-unit>
       <trans-unit id="ytw1cui" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Cales destes son números transcendentes?</target>
       </trans-unit>
       <trans-unit id="2hyqtyi" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Constante de Liouville</target>
       </trans-unit>
       <trans-unit id="nhgs59y" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Constante de Champernowne</target>
       </trans-unit>
       <trans-unit id="4qqmes9" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordena estes elementos químicos de menor a maior número atómico</target>
       </trans-unit>
       <trans-unit id="xmppq73" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Acéptanse tres tipos de preguntas. Cada liña debe comezar co número de tipo, seguido de @, o nivel e o resto dos campos separados con #:</target>
       </trans-unit>
       <trans-unit id="r9bz63r" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipo 0 (opción múltiple): 0@Nivel#Solución#Pregunta#OpciónA#OpciónB[#OpciónC][#OpciónD][#OpciónE][#OpciónF]. A solución é unha combinación en maiúsculas de A, B, C, D, E, F que identifica as opcións correctas (p. ex. A, AB, ACD, ABCDEF). Usa ata 6 letras e nunca máis que o número de opcións. Deixa Solución baleira se ningunha opción é correcta.</target>
       </trans-unit>
       <trans-unit id="d3tbblq" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipo 1 (ordenar): 1@Nivel#Pregunta#Elemento1#Elemento2#Elemento3[#Elemento4][#Elemento5][#Elemento6]. Proporciona entre 3 e 6 elementos xa listados na orde correcta segundo o criterio da pregunta.</target>
       </trans-unit>
       <trans-unit id="941sama" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipo 2 (palabra/definición): 2@Nivel#Palabra#Definición.</target>
       </trans-unit>
       <trans-unit id="3hmoicl" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Non inclúas o carácter # dentro de ningún campo.</target>
       </trans-unit>
       <trans-unit id="yndh9s4" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuídas entre os 5 niveis (0=baixo, 1=medio, 2=alto, 3=experto, 4=mestre)</target>
       </trans-unit>
       <trans-unit id="pc0km8t" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuídas entre os 4 niveis (0=baixo, 1=medio, 2=alto, 3=experto)</target>
       </trans-unit>
       <trans-unit id="hqkmwek" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuídas entre os 3 niveis (0=baixo, 1=medio, 2=alto)</target>
       </trans-unit>
       <trans-unit id="9zc9zfb" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nivel 0 debe conter as preguntas máis fáciles (feitos básicos e lembranza simple); cada nivel seguinte debe ser estritamente máis difícil que o anterior (máis razoamento, opcións máis longas ou complicadas, vocabulario máis abstracto), e o nivel 4 (mestre) debe conter as preguntas máis difíciles.</target>
       </trans-unit>
       <trans-unit id="6y0bedc" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nivel 0 debe conter as preguntas máis fáciles (feitos básicos e lembranza simple); cada nivel seguinte debe ser estritamente máis difícil que o anterior (máis razoamento, opcións máis longas ou complicadas, vocabulario máis abstracto), e o nivel 3 (experto) debe conter as preguntas máis difíciles.</target>
       </trans-unit>
       <trans-unit id="shzkekk" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nivel 0 debe conter as preguntas máis fáciles (feitos básicos e lembranza simple); cada nivel seguinte debe ser estritamente máis difícil que o anterior (máis razoamento, opcións máis longas ou complicadas, vocabulario máis abstracto), e o nivel 2 (alto) debe conter as preguntas máis difíciles.</target>
       </trans-unit>
       <trans-unit id="d029wma" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~O teu navegador non é compatible con este tipo de actividade.</target>
       </trans-unit>
       <trans-unit id="0xhf8r4" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Debes engadir polo menos unha pregunta.</target>
       </trans-unit>
       <trans-unit id="1eu30bs" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Debes ter polo menos unha pregunta.</target>
       </trans-unit>
       <trans-unit id="jeyen0z" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Pregunta %s: o texto da pregunta non pode estar baleiro.</target>
       </trans-unit>
       <trans-unit id="07zxp6i" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Pregunta %s: enche todas as opcións de resposta.</target>
       </trans-unit>
       <trans-unit id="p048vrr" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: indica cal opción é a resposta correcta.</target>
       </trans-unit>
       <trans-unit id="rz4v0hm" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Debes engadir polo menos %s preguntas.</target>
       </trans-unit>
       <trans-unit id="t0y2yqq" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Aviso: o nivel inicial seleccionado non ten preguntas. O cuestionario comezará usando o nivel de reserva.</target>
       </trans-unit>
       <trans-unit id="6rd8cwy" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indica un nome para cada nivel.</target>
       </trans-unit>
       <trans-unit id="2o2j8lf" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~O nivel «%s» debe ter polo menos 2 preguntas.</target>
       </trans-unit>
       <trans-unit id="49j9of4" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indica o tempo que se mostrará a solución.</target>
       </trans-unit>
       <trans-unit id="zy750wh" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: marca polo menos unha resposta correcta.</target>
       </trans-unit>
       <trans-unit id="lxkxyw9" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona a palabra ou frase solución.</target>
       </trans-unit>
       <trans-unit id="2xrm4sj" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona a definición.</target>
       </trans-unit>
       <trans-unit id="9yuqjw6" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Pregunta %s: asigna unha orde única do 1 ao %n a cada opción.</target>
       </trans-unit>
       <trans-unit id="3ef1zgh" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL de audio</target>
       </trans-unit>
       <trans-unit id="ul2ieoy" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Amosar as opcións de audio</target>
       </trans-unit>
       <trans-unit id="zai151r" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Crea un cuestionario de opción múltiple cuxa dificultade se adapta ao alumno. Escolle o número de niveis de dificultade (3, 4 ou 5) e asigna un a cada pregunta; o cuestionario sobe un nivel tras dúas respostas correctas seguidas e baixa tras dúas incorrectas seguidas.</target>
       </trans-unit>
       <trans-unit id="cb5ohtq" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Número de niveis</target>
       </trans-unit>
       <trans-unit id="fmc6i40" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nome do nivel 1</target>
       </trans-unit>
       <trans-unit id="icwfftj" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Fácil</target>
       </trans-unit>
       <trans-unit id="h9g18tq" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nome do nivel 2</target>
       </trans-unit>
       <trans-unit id="x1a1nuu" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nome do nivel 3</target>
       </trans-unit>
       <trans-unit id="vt95xs9" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Difícil</target>
       </trans-unit>
       <trans-unit id="gbfl68a" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nome do nivel 4</target>
       </trans-unit>
       <trans-unit id="05v6iwj" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Experto</target>
       </trans-unit>
       <trans-unit id="0pkznbz" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nome do nivel 5</target>
       </trans-unit>
       <trans-unit id="9qwr5oi" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Mestre</target>
       </trans-unit>
       <trans-unit id="ijb3mor" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Nivel inicial</target>
       </trans-unit>
       <trans-unit id="cfm5ox2" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Pon 0 para desactivar o límite de tempo.</target>
       </trans-unit>
       <trans-unit id="sr64d5z" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Mestura as opcións de resposta durante a execución</target>
       </trans-unit>
       <trans-unit id="fzhyj2f" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Distingue maiúsculas e minúsculas (tipo palabra)</target>
       </trans-unit>
       <trans-unit id="u9zuncm" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Esixe acentos correctos (tipo palabra)</target>
       </trans-unit>
       <trans-unit id="xergdhp" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtro de nivel</target>
       </trans-unit>
       <trans-unit id="ztcgwcf" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Recargar a imaxe</target>
       </trans-unit>
       <trans-unit id="r99ypao" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Cuestionario adaptativo</target>
       </trans-unit>
       <trans-unit id="4w9n4qn" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Fai clic nunha opción para escoller a túa resposta.</target>
       </trans-unit>
       <trans-unit id="nth9vlc" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Nivel máis alto acadado</target>
       </trans-unit>
       <trans-unit id="f3h71k2" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Subes de nivel!</target>
       </trans-unit>
       <trans-unit id="4r0edwu" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Baixas de nivel</target>
       </trans-unit>
       <trans-unit id="u4il9nc" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Informe final</target>
       </trans-unit>
       <trans-unit id="n1dh2n8" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Excelente. Dominas os contidos de máis alto nivel.</target>
       </trans-unit>
       <trans-unit id="sp90dv6" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bo traballo. Acadaches o nivel intermedio.</target>
       </trans-unit>
       <trans-unit id="cvd7j6s" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Precisas un pouco máis de práctica. Repasa os contidos básicos.</target>
       </trans-unit>
       <trans-unit id="99kqk6m" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pausar o audio</target>
       </trans-unit>
       <trans-unit id="qcjhcec" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Ilustración</target>
       </trans-unit>
       <trans-unit id="5drzlm4" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Escolle a resposta correcta para cada pregunta. Para subir ao seguinte nivel debes responder correctamente dúas preguntas seguidas. Se fallas dúas seguidas, baixarás ao nivel anterior.</target>
       </trans-unit>
       <trans-unit id="o8n34ta" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Acabouse o tempo!</target>
       </trans-unit>
       <trans-unit id="nugcy0g" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Crea %total% preguntas mixtas de cuestionario adaptativo %distribution% e dos tres tipos de pregunta admitidos. Cada liña debe comezar co número de tipo seguido de @, logo o nivel e logo o resto dos campos separados con #. Nunca poñas # dentro dun campo. As tres formas de liña admitidas son: Tipo 0 (opción múltiple): 0@Nivel#Solución#Pregunta#OpciónA#OpciónB[#OpciónC][#OpciónD][#OpciónE][#OpciónF] — A solución é unha combinación en maiúsculas das letras A, B, C, D, E, F que identifica as opcións correctas (p. ex. A, AB, ACD, ABCDEF); usa ata 6 letras e nunca máis que o número de opcións; deixa a solución baleira se ningunha opción é correcta. Tipo 1 (ordenar): 1@Nivel#Pregunta#Elemento1#Elemento2#Elemento3[#Elemento4][#Elemento5][#Elemento6] — proporciona entre 3 e 6 elementos xa listados na orde correcta segundo o criterio da pregunta. Tipo 2 (palabra/definición): 2@Nivel#Palabra#Definición. A dificultade debe aumentar co nivel: %ladder% Dentro de cada nivel debes incluír preguntas dos tres tipos (Tipo 0, Tipo 1 e Tipo 2): xera arredor de %perLevel% preguntas por nivel e asegúrate de que cada nivel combine seleccionar (Tipo 0), ordenar (Tipo 1) e palabra/definición (Tipo 2). Non poñas todas do mesmo tipo xuntas; intercala os tres tipos dentro de cada nivel.</target>
       </trans-unit>
       <trans-unit id="y1mnywm" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Xera a vista previa do circuíto antes de gardar</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="9qtdmwo" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Livello: 0 (basso), 1 (medio), 2 (alto), 3 (esperto) o 4 (maestro).</target>
       </trans-unit>
       <trans-unit id="fnlowfw" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Livello: 0 (basso), 1 (medio), 2 (alto) o 3 (esperto).</target>
       </trans-unit>
       <trans-unit id="c1bj6nd" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Livello: 0 (basso), 1 (medio) o 2 (alto).</target>
       </trans-unit>
       <trans-unit id="hk9cxsr" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpzioneE</target>
       </trans-unit>
       <trans-unit id="7qwdaqd" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpzioneF</target>
       </trans-unit>
       <trans-unit id="jyobeku" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Quali dei seguenti sono numeri primi?</target>
       </trans-unit>
       <trans-unit id="7h7jf6z" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordina dal più grande al più piccolo</target>
       </trans-unit>
       <trans-unit id="686fn8s" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefante</target>
       </trans-unit>
       <trans-unit id="msd9edm" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Topo</target>
       </trans-unit>
       <trans-unit id="xfunjyl" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Quali di questi sono numeri trascendenti?</target>
       </trans-unit>
       <trans-unit id="kzue2uw" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Costante di Liouville</target>
       </trans-unit>
       <trans-unit id="emzuke8" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Costante di Champernowne</target>
       </trans-unit>
       <trans-unit id="micg4af" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordina questi elementi chimici dal numero atomico più basso al più alto</target>
       </trans-unit>
       <trans-unit id="i90iqn8" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Sono accettati tre tipi di domande. Ogni riga deve iniziare con il numero del tipo, seguito da @, il livello e gli altri campi separati con #:</target>
       </trans-unit>
       <trans-unit id="t68wesa" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipo 0 (scelta multipla): 0@Livello#Soluzione#Domanda#OpzioneA#OpzioneB[#OpzioneC][#OpzioneD][#OpzioneE][#OpzioneF]. La soluzione è una combinazione in maiuscolo di A, B, C, D, E, F che identifica le opzioni corrette (es. A, AB, ACD, ABCDEF). Usa fino a 6 lettere e mai più del numero di opzioni. Lascia Soluzione vuota se nessuna opzione è corretta.</target>
       </trans-unit>
       <trans-unit id="zqmwcwg" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipo 1 (ordinare): 1@Livello#Domanda#Elemento1#Elemento2#Elemento3[#Elemento4][#Elemento5][#Elemento6]. Fornisci tra 3 e 6 elementi già elencati nell'ordine corretto secondo il criterio della domanda.</target>
       </trans-unit>
       <trans-unit id="d42ux13" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipo 2 (parola/definizione): 2@Livello#Parola#Definizione.</target>
       </trans-unit>
       <trans-unit id="d526kxb" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Non includere il carattere # all'interno di alcun campo.</target>
       </trans-unit>
       <trans-unit id="buhdxa0" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuite tra i 5 livelli (0=basso, 1=medio, 2=alto, 3=esperto, 4=maestro)</target>
       </trans-unit>
       <trans-unit id="iqskrrj" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuite tra i 4 livelli (0=basso, 1=medio, 2=alto, 3=esperto)</target>
       </trans-unit>
       <trans-unit id="keoaado" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuite tra i 3 livelli (0=basso, 1=medio, 2=alto)</target>
       </trans-unit>
       <trans-unit id="0k7yb5p" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Il livello 0 deve contenere le domande più facili (fatti di base e semplice memorizzazione); ogni livello successivo deve essere rigorosamente più impegnativo del precedente (più ragionamento, opzioni più lunghe o complicate, vocabolario più astratto), e il livello 4 (maestro) deve contenere le domande più difficili.</target>
       </trans-unit>
       <trans-unit id="f5daks5" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Il livello 0 deve contenere le domande più facili (fatti di base e semplice memorizzazione); ogni livello successivo deve essere rigorosamente più impegnativo del precedente (più ragionamento, opzioni più lunghe o complicate, vocabolario più astratto), e il livello 3 (esperto) deve contenere le domande più difficili.</target>
       </trans-unit>
       <trans-unit id="lzrhk98" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Il livello 0 deve contenere le domande più facili (fatti di base e semplice memorizzazione); ogni livello successivo deve essere rigorosamente più impegnativo del precedente (più ragionamento, opzioni più lunghe o complicate, vocabolario più astratto), e il livello 2 (alto) deve contenere le domande più difficili.</target>
       </trans-unit>
       <trans-unit id="ytj131f" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~Il tuo browser non è compatibile con questo tipo di attività.</target>
       </trans-unit>
       <trans-unit id="bchjnlb" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Devi aggiungere almeno una domanda.</target>
       </trans-unit>
       <trans-unit id="mhxiq9r" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Devi avere almeno una domanda.</target>
       </trans-unit>
       <trans-unit id="0hpxz6p" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Domanda %s: il testo della domanda non può essere vuoto.</target>
       </trans-unit>
       <trans-unit id="aenf6ke" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Domanda %s: compila tutte le opzioni di risposta.</target>
       </trans-unit>
       <trans-unit id="enphg3m" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Domanda %s: indica quale opzione è la risposta corretta.</target>
       </trans-unit>
       <trans-unit id="blmfk6q" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Devi aggiungere almeno %s domande.</target>
       </trans-unit>
       <trans-unit id="dttmaxu" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Avviso: il livello iniziale selezionato non ha domande. Il quiz inizierà usando il livello di riserva.</target>
       </trans-unit>
       <trans-unit id="jjho9de" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indica un nome per ogni livello.</target>
       </trans-unit>
       <trans-unit id="04hwbzu" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~Il livello «%s» deve avere almeno 2 domande.</target>
       </trans-unit>
       <trans-unit id="r1k5ymd" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indica il tempo per cui sarà mostrata la soluzione.</target>
       </trans-unit>
       <trans-unit id="gxcwbyk" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Domanda %s: indica almeno una risposta corretta.</target>
       </trans-unit>
       <trans-unit id="da19h7d" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Domanda %s: fornisci la parola o la frase soluzione.</target>
       </trans-unit>
       <trans-unit id="2bm91cz" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Domanda %s: fornisci la definizione.</target>
       </trans-unit>
       <trans-unit id="3dr34zj" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Domanda %s: assegna un ordine univoco da 1 a %n a ogni opzione.</target>
       </trans-unit>
       <trans-unit id="1wj0ai6" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL audio</target>
       </trans-unit>
       <trans-unit id="3ydn2kn" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Mostra le opzioni audio</target>
       </trans-unit>
       <trans-unit id="65abn27" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Crea un quiz a scelta multipla la cui difficoltà si adatta allo studente. Scegli il numero di livelli di difficoltà (3, 4 o 5) e assegnane uno a ogni domanda; il quiz sale di un livello dopo due risposte corrette di fila e scende dopo due risposte errate di fila.</target>
       </trans-unit>
       <trans-unit id="rsnswk4" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Numero di livelli</target>
       </trans-unit>
       <trans-unit id="05wmgd7" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nome del livello 1</target>
       </trans-unit>
       <trans-unit id="6lr6ldm" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Facile</target>
       </trans-unit>
       <trans-unit id="p9ksohh" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nome del livello 2</target>
       </trans-unit>
       <trans-unit id="7auibaj" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nome del livello 3</target>
       </trans-unit>
       <trans-unit id="d2pf286" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Difficile</target>
       </trans-unit>
       <trans-unit id="nc1xmcq" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nome del livello 4</target>
       </trans-unit>
       <trans-unit id="dcfnlj1" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Esperto</target>
       </trans-unit>
       <trans-unit id="9ezsnnv" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nome del livello 5</target>
       </trans-unit>
       <trans-unit id="q622l9k" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Maestro</target>
       </trans-unit>
       <trans-unit id="5h6p3zt" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Livello iniziale</target>
       </trans-unit>
       <trans-unit id="7ffizzz" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Imposta 0 per disattivare il limite di tempo.</target>
       </trans-unit>
       <trans-unit id="6ledp9v" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Mescola le opzioni di risposta durante l'esecuzione</target>
       </trans-unit>
       <trans-unit id="eqhs9wb" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Confronto delle risposte sensibile alle maiuscole (tipo parola)</target>
       </trans-unit>
       <trans-unit id="o2vfsbf" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Richiedi accenti corretti (tipo parola)</target>
       </trans-unit>
       <trans-unit id="fmr6q33" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtro di livello</target>
       </trans-unit>
       <trans-unit id="hrneuwl" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Ricarica l'immagine</target>
       </trans-unit>
       <trans-unit id="f7s8frf" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Quiz adattativo</target>
       </trans-unit>
       <trans-unit id="qbzvll9" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Fai clic su un'opzione per scegliere la tua risposta.</target>
       </trans-unit>
       <trans-unit id="ogjcjq0" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Livello più alto raggiunto</target>
       </trans-unit>
       <trans-unit id="5h3lqaj" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Sali di livello!</target>
       </trans-unit>
       <trans-unit id="pjgbe5f" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Scendi di livello</target>
       </trans-unit>
       <trans-unit id="od6obji" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Rapporto finale</target>
       </trans-unit>
       <trans-unit id="z4idelo" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Eccellente. Padroneggi i contenuti di livello più alto.</target>
       </trans-unit>
       <trans-unit id="qgkfkip" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Ottimo lavoro. Hai raggiunto il livello intermedio.</target>
       </trans-unit>
       <trans-unit id="345ws0a" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Hai bisogno di un po' più di pratica. Ripassa i contenuti di base.</target>
       </trans-unit>
       <trans-unit id="gpw1cc6" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Metti in pausa l'audio</target>
       </trans-unit>
       <trans-unit id="hovtpp5" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Illustrazione</target>
       </trans-unit>
       <trans-unit id="atzfgnp" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Scegli la risposta corretta per ogni domanda. Per salire al livello successivo devi rispondere correttamente a due domande di fila. Se sbagli due domande di fila, scenderai al livello precedente.</target>
       </trans-unit>
       <trans-unit id="4f1kslo" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Tempo scaduto!</target>
       </trans-unit>
       <trans-unit id="7o1wx8a" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Crea %total% domande miste di quiz adattativo %distribution% e tra i tre tipi di domanda supportati. Ogni riga deve iniziare con il numero del tipo seguito da @, poi il livello e poi gli altri campi separati con #. Non mettere mai # all'interno di un campo. Le tre forme di riga accettate sono: Tipo 0 (scelta multipla): 0@Livello#Soluzione#Domanda#OpzioneA#OpzioneB[#OpzioneC][#OpzioneD][#OpzioneE][#OpzioneF] — La soluzione è una combinazione in maiuscolo delle lettere A, B, C, D, E, F che identifica le opzioni corrette (es. A, AB, ACD, ABCDEF); usa fino a 6 lettere e mai più del numero di opzioni; lascia la soluzione vuota se nessuna opzione è corretta. Tipo 1 (ordinare): 1@Livello#Domanda#Elemento1#Elemento2#Elemento3[#Elemento4][#Elemento5][#Elemento6] — fornisci tra 3 e 6 elementi già elencati nell'ordine corretto secondo il criterio della domanda. Tipo 2 (parola/definizione): 2@Livello#Parola#Definizione. La difficoltà deve aumentare con il livello: %ladder% All'interno di ogni singolo livello devi includere domande di tutti e tre i tipi (Tipo 0, Tipo 1 e Tipo 2): genera circa %perLevel% domande per livello e assicurati che ogni livello mescoli scelta multipla (Tipo 0), ordinamento (Tipo 1) e parola/definizione (Tipo 2). Non mettere insieme tutte le domande dello stesso tipo; alterna i tre tipi all'interno di ogni livello.</target>
       </trans-unit>
       <trans-unit id="018wjlh" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Genera l'anteprima del circuito prima di salvare</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="rbp3nom" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nível: 0 (baixo), 1 (médio), 2 (alto), 3 (especialista) ou 4 (mestre).</target>
       </trans-unit>
       <trans-unit id="1ltab78" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nível: 0 (baixo), 1 (médio), 2 (alto) ou 3 (especialista).</target>
       </trans-unit>
       <trans-unit id="iqp6lnq" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nível: 0 (baixo), 1 (médio) ou 2 (alto).</target>
       </trans-unit>
       <trans-unit id="gi30ipb" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpçãoE</target>
       </trans-unit>
       <trans-unit id="1xxnzv0" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpçãoF</target>
       </trans-unit>
       <trans-unit id="xng75va" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Quais dos seguintes são números primos?</target>
       </trans-unit>
       <trans-unit id="nw8s7o2" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordena do maior para o menor</target>
       </trans-unit>
       <trans-unit id="zeqlqo7" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefante</target>
       </trans-unit>
       <trans-unit id="f26qrhb" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Rato</target>
       </trans-unit>
       <trans-unit id="afwa1oq" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Quais destes são números transcendentes?</target>
       </trans-unit>
       <trans-unit id="15gegzu" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Constante de Liouville</target>
       </trans-unit>
       <trans-unit id="ow97q0q" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Constante de Champernowne</target>
       </trans-unit>
       <trans-unit id="adox97s" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordena estes elementos químicos do menor para o maior número atómico</target>
       </trans-unit>
       <trans-unit id="wglprmq" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~São aceites três tipos de perguntas. Cada linha deve começar com o número do tipo, seguido de @, o nível e os restantes campos separados com #:</target>
       </trans-unit>
       <trans-unit id="lf00v3d" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipo 0 (escolha múltipla): 0@Nível#Solução#Pergunta#OpçãoA#OpçãoB[#OpçãoC][#OpçãoD][#OpçãoE][#OpçãoF]. A solução é uma combinação em maiúsculas de A, B, C, D, E, F que identifica as opções corretas (p. ex. A, AB, ACD, ABCDEF). Usa até 6 letras e nunca mais do que o número de opções. Deixa Solução vazia se nenhuma opção estiver correta.</target>
       </trans-unit>
       <trans-unit id="4xwbkt6" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipo 1 (ordenar): 1@Nível#Pergunta#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Fornece entre 3 e 6 itens já listados na ordem correta de acordo com o critério da pergunta.</target>
       </trans-unit>
       <trans-unit id="g5pvvgu" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipo 2 (palavra/definição): 2@Nível#Palavra#Definição.</target>
       </trans-unit>
       <trans-unit id="0ev8jf2" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Não incluas o caractere # dentro de nenhum campo.</target>
       </trans-unit>
       <trans-unit id="shl10oj" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuídas pelos 5 níveis (0=baixo, 1=médio, 2=alto, 3=especialista, 4=mestre)</target>
       </trans-unit>
       <trans-unit id="ti61bao" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuídas pelos 4 níveis (0=baixo, 1=médio, 2=alto, 3=especialista)</target>
       </trans-unit>
       <trans-unit id="fpd9fdv" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuídas pelos 3 níveis (0=baixo, 1=médio, 2=alto)</target>
       </trans-unit>
       <trans-unit id="xppk2z0" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nível 0 deve conter as perguntas mais fáceis (factos básicos e memorização simples); cada nível seguinte deve ser estritamente mais difícil do que o anterior (mais raciocínio, opções mais longas ou complicadas, vocabulário mais abstrato), e o nível 4 (mestre) deve conter as perguntas mais difíceis.</target>
       </trans-unit>
       <trans-unit id="bjz9aib" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nível 0 deve conter as perguntas mais fáceis (factos básicos e memorização simples); cada nível seguinte deve ser estritamente mais difícil do que o anterior (mais raciocínio, opções mais longas ou complicadas, vocabulário mais abstrato), e o nível 3 (especialista) deve conter as perguntas mais difíceis.</target>
       </trans-unit>
       <trans-unit id="o0k20mk" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~O nível 0 deve conter as perguntas mais fáceis (factos básicos e memorização simples); cada nível seguinte deve ser estritamente mais difícil do que o anterior (mais raciocínio, opções mais longas ou complicadas, vocabulário mais abstrato), e o nível 2 (alto) deve conter as perguntas mais difíceis.</target>
       </trans-unit>
       <trans-unit id="kp2i8dt" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~O teu navegador não é compatível com este tipo de atividade.</target>
       </trans-unit>
       <trans-unit id="78aygkh" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Tens de adicionar pelo menos uma pergunta.</target>
       </trans-unit>
       <trans-unit id="b3k2f50" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Tens de ter pelo menos uma pergunta.</target>
       </trans-unit>
       <trans-unit id="g0garet" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Pergunta %s: o texto da pergunta não pode estar vazio.</target>
       </trans-unit>
       <trans-unit id="93mev9e" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Pergunta %s: preenche todas as opções de resposta.</target>
       </trans-unit>
       <trans-unit id="l6z7q51" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Pergunta %s: indica qual opção é a resposta correta.</target>
       </trans-unit>
       <trans-unit id="h8wb94s" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Tens de adicionar pelo menos %s perguntas.</target>
       </trans-unit>
       <trans-unit id="6y4patk" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Aviso: o nível inicial selecionado não tem perguntas. O questionário começará usando o nível de reserva.</target>
       </trans-unit>
       <trans-unit id="lvx4pi3" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indica um nome para cada nível.</target>
       </trans-unit>
       <trans-unit id="a99u6tw" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~O nível «%s» deve ter pelo menos 2 perguntas.</target>
       </trans-unit>
       <trans-unit id="ixano4v" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indica o tempo durante o qual a solução será exibida.</target>
       </trans-unit>
       <trans-unit id="aey9qzu" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Pergunta %s: marca pelo menos uma resposta correta.</target>
       </trans-unit>
       <trans-unit id="rbd53a8" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Pergunta %s: fornece a palavra ou frase solução.</target>
       </trans-unit>
       <trans-unit id="n0q4xol" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Pergunta %s: fornece a definição.</target>
       </trans-unit>
       <trans-unit id="99a310l" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Pergunta %s: atribui uma ordem única de 1 a %n a cada opção.</target>
       </trans-unit>
       <trans-unit id="awa71i5" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL de áudio</target>
       </trans-unit>
       <trans-unit id="3sqvvoi" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Mostrar opções de áudio</target>
       </trans-unit>
       <trans-unit id="xplcbsn" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Cria um questionário de escolha múltipla cuja dificuldade se adapta ao aluno. Escolhe o número de níveis de dificuldade (3, 4 ou 5) e atribui um a cada pergunta; o questionário sobe um nível após duas respostas corretas seguidas e desce após duas incorretas seguidas.</target>
       </trans-unit>
       <trans-unit id="zmiy1jb" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Número de níveis</target>
       </trans-unit>
       <trans-unit id="3owmnrq" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nome do nível 1</target>
       </trans-unit>
       <trans-unit id="o2z9sy0" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Fácil</target>
       </trans-unit>
       <trans-unit id="9e524qu" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nome do nível 2</target>
       </trans-unit>
       <trans-unit id="xfzfg7x" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nome do nível 3</target>
       </trans-unit>
       <trans-unit id="gxi37qc" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Difícil</target>
       </trans-unit>
       <trans-unit id="s3w34pm" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nome do nível 4</target>
       </trans-unit>
       <trans-unit id="qmbdiej" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Especialista</target>
       </trans-unit>
       <trans-unit id="vbpnz6e" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nome do nível 5</target>
       </trans-unit>
       <trans-unit id="kbsp3b9" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Mestre</target>
       </trans-unit>
       <trans-unit id="l6julg7" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Nível inicial</target>
       </trans-unit>
       <trans-unit id="2ayo29v" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Define 0 para desativar o limite de tempo.</target>
       </trans-unit>
       <trans-unit id="bnajz72" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Baralhar as opções de resposta durante a execução</target>
       </trans-unit>
       <trans-unit id="abdod8j" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Distinguir maiúsculas e minúsculas (tipo palavra)</target>
       </trans-unit>
       <trans-unit id="0kraf80" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Exigir acentos corretos (tipo palavra)</target>
       </trans-unit>
       <trans-unit id="7bartca" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtro de nível</target>
       </trans-unit>
       <trans-unit id="tv2ingp" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Recarregar imagem</target>
       </trans-unit>
       <trans-unit id="cbbqwgo" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Questionário adaptativo</target>
       </trans-unit>
       <trans-unit id="gtmr683" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Clica numa opção para escolher a tua resposta.</target>
       </trans-unit>
       <trans-unit id="q49r5mz" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Nível mais alto alcançado</target>
       </trans-unit>
       <trans-unit id="sk0k6ny" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Sobes de nível!</target>
       </trans-unit>
       <trans-unit id="rd82u2f" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Desces de nível</target>
       </trans-unit>
       <trans-unit id="vbjokx5" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Relatório final</target>
       </trans-unit>
       <trans-unit id="tk8mbe3" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Excelente. Dominas os conteúdos de nível mais alto.</target>
       </trans-unit>
       <trans-unit id="c898p6o" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bom trabalho. Atingiste o nível intermédio.</target>
       </trans-unit>
       <trans-unit id="7huvi4e" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Precisas de um pouco mais de prática. Revê os conteúdos básicos.</target>
       </trans-unit>
       <trans-unit id="68wk5kv" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pausar áudio</target>
       </trans-unit>
       <trans-unit id="r2rrlzb" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Ilustração</target>
       </trans-unit>
       <trans-unit id="25zpkyx" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Escolhe a resposta correta para cada pergunta. Para subir ao próximo nível tens de responder corretamente a duas perguntas seguidas. Se errares duas seguidas, descerás ao nível anterior.</target>
       </trans-unit>
       <trans-unit id="ha81qvr" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Acabou o tempo!</target>
       </trans-unit>
       <trans-unit id="hrn9d4w" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Cria %total% perguntas mistas de questionário adaptativo %distribution% e dos três tipos de pergunta suportados. Cada linha deve começar com o número do tipo seguido de @, depois o nível e depois os restantes campos separados com #. Nunca coloques # dentro de um campo. As três formas de linha aceites são: Tipo 0 (escolha múltipla): 0@Nível#Solução#Pergunta#OpçãoA#OpçãoB[#OpçãoC][#OpçãoD][#OpçãoE][#OpçãoF] — A solução é uma combinação em maiúsculas das letras A, B, C, D, E, F que identifica as opções corretas (p. ex. A, AB, ACD, ABCDEF); usa até 6 letras e nunca mais do que o número de opções; deixa a solução vazia se nenhuma opção estiver correta. Tipo 1 (ordenar): 1@Nível#Pergunta#Item1#Item2#Item3[#Item4][#Item5][#Item6] — fornece entre 3 e 6 itens já listados na ordem correta de acordo com o critério da pergunta. Tipo 2 (palavra/definição): 2@Nível#Palavra#Definição. A dificuldade deve aumentar com o nível: %ladder% Dentro de cada nível deves incluir perguntas dos três tipos (Tipo 0, Tipo 1 e Tipo 2): gera cerca de %perLevel% perguntas por nível e garante que cada nível combine escolha múltipla (Tipo 0), ordenar (Tipo 1) e palavra/definição (Tipo 2). Não coloques todas do mesmo tipo juntas; intercala os três tipos dentro de cada nível.</target>
       </trans-unit>
       <trans-unit id="wbco08i" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Gera a pré-visualização do circuito antes de guardar</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="cq3ifph" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nivel: 0 (scăzut), 1 (mediu), 2 (ridicat), 3 (expert) sau 4 (maestru).</target>
       </trans-unit>
       <trans-unit id="953viei" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nivel: 0 (scăzut), 1 (mediu), 2 (ridicat) sau 3 (expert).</target>
       </trans-unit>
       <trans-unit id="atxh1qt" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nivel: 0 (scăzut), 1 (mediu) sau 2 (ridicat).</target>
       </trans-unit>
       <trans-unit id="c7qmhrj" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpțiuneaE</target>
       </trans-unit>
       <trans-unit id="eydrd9t" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpțiuneaF</target>
       </trans-unit>
       <trans-unit id="incyool" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Care dintre următoarele sunt numere prime?</target>
       </trans-unit>
       <trans-unit id="3z3xsjf" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Sortează de la cel mai mare la cel mai mic</target>
       </trans-unit>
       <trans-unit id="fbkwb7b" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefant</target>
       </trans-unit>
       <trans-unit id="uf0rgg2" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Șoarece</target>
       </trans-unit>
       <trans-unit id="6e6gxy5" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Care dintre acestea sunt numere transcendente?</target>
       </trans-unit>
       <trans-unit id="6sj8e71" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Constanta lui Liouville</target>
       </trans-unit>
       <trans-unit id="2z35dkc" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Constanta lui Champernowne</target>
       </trans-unit>
       <trans-unit id="mujg8uv" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Sortează aceste elemente chimice de la cel mai mic la cel mai mare număr atomic</target>
       </trans-unit>
       <trans-unit id="rknv1t9" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~Sunt acceptate trei tipuri de întrebări. Fiecare linie trebuie să înceapă cu numărul tipului, urmat de @, nivelul și restul câmpurilor separate cu #:</target>
       </trans-unit>
       <trans-unit id="gjspkod" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipul 0 (alegere multiplă): 0@Nivel#Soluție#Întrebare#OpțiuneaA#OpțiuneaB[#OpțiuneaC][#OpțiuneaD][#OpțiuneaE][#OpțiuneaF]. Soluția este o combinație de majuscule din A, B, C, D, E, F care identifică opțiunile corecte (de ex. A, AB, ACD, ABCDEF). Folosește până la 6 litere și niciodată mai multe decât numărul de opțiuni. Lasă Soluția goală dacă nicio opțiune nu este corectă.</target>
       </trans-unit>
       <trans-unit id="f6b506d" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipul 1 (sortare): 1@Nivel#Întrebare#Element1#Element2#Element3[#Element4][#Element5][#Element6]. Furnizează între 3 și 6 elemente deja enumerate în ordinea corectă conform criteriului întrebării.</target>
       </trans-unit>
       <trans-unit id="jgwnab5" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipul 2 (cuvânt/definiție): 2@Nivel#Cuvânt#Definiție.</target>
       </trans-unit>
       <trans-unit id="uzpnzes" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~Nu include caracterul # în interiorul niciunui câmp.</target>
       </trans-unit>
       <trans-unit id="28d622b" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuite echilibrat pe cele 5 niveluri (0=scăzut, 1=mediu, 2=ridicat, 3=expert, 4=maestru)</target>
       </trans-unit>
       <trans-unit id="hwr4f6t" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuite echilibrat pe cele 4 niveluri (0=scăzut, 1=mediu, 2=ridicat, 3=expert)</target>
       </trans-unit>
       <trans-unit id="ifq2ww0" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuite echilibrat pe cele 3 niveluri (0=scăzut, 1=mediu, 2=ridicat)</target>
       </trans-unit>
       <trans-unit id="7k185uf" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelul 0 trebuie să conțină cele mai ușoare întrebări (fapte de bază și reamintire simplă); fiecare nivel următor trebuie să fie strict mai dificil decât cel anterior (mai mult raționament, opțiuni mai lungi sau mai complicate, vocabular mai abstract), iar nivelul 4 (maestru) trebuie să conțină cele mai dificile întrebări.</target>
       </trans-unit>
       <trans-unit id="axdnyc0" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelul 0 trebuie să conțină cele mai ușoare întrebări (fapte de bază și reamintire simplă); fiecare nivel următor trebuie să fie strict mai dificil decât cel anterior (mai mult raționament, opțiuni mai lungi sau mai complicate, vocabular mai abstract), iar nivelul 3 (expert) trebuie să conțină cele mai dificile întrebări.</target>
       </trans-unit>
       <trans-unit id="ha2f8if" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~Nivelul 0 trebuie să conțină cele mai ușoare întrebări (fapte de bază și reamintire simplă); fiecare nivel următor trebuie să fie strict mai dificil decât cel anterior (mai mult raționament, opțiuni mai lungi sau mai complicate, vocabular mai abstract), iar nivelul 2 (ridicat) trebuie să conțină cele mai dificile întrebări.</target>
       </trans-unit>
       <trans-unit id="hka3vtc" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~Browserul tău nu este compatibil cu acest tip de activitate.</target>
       </trans-unit>
       <trans-unit id="9i1tbkk" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Trebuie să adaugi cel puțin o întrebare.</target>
       </trans-unit>
       <trans-unit id="trkm1vj" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Trebuie să ai cel puțin o întrebare.</target>
       </trans-unit>
       <trans-unit id="v1ec5x0" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Întrebarea %s: textul întrebării nu poate fi gol.</target>
       </trans-unit>
       <trans-unit id="hjptj2j" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Întrebarea %s: completează toate opțiunile de răspuns.</target>
       </trans-unit>
       <trans-unit id="gztiq8g" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Întrebarea %s: indică ce opțiune este răspunsul corect.</target>
       </trans-unit>
       <trans-unit id="e757315" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Trebuie să adaugi cel puțin %s întrebări.</target>
       </trans-unit>
       <trans-unit id="tb43muf" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Avertisment: nivelul inițial selectat nu are întrebări. Testul va începe folosind nivelul de rezervă.</target>
       </trans-unit>
       <trans-unit id="i5tqjgg" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indică un nume pentru fiecare nivel.</target>
       </trans-unit>
       <trans-unit id="fah45fr" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~Nivelul „%s“ trebuie să aibă cel puțin 2 întrebări.</target>
       </trans-unit>
       <trans-unit id="s8gvgnr" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indică timpul în care va fi afișată soluția.</target>
       </trans-unit>
       <trans-unit id="r3rq61x" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Întrebarea %s: marchează cel puțin un răspuns corect.</target>
       </trans-unit>
       <trans-unit id="59mnoqj" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Întrebarea %s: furnizează cuvântul sau fraza soluție.</target>
       </trans-unit>
       <trans-unit id="odc4v2z" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Întrebarea %s: furnizează definiția.</target>
       </trans-unit>
       <trans-unit id="0r81bit" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Întrebarea %s: atribuie o ordine unică de la 1 la %n fiecărei opțiuni.</target>
       </trans-unit>
       <trans-unit id="52kewb2" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL audio</target>
       </trans-unit>
       <trans-unit id="rgy7dpr" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Afișează opțiunile audio</target>
       </trans-unit>
       <trans-unit id="x7td0zt" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Creează un test cu alegere multiplă a cărui dificultate se adaptează cursantului. Alege numărul de niveluri de dificultate (3, 4 sau 5) și atribuie câte unul fiecărei întrebări; testul urcă un nivel după două răspunsuri corecte la rând și coboară după două răspunsuri greșite la rând.</target>
       </trans-unit>
       <trans-unit id="8lvyhs2" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Numărul de niveluri</target>
       </trans-unit>
       <trans-unit id="yxt96d5" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Numele nivelului 1</target>
       </trans-unit>
       <trans-unit id="25kn9uq" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Ușor</target>
       </trans-unit>
       <trans-unit id="3nbg90h" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Numele nivelului 2</target>
       </trans-unit>
       <trans-unit id="vycpkzd" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Numele nivelului 3</target>
       </trans-unit>
       <trans-unit id="9g0o7d6" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Greu</target>
       </trans-unit>
       <trans-unit id="0lquubx" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Numele nivelului 4</target>
       </trans-unit>
       <trans-unit id="u04q5f5" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Expert</target>
       </trans-unit>
       <trans-unit id="3c2eaob" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Numele nivelului 5</target>
       </trans-unit>
       <trans-unit id="ov2g552" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Maestru</target>
       </trans-unit>
       <trans-unit id="irjnsvf" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Nivel inițial</target>
       </trans-unit>
       <trans-unit id="tcbm1j2" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Setează la 0 pentru a dezactiva limita de timp.</target>
       </trans-unit>
       <trans-unit id="hk84hfc" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Amestecă opțiunile de răspuns la rulare</target>
       </trans-unit>
       <trans-unit id="lmpu5u9" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Potrivire a răspunsurilor sensibilă la majuscule (tip cuvânt)</target>
       </trans-unit>
       <trans-unit id="cnllj2l" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Solicită diacritice corecte (tip cuvânt)</target>
       </trans-unit>
       <trans-unit id="6w2e4b0" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtru de nivel</target>
       </trans-unit>
       <trans-unit id="vxbco74" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Reîncarcă imaginea</target>
       </trans-unit>
       <trans-unit id="0nubauq" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Test adaptativ</target>
       </trans-unit>
       <trans-unit id="km38zbo" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Fă clic pe o opțiune pentru a alege răspunsul.</target>
       </trans-unit>
       <trans-unit id="98q6lna" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Cel mai înalt nivel atins</target>
       </trans-unit>
       <trans-unit id="xq9w36e" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Ai urcat un nivel!</target>
       </trans-unit>
       <trans-unit id="gx9djz4" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Ai coborât un nivel</target>
       </trans-unit>
       <trans-unit id="sizxffs" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Raport final</target>
       </trans-unit>
       <trans-unit id="zaax4pm" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Excelent. Stăpânești conținuturile de cel mai înalt nivel.</target>
       </trans-unit>
       <trans-unit id="36b3rpr" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bravo. Ai atins nivelul intermediar.</target>
       </trans-unit>
       <trans-unit id="kclcgi9" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Ai nevoie de puțin mai mult exercițiu. Recapitulează conținuturile de bază.</target>
       </trans-unit>
       <trans-unit id="yc9yww6" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pune audio pe pauză</target>
       </trans-unit>
       <trans-unit id="8k7io7o" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Ilustrație</target>
       </trans-unit>
       <trans-unit id="391iksq" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Alege răspunsul corect pentru fiecare întrebare. Pentru a urca la nivelul următor trebuie să răspunzi corect la două întrebări la rând. Dacă greșești două la rând, vei coborî la nivelul anterior.</target>
       </trans-unit>
       <trans-unit id="ms9lvxg" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~Timpul a expirat!</target>
       </trans-unit>
       <trans-unit id="z4zclje" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Creează %total% întrebări mixte pentru testul adaptativ %distribution% și din cele trei tipuri de întrebări acceptate. Fiecare linie trebuie să înceapă cu numărul tipului urmat de @, apoi nivelul și apoi restul câmpurilor separate cu #. Nu pune niciodată # în interiorul unui câmp. Cele trei forme de linie acceptate sunt: Tipul 0 (alegere multiplă): 0@Nivel#Soluție#Întrebare#OpțiuneaA#OpțiuneaB[#OpțiuneaC][#OpțiuneaD][#OpțiuneaE][#OpțiuneaF] — Soluția este o combinație de majuscule din literele A, B, C, D, E, F care identifică opțiunile corecte (de ex. A, AB, ACD, ABCDEF); folosește până la 6 litere și niciodată mai multe decât numărul de opțiuni; lasă soluția goală dacă nicio opțiune nu este corectă. Tipul 1 (sortare): 1@Nivel#Întrebare#Element1#Element2#Element3[#Element4][#Element5][#Element6] — furnizează între 3 și 6 elemente deja enumerate în ordinea corectă conform criteriului întrebării. Tipul 2 (cuvânt/definiție): 2@Nivel#Cuvânt#Definiție. Dificultatea trebuie să crească odată cu nivelul: %ladder% În interiorul fiecărui nivel trebuie să incluzi întrebări din toate cele trei tipuri (Tipul 0, Tipul 1 și Tipul 2): generează aproximativ %perLevel% întrebări pe nivel și asigură-te că fiecare nivel combină alegere multiplă (Tipul 0), sortare (Tipul 1) și cuvânt/definiție (Tipul 2). Nu pune toate de același tip împreună; alternează cele trei tipuri în interiorul fiecărui nivel.</target>
       </trans-unit>
       <trans-unit id="h6qk5u0" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Generează previzualizarea circuitului înainte de salvare</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15063,299 +15063,299 @@
       </trans-unit>
       <trans-unit id="w8l0af0" resname="Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).">
         <source>Level: 0 (low), 1 (medium), 2 (high), 3 (expert) or 4 (master).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà), 2 (alt), 3 (expert) o 4 (mestre).</target>
       </trans-unit>
       <trans-unit id="nhdra8o" resname="Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).">
         <source>Level: 0 (low), 1 (medium), 2 (high) or 3 (expert).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà), 2 (alt) o 3 (expert).</target>
       </trans-unit>
       <trans-unit id="x2gku43" resname="Level: 0 (low), 1 (medium) or 2 (high).">
         <source>Level: 0 (low), 1 (medium) or 2 (high).</source>
-        <target></target>
+        <target>~Nivell: 0 (baix), 1 (mitjà) o 2 (alt).</target>
       </trans-unit>
       <trans-unit id="fwnw8xz" resname="OptionE">
         <source>OptionE</source>
-        <target></target>
+        <target>~OpcióE</target>
       </trans-unit>
       <trans-unit id="47xwgz2" resname="OptionF">
         <source>OptionF</source>
-        <target></target>
+        <target>~OpcióF</target>
       </trans-unit>
       <trans-unit id="kwt795v" resname="Which of the following are prime numbers?">
         <source>Which of the following are prime numbers?</source>
-        <target></target>
+        <target>~Quins dels següents són nombres primers?</target>
       </trans-unit>
       <trans-unit id="lc50pdl" resname="Sort from largest to smallest">
         <source>Sort from largest to smallest</source>
-        <target></target>
+        <target>~Ordena de major a menor</target>
       </trans-unit>
       <trans-unit id="r7sx1lz" resname="Elephant">
         <source>Elephant</source>
-        <target></target>
+        <target>~Elefant</target>
       </trans-unit>
       <trans-unit id="orcd0v9" resname="Mouse">
         <source>Mouse</source>
-        <target></target>
+        <target>~Ratolí</target>
       </trans-unit>
       <trans-unit id="dsfp8a7" resname="Which of these are transcendental numbers?">
         <source>Which of these are transcendental numbers?</source>
-        <target></target>
+        <target>~Quins d'aquests són nombres transcendents?</target>
       </trans-unit>
       <trans-unit id="2wawkwn" resname="Liouville constant">
         <source>Liouville constant</source>
-        <target></target>
+        <target>~Constant de Liouville</target>
       </trans-unit>
       <trans-unit id="2jn1j3u" resname="Champernowne constant">
         <source>Champernowne constant</source>
-        <target></target>
+        <target>~Constant de Champernowne</target>
       </trans-unit>
       <trans-unit id="kiorbhf" resname="Sort these chemical elements from lowest to highest atomic number">
         <source>Sort these chemical elements from lowest to highest atomic number</source>
-        <target></target>
+        <target>~Ordena estos elements químics de menor a major nombre atòmic</target>
       </trans-unit>
       <trans-unit id="rls3t0p" resname="Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:">
         <source>Three question types are accepted. Every line must start with the type number, followed by @, the level, and the rest of the fields separated with #:</source>
-        <target></target>
+        <target>~S'accepten tres tipus de preguntes. Cada línia ha de començar amb el número de tipus, seguit de @, el nivell i la resta de camps separats amb #:</target>
       </trans-unit>
       <trans-unit id="zgvr37z" resname="Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.">
         <source>Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF]. Solution is an uppercase combination of A, B, C, D, E, F matching the correct options (e.g. A, AB, ACD, ABCDEF). Use up to 6 letters and never more than the number of options. Leave Solution empty if no option is correct.</source>
-        <target></target>
+        <target>~Tipus 0 (opció múltiple): 0@Nivell#Solució#Pregunta#OpcióA#OpcióB[#OpcióC][#OpcióD][#OpcióE][#OpcióF]. La solució és una combinació en majúscules d'A, B, C, D, E, F que identifica les opcions correctes (p. ex. A, AB, ACD, ABCDEF). Usa fins a 6 lletres i mai més que el nombre d'opcions. Deixa Solució buida si cap opció no és correcta.</target>
       </trans-unit>
       <trans-unit id="dgb96k3" resname="Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.">
         <source>Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6]. Provide between 3 and 6 items already listed in the correct order according to the question criterion.</source>
-        <target></target>
+        <target>~Tipus 1 (ordenar): 1@Nivell#Pregunta#Element1#Element2#Element3[#Element4][#Element5][#Element6]. Proporciona entre 3 i 6 elements ja llistats en l'orde correcte segons el criteri de la pregunta.</target>
       </trans-unit>
       <trans-unit id="gyuwzvv" resname="Type 2 (word/definition): 2@Level#Word#Definition.">
         <source>Type 2 (word/definition): 2@Level#Word#Definition.</source>
-        <target></target>
+        <target>~Tipus 2 (paraula/definició): 2@Nivell#Paraula#Definició.</target>
       </trans-unit>
       <trans-unit id="x3ooezz" resname="Do not include the # character inside any field.">
         <source>Do not include the # character inside any field.</source>
-        <target></target>
+        <target>~No inclogues el caràcter # dins de cap camp.</target>
       </trans-unit>
       <trans-unit id="vyvsyt1" resname="balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)">
         <source>balanced across the 5 levels (0=low, 1=medium, 2=high, 3=expert, 4=master)</source>
-        <target></target>
+        <target>~distribuïdes entre els 5 nivells (0=baix, 1=mitjà, 2=alt, 3=expert, 4=mestre)</target>
       </trans-unit>
       <trans-unit id="g89wfgu" resname="balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)">
         <source>balanced across the 4 levels (0=low, 1=medium, 2=high, 3=expert)</source>
-        <target></target>
+        <target>~distribuïdes entre els 4 nivells (0=baix, 1=mitjà, 2=alt, 3=expert)</target>
       </trans-unit>
       <trans-unit id="9223oz0" resname="balanced across the 3 levels (0=low, 1=medium, 2=high)">
         <source>balanced across the 3 levels (0=low, 1=medium, 2=high)</source>
-        <target></target>
+        <target>~distribuïdes entre els 3 nivells (0=baix, 1=mitjà, 2=alt)</target>
       </trans-unit>
       <trans-unit id="wvb7kle" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 4 (master) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contindre les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 4 (mestre) ha de contindre les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="22rff82" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 3 (expert) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contindre les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 3 (expert) ha de contindre les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="uivl5zj" resname="Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.">
         <source>Level 0 must contain the easiest questions (basic facts and simple recall); each subsequent level must be strictly more challenging than the previous one (more reasoning, longer or trickier options, more abstract vocabulary), and level 2 (high) must contain the hardest questions.</source>
-        <target></target>
+        <target>~El nivell 0 ha de contindre les preguntes més fàcils (fets bàsics i record simple); cada nivell següent ha de ser estrictament més difícil que l'anterior (més raonament, opcions més llargues o complicades, vocabulari més abstracte), i el nivell 2 (alt) ha de contindre les preguntes més difícils.</target>
       </trans-unit>
       <trans-unit id="pq87ejt" resname="Your browser is not compatible with this type of activity.">
         <source>Your browser is not compatible with this type of activity.</source>
-        <target></target>
+        <target>~El teu navegador no és compatible amb este tipus d'activitat.</target>
       </trans-unit>
       <trans-unit id="egbkfma" resname="You must add at least one question.">
         <source>You must add at least one question.</source>
-        <target></target>
+        <target>~Has d'afegir almenys una pregunta.</target>
       </trans-unit>
       <trans-unit id="e1ag8lt" resname="You must have at least one question.">
         <source>You must have at least one question.</source>
-        <target></target>
+        <target>~Has de tindre almenys una pregunta.</target>
       </trans-unit>
       <trans-unit id="djjl1s7" resname="Question %s: the question text cannot be empty.">
         <source>Question %s: the question text cannot be empty.</source>
-        <target></target>
+        <target>~Pregunta %s: el text de la pregunta no pot estar buit.</target>
       </trans-unit>
       <trans-unit id="9mgmpu7" resname="Question %s: please fill in all answer options.">
         <source>Question %s: please fill in all answer options.</source>
-        <target></target>
+        <target>~Pregunta %s: ompli totes les opcions de resposta.</target>
       </trans-unit>
       <trans-unit id="v0ll1yl" resname="Question %s: please mark which option is the correct answer.">
         <source>Question %s: please mark which option is the correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: indica quina opció és la resposta correcta.</target>
       </trans-unit>
       <trans-unit id="dvimw14" resname="You must add at least %s questions.">
         <source>You must add at least %s questions.</source>
-        <target></target>
+        <target>~Has d'afegir almenys %s preguntes.</target>
       </trans-unit>
       <trans-unit id="7fo1ci0" resname="Warning: the selected initial level has no questions. The quiz will start using the fallback level.">
         <source>Warning: the selected initial level has no questions. The quiz will start using the fallback level.</source>
-        <target></target>
+        <target>~Avís: el nivell inicial seleccionat no té preguntes. El qüestionari començarà usant el nivell de reserva.</target>
       </trans-unit>
       <trans-unit id="69lhtpx" resname="Please provide a name for every level.">
         <source>Please provide a name for every level.</source>
-        <target></target>
+        <target>~Indica un nom per a cada nivell.</target>
       </trans-unit>
       <trans-unit id="ef90pdf" resname="Level &quot;%s&quot; must have at least 2 questions.">
         <source>Level "%s" must have at least 2 questions.</source>
-        <target></target>
+        <target>~El nivell «%s» ha de tindre almenys 2 preguntes.</target>
       </trans-unit>
       <trans-unit id="nn9mqse" resname="Please indicate the time the solution will be displayed.">
         <source>Please indicate the time the solution will be displayed.</source>
-        <target></target>
+        <target>~Indica el temps que es mostrarà la solució.</target>
       </trans-unit>
       <trans-unit id="r4v2jgz" resname="Question %s: please mark at least one correct answer.">
         <source>Question %s: please mark at least one correct answer.</source>
-        <target></target>
+        <target>~Pregunta %s: marca almenys una resposta correcta.</target>
       </trans-unit>
       <trans-unit id="ze68nmo" resname="Question %s: please provide the solution word or phrase.">
         <source>Question %s: please provide the solution word or phrase.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona la paraula o frase solució.</target>
       </trans-unit>
       <trans-unit id="11gvbyk" resname="Question %s: please provide the definition.">
         <source>Question %s: please provide the definition.</source>
-        <target></target>
+        <target>~Pregunta %s: proporciona la definició.</target>
       </trans-unit>
       <trans-unit id="4904fap" resname="Question %s: please specify a unique order from 1 to %n for every option.">
         <source>Question %s: please specify a unique order from 1 to %n for every option.</source>
-        <target></target>
+        <target>~Pregunta %s: assigna un orde únic de l'1 al %n a cada opció.</target>
       </trans-unit>
       <trans-unit id="0tcclb5" resname="Audio URL">
         <source>Audio URL</source>
-        <target></target>
+        <target>~URL d'àudio</target>
       </trans-unit>
       <trans-unit id="1g7res5" resname="Show audio options">
         <source>Show audio options</source>
-        <target></target>
+        <target>~Mostra les opcions d'àudio</target>
       </trans-unit>
       <trans-unit id="ivw1gq1" resname="Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.">
         <source>Create a multiple-choice quiz whose difficulty adapts to the learner. Choose the number of difficulty levels (3, 4 or 5) and assign one to each question; the quiz goes up a level after two correct answers in a row and down after two wrong answers in a row.</source>
-        <target></target>
+        <target>~Crea un qüestionari d'opció múltiple la dificultat del qual s'adapta a l'alumne. Tria el nombre de nivells de dificultat (3, 4 o 5) i assigna'n un a cada pregunta; el qüestionari puja un nivell després de dos respostes correctes seguides i baixa després de dos incorrectes seguides.</target>
       </trans-unit>
       <trans-unit id="19oyf6g" resname="Number of levels">
         <source>Number of levels</source>
-        <target></target>
+        <target>~Nombre de nivells</target>
       </trans-unit>
       <trans-unit id="9dpehkd" resname="Level 1 name">
         <source>Level 1 name</source>
-        <target></target>
+        <target>~Nom del nivell 1</target>
       </trans-unit>
       <trans-unit id="4r13rvp" resname="Easy">
         <source>Easy</source>
-        <target></target>
+        <target>~Fàcil</target>
       </trans-unit>
       <trans-unit id="5aicype" resname="Level 2 name">
         <source>Level 2 name</source>
-        <target></target>
+        <target>~Nom del nivell 2</target>
       </trans-unit>
       <trans-unit id="vc37mwt" resname="Level 3 name">
         <source>Level 3 name</source>
-        <target></target>
+        <target>~Nom del nivell 3</target>
       </trans-unit>
       <trans-unit id="8gmoxgw" resname="Hard">
         <source>Hard</source>
-        <target></target>
+        <target>~Difícil</target>
       </trans-unit>
       <trans-unit id="g86l3pz" resname="Level 4 name">
         <source>Level 4 name</source>
-        <target></target>
+        <target>~Nom del nivell 4</target>
       </trans-unit>
       <trans-unit id="2d34hmz" resname="Expert">
         <source>Expert</source>
-        <target></target>
+        <target>~Expert</target>
       </trans-unit>
       <trans-unit id="jypq1xz" resname="Level 5 name">
         <source>Level 5 name</source>
-        <target></target>
+        <target>~Nom del nivell 5</target>
       </trans-unit>
       <trans-unit id="tmq6oit" resname="Master">
         <source>Master</source>
-        <target></target>
+        <target>~Mestre</target>
       </trans-unit>
       <trans-unit id="pq3nko4" resname="Initial level">
         <source>Initial level</source>
-        <target></target>
+        <target>~Nivell inicial</target>
       </trans-unit>
       <trans-unit id="ctabkhl" resname="Set to 0 to disable the time limit.">
         <source>Set to 0 to disable the time limit.</source>
-        <target></target>
+        <target>~Posa 0 per a desactivar el límit de temps.</target>
       </trans-unit>
       <trans-unit id="2fcvew8" resname="Shuffle answer options at runtime">
         <source>Shuffle answer options at runtime</source>
-        <target></target>
+        <target>~Barreja les opcions de resposta durant l'execució</target>
       </trans-unit>
       <trans-unit id="4cb48hk" resname="Case-sensitive answer matching (word type)">
         <source>Case-sensitive answer matching (word type)</source>
-        <target></target>
+        <target>~Distingix majúscules i minúscules (tipus paraula)</target>
       </trans-unit>
       <trans-unit id="p61jyui" resname="Require correct accents (word type)">
         <source>Require correct accents (word type)</source>
-        <target></target>
+        <target>~Exigix accents correctes (tipus paraula)</target>
       </trans-unit>
       <trans-unit id="f1x3b12" resname="Level filter">
         <source>Level filter</source>
-        <target></target>
+        <target>~Filtre de nivell</target>
       </trans-unit>
       <trans-unit id="lwbuznf" resname="Reload image">
         <source>Reload image</source>
-        <target></target>
+        <target>~Torna a carregar la imatge</target>
       </trans-unit>
       <trans-unit id="9ixcty8" resname="Adaptative Quiz">
         <source>Adaptative Quiz</source>
-        <target></target>
+        <target>~Qüestionari adaptatiu</target>
       </trans-unit>
       <trans-unit id="cor2e4h" resname="Click on an option to choose your answer.">
         <source>Click on an option to choose your answer.</source>
-        <target></target>
+        <target>~Fes clic en una opció per a triar la teua resposta.</target>
       </trans-unit>
       <trans-unit id="1cx3izq" resname="Highest level reached">
         <source>Highest level reached</source>
-        <target></target>
+        <target>~Nivell més alt assolit</target>
       </trans-unit>
       <trans-unit id="wdpvkw1" resname="Level up!">
         <source>Level up!</source>
-        <target></target>
+        <target>~Puges de nivell!</target>
       </trans-unit>
       <trans-unit id="yexmaob" resname="Level down">
         <source>Level down</source>
-        <target></target>
+        <target>~Baixes de nivell</target>
       </trans-unit>
       <trans-unit id="06ex9sh" resname="Final report">
         <source>Final report</source>
-        <target></target>
+        <target>~Informe final</target>
       </trans-unit>
       <trans-unit id="hbvdma2" resname="Excellent. You dominate the highest-level contents.">
         <source>Excellent. You dominate the highest-level contents.</source>
-        <target></target>
+        <target>~Excel·lent. Domines els continguts de més alt nivell.</target>
       </trans-unit>
       <trans-unit id="z13lsxu" resname="Good job. You have achieved the intermediate level.">
         <source>Good job. You have achieved the intermediate level.</source>
-        <target></target>
+        <target>~Bona faena. Has assolit el nivell intermedi.</target>
       </trans-unit>
       <trans-unit id="z44mbo3" resname="You need a bit more practice. Review the basic contents.">
         <source>You need a bit more practice. Review the basic contents.</source>
-        <target></target>
+        <target>~Necessites una miqueta més de pràctica. Repassa els continguts bàsics.</target>
       </trans-unit>
       <trans-unit id="38cw8c8" resname="Pause audio">
         <source>Pause audio</source>
-        <target></target>
+        <target>~Pausa l'àudio</target>
       </trans-unit>
       <trans-unit id="ot8h6nn" resname="Illustration">
         <source>Illustration</source>
-        <target></target>
+        <target>~Il·lustració</target>
       </trans-unit>
       <trans-unit id="uayhhwc" resname="Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.">
         <source>Choose the correct answer for each question. To move up to the next level, you must answer two questions correctly in a row. If you get two questions wrong in a row, you will move down to the previous level.</source>
-        <target></target>
+        <target>~Tria la resposta correcta per a cada pregunta. Per a pujar al següent nivell has de respondre correctament dos preguntes seguides. Si falles dos seguides, baixaràs al nivell anterior.</target>
       </trans-unit>
       <trans-unit id="v10qz6s" resname="Time&apos;s up!">
         <source>Time's up!</source>
-        <target></target>
+        <target>~S'ha acabat el temps!</target>
       </trans-unit>
       <trans-unit id="ykit1js" resname="Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.">
         <source>Create %total% mixed adaptative-quiz questions %distribution% and across the three supported question types. Every line must start with the type number followed by @, then the level, then the remaining fields separated with #. Never put # inside a field. The three accepted line shapes are: Type 0 (multiple-choice): 0@Level#Solution#Question#OptionA#OptionB[#OptionC][#OptionD][#OptionE][#OptionF] — Solution is an uppercase combination of the letters A, B, C, D, E, F identifying the correct options (e.g. A, AB, ACD, ABCDEF); use up to 6 letters and never more than the number of options; leave Solution empty if no option is correct. Type 1 (sort/order): 1@Level#Question#Item1#Item2#Item3[#Item4][#Item5][#Item6] — provide between 3 and 6 items already listed in the correct order according to the question criterion. Type 2 (word/definition): 2@Level#Word#Definition. Difficulty must increase with the level: %ladder% Inside every single level you must include questions of all three types (Type 0, Type 1 and Type 2): produce around %perLevel% questions per level and make sure each level mixes select/multiple-choice (Type 0), sort/order (Type 1) and word/definition (Type 2). Do not put all the same type together; interleave the three types within each level.</source>
-        <target></target>
+        <target>~Crea %total% preguntes mixtes de qüestionari adaptatiu %distribution% i dels tres tipus de pregunta admesos. Cada línia ha de començar amb el número de tipus seguit de @, després el nivell i després la resta de camps separats amb #. Mai poses # dins d'un camp. Les tres formes de línia admeses són: Tipus 0 (opció múltiple): 0@Nivell#Solució#Pregunta#OpcióA#OpcióB[#OpcióC][#OpcióD][#OpcióE][#OpcióF] — La solució és una combinació en majúscules de les lletres A, B, C, D, E, F que identifica les opcions correctes (p. ex. A, AB, ACD, ABCDEF); usa fins a 6 lletres i mai més que el nombre d'opcions; deixa la solució buida si cap opció no és correcta. Tipus 1 (ordenar): 1@Nivell#Pregunta#Element1#Element2#Element3[#Element4][#Element5][#Element6] — proporciona entre 3 i 6 elements ja llistats en l'orde correcte segons el criteri de la pregunta. Tipus 2 (paraula/definició): 2@Nivell#Paraula#Definició. La dificultat ha d'augmentar amb el nivell: %ladder% Dins de cada nivell has d'incloure preguntes dels tres tipus (Tipus 0, Tipus 1 i Tipus 2): genera al voltant de %perLevel% preguntes per nivell i assegura't que cada nivell combine seleccionar (Tipus 0), ordenar (Tipus 1) i paraula/definició (Tipus 2). No poses totes del mateix tipus juntes; intercala els tres tipus dins de cada nivell.</target>
       </trans-unit>
       <trans-unit id="34ld9ai" resname="Please render the circuit preview before saving.">
         <source>Please render the circuit preview before saving.</source>
-        <target></target>
+        <target>~Genera la vista prèvia del circuit abans de guardar</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Closes #1921

cc @ignaciogros

## What

Generated automatic translations for the empty `<target></target>` entries across the 9 requested language files, using the Spanish translation (`messages.es.xlf`) as the reference.

- **74 strings** translated per file (the same set is empty in every file).
- Each translation is prefixed with `~` so collaborators can identify the strings that still need human review.
- Strings that were not translated in `messages.es.xlf` were left untouched (none applied here — all 74 had a Spanish reference).

**Files updated:** `messages.ca.xlf`, `messages.de.xlf`, `messages.eo.xlf`, `messages.eu.xlf`, `messages.gl.xlf`, `messages.it.xlf`, `messages.pt.xlf`, `messages.ro.xlf`, `messages.va.xlf`

## Guarantees requested in the issue

- Only the content of the originally empty `<target>` tags changed — identifiers, source strings and indentation are untouched.
- Diff is exactly **666 insertions / 666 deletions** (74 × 9), every changed line is a `<target>` line.
- Placeholders (`%s`, `%n`, `%total%`, `%distribution%`, `%ladder%`, `%perLevel%`) are preserved verbatim.
- All 9 files remain well-formed XML.
- No empty `<target></target>` remain in any of the 9 files.

> Note: this depends on #1920 (now merged into `main`), which introduced the new untranslated strings.
