### PR TITLE
fix: critical/perf bugs in asset deletion, uploads, exports & navigation (follow-up to #1896)

### DIFF
--- a/src/routes/assets.spec.ts
+++ b/src/routes/assets.spec.ts
@@ -750,6 +750,22 @@ describe('Assets Routes', () => {
 
             expect(res.status).toBe(404);
         });
+
+        it('should not leak metadata of an asset owned by another project', async () => {
+            // Asset belongs to project 2, but is requested via project 1's URL.
+            mockAssets.set(7, {
+                id: 7,
+                project_id: 2,
+                filename: 'secret.png',
+                mime_type: 'image/png',
+                file_size: '2048',
+                client_id: 'client-secret',
+            });
+
+            const res = await handle(new Request(`http://localhost/api/projects/1/assets/7/metadata`));
+
+            expect(res.status).toBe(404);
+        });
     });
 
     describe('DELETE /api/projects/:projectId/assets/:assetId', () => {
@@ -784,6 +800,31 @@ describe('Assets Routes', () => {
             );
 
             expect(res.status).toBe(404);
+        });
+
+        it('should not delete an asset owned by another project (cross-tenant IDOR)', async () => {
+            const filePath = path.join(testDir, 'other-tenant.txt');
+            await fs.writeFile(filePath, 'Belongs to project 2');
+
+            // Asset belongs to project 2; attacker owns project 1 and targets it
+            // via /api/projects/1/assets/9 with the global numeric id.
+            mockAssets.set(9, {
+                id: 9,
+                project_id: 2,
+                filename: 'other-tenant.txt',
+                storage_path: filePath,
+            });
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/9`, {
+                    method: 'DELETE',
+                }),
+            );
+
+            expect(res.status).toBe(404);
+            // The asset row and its file must survive.
+            expect(mockAssets.has(9)).toBe(true);
+            expect(await fs.pathExists(filePath)).toBe(true);
         });
     });
 

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -844,6 +844,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
 
             // GET /:assetId/metadata - Get asset metadata
             .get('/:assetId/metadata', async ({ params, set }) => {
+                const { projectId } = params;
                 const assetId = parseInt(params.assetId, 10);
 
                 if (isNaN(assetId)) {
@@ -851,8 +852,17 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     return { success: false, error: 'Invalid asset ID' };
                 }
 
+                // Resolve the URL project so we can enforce asset ownership.
+                const projectIdNum = await getNumericProjectId(projectId);
+                if (projectIdNum === null) {
+                    set.status = 404;
+                    return { success: false, error: 'Project not found' };
+                }
+
                 const asset = await queries.findAssetById(database, assetId);
-                if (!asset) {
+                // findAssetById is a global lookup; the asset must belong to the
+                // project named in the URL or this leaks other tenants' metadata.
+                if (!asset || asset.project_id !== projectIdNum) {
                     set.status = 404;
                     return { success: false, error: 'Asset not found' };
                 }
@@ -919,6 +929,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
 
             // DELETE /:assetId - Delete asset by numeric ID (legacy)
             .delete('/:assetId', async ({ params, set }) => {
+                const { projectId } = params;
                 const assetId = parseInt(params.assetId, 10);
 
                 if (isNaN(assetId)) {
@@ -926,8 +937,19 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     return { success: false, error: 'Invalid asset ID' };
                 }
 
+                // Resolve the URL project so we can enforce asset ownership.
+                const projectIdNum = await getNumericProjectId(projectId);
+                if (projectIdNum === null) {
+                    set.status = 404;
+                    return { success: false, error: 'Project not found' };
+                }
+
                 const asset = await queries.findAssetById(database, assetId);
-                if (!asset) {
+                // findAssetById is a global lookup; without scoping the asset to
+                // the URL project, any authenticated user could delete another
+                // tenant's asset (file + DB row) by numeric ID. Mirror the
+                // ownership guard used by GET '/:assetId'.
+                if (!asset || asset.project_id !== projectIdNum) {
                     set.status = 404;
                     return { success: false, error: 'Asset not found' };
                 }

--- a/src/routes/convert.spec.ts
+++ b/src/routes/convert.spec.ts
@@ -577,6 +577,27 @@ describe('Convert Routes', () => {
             expect(body.message).toContain('download=1');
         });
 
+        it('should not leak extract-* temp directories after a conversion', async () => {
+            const elpBuffer = await createTestElpBuffer();
+            const formData = new FormData();
+            formData.append('file', new Blob([elpBuffer], { type: 'application/zip' }), 'test.elp');
+
+            const res = await app.handle(
+                new Request('http://localhost/api/convert/elp', {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${authToken}` },
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(200);
+
+            // The per-conversion extraction directory must be cleaned up; the
+            // route-level finally only removes the convert-* upload dir.
+            const entries = await fs.readdir(path.join(testDir, 'tmp'));
+            expect(entries.some(name => name.startsWith('extract-'))).toBe(false);
+        });
+
         it('should return ELPX file with download=1', async () => {
             // base.css is already created in beforeEach at the correct path
             const elpBuffer = await createTestElpBuffer();

--- a/src/routes/convert.ts
+++ b/src/routes/convert.ts
@@ -196,13 +196,14 @@ export function createConvertRoutes(deps: ConvertDependencies = defaultDeps) {
     ): Promise<ExportResult & { filename?: string }> {
         let ydoc: Y.Doc | null = null;
         let wrapper: InstanceType<typeof ServerYjsDocumentWrapper> | null = null;
+        let extractDir: string | null = null;
 
         try {
             // Read ELP file
             const elpBuffer = await fs.readFile(elpFilePath);
 
             // Create extraction directory for assets
-            const extractDir = path.join(tempDir!, `extract-${randomUUID()}`);
+            extractDir = path.join(tempDir!, `extract-${randomUUID()}`);
             await fs.ensureDir(extractDir);
 
             // Import ELP to Y.Doc using unified import system
@@ -260,6 +261,13 @@ export function createConvertRoutes(deps: ConvertDependencies = defaultDeps) {
             // Cleanup Y.Doc
             if (wrapper) {
                 wrapper.destroy();
+            }
+            // Remove the per-conversion extraction directory. The route-level
+            // finally only removes the upload dir (convert-*), so without this
+            // every convert/export call would permanently leak an extract-*
+            // directory full of extracted assets under FILES_DIR/tmp.
+            if (extractDir) {
+                await fs.remove(extractDir).catch(() => {});
             }
         }
     }

--- a/src/routes/idevices.spec.ts
+++ b/src/routes/idevices.spec.ts
@@ -718,6 +718,63 @@ describe('iDevices Routes', () => {
             // Should be either 403 (path traversal blocked) or 404 (file not found)
             expect([403, 404]).toContain(res.status);
         });
+
+        it('should reject traversal in odeIdeviceId on base64 upload', async () => {
+            const res = await handle(
+                new Request('http://localhost/api/idevices/upload/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        odeIdeviceId: '../../../../../../tmp/evil',
+                        file: 'data:text/plain;base64,SGVsbG8=',
+                        filename: 'evil.txt',
+                        odeSessionId: 'trav-session',
+                    }),
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.code).toContain('invalid identifier');
+        });
+
+        it('should reject traversal in odeSessionId on base64 upload', async () => {
+            const res = await handle(
+                new Request('http://localhost/api/idevices/upload/file/resources', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        odeIdeviceId: 'valid-idevice',
+                        file: 'data:text/plain;base64,SGVsbG8=',
+                        filename: 'evil.txt',
+                        odeSessionId: '../../../../etc',
+                    }),
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.code).toContain('invalid identifier');
+        });
+
+        it('should reject traversal in odeIdeviceId on large upload', async () => {
+            const form = new FormData();
+            form.append('odeIdeviceId', '../../../../../../tmp/evil');
+            form.append('odeSessionId', 'trav-session');
+            form.append('filename', 'evil.txt');
+            form.append('file', new Blob(['evil'], { type: 'text/plain' }), 'evil.txt');
+
+            const res = await handle(
+                new Request('http://localhost/api/idevices/upload/large/file/resources', {
+                    method: 'POST',
+                    body: form,
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.code).toContain('invalid identifier');
+        });
     });
 
     describe('CSS URL rewriting', () => {

--- a/src/routes/idevices.ts
+++ b/src/routes/idevices.ts
@@ -458,9 +458,20 @@ export const idevicesRoutes = new Elysia({ name: 'idevices-routes' })
             cleanFilename = 'file_' + Date.now();
         }
 
-        // Get iDevice directory
+        // Get iDevice directory. odeSessionId and odeIdeviceId are attacker
+        // controlled; build the path with safeJoin so traversal segments
+        // (e.g. '../../etc') are rejected before any filesystem write.
         const filesDir = getFilesDir();
-        const iDeviceDir = path.join(filesDir, 'tmp', odeSessionId, 'content', 'resources', odeIdeviceId);
+        let iDeviceDir: string;
+        try {
+            iDeviceDir = safeJoin(filesDir, 'tmp', odeSessionId, 'content', 'resources', odeIdeviceId);
+        } catch (err) {
+            if (err instanceof UnsafePathError) {
+                set.status = 400;
+                return { code: 'error: invalid identifier' };
+            }
+            throw err;
+        }
 
         // Ensure directory exists
         await fse.ensureDir(iDeviceDir);
@@ -566,9 +577,20 @@ export const idevicesRoutes = new Elysia({ name: 'idevices-routes' })
             cleanFilename = 'file_' + Date.now();
         }
 
-        // Get iDevice directory
+        // Get iDevice directory. odeSessionId and odeIdeviceId are attacker
+        // controlled; build the path with safeJoin so traversal segments
+        // (e.g. '../../etc') are rejected before any filesystem write.
         const filesDir = getFilesDir();
-        const iDeviceDir = path.join(filesDir, 'tmp', odeSessionId, 'content', 'resources', odeIdeviceId);
+        let iDeviceDir: string;
+        try {
+            iDeviceDir = safeJoin(filesDir, 'tmp', odeSessionId, 'content', 'resources', odeIdeviceId);
+        } catch (err) {
+            if (err instanceof UnsafePathError) {
+                set.status = 400;
+                return { code: 'error: invalid identifier' };
+            }
+            throw err;
+        }
 
         // Ensure directory exists
         await fse.ensureDir(iDeviceDir);

--- a/src/routes/project.spec.ts
+++ b/src/routes/project.spec.ts
@@ -727,6 +727,27 @@ describe('Project Routes', () => {
 
     describe('POST /api/project/upload-chunk', () => {
         it('should handle chunk upload', async () => {
+            const token = await createAuthToken(1);
+            const formData = new FormData();
+            formData.append('odeFilePart', new Blob(['test chunk data']));
+            formData.append('odeFileName', 'test.elp');
+            formData.append('odeSessionId', 'chunk-test-session');
+
+            const res = await app.handle(
+                new Request('http://localhost/api/project/upload-chunk', {
+                    method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.responseMessage).toBe('OK');
+            expect(body.odeFileName).toBe('test.elp');
+        });
+
+        it('should require authentication', async () => {
             const formData = new FormData();
             formData.append('odeFilePart', new Blob(['test chunk data']));
             formData.append('odeFileName', 'test.elp');
@@ -739,17 +760,17 @@ describe('Project Routes', () => {
                 }),
             );
 
-            expect(res.status).toBe(200);
+            expect(res.status).toBe(401);
             const body = await res.json();
-            expect(body.responseMessage).toBe('OK');
-            expect(body.odeFileName).toBe('test.elp');
+            expect(body.success).toBe(false);
         });
 
         it('should return error when missing required fields', async () => {
+            const token = await createAuthToken(1);
             const res = await app.handle(
                 new Request('http://localhost/api/project/upload-chunk', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', Cookie: `auth=${token}` },
                     body: JSON.stringify({}),
                 }),
             );
@@ -759,7 +780,50 @@ describe('Project Routes', () => {
             expect(body.responseMessage).toContain('error');
         });
 
+        it('should reject path traversal in odeFileName', async () => {
+            const token = await createAuthToken(1);
+            const formData = new FormData();
+            formData.append('odeFilePart', new Blob(['malicious']));
+            formData.append('odeFileName', '../../../../../../tmp/pwned.txt');
+            formData.append('odeSessionId', 'chunk-test-session');
+
+            const res = await app.handle(
+                new Request('http://localhost/api/project/upload-chunk', {
+                    method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.responseMessage).toContain('odeFileName');
+            // Ensure nothing was written outside the session temp dir.
+            expect(await fs.pathExists('/tmp/pwned.txt')).toBe(false);
+        });
+
+        it('should reject path traversal in odeSessionId', async () => {
+            const token = await createAuthToken(1);
+            const formData = new FormData();
+            formData.append('odeFilePart', new Blob(['malicious']));
+            formData.append('odeFileName', 'file.elp');
+            formData.append('odeSessionId', '../../../../etc');
+
+            const res = await app.handle(
+                new Request('http://localhost/api/project/upload-chunk', {
+                    method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
+                    body: formData,
+                }),
+            );
+
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.responseMessage).toContain('odeSessionId');
+        });
+
         it('should handle Buffer input', async () => {
+            const token = await createAuthToken(1);
             const formData = new FormData();
             const buffer = Buffer.from('buffer chunk data');
             formData.append('odeFilePart', new Blob([buffer]));
@@ -769,6 +833,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/project/upload-chunk', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                     body: formData,
                 }),
             );
@@ -3433,6 +3498,7 @@ describe('Project Routes', () => {
 
     describe('Upload Chunk Error Handling', () => {
         it('should return error message on upload failure', async () => {
+            const token = await createAuthToken(1);
             // Test missing required parameters
             const formData = new FormData();
             formData.append('odeFileName', 'test.elp');
@@ -3441,6 +3507,7 @@ describe('Project Routes', () => {
             const res = await app.handle(
                 new Request('http://localhost/api/project/upload-chunk', {
                     method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
                     body: formData,
                 }),
             );

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -98,6 +98,7 @@ export async function resolveDefaultThemeForNewProject(
 }
 import { getAppVersion } from '../utils/version';
 import { buildSiteThemeUrl } from '../utils/site-theme-url';
+import { isSafePathSegment, isWithinBase } from '../utils/safe-path';
 import {
     notifyVisibilityChanged as notifyVisibilityChangedDefault,
     notifyCollaboratorRemoved as notifyCollaboratorRemovedDefault,
@@ -486,7 +487,14 @@ export function createProjectRoutes(deps: ProjectDependencies = defaultDependenc
             // =====================================================
 
             // POST /api/project/upload-chunk - Upload a file chunk
-            .post('/upload-chunk', async ({ body, set }) => {
+            .post('/upload-chunk', async ({ body, set, currentUser }) => {
+                // This fallback upload endpoint writes attacker-controlled bytes
+                // to disk, so it must require authentication like every other
+                // state-changing handler in this group.
+                if (!currentUser) {
+                    set.status = 401;
+                    return { responseMessage: 'error: authentication required', success: false };
+                }
                 try {
                     const { odeFilePart, odeFileName, odeSessionId } = body as ProjectUploadChunkRequest;
 
@@ -498,12 +506,27 @@ export function createProjectRoutes(deps: ProjectDependencies = defaultDependenc
                         };
                     }
 
+                    // odeSessionId becomes a directory segment; reject anything
+                    // that is not a single safe segment (UUIDs and legacy
+                    // timestamp ids both qualify) so it cannot escape FILES_DIR.
+                    if (!isSafePathSegment(odeSessionId)) {
+                        set.status = 400;
+                        return { responseMessage: 'error: invalid odeSessionId', success: false };
+                    }
+
                     // Get or create session temp directory
                     const tempDir = getOdeSessionTempDir(odeSessionId);
                     await fs.ensureDir(tempDir);
 
-                    // Build target file path
+                    // Build target file path. odeFileName is a user-chosen name
+                    // (may contain spaces/unicode), so instead of restricting the
+                    // charset we assert the resolved path stays inside tempDir,
+                    // rejecting traversal like '../../etc/cron.d/x'.
                     const targetPath = path.join(tempDir, odeFileName);
+                    if (!isWithinBase(tempDir, targetPath)) {
+                        set.status = 400;
+                        return { responseMessage: 'error: invalid odeFileName', success: false };
+                    }
 
                     // Get the chunk data
                     let chunkBuffer: Buffer;

--- a/src/shared/export/exporters/BaseExporter.spec.ts
+++ b/src/shared/export/exporters/BaseExporter.spec.ts
@@ -1685,11 +1685,13 @@ describe('BaseExporter', () => {
             });
         });
 
-        it('should handle more than 20 pages with same title (maxAttempts limit)', () => {
-            // Create 23 pages: 1 index + 22 pages all titled "Test"
+        it('should give every page a unique filename beyond 20 duplicates (no overwrite)', () => {
+            // Create 31 pages: 1 index + 30 pages all titled "Test". Past the old
+            // 20-attempt cap, distinct pages used to collapse onto a single
+            // filename, silently overwriting each other in the export ZIP.
             const pages: ExportPage[] = [{ id: 'page-0', title: 'Home', parentId: null, order: 0, blocks: [] }];
 
-            for (let i = 1; i <= 22; i++) {
+            for (let i = 1; i <= 30; i++) {
                 pages.push({
                     id: `page-${i}`,
                     title: 'Test',
@@ -1701,20 +1703,38 @@ describe('BaseExporter', () => {
 
             const map = exporter.testBuildPageFilenameMap(pages);
 
-            // First page is index.html
+            // First page is index.html, first "Test" page gets test.html (no suffix).
             expect(map.get('page-0')).toBe('index.html');
-
-            // First "Test" page gets test.html (no suffix)
             expect(map.get('page-1')).toBe('test.html');
 
-            // Pages 2-21 get test-2.html through test-21.html (collisions start at 2)
-            for (let i = 2; i <= 21; i++) {
+            // Every subsequent duplicate gets a deterministic, incrementing name
+            // with no cap: test-2.html … test-30.html.
+            for (let i = 2; i <= 30; i++) {
                 expect(map.get(`page-${i}`)).toBe(`test-${i}.html`);
             }
 
-            // Page 22 exceeds maxAttempts (20), falls back to last attempted filename
-            // This is intentional - after 20 attempts, the algorithm gives up
-            expect(map.get('page-22')).toBe('test-21.html');
+            // Crucially, every page maps to a distinct filename (one ZIP entry
+            // per page — no silent drops).
+            const filenames = Array.from(map.values());
+            expect(new Set(filenames).size).toBe(filenames.length);
+        });
+
+        it('should give non-Latin-script titles unique filenames (no empty-name collisions)', () => {
+            // CJK/Arabic/etc. titles sanitize to an empty base; they must still
+            // each receive a distinct filename rather than all collapsing.
+            const pages: ExportPage[] = [{ id: 'page-0', title: 'Home', parentId: null, order: 0, blocks: [] }];
+            for (let i = 1; i <= 25; i++) {
+                pages.push({ id: `page-${i}`, title: '中文页面', parentId: null, order: i, blocks: [] });
+            }
+
+            const map = exporter.testBuildPageFilenameMap(pages);
+
+            expect(map.get('page-1')).toBe('page.html');
+            expect(map.get('page-2')).toBe('page-2.html');
+            expect(map.get('page-25')).toBe('page-25.html');
+
+            const filenames = Array.from(map.values());
+            expect(new Set(filenames).size).toBe(filenames.length);
         });
 
         it('should increment trailing numbers in filename on collision', () => {

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -355,13 +355,18 @@ export abstract class BaseExporter {
      */
     sanitizePageFilename(title: string | null | undefined): string {
         if (!title) return 'page';
-        return title
+        const sanitized = title
             .toLowerCase()
             .normalize('NFD')
             .replace(/[\u0300-\u036f]/g, '') // Remove accents
             .replace(/[^a-z0-9\s-]/g, '')
             .replace(/\s+/g, '-')
             .substring(0, 50);
+        // Titles written entirely in non-Latin scripts (CJK, Arabic, Cyrillic,
+        // Greek, Hebrew, \u2026) strip down to an empty string. Fall back to 'page'
+        // so every page still gets a usable base name and uniqueness handling
+        // below can disambiguate them.
+        return sanitized || 'page';
     }
 
     /**
@@ -851,7 +856,6 @@ export abstract class BaseExporter {
     protected buildPageFilenameMap(pages: ExportPage[]): Map<string, string> {
         const filenameMap = new Map<string, string>();
         const usedFilenames = new Set<string>();
-        const maxAttempts = 20;
 
         for (let i = 0; i < pages.length; i++) {
             const page = pages[i];
@@ -876,21 +880,26 @@ export abstract class BaseExporter {
                     const startNum = parseInt(match[2], 10);
                     let counter = startNum + 1;
 
-                    while (counter <= startNum + maxAttempts) {
+                    while (usedFilenames.has(filename)) {
                         filename = `${base}${counter}.html`;
-                        if (!usedFilenames.has(filename)) break;
                         counter++;
                     }
                 } else {
                     // No trailing number: append -2, -3, etc. (first page is implicitly "1")
                     let counter = 2;
-                    while (usedFilenames.has(filename) && counter <= maxAttempts + 1) {
+                    while (usedFilenames.has(filename)) {
                         filename = `${baseFilename}-${counter}.html`;
                         counter++;
                     }
                 }
             }
 
+            // Uniqueness is guaranteed by construction: the loops above keep
+            // incrementing until a free name is found, and the page count is
+            // finite. Never cap the attempts — a duplicate filename here would
+            // make distinct pages overwrite each other in the export ZIP
+            // (FflateZipProvider.addFile is a silent Map.set), silently dropping
+            // every page beyond the collision.
             usedFilenames.add(filename);
             filenameMap.set(page.id, filename);
         }

--- a/src/shared/export/exporters/ImsExporter.spec.ts
+++ b/src/shared/export/exporters/ImsExporter.spec.ts
@@ -576,5 +576,49 @@ describe('ImsExporter', () => {
             expect(manifest).toContain('<file href="content.xml"/>');
             expect(manifest).toContain('<file href="content.dtd"/>');
         });
+
+        it('should keep hidden pages in the re-editable content.xml', async () => {
+            // A hidden page (visibility: false) must NOT be rendered into the
+            // package HTML or the manifest, but MUST survive in content.xml so a
+            // re-import recovers it.
+            const pagesWithHidden: ExportPage[] = [
+                samplePages[0],
+                samplePages[1],
+                {
+                    id: 'page-hidden',
+                    title: 'Secret Draft',
+                    parentId: null,
+                    order: 2,
+                    properties: { visibility: false },
+                    blocks: [
+                        {
+                            id: 'block-hidden',
+                            name: 'Content',
+                            order: 0,
+                            components: [
+                                {
+                                    id: 'comp-hidden',
+                                    type: 'FreeTextIdevice',
+                                    order: 0,
+                                    content: '<p>Teacher-only notes</p>',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+            document = new MockDocument({}, pagesWithHidden);
+            exporter = new ImsExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            // content.xml retains the hidden page (re-import recovers it).
+            const contentXml = zip.files.get('content.xml') as string;
+            expect(contentXml).toContain('Secret Draft');
+
+            // The hidden page is excluded from the rendered organization/manifest.
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).not.toContain('Secret Draft');
+        });
     });
 });

--- a/src/shared/export/exporters/ImsExporter.ts
+++ b/src/shared/export/exporters/ImsExporter.ts
@@ -54,6 +54,14 @@ export class ImsExporter extends Html5Exporter {
             // Pre-process pages: add filenames to asset URLs
             pages = await this.preprocessPagesForExport(pages);
 
+            // Keep the complete (pre-visibility-filter) page list for the
+            // re-editable content.xml. Hidden pages (drafts / teacher-only) must
+            // survive an IMS export -> re-import round trip; only the rendered
+            // HTML and the imsmanifest organization below exclude them. The
+            // SCORM exporters get this for free via getContentXml(); IMS builds
+            // content.xml from `pages`, so it must retain the full list here.
+            const allPagesForContentXml = pages;
+
             // Filter out hidden pages (visibility: false)
             pages = pages.filter(p => this.isPageVisible(p, pages));
 
@@ -306,8 +314,10 @@ export class ImsExporter extends Html5Exporter {
             // 8. Add project assets (with tracking for ELPX manifest)
             await this.addAssetsToZipWithResourcePath(fileList);
 
-            // 8b. Add content.xml (ODE format) and content.dtd for re-editing
-            const contentXml = generateOdeXml(meta, pages);
+            // 8b. Add content.xml (ODE format) and content.dtd for re-editing.
+            // Use the full page list (incl. hidden pages) so nothing is lost on
+            // re-import — see allPagesForContentXml above.
+            const contentXml = generateOdeXml(meta, allPagesForContentXml);
             addFile('content.xml', contentXml);
             addFile(ODE_DTD_FILENAME, ODE_DTD_CONTENT);
             commonFiles.push('content.xml', ODE_DTD_FILENAME);

--- a/src/shared/export/renderers/PageRenderer.spec.ts
+++ b/src/shared/export/renderers/PageRenderer.spec.ts
@@ -379,6 +379,88 @@ describe('PageRenderer', () => {
             // First page gets main-node class too
             expect(html).toContain('class="active main-node daddy"');
         });
+
+        it('should mark ancestors of the current page with current-page-parent', () => {
+            const pages: ExportPage[] = [
+                createTestPage({ id: 'root', title: 'Root' }),
+                createTestPage({ id: 'section', title: 'Section', parentId: 'root', order: 1 }),
+                createTestPage({ id: 'leaf', title: 'Leaf', parentId: 'section', order: 2 }),
+            ];
+
+            const html = renderer.renderNavigation(pages, 'leaf', '');
+
+            // The middle ancestor is highlighted; the deep current page is active.
+            expect(html).toContain('class="current-page-parent"');
+            expect(html).toContain('class="active"');
+            expect(html).toContain('Leaf');
+        });
+
+        it('should exclude a hidden subtree and its descendants from navigation', () => {
+            const pages: ExportPage[] = [
+                createTestPage({ id: 'root', title: 'Root' }),
+                createTestPage({
+                    id: 'hidden-parent',
+                    title: 'HiddenParent',
+                    parentId: 'root',
+                    order: 1,
+                    properties: { visibility: false },
+                }),
+                createTestPage({ id: 'hidden-child', title: 'HiddenChild', parentId: 'hidden-parent', order: 2 }),
+                createTestPage({ id: 'visible', title: 'VisiblePage', parentId: 'root', order: 3 }),
+            ];
+
+            const html = renderer.renderNavigation(pages, 'root', '');
+
+            expect(html).toContain('VisiblePage');
+            // Both the hidden page and its (otherwise visible) child are dropped.
+            expect(html).not.toContain('HiddenParent');
+            expect(html).not.toContain('HiddenChild');
+        });
+
+        it('should produce identical output across repeated renders (memoization is stateless per call)', () => {
+            const pages: ExportPage[] = [
+                createTestPage({ id: 'root', title: 'Root' }),
+                createTestPage({ id: 'a', title: 'A', parentId: 'root', order: 1 }),
+                createTestPage({ id: 'b', title: 'B', parentId: 'a', order: 2 }),
+                createTestPage({ id: 'c', title: 'C', parentId: 'root', order: 3 }),
+            ];
+
+            const first = renderer.renderNavigation(pages, 'b', '');
+            const second = renderer.renderNavigation(pages, 'b', '');
+
+            expect(first).toBe(second);
+        });
+    });
+
+    describe('renderNavItem (public entry point)', () => {
+        it('should render a single item with its visible children', () => {
+            const pages: ExportPage[] = [
+                createTestPage({ id: 'root', title: 'Root' }),
+                createTestPage({ id: 'parent', title: 'Parent', parentId: 'root', order: 1 }),
+                createTestPage({ id: 'child', title: 'Child', parentId: 'parent', order: 2 }),
+            ];
+
+            const html = renderer.renderNavItem(pages[1], pages, 'child', '');
+
+            expect(html).toContain('Parent');
+            expect(html).toContain('Child');
+            expect(html).toContain('class="other-section"');
+        });
+
+        it('should return empty string for a hidden page', () => {
+            const pages: ExportPage[] = [
+                createTestPage({ id: 'root', title: 'Root' }),
+                createTestPage({
+                    id: 'hidden',
+                    title: 'Hidden',
+                    parentId: 'root',
+                    order: 1,
+                    properties: { visibility: false },
+                }),
+            ];
+
+            expect(renderer.renderNavItem(pages[1], pages, 'root', '')).toBe('');
+        });
     });
 
     describe('renderNavButtons', () => {

--- a/src/shared/export/renderers/PageRenderer.ts
+++ b/src/shared/export/renderers/PageRenderer.ts
@@ -26,6 +26,23 @@ import {
     formatShortLicenseText,
 } from '../constants';
 import { trans } from '../../../services/translation';
+
+/**
+ * Precomputed lookups shared across a single navigation render so each nav node
+ * costs O(1) instead of re-scanning the whole page array. See
+ * PageRenderer.buildNavRenderContext.
+ */
+interface NavRenderContext {
+    /** id → page. */
+    idIndex: Map<string, ExportPage>;
+    /** parentId (or null for roots) → children, in original page order. */
+    childrenByParent: Map<string | null, ExportPage[]>;
+    /** Memoized visibility check (same semantics as isPageVisible). */
+    isVisible: (page: ExportPage) => boolean;
+    /** Strict ancestors of the current page. */
+    ancestorsOfCurrent: Set<string>;
+}
+
 /**
  * PageRenderer class
  * Renders complete HTML pages for export
@@ -370,11 +387,20 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         basePath: string,
         pageFilenameMap?: Map<string, string>,
     ): string {
-        const rootPages = allPages.filter(p => !p.parentId);
+        // Precompute indices ONCE per navigation render. The previous
+        // implementation re-scanned the full page array for every nav node
+        // (children filter + recursive visibility/ancestry walks, each doing an
+        // O(n) find per level), making rendering O(n²·depth) per page and the
+        // whole HTML5 export/preview O(n³·depth). For courses with hundreds of
+        // pages that dominated export time on the browser main thread. The
+        // precomputed structures below make navigation O(n) per page with
+        // identical output.
+        const ctx = this.buildNavRenderContext(allPages, currentPageId);
+        const rootPages = ctx.childrenByParent.get(null) ?? [];
 
         let html = '<nav id="siteNav">\n<ul>\n';
         for (const page of rootPages) {
-            html += this.renderNavItem(page, allPages, currentPageId, basePath, pageFilenameMap);
+            html += this.renderNavItemFast(page, allPages, currentPageId, basePath, pageFilenameMap, ctx);
         }
         html += '</ul>\n</nav>';
 
@@ -382,7 +408,118 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
     }
 
     /**
-     * Render a single navigation item (recursive for children)
+     * Build the per-render navigation index: an id→page map, a parentId→children
+     * map (preserving page array order; root pages keyed under `null`), a
+     * memoized visibility cache, and the set of the current page's ancestors.
+     * This collapses the repeated O(n) scans in renderNavItem/isPageVisible/
+     * isAncestorOf into a single O(n) pass with O(1) lookups thereafter.
+     */
+    private buildNavRenderContext(allPages: ExportPage[], currentPageId: string): NavRenderContext {
+        const idIndex = new Map<string, ExportPage>();
+        const childrenByParent = new Map<string | null, ExportPage[]>();
+        const rootId = allPages[0]?.id;
+
+        for (const page of allPages) {
+            idIndex.set(page.id, page);
+            const key = page.parentId ?? null;
+            const bucket = childrenByParent.get(key);
+            if (bucket) {
+                bucket.push(page);
+            } else {
+                childrenByParent.set(key, [page]);
+            }
+        }
+
+        const visibleCache = new Map<string, boolean>();
+        const isVisible = (page: ExportPage): boolean => {
+            const cached = visibleCache.get(page.id);
+            if (cached !== undefined) return cached;
+            let result: boolean;
+            if (page.id === rootId) {
+                result = true;
+            } else if (this.isFalsyProperty(page.properties?.visibility)) {
+                result = false;
+            } else if (page.parentId) {
+                const parent = idIndex.get(page.parentId);
+                result = parent ? isVisible(parent) : true;
+            } else {
+                result = true;
+            }
+            visibleCache.set(page.id, result);
+            return result;
+        };
+
+        // Ancestor chain of the current page (strict ancestors only), with a
+        // cycle guard so malformed parent links cannot loop forever.
+        const ancestorsOfCurrent = new Set<string>();
+        let cursor = idIndex.get(currentPageId);
+        while (cursor?.parentId && !ancestorsOfCurrent.has(cursor.parentId)) {
+            ancestorsOfCurrent.add(cursor.parentId);
+            cursor = idIndex.get(cursor.parentId);
+        }
+
+        return { idIndex, childrenByParent, isVisible, ancestorsOfCurrent };
+    }
+
+    /**
+     * Optimized counterpart to renderNavItem that uses the precomputed
+     * NavRenderContext. Output is byte-for-byte identical to renderNavItem;
+     * only the lookups differ (O(1) map access instead of O(n) array scans).
+     */
+    private renderNavItemFast(
+        page: ExportPage,
+        allPages: ExportPage[],
+        currentPageId: string,
+        basePath: string,
+        pageFilenameMap: Map<string, string> | undefined,
+        ctx: NavRenderContext,
+    ): string {
+        if (!ctx.isVisible(page)) {
+            return '';
+        }
+
+        const children = (ctx.childrenByParent.get(page.id) ?? []).filter(child => ctx.isVisible(child));
+        const isCurrent = page.id === currentPageId;
+        const hasChildren = children.length > 0;
+        const isAncestor = ctx.ancestorsOfCurrent.has(page.id);
+        const isFirstPage = page.id === allPages[0]?.id;
+
+        const liClass = isCurrent ? ' class="active"' : isAncestor ? ' class="current-page-parent"' : '';
+        const link = this.getPageLink(page, allPages, basePath, pageFilenameMap);
+
+        const linkClasses: string[] = [];
+        if (isCurrent) linkClasses.push('active');
+        if (isFirstPage) linkClasses.push('main-node');
+        linkClasses.push(hasChildren ? 'daddy' : 'no-ch');
+
+        if (this.isPageHighlighted(page)) {
+            linkClasses.push('highlighted-link');
+        }
+
+        let html = `<li${liClass}>`;
+        html += ` <a href="${link}" class="${linkClasses.join(' ')}">${this.escapeHtml(page.title)}</a>\n`;
+
+        if (hasChildren) {
+            html += '<ul class="other-section">\n';
+            for (const child of children) {
+                html += this.renderNavItemFast(child, allPages, currentPageId, basePath, pageFilenameMap, ctx);
+            }
+            html += '</ul>\n';
+        }
+
+        html += '</li>\n';
+        return html;
+    }
+
+    /**
+     * Render a single navigation item (recursive for children).
+     *
+     * Public entry point kept for backward compatibility; it builds a
+     * NavRenderContext on demand and delegates to the optimized renderer so
+     * there is a single source of truth for the markup. Callers rendering a
+     * whole tree should prefer renderNavigation, which builds the context once
+     * and reuses it across every node.
+     *
      * @param page - Page to render
      * @param allPages - All pages
      * @param currentPageId - Current page ID
@@ -397,46 +534,8 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         basePath: string,
         pageFilenameMap?: Map<string, string>,
     ): string {
-        // Skip hidden pages (except we check at parent level to preserve hierarchy)
-        if (!this.isPageVisible(page, allPages)) {
-            return '';
-        }
-
-        // Filter children to only visible ones
-        const children = allPages.filter(p => p.parentId === page.id && this.isPageVisible(p, allPages));
-        const isCurrent = page.id === currentPageId;
-        const hasChildren = children.length > 0;
-        const isAncestor = this.isAncestorOf(page.id, currentPageId, allPages);
-        const isFirstPage = page.id === allPages[0]?.id;
-
-        // Build li class attribute
-        const liClass = isCurrent ? ' class="active"' : isAncestor ? ' class="current-page-parent"' : '';
-        const link = this.getPageLink(page, allPages, basePath, pageFilenameMap);
-
-        // Build link classes: main-node for first page, daddy/no-ch for children, active if current
-        const linkClasses: string[] = [];
-        if (isCurrent) linkClasses.push('active');
-        if (isFirstPage) linkClasses.push('main-node');
-        linkClasses.push(hasChildren ? 'daddy' : 'no-ch');
-
-        // Add highlighted-link class if page is highlighted
-        if (this.isPageHighlighted(page)) {
-            linkClasses.push('highlighted-link');
-        }
-
-        let html = `<li${liClass}>`;
-        html += ` <a href="${link}" class="${linkClasses.join(' ')}">${this.escapeHtml(page.title)}</a>\n`;
-
-        if (hasChildren) {
-            html += '<ul class="other-section">\n';
-            for (const child of children) {
-                html += this.renderNavItem(child, allPages, currentPageId, basePath, pageFilenameMap);
-            }
-            html += '</ul>\n';
-        }
-
-        html += '</li>\n';
-        return html;
+        const ctx = this.buildNavRenderContext(allPages, currentPageId);
+        return this.renderNavItemFast(page, allPages, currentPageId, basePath, pageFilenameMap, ctx);
     }
 
     /**


### PR DESCRIPTION
## Summary

Builds on #1896 (security hardening). I ran a multi-agent audit over the **post-#1896** tree to hunt critical correctness and performance bugs. The run was cut short (only the route-correctness and export-correctness finders completed before a billing limit stopped the rest), but it surfaced **8 adversarially-verified bugs** (each confirmed 3/3 by independent reproduce / refute / impact reviewers). This PR fixes **7 of them**; the 8th is documented below as a follow-up.

Branch is stacked on `hotfix/security-fixes` so it composes with the improvements already in #1896.

## Fixes

### Security / data-loss (route layer)

- **Cross-tenant asset deletion (IDOR, critical)** — `DELETE /api/projects/:projectId/assets/:assetId` and `GET …/metadata` resolved the asset via the unscoped `findAssetById` and never checked it belonged to the URL project. Any authenticated user could permanently delete (file + DB row) or read metadata of *another tenant's* asset by enumerating numeric ids. Now enforces `asset.project_id === projectIdNum`, mirroring the guard already present on `GET /:assetId`.
- **Unauthenticated arbitrary file write via `upload-chunk` (critical)** — `POST /api/project/upload-chunk` had no auth and joined the attacker-controlled `odeFileName` straight into a filesystem path, then `appendFile`'d the body. Now requires authentication, validates `odeSessionId` as a safe segment, and asserts the resolved target stays inside the session temp dir (`isWithinBase`) — traversal like `../../etc/cron.d/x` is rejected while legitimate names with spaces/unicode still work.
- **iDevice upload path traversal (high)** — both `…/upload/file/resources` and `…/upload/large/file/resources` built the destination from unsanitized `odeSessionId`/`odeIdeviceId`. Now built with `safeJoin`, rejecting traversal before any write.
- **Temp-dir leak on every conversion (high)** — `convert.ts runExport` created `extract-<uuid>/` per call and never removed it (the route only cleaned the sibling `convert-<uuid>/`), leaking the full extracted asset payload under `FILES_DIR/tmp` on every `/api/convert/*` call. Now removed in the `finally`.

### Export correctness

- **Pages silently overwritten in exports (high)** — `BaseExporter.buildPageFilenameMap` capped collision resolution at 20 attempts; past the cap, distinct pages collapsed onto one filename and silently overwrote each other in the ZIP (`addFile` is a `Map.set`). Triggered by ≥22 identically-titled pages, and *automatically* for any course titled entirely in non-Latin scripts (CJK/Arabic/Cyrillic/…), whose titles all sanitize to the empty string. Uniqueness is now guaranteed by construction, and `sanitizePageFilename` falls back to `page` for empty-sanitized titles.
- **IMS export drops hidden pages on re-import (high)** — `ImsExporter` baked the visibility filter into the re-editable `content.xml`, so hidden pages (drafts / teacher-only) were permanently lost when re-editing from the IMS package. `content.xml` now uses the full page list like the SCORM exporters; rendered HTML and the manifest still exclude hidden pages.

### Performance

- **O(n²·depth) navigation rendering (medium)** — `PageRenderer` rebuilt the whole site nav per page, re-scanning the full page array for children/visibility/ancestry at every node, making HTML5 export *and* every preview refresh O(n³·depth) on the browser main thread. Now precomputes a children index, memoized visibility set, id index and the current page's ancestor set once per render. Output is **byte-for-byte identical** (verified by the existing renderer specs).

## Follow-up (not in this PR)

Tracked in #1927.

- **`exe-node:` internal links rewritten irreversibly into `content.xml` (high)** — `ElpxExporter`/`Html5Exporter`/`ImsExporter` feed `replaceInternalLinks`-processed pages into `content.xml`, but the importer only understands `exe-node:`, so internal page links degrade after an export → re-import round trip. The correct fix splits `preprocessPagesForExport` so internal-link rewriting happens at HTML render time (mirroring how `exe-package:elp` was already moved). That is a cross-cutting change to the render path of every exporter and needs broad round-trip E2E across all formats, so I've left it out of this PR to keep it focused and low-risk. Happy to do it as a dedicated follow-up.

## Testing

- `make fix` — clean.
- `make test-unit` — **7316 pass, 0 fail**; coverage gate green (all 219 files ≥ 90%).
- `make test-integration` — **709 pass, 0 fail**.
- Every fix ships colocated tests (cross-tenant IDOR block, unauth + traversal rejection, temp-dir cleanup, >20-duplicate and non-Latin filename uniqueness, IMS hidden-page round trip, nav ancestor/hidden-subtree rendering).

The export changes touch the export flow, so `make test-e2e-static` should be exercised in CI.

