### PR TITLE
fix(export): keep exe-node: internal links in content.xml across round trips (#1927)

### DIFF
--- a/src/shared/export/exporters/BaseExporter.spec.ts
+++ b/src/shared/export/exporters/BaseExporter.spec.ts
@@ -1405,154 +1405,6 @@ describe('BaseExporter', () => {
         });
     });
 
-    describe('Internal Link Handling', () => {
-        describe('buildPageUrlMap', () => {
-            it('should map first page to index.html', () => {
-                const pages = [
-                    { id: 'page-1', title: 'Home', blocks: [] },
-                    { id: 'page-2', title: 'About', blocks: [] },
-                ];
-                const map = (exporter as any).buildPageUrlMap(pages);
-
-                expect(map.get('page-1')).toEqual({
-                    url: 'index.html',
-                    urlFromSubpage: '../index.html',
-                });
-            });
-
-            it('should map other pages to html/ directory', () => {
-                const pages = [
-                    { id: 'page-1', title: 'Home', blocks: [] },
-                    { id: 'page-2', title: 'About Us', blocks: [] },
-                    { id: 'page-3', title: 'Contact', blocks: [] },
-                ];
-                const map = (exporter as any).buildPageUrlMap(pages);
-
-                expect(map.get('page-2')).toEqual({
-                    url: 'html/about-us.html',
-                    urlFromSubpage: 'about-us.html',
-                });
-                expect(map.get('page-3')).toEqual({
-                    url: 'html/contact.html',
-                    urlFromSubpage: 'contact.html',
-                });
-            });
-
-            it('should sanitize page titles with special characters', () => {
-                const pages = [
-                    { id: 'page-1', title: 'Home', blocks: [] },
-                    { id: 'page-2', title: 'Capítulo 1: Introducción', blocks: [] },
-                ];
-                const map = (exporter as any).buildPageUrlMap(pages);
-
-                expect(map.get('page-2')).toEqual({
-                    url: 'html/capitulo-1-introduccion.html',
-                    urlFromSubpage: 'capitulo-1-introduccion.html',
-                });
-            });
-        });
-
-        describe('replaceInternalLinks', () => {
-            it('should replace exe-node links with page URLs from index', () => {
-                const pageUrlMap = new Map([
-                    ['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }],
-                    ['page-2', { url: 'html/about.html', urlFromSubpage: 'about.html' }],
-                ]);
-
-                const content = '<a href="exe-node:page-2">Go to About</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="html/about.html">Go to About</a>');
-            });
-
-            it('should replace exe-node links with relative URLs from subpage', () => {
-                const pageUrlMap = new Map([
-                    ['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }],
-                    ['page-2', { url: 'html/about.html', urlFromSubpage: 'about.html' }],
-                ]);
-
-                const content = '<a href="exe-node:page-1">Go to Home</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, false);
-
-                expect(result).toBe('<a href="../index.html">Go to Home</a>');
-            });
-
-            it('should handle multiple links in content', () => {
-                const pageUrlMap = new Map([
-                    ['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }],
-                    ['page-2', { url: 'html/about.html', urlFromSubpage: 'about.html' }],
-                    ['page-3', { url: 'html/contact.html', urlFromSubpage: 'contact.html' }],
-                ]);
-
-                const content = '<a href="exe-node:page-2">About</a> and <a href="exe-node:page-3">Contact</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="html/about.html">About</a> and <a href="html/contact.html">Contact</a>');
-            });
-
-            it('should leave non-matching links unchanged', () => {
-                const pageUrlMap = new Map([['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }]]);
-
-                const content = '<a href="exe-node:unknown-page">Unknown</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="exe-node:unknown-page">Unknown</a>');
-            });
-
-            it('should handle content without exe-node links', () => {
-                const pageUrlMap = new Map([['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }]]);
-
-                const content = '<a href="https://example.com">External</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="https://example.com">External</a>');
-            });
-
-            it('should handle empty content', () => {
-                const pageUrlMap = new Map();
-                const result = (exporter as any).replaceInternalLinks('', pageUrlMap, true);
-
-                expect(result).toBe('');
-            });
-
-            it('should handle links with single quotes', () => {
-                const pageUrlMap = new Map([['page-2', { url: 'html/about.html', urlFromSubpage: 'about.html' }]]);
-
-                const content = "<a href='exe-node:page-2'>About</a>";
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="html/about.html">About</a>');
-            });
-
-            it('should preserve anchor fragment from index page', () => {
-                const pageUrlMap = new Map([['page-2', { url: 'html/about.html', urlFromSubpage: 'about.html' }]]);
-
-                const content = '<a href="exe-node:page-2#section1">About Section 1</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="html/about.html#section1">About Section 1</a>');
-            });
-
-            it('should preserve anchor fragment from subpage', () => {
-                const pageUrlMap = new Map([['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }]]);
-
-                const content = '<a href="exe-node:page-1#intro">Go to Intro</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, false);
-
-                expect(result).toBe('<a href="../index.html#intro">Go to Intro</a>');
-            });
-
-            it('should leave anchor fragment link unchanged when page not found', () => {
-                const pageUrlMap = new Map([['page-1', { url: 'index.html', urlFromSubpage: '../index.html' }]]);
-
-                const content = '<a href="exe-node:unknown-page#section">Unknown</a>';
-                const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-                expect(result).toBe('<a href="exe-node:unknown-page#section">Unknown</a>');
-            });
-        });
-    });
-
     describe('buildPageFilenameMap', () => {
         it('should map first page to index.html', () => {
             const pages: ExportPage[] = [
@@ -1661,28 +1513,18 @@ describe('BaseExporter', () => {
             expect(map.get('page-2')).toBe('nueva-pagina.html');
         });
 
-        it('should work correctly with buildPageUrlMap integration', () => {
+        it('should produce collision-safe filenames for duplicate titles', () => {
             const pages: ExportPage[] = [
                 { id: 'page-1', title: 'Home', parentId: null, order: 0, blocks: [] },
                 { id: 'page-2', title: 'Test', parentId: null, order: 1, blocks: [] },
                 { id: 'page-3', title: 'Test', parentId: null, order: 2, blocks: [] },
             ];
 
-            // buildPageUrlMap internally uses buildPageFilenameMap
-            const urlMap = (exporter as any).buildPageUrlMap(pages);
+            const map = exporter.testBuildPageFilenameMap(pages);
 
-            expect(urlMap.get('page-1')).toEqual({
-                url: 'index.html',
-                urlFromSubpage: '../index.html',
-            });
-            expect(urlMap.get('page-2')).toEqual({
-                url: 'html/test.html',
-                urlFromSubpage: 'test.html',
-            });
-            expect(urlMap.get('page-3')).toEqual({
-                url: 'html/test-2.html',
-                urlFromSubpage: 'test-2.html',
-            });
+            expect(map.get('page-1')).toBe('index.html');
+            expect(map.get('page-2')).toBe('test.html');
+            expect(map.get('page-3')).toBe('test-2.html');
         });
 
         it('should handle more than 20 pages with same title (maxAttempts limit)', () => {

--- a/src/shared/export/exporters/BaseExporter.ts
+++ b/src/shared/export/exporters/BaseExporter.ts
@@ -789,11 +789,15 @@ export abstract class BaseExporter {
     }
 
     /**
-     * Pre-process pages to add filenames to asset URLs in all component content
-     * And converts internal links (exe-node:) to proper page URLs
+     * Pre-process pages to add filenames to asset URLs in all component content.
      *
-     * Note: exe-package:elp protocol transformation is now done in PageRenderer.renderPageContent()
-     * so the XML content keeps the original protocol for re-import compatibility
+     * This only performs XML-safe rewrites: asset URLs become {{context_path}}/... which
+     * is reversed on import, so the persisted content.xml stays re-importable.
+     *
+     * Note: exe-node: internal links and the exe-package:elp protocol are NOT rewritten
+     * here. Both are transformed at render time (PageRenderer.renderPageContent /
+     * renderSinglePage) so the XML keeps the original references and survives an
+     * export → re-import round trip (#1927).
      */
     async preprocessPagesForExport(pages: ExportPage[]): Promise<ExportPage[]> {
         const componentCount = pages.reduce((total, page) => {
@@ -809,20 +813,12 @@ export abstract class BaseExporter {
         // This ensures multiple exports on the same document work correctly
         const clonedPages: ExportPage[] = JSON.parse(JSON.stringify(pages));
 
-        // Build page URL map for internal link conversion
-        const pageUrlMap = this.buildPageUrlMap(clonedPages);
-
-        for (let pageIndex = 0; pageIndex < clonedPages.length; pageIndex++) {
-            const page = clonedPages[pageIndex];
-            const isIndex = pageIndex === 0;
-
+        for (const page of clonedPages) {
             for (const block of page.blocks || []) {
                 for (const component of block.components || []) {
                     if (component.content) {
                         // Add filenames to asset URLs in content
                         component.content = await this.addFilenamesToAssetUrls(component.content);
-                        // Convert internal links to proper page URLs
-                        component.content = this.replaceInternalLinks(component.content, pageUrlMap, isIndex);
                     }
                     // Also process properties (jsonProperties may contain asset URLs)
                     if (component.properties && Object.keys(component.properties).length > 0) {
@@ -898,72 +894,10 @@ export abstract class BaseExporter {
         return filenameMap;
     }
 
-    /**
-     * Build a map of page IDs to their export URLs
-     * Used for internal link (exe-node:) conversion
-     */
-    protected buildPageUrlMap(pages: ExportPage[]): Map<string, { url: string; urlFromSubpage: string }> {
-        const map = new Map<string, { url: string; urlFromSubpage: string }>();
-        const filenameMap = this.buildPageFilenameMap(pages);
-
-        for (let i = 0; i < pages.length; i++) {
-            const page = pages[i];
-            const filename = filenameMap.get(page.id) || 'page.html';
-            const isFirstPage = i === 0;
-
-            if (isFirstPage) {
-                // First page is index.html
-                map.set(page.id, {
-                    url: 'index.html',
-                    urlFromSubpage: '../index.html',
-                });
-            } else {
-                // Other pages are in html/ directory
-                map.set(page.id, {
-                    url: `html/${filename}`,
-                    urlFromSubpage: filename,
-                });
-            }
-        }
-
-        return map;
-    }
-
-    /**
-     * Replace exe-node: internal links with proper page URLs
-     *
-     * @param content - HTML content
-     * @param pageUrlMap - Map of page IDs to their export URLs
-     * @param isFromIndex - Whether the content is from the index page (affects relative paths)
-     * @returns Content with internal links replaced
-     */
-    protected replaceInternalLinks(
-        content: string,
-        pageUrlMap: Map<string, { url: string; urlFromSubpage: string }>,
-        isFromIndex: boolean,
-    ): string {
-        if (!content || !content.includes('exe-node:')) {
-            return content;
-        }
-
-        // Replace href="exe-node:pageId" or href="exe-node:pageId#anchor" with actual page URLs
-        return content.replace(/href=["']exe-node:([^"']+)["']/gi, (match, pageIdWithAnchor) => {
-            // Split pageId from optional anchor fragment (e.g. "pageId#section1")
-            const hashIdx = pageIdWithAnchor.indexOf('#');
-            const pageId = hashIdx !== -1 ? pageIdWithAnchor.substring(0, hashIdx) : pageIdWithAnchor;
-            const anchorFragment = hashIdx !== -1 ? pageIdWithAnchor.substring(hashIdx) : '';
-
-            const pageUrls = pageUrlMap.get(pageId);
-            if (pageUrls) {
-                // Use the appropriate URL based on whether we're on index or subpage
-                const url = isFromIndex ? pageUrls.url : pageUrls.urlFromSubpage;
-                return `href="${url}${anchorFragment}"`;
-            }
-            // If page not found, leave the link unchanged (might be an external link or error)
-            console.warn(`[BaseExporter] Internal link target not found: ${pageId}`);
-            return match;
-        });
-    }
+    // Note: exe-node: internal links are no longer rewritten here. The rewrite moved to
+    // render time (PageRenderer.replaceInternalLinks / replaceSinglePageInternalLinks), so
+    // the source HTML that feeds content.xml keeps the original exe-node: references and
+    // survives an export → re-import round trip (#1927).
 
     /**
      * Replace exe-package:elp protocol with client-side download handler

--- a/src/shared/export/exporters/ElpxExporter.spec.ts
+++ b/src/shared/export/exporters/ElpxExporter.spec.ts
@@ -1205,3 +1205,99 @@ describe('ElpxExporter', () => {
         });
     });
 });
+
+// Regression coverage for #1927: the re-editable content.xml must keep exe-node:
+// internal links so they survive an export -> re-import round trip. The exported
+// HTML pages still resolve to static paths at render time.
+const internalLinkPages: ExportPage[] = [
+    {
+        id: 'page-1',
+        title: 'Home',
+        parentId: null,
+        order: 0,
+        blocks: [
+            {
+                id: 'block-1',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-1',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content:
+                            '<p>Go to <a href="exe-node:page-2">About</a> and <a href="exe-node:page-2#sec">a section</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'page-2',
+        title: 'About',
+        parentId: null,
+        order: 1,
+        blocks: [
+            {
+                id: 'block-2',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-2',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content: '<p>Back to <a href="exe-node:page-1">Home</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function exportElpxZip(pages: ExportPage[]): Promise<MockZipProvider> {
+    const zip = new MockZipProvider();
+    const exporter = new ElpxExporter(
+        new MockDocument({}, pages),
+        new MockResourceProvider(),
+        new MockAssetProvider(),
+        zip,
+    );
+    await exporter.export();
+    return zip;
+}
+
+describe('ElpxExporter — internal link round-trip (#1927)', () => {
+    it('keeps exe-node: internal links in content.xml', async () => {
+        const zip = await exportElpxZip(internalLinkPages);
+        const contentXml = zip.files.get('content.xml') as string;
+
+        // The re-editable XML must retain the original protocol...
+        expect(contentXml).toContain('exe-node:page-2');
+        expect(contentXml).toContain('exe-node:page-1');
+        // ...and must NOT leak the static export path into the persisted XML.
+        expect(contentXml).not.toContain('html/about.html');
+        expect(contentXml).not.toContain('../index.html');
+    });
+
+    it('preserves the anchor fragment on exe-node links in content.xml', async () => {
+        const zip = await exportElpxZip(internalLinkPages);
+        const contentXml = zip.files.get('content.xml') as string;
+
+        expect(contentXml).toContain('exe-node:page-2#sec');
+    });
+
+    it('still renders the static path in the exported HTML pages', async () => {
+        const zip = await exportElpxZip(internalLinkPages);
+        const indexHtml = zip.files.get('index.html') as string;
+        const aboutHtml = zip.files.get('html/about.html') as string;
+
+        // Index page links down into html/ ...
+        expect(indexHtml).toContain('href="html/about.html"');
+        expect(indexHtml).toContain('href="html/about.html#sec"');
+        expect(indexHtml).not.toContain('exe-node:');
+        // ...subpage links back up to the index.
+        expect(aboutHtml).toContain('href="../index.html"');
+        expect(aboutHtml).not.toContain('exe-node:');
+    });
+});

--- a/src/shared/export/exporters/Html5Exporter.spec.ts
+++ b/src/shared/export/exporters/Html5Exporter.spec.ts
@@ -2620,3 +2620,89 @@ describe('Html5Exporter', () => {
         });
     });
 });
+
+// Regression coverage for #1927: the re-editable content.xml must keep exe-node:
+// internal links so they survive an export -> re-import round trip. The exported
+// HTML pages still resolve to static paths at render time.
+const internalLinkPages: ExportPage[] = [
+    {
+        id: 'page-1',
+        title: 'Home',
+        parentId: null,
+        order: 0,
+        blocks: [
+            {
+                id: 'block-1',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-1',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content:
+                            '<p>Go to <a href="exe-node:page-2">About</a> and <a href="exe-node:page-2#sec">a section</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'page-2',
+        title: 'About',
+        parentId: null,
+        order: 1,
+        blocks: [
+            {
+                id: 'block-2',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-2',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content: '<p>Back to <a href="exe-node:page-1">Home</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function exportHtml5Zip(pages: ExportPage[]): Promise<MockZipProvider> {
+    const zip = new MockZipProvider();
+    const exporter = new Html5Exporter(
+        new MockDocument({}, pages),
+        new MockResourceProvider(),
+        new MockAssetProvider(),
+        zip,
+    );
+    await exporter.export();
+    return zip;
+}
+
+describe('Html5Exporter — internal link round-trip (#1927)', () => {
+    it('keeps exe-node: internal links in content.xml', async () => {
+        const zip = await exportHtml5Zip(internalLinkPages);
+        const contentXml = zip.files.get('content.xml') as string;
+
+        expect(contentXml).toContain('exe-node:page-2');
+        expect(contentXml).toContain('exe-node:page-1');
+        expect(contentXml).toContain('exe-node:page-2#sec');
+        expect(contentXml).not.toContain('html/about.html');
+        expect(contentXml).not.toContain('../index.html');
+    });
+
+    it('still renders the static path in the exported HTML pages', async () => {
+        const zip = await exportHtml5Zip(internalLinkPages);
+        const indexHtml = zip.files.get('index.html') as string;
+        const aboutHtml = zip.files.get('html/about.html') as string;
+
+        expect(indexHtml).toContain('href="html/about.html"');
+        expect(indexHtml).toContain('href="html/about.html#sec"');
+        expect(indexHtml).not.toContain('exe-node:');
+        expect(aboutHtml).toContain('href="../index.html"');
+        expect(aboutHtml).not.toContain('exe-node:');
+    });
+});

--- a/src/shared/export/exporters/ImsExporter.spec.ts
+++ b/src/shared/export/exporters/ImsExporter.spec.ts
@@ -578,3 +578,89 @@ describe('ImsExporter', () => {
         });
     });
 });
+
+// Regression coverage for #1927: the re-editable content.xml must keep exe-node:
+// internal links so they survive an export -> re-import round trip. The exported
+// HTML pages still resolve to static paths at render time.
+const internalLinkPages: ExportPage[] = [
+    {
+        id: 'page-1',
+        title: 'Home',
+        parentId: null,
+        order: 0,
+        blocks: [
+            {
+                id: 'block-1',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-1',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content:
+                            '<p>Go to <a href="exe-node:page-2">About</a> and <a href="exe-node:page-2#sec">a section</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'page-2',
+        title: 'About',
+        parentId: null,
+        order: 1,
+        blocks: [
+            {
+                id: 'block-2',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-2',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content: '<p>Back to <a href="exe-node:page-1">Home</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function exportImsZip(pages: ExportPage[]): Promise<MockZipProvider> {
+    const zip = new MockZipProvider();
+    const exporter = new ImsExporter(
+        new MockDocument({}, pages),
+        new MockResourceProvider(),
+        new MockAssetProvider(),
+        zip,
+    );
+    await exporter.export();
+    return zip;
+}
+
+describe('ImsExporter — internal link round-trip (#1927)', () => {
+    it('keeps exe-node: internal links in content.xml', async () => {
+        const zip = await exportImsZip(internalLinkPages);
+        const contentXml = zip.files.get('content.xml') as string;
+
+        expect(contentXml).toContain('exe-node:page-2');
+        expect(contentXml).toContain('exe-node:page-1');
+        expect(contentXml).toContain('exe-node:page-2#sec');
+        expect(contentXml).not.toContain('html/about.html');
+        expect(contentXml).not.toContain('../index.html');
+    });
+
+    it('still renders the static path in the exported HTML pages', async () => {
+        const zip = await exportImsZip(internalLinkPages);
+        const indexHtml = zip.files.get('index.html') as string;
+        const aboutHtml = zip.files.get('html/about.html') as string;
+
+        expect(indexHtml).toContain('href="html/about.html"');
+        expect(indexHtml).toContain('href="html/about.html#sec"');
+        expect(indexHtml).not.toContain('exe-node:');
+        expect(aboutHtml).toContain('href="../index.html"');
+        expect(aboutHtml).not.toContain('exe-node:');
+    });
+});

--- a/src/shared/export/exporters/PageExporter.spec.ts
+++ b/src/shared/export/exporters/PageExporter.spec.ts
@@ -482,99 +482,10 @@ describe('PageExporter', () => {
         });
     });
 
+    // Note: the single-page exe-node: → anchor rewrite and named-anchor namespacing now
+    // live in PageRenderer (replaceSinglePageInternalLinks / namespaceSinglePageAnchors) and
+    // are unit-tested there. The tests below cover the end-to-end single-page export behaviour.
     describe('Internal Link Handling (Single Page)', () => {
-        it('should build page URL map with anchor fragments', () => {
-            const pages = [
-                { id: 'page-1', title: 'Home', blocks: [] },
-                { id: 'page-2', title: 'About', blocks: [] },
-                { id: 'page-3', title: 'Contact', blocks: [] },
-            ];
-            const map = (exporter as any).buildPageUrlMap(pages);
-
-            // All pages should use anchor fragments for single-page export
-            // Uses section-{id} to match IDs from renderSinglePageSection
-            expect(map.get('page-1')).toEqual({
-                url: '#section-page-1',
-                urlFromSubpage: '#section-page-1',
-            });
-            expect(map.get('page-2')).toEqual({
-                url: '#section-page-2',
-                urlFromSubpage: '#section-page-2',
-            });
-            expect(map.get('page-3')).toEqual({
-                url: '#section-page-3',
-                urlFromSubpage: '#section-page-3',
-            });
-        });
-
-        it('should convert exe-node links to anchor fragments', () => {
-            const pageUrlMap = new Map([
-                ['page-1', { url: '#section-page-1', urlFromSubpage: '#section-page-1' }],
-                ['page-2', { url: '#section-page-2', urlFromSubpage: '#section-page-2' }],
-            ]);
-
-            const content = '<a href="exe-node:page-2">Go to About</a>';
-            const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-            expect(result).toBe('<a href="#section-page-2">Go to About</a>');
-        });
-
-        it('should use same anchor format regardless of page position', () => {
-            const pageUrlMap = new Map([['page-1', { url: '#section-page-1', urlFromSubpage: '#section-page-1' }]]);
-
-            // From first page
-            const result1 = (exporter as any).replaceInternalLinks(
-                '<a href="exe-node:page-1">Link</a>',
-                pageUrlMap,
-                true,
-            );
-            // From other page (doesn't matter for single page)
-            const result2 = (exporter as any).replaceInternalLinks(
-                '<a href="exe-node:page-1">Link</a>',
-                pageUrlMap,
-                false,
-            );
-
-            // Both should produce the same anchor link
-            expect(result1).toBe('<a href="#section-page-1">Link</a>');
-            expect(result2).toBe('<a href="#section-page-1">Link</a>');
-        });
-
-        it('should namespace anchor fragment with page id when exe-node link has an anchor', () => {
-            const pageUrlMap = new Map([['page-2', { url: '#section-page-2', urlFromSubpage: '#section-page-2' }]]);
-
-            // exe-node:pageId#anchor → #pageId--anchor (namespaced to avoid collisions)
-            const content = '<a href="exe-node:page-2#section1">Jump to section</a>';
-            const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-
-            expect(result).toBe('<a href="#page-2--section1">Jump to section</a>');
-        });
-
-        it('should namespace anchor regardless of isFromIndex when anchor is present', () => {
-            const pageUrlMap = new Map([['page-1', { url: '#section-page-1', urlFromSubpage: '#section-page-1' }]]);
-
-            const content = '<a href="exe-node:page-1#intro">Go to Intro</a>';
-            const resultFromIndex = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-            const resultFromSubpage = (exporter as any).replaceInternalLinks(content, pageUrlMap, false);
-
-            expect(resultFromIndex).toBe('<a href="#page-1--intro">Go to Intro</a>');
-            expect(resultFromSubpage).toBe('<a href="#page-1--intro">Go to Intro</a>');
-        });
-
-        it('should not mangle content without exe-node links', () => {
-            const pageUrlMap = new Map([['page-1', { url: '#section-page-1', urlFromSubpage: '#section-page-1' }]]);
-            const content = '<a href="https://example.com">External</a>';
-            const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-            expect(result).toBe('<a href="https://example.com">External</a>');
-        });
-
-        it('should leave unknown exe-node links unchanged', () => {
-            const pageUrlMap = new Map<string, { url: string; urlFromSubpage: string }>();
-            const content = '<a href="exe-node:unknown-page">Link</a>';
-            const result = (exporter as any).replaceInternalLinks(content, pageUrlMap, true);
-            expect(result).toBe('<a href="exe-node:unknown-page">Link</a>');
-        });
-
         it('should generate sections with section-{id} IDs in single-page HTML', () => {
             const html = exporter.generateSinglePageHtml(samplePages, document.getMetadata(), []);
 
@@ -701,43 +612,6 @@ describe('PageExporter', () => {
             expect(indexHtml).toContain('id="page-2--myanchor"');
             // Should NOT contain raw exe-node: or un-namespaced anchor
             expect(indexHtml).not.toContain('href="exe-node:page-2#myanchor"');
-        });
-    });
-
-    describe('namespaceSinglePageAnchors', () => {
-        it('should prefix id on named anchors (a without href)', () => {
-            const content = '<p><a id="intro">Introduction</a></p>';
-            const result = (exporter as any).namespaceSinglePageAnchors(content, 'page-2');
-            expect(result).toBe('<p><a id="page-2--intro">Introduction</a></p>');
-        });
-
-        it('should prefix name on named anchors', () => {
-            const content = '<p><a name="section1">Section 1</a></p>';
-            const result = (exporter as any).namespaceSinglePageAnchors(content, 'page-2');
-            expect(result).toBe('<p><a name="page-2--section1">Section 1</a></p>');
-        });
-
-        it('should NOT modify anchors that have href (regular links)', () => {
-            const content = '<a href="https://example.com" id="link1">External</a>';
-            const result = (exporter as any).namespaceSinglePageAnchors(content, 'page-2');
-            expect(result).toBe('<a href="https://example.com" id="link1">External</a>');
-        });
-
-        it('should NOT modify non-anchor elements with id', () => {
-            const content = '<div id="mydiv">Content</div>';
-            const result = (exporter as any).namespaceSinglePageAnchors(content, 'page-2');
-            expect(result).toBe('<div id="mydiv">Content</div>');
-        });
-
-        it('should handle empty/null content', () => {
-            expect((exporter as any).namespaceSinglePageAnchors('', 'page-1')).toBe('');
-            expect((exporter as any).namespaceSinglePageAnchors(null, 'page-1')).toBe(null);
-        });
-
-        it('should handle content without any anchors', () => {
-            const content = '<p>Just text</p>';
-            const result = (exporter as any).namespaceSinglePageAnchors(content, 'page-1');
-            expect(result).toBe('<p>Just text</p>');
         });
     });
 
@@ -871,5 +745,90 @@ describe('PageExporter', () => {
             expect(indexHtml).toContain('libs/exe_math/tex-mml-svg.js');
             expect(indexHtml).toContain('libs/exe_tooltips/exe_tooltips.js');
         });
+    });
+});
+
+// Regression coverage for #1927: the single-page content.xml must keep raw exe-node:
+// internal links so they survive an export -> re-import round trip. The exported
+// single HTML page still resolves them to in-page anchors at render time.
+const internalLinkPages: ExportPage[] = [
+    {
+        id: 'page-1',
+        title: 'Home',
+        parentId: null,
+        order: 0,
+        blocks: [
+            {
+                id: 'block-1',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-1',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content:
+                            '<p>Go to <a href="exe-node:page-2">About</a> and <a href="exe-node:page-2#sec">a section</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'page-2',
+        title: 'About',
+        parentId: null,
+        order: 1,
+        blocks: [
+            {
+                id: 'block-2',
+                name: 'Content Block',
+                order: 0,
+                components: [
+                    {
+                        id: 'comp-2',
+                        type: 'FreeTextIdevice',
+                        order: 0,
+                        content: '<p>Back to <a href="exe-node:page-1">Home</a>.</p>',
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function exportPageZip(pages: ExportPage[]): Promise<MockZipProvider> {
+    const zip = new MockZipProvider();
+    const exporter = new PageExporter(
+        new MockDocument({}, pages),
+        new MockResourceProvider(),
+        new MockAssetProvider(),
+        zip,
+    );
+    await exporter.export();
+    return zip;
+}
+
+describe('PageExporter — internal link round-trip (#1927)', () => {
+    it('keeps exe-node: internal links in content.xml', async () => {
+        const zip = await exportPageZip(internalLinkPages);
+        const contentXml = zip.files.get('content.xml') as string;
+
+        expect(contentXml).toContain('exe-node:page-2');
+        expect(contentXml).toContain('exe-node:page-1');
+        expect(contentXml).toContain('exe-node:page-2#sec');
+        // Single-page rewrite must not leak into the persisted XML.
+        expect(contentXml).not.toContain('#section-page-2');
+        expect(contentXml).not.toContain('#page-2--sec');
+    });
+
+    it('still renders in-page anchors in the exported single HTML page', async () => {
+        const zip = await exportPageZip(internalLinkPages);
+        const indexHtml = zip.files.get('index.html') as string;
+
+        expect(indexHtml).toContain('href="#section-page-2"');
+        expect(indexHtml).toContain('href="#page-2--sec"');
+        expect(indexHtml).toContain('href="#section-page-1"');
+        expect(indexHtml).not.toContain('exe-node:');
     });
 });

--- a/src/shared/export/exporters/PageExporter.ts
+++ b/src/shared/export/exporters/PageExporter.ts
@@ -16,15 +16,13 @@
 import type { ExportPage, ExportMetadata, ExportOptions, ExportResult, FaviconInfo } from '../interfaces';
 import { Html5Exporter } from './Html5Exporter';
 
-// Regex to match <a> elements that have id or name but NO href (named anchors only)
-const NAMED_ANCHOR_RE = /<a\s+(?=[^>]*(?:\bid\b|\bname\b)=)(?![^>]*\bhref\b=)[^>]*>/gi;
-const ID_NAME_ATTR_RE = /\b(id|name)="([^"]+)"/gi;
-
 /**
  * PageExporter - Single-page HTML export
  *
- * For internal links, uses anchor fragments (#page-content-pageId)
- * instead of file paths since all content is on one page.
+ * For internal links, uses anchor fragments (#section-pageId) instead of file paths
+ * since all content is on one page. The exe-node: → anchor rewrite and named-anchor
+ * namespacing are applied at render time in PageRenderer.renderSinglePage(), so the
+ * re-editable content.xml keeps the raw exe-node: references (#1927).
  */
 export class PageExporter extends Html5Exporter {
     /**
@@ -249,107 +247,6 @@ export class PageExporter extends Html5Exporter {
             addExeLink: meta.addExeLink ?? true,
             // Pre-translated nav labels (resolved from XLF at export time)
             navLabels,
-        });
-    }
-
-    /**
-     * Override pre-processing to namespace named anchors before resolving internal links.
-     * In single-page export all pages share one HTML document, so anchor ids like "intro"
-     * on different pages would collide. We prefix them with the page id (e.g. "page-2--intro")
-     * so that exe-node:page-2#intro resolves unambiguously.
-     */
-    async preprocessPagesForExport(pages: ExportPage[]): Promise<ExportPage[]> {
-        const clonedPages: ExportPage[] = JSON.parse(JSON.stringify(pages));
-        const pageUrlMap = this.buildPageUrlMap(clonedPages);
-
-        for (let pageIndex = 0; pageIndex < clonedPages.length; pageIndex++) {
-            const page = clonedPages[pageIndex];
-            const isIndex = pageIndex === 0;
-
-            for (const block of page.blocks || []) {
-                for (const component of block.components || []) {
-                    if (component.content) {
-                        component.content = await this.addFilenamesToAssetUrls(component.content);
-                        // Namespace anchors BEFORE resolving links so links know the prefix
-                        component.content = this.namespaceSinglePageAnchors(component.content, page.id);
-                        component.content = this.replaceInternalLinks(component.content, pageUrlMap, isIndex);
-                    }
-                    if (component.properties && Object.keys(component.properties).length > 0) {
-                        const propsStr = JSON.stringify(component.properties);
-                        const processedStr = await this.addFilenamesToAssetUrls(propsStr);
-                        component.properties = JSON.parse(processedStr);
-                    }
-                }
-            }
-        }
-        return clonedPages;
-    }
-
-    /**
-     * Prefix id/name attributes on named anchors (<a> without href) with the page id.
-     * This avoids collisions when all pages are merged into a single HTML document.
-     * E.g. <a id="intro"> on page "page-2" becomes <a id="page-2--intro">
-     */
-    namespaceSinglePageAnchors(content: string, pageId: string): string {
-        if (!content) return content;
-        return content.replace(NAMED_ANCHOR_RE, match =>
-            match.replace(ID_NAME_ATTR_RE, (_, attr, value) => `${attr}="${pageId}--${value}"`),
-        );
-    }
-
-    /**
-     * Override page URL map for single-page export
-     * Uses anchor fragments instead of file paths
-     */
-    protected buildPageUrlMap(pages: ExportPage[]): Map<string, { url: string; urlFromSubpage: string }> {
-        const map = new Map<string, { url: string; urlFromSubpage: string }>();
-
-        for (const page of pages) {
-            // All pages use anchor fragments on the same page
-            // Uses section-{id} to match the IDs generated in renderSinglePageSection
-            const anchor = `#section-${page.id}`;
-            map.set(page.id, {
-                url: anchor,
-                urlFromSubpage: anchor, // Same since it's all one page
-            });
-        }
-
-        return map;
-    }
-
-    /**
-     * Override internal link replacement for single-page export.
-     * When a link carries its own anchor (exe-node:pageId#anchor), use just #anchor
-     * since all content is in the same document. Without an anchor, use #section-pageId.
-     */
-    protected replaceInternalLinks(
-        content: string,
-        pageUrlMap: Map<string, { url: string; urlFromSubpage: string }>,
-        isFromIndex: boolean,
-    ): string {
-        if (!content || !content.includes('exe-node:')) {
-            return content;
-        }
-
-        return content.replace(/href=["']exe-node:([^"']+)["']/gi, (match, pageIdWithAnchor) => {
-            const hashIdx = pageIdWithAnchor.indexOf('#');
-            const pageId = hashIdx !== -1 ? pageIdWithAnchor.substring(0, hashIdx) : pageIdWithAnchor;
-            const anchorFragment = hashIdx !== -1 ? pageIdWithAnchor.substring(hashIdx) : '';
-
-            if (!pageUrlMap.has(pageId)) {
-                console.warn(`[PageExporter] Internal link target not found: ${pageId}`);
-                return match;
-            }
-
-            // If the link has its own anchor, prefix it with the target page id
-            // so it matches the namespaced id/name (e.g. #intro → #page-2--intro)
-            if (anchorFragment) {
-                return `href="#${pageId}--${anchorFragment.substring(1)}"`;
-            }
-
-            // No anchor: navigate to the page section
-            const pageUrl = pageUrlMap.get(pageId)!;
-            return `href="${isFromIndex ? pageUrl.url : pageUrl.urlFromSubpage}"`;
         });
     }
 

--- a/src/shared/export/renderers/PageRenderer.spec.ts
+++ b/src/shared/export/renderers/PageRenderer.spec.ts
@@ -1843,4 +1843,123 @@ describe('PageRenderer', () => {
             expect(html).toContain('theme/icons/warning.png');
         });
     });
+
+    // Render-time internal-link rewrites for #1927. These run on the rendered HTML so the
+    // source feeding content.xml keeps the original exe-node: references.
+    describe('replaceInternalLinks (multi-page)', () => {
+        const allPages: ExportPage[] = [
+            { id: 'page-1', title: 'Home', parentId: null, order: 0, blocks: [] },
+            { id: 'page-2', title: 'About', parentId: null, order: 1, blocks: [] },
+        ];
+
+        it('resolves exe-node to html/<file> from the index', () => {
+            const out = renderer.replaceInternalLinks('<a href="exe-node:page-2">About</a>', allPages, '');
+            expect(out).toBe('<a href="html/about.html">About</a>');
+        });
+
+        it('resolves exe-node to the index from a subpage (basePath ../)', () => {
+            const out = renderer.replaceInternalLinks('<a href="exe-node:page-1">Home</a>', allPages, '../');
+            expect(out).toBe('<a href="../index.html">Home</a>');
+        });
+
+        it('preserves the #anchor fragment', () => {
+            const out = renderer.replaceInternalLinks('<a href="exe-node:page-2#sec">Sec</a>', allPages, '');
+            expect(out).toBe('<a href="html/about.html#sec">Sec</a>');
+        });
+
+        it('uses the collision-safe filename from pageFilenameMap', () => {
+            const map = new Map([['page-2', 'about-2.html']]);
+            const out = renderer.replaceInternalLinks('<a href="exe-node:page-2">About</a>', allPages, '', map);
+            expect(out).toBe('<a href="html/about-2.html">About</a>');
+        });
+
+        it('leaves an unknown target unchanged', () => {
+            const out = renderer.replaceInternalLinks('<a href="exe-node:page-999">X</a>', allPages, '');
+            expect(out).toBe('<a href="exe-node:page-999">X</a>');
+        });
+
+        it('returns content without exe-node links unchanged', () => {
+            const content = '<a href="https://example.com">Ext</a>';
+            expect(renderer.replaceInternalLinks(content, allPages, '')).toBe(content);
+        });
+
+        it('handles empty content', () => {
+            expect(renderer.replaceInternalLinks('', allPages, '')).toBe('');
+        });
+
+        it('replaces multiple links in a single pass', () => {
+            const out = renderer.replaceInternalLinks(
+                '<a href="exe-node:page-2">A</a> <a href="exe-node:page-1">H</a>',
+                allPages,
+                '',
+            );
+            expect(out).toBe('<a href="html/about.html">A</a> <a href="index.html">H</a>');
+        });
+    });
+
+    describe('namespaceSinglePageAnchors', () => {
+        it('prefixes id on named anchors (a without href)', () => {
+            expect(renderer.namespaceSinglePageAnchors('<p><a id="intro">I</a></p>', 'page-2')).toBe(
+                '<p><a id="page-2--intro">I</a></p>',
+            );
+        });
+
+        it('prefixes name on named anchors', () => {
+            expect(renderer.namespaceSinglePageAnchors('<p><a name="s1">S</a></p>', 'page-2')).toBe(
+                '<p><a name="page-2--s1">S</a></p>',
+            );
+        });
+
+        it('does not touch anchors that have href (regular links)', () => {
+            const c = '<a href="https://example.com" id="link1">E</a>';
+            expect(renderer.namespaceSinglePageAnchors(c, 'page-2')).toBe(c);
+        });
+
+        it('does not touch non-anchor elements with id', () => {
+            const c = '<div id="mydiv">C</div>';
+            expect(renderer.namespaceSinglePageAnchors(c, 'page-2')).toBe(c);
+        });
+
+        it('handles empty and null content', () => {
+            expect(renderer.namespaceSinglePageAnchors('', 'page-1')).toBe('');
+            expect((renderer as any).namespaceSinglePageAnchors(null, 'page-1')).toBe(null);
+        });
+
+        it('handles content without anchors', () => {
+            expect(renderer.namespaceSinglePageAnchors('<p>Just text</p>', 'page-1')).toBe('<p>Just text</p>');
+        });
+    });
+
+    describe('replaceSinglePageInternalLinks', () => {
+        const allPages: ExportPage[] = [
+            { id: 'page-1', title: 'Home', parentId: null, order: 0, blocks: [] },
+            { id: 'page-2', title: 'About', parentId: null, order: 1, blocks: [] },
+        ];
+
+        it('resolves a plain exe-node link to the page section', () => {
+            expect(renderer.replaceSinglePageInternalLinks('<a href="exe-node:page-2">A</a>', allPages)).toBe(
+                '<a href="#section-page-2">A</a>',
+            );
+        });
+
+        it('resolves an anchored exe-node link to the namespaced anchor', () => {
+            expect(renderer.replaceSinglePageInternalLinks('<a href="exe-node:page-2#intro">A</a>', allPages)).toBe(
+                '<a href="#page-2--intro">A</a>',
+            );
+        });
+
+        it('leaves an unknown target unchanged', () => {
+            const c = '<a href="exe-node:nope">X</a>';
+            expect(renderer.replaceSinglePageInternalLinks(c, allPages)).toBe(c);
+        });
+
+        it('returns content without exe-node links unchanged', () => {
+            const c = '<a href="https://example.com">E</a>';
+            expect(renderer.replaceSinglePageInternalLinks(c, allPages)).toBe(c);
+        });
+
+        it('handles empty content', () => {
+            expect(renderer.replaceSinglePageInternalLinks('', allPages)).toBe('');
+        });
+    });
 });

--- a/src/shared/export/renderers/PageRenderer.ts
+++ b/src/shared/export/renderers/PageRenderer.ts
@@ -26,6 +26,13 @@ import {
     formatShortLicenseText,
 } from '../constants';
 import { trans } from '../../../services/translation';
+
+// Matches an opening <a> tag that is a *named anchor* (has id or name) and is NOT a link
+// (no href). Used by single-page export to namespace anchor ids so they don't collide when
+// every page is merged into one document.
+const NAMED_ANCHOR_RE = /<a\s+(?=[^>]*(?:\bid\b|\bname\b)=)(?![^>]*\bhref\b=)[^>]*>/gi;
+const ID_NAME_ATTR_RE = /\b(id|name)="([^"]+)"/gi;
+
 /**
  * PageRenderer class
  * Renders complete HTML pages for export
@@ -124,14 +131,23 @@ export class PageRenderer {
         const originalContent = this.collectPageContent(page);
         const detectedLibraries = providedDetectedLibraries ?? this.detectContentLibraries(originalContent);
 
-        // Render page content (includes exe-package:elp → onclick transformation)
-        const pageContent = this.renderPageContent(page, basePath, projectTitle, assetExportPathMap, {
-            author: options.author,
-            description: options.description,
-            license: options.license,
-            language: options.language,
-            translatedLicense: options.navLabels?.license,
-        });
+        // Render page content (includes exe-package:elp → onclick transformation and,
+        // because allPages is provided, the render-time exe-node: → static path rewrite)
+        const pageContent = this.renderPageContent(
+            page,
+            basePath,
+            projectTitle,
+            assetExportPathMap,
+            {
+                author: options.author,
+                description: options.description,
+                license: options.license,
+                language: options.language,
+                translatedLicense: options.navLabels?.license,
+            },
+            allPages,
+            options.pageFilenameMap,
+        );
 
         // Calculate page counter values
         const total = totalPages ?? allPages.length;
@@ -632,6 +648,8 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
             language?: string;
             translatedLicense?: string;
         },
+        allPages?: ExportPage[],
+        pageFilenameMap?: Map<string, string>,
     ): string {
         let html = '';
 
@@ -647,6 +665,16 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         // This is done here at render time, not during preprocessing, so the XML keeps the original protocol
         if (projectTitle) {
             html = this.replaceElpxProtocol(html, projectTitle);
+        }
+
+        // Rewrite exe-node: internal links to their static export paths. Like the
+        // exe-package:elp transform above, this happens at render time (not during
+        // preprocessing) so the re-editable content.xml keeps the original exe-node:
+        // references and survives an export → re-import round trip (#1927).
+        // Only applies for multi-page exports, which pass allPages; the single-page
+        // export handles its own anchor-based rewrite in renderSinglePage().
+        if (allPages && allPages.length > 0) {
+            html = this.replaceInternalLinks(html, allPages, basePath, pageFilenameMap);
         }
 
         // Sync project properties for download-source-file and similar iDevices
@@ -746,6 +774,100 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         result = result.replace(/download="exe-package:elp-name"/g, `download="${safeTitle}.elpx"`);
 
         return result;
+    }
+
+    /**
+     * Rewrite exe-node: internal links to their static export paths at render time.
+     *
+     * Reuses getPageLink() — the same helper that builds navigation links — so internal
+     * links and nav links stay consistent (single source of truth). basePath already
+     * encodes from-subpage relativity ('' on index, '../' on subpages). The #anchor
+     * fragment, if any, is preserved. Unknown targets are left untouched (external link
+     * or stale reference) so nothing is silently dropped.
+     *
+     * Kept out of preprocessPagesForExport so the source HTML that feeds content.xml
+     * keeps the exe-node: protocol and survives an export → re-import round trip (#1927).
+     *
+     * @param content - Rendered page HTML
+     * @param allPages - All export pages (used to resolve the target and its filename)
+     * @param basePath - Base path of the current page ('' for index, '../' for subpages)
+     * @param pageFilenameMap - Collision-safe page id → filename map
+     * @returns HTML with exe-node: links replaced by static export paths
+     */
+    replaceInternalLinks(
+        content: string,
+        allPages: ExportPage[],
+        basePath: string,
+        pageFilenameMap?: Map<string, string>,
+    ): string {
+        if (!content || !content.includes('exe-node:')) {
+            return content;
+        }
+
+        return content.replace(/href=["']exe-node:([^"']+)["']/gi, (match, pageIdWithAnchor) => {
+            const hashIdx = pageIdWithAnchor.indexOf('#');
+            const pageId = hashIdx !== -1 ? pageIdWithAnchor.substring(0, hashIdx) : pageIdWithAnchor;
+            const anchorFragment = hashIdx !== -1 ? pageIdWithAnchor.substring(hashIdx) : '';
+
+            const target = allPages.find(p => p.id === pageId);
+            if (!target) {
+                console.warn(`[PageRenderer] Internal link target not found: ${pageId}`);
+                return match;
+            }
+
+            const url = this.getPageLink(target, allPages, basePath, pageFilenameMap);
+            return `href="${url}${anchorFragment}"`;
+        });
+    }
+
+    /**
+     * Prefix id/name attributes on named anchors (<a> without href) with the page id.
+     * Single-page export merges every page into one document, so anchor ids like "intro"
+     * on different pages would collide; e.g. <a id="intro"> on page "page-2" becomes
+     * <a id="page-2--intro">. Applied at render time so content.xml keeps the raw ids.
+     *
+     * @param content - Rendered page HTML
+     * @param pageId - Id of the page the content belongs to
+     * @returns HTML with named-anchor ids/names namespaced
+     */
+    namespaceSinglePageAnchors(content: string, pageId: string): string {
+        if (!content) return content;
+        return content.replace(NAMED_ANCHOR_RE, match =>
+            match.replace(ID_NAME_ATTR_RE, (_, attr, value) => `${attr}="${pageId}--${value}"`),
+        );
+    }
+
+    /**
+     * Rewrite exe-node: internal links to in-page anchors for single-page export.
+     * A link carrying its own anchor (exe-node:pageId#anchor) resolves to the namespaced
+     * anchor (#pageId--anchor, matching namespaceSinglePageAnchors); without an anchor it
+     * resolves to the page section (#section-pageId). Unknown targets are left untouched.
+     * Applied at render time so content.xml keeps the raw exe-node: references (#1927).
+     *
+     * @param content - Rendered page HTML
+     * @param allPages - All export pages (used to validate the target id)
+     * @returns HTML with exe-node: links replaced by in-page anchors
+     */
+    replaceSinglePageInternalLinks(content: string, allPages: ExportPage[]): string {
+        if (!content || !content.includes('exe-node:')) {
+            return content;
+        }
+
+        const pageIds = new Set(allPages.map(p => p.id));
+
+        return content.replace(/href=["']exe-node:([^"']+)["']/gi, (match, pageIdWithAnchor) => {
+            const hashIdx = pageIdWithAnchor.indexOf('#');
+            const pageId = hashIdx !== -1 ? pageIdWithAnchor.substring(0, hashIdx) : pageIdWithAnchor;
+            const anchor = hashIdx !== -1 ? pageIdWithAnchor.substring(hashIdx + 1) : '';
+
+            if (!pageIds.has(pageId)) {
+                console.warn(`[PageRenderer] Internal link target not found: ${pageId}`);
+                return match;
+            }
+
+            // With an anchor: jump to the namespaced anchor; without: jump to the section.
+            return anchor ? `href="#${pageId}--${anchor}"` : `href="#section-${pageId}"`;
+        });
     }
 
     /**
@@ -1040,6 +1162,20 @@ ${userFooterHtml}</div></footer>`;
             // moves the .page-title element out of .page-header via movePageTitle()
             const pageTitleClass = hideTitle ? 'page-title sr-av' : 'page-title';
 
+            // Render the section content WITHOUT allPages so the multi-page exe-node:
+            // rewrite is skipped; single-page uses its own anchor-based rewrite instead.
+            let sectionContent = this.renderPageContent(page, '', projectTitle, undefined, {
+                author: options.author,
+                description: options.description,
+                license: options.license,
+                language: options.language,
+                translatedLicense: navLabels?.license,
+            });
+            // Namespace this page's named anchors, then resolve exe-node: links to in-page
+            // anchors — both at render time so content.xml keeps the raw source (#1927).
+            sectionContent = this.namespaceSinglePageAnchors(sectionContent, page.id);
+            sectionContent = this.replaceSinglePageInternalLinks(sectionContent, allPages);
+
             // Single-page sections use main-header > page-header structure for CSS compatibility
             contentHtml += `<section id="section-${page.id}">
 <header class="main-header">
@@ -1048,13 +1184,7 @@ ${userFooterHtml}</div></footer>`;
 </div>
 </header>
 <div class="page-content">
-${this.renderPageContent(page, '', projectTitle, undefined, {
-    author: options.author,
-    description: options.description,
-    license: options.license,
-    language: options.language,
-    translatedLicense: navLabels?.license,
-})}
+${sectionContent}
 </div>
 </section>\n`;
         }

--- a/test/e2e/playwright/specs/internal-links-roundtrip.spec.ts
+++ b/test/e2e/playwright/specs/internal-links-roundtrip.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E round-trip test for internal links (#1927).
+ *
+ * Builds a real project with an `exe-node:` internal link, downloads it as ELPX through the
+ * browser export pipeline, and verifies:
+ *   1. the re-editable content.xml inside the package keeps the `exe-node:` reference
+ *      (not the static `html/...` export path), and
+ *   2. re-importing the downloaded package restores the link as `exe-node:` in the document.
+ *
+ * Before the fix, content.xml persisted `html/about.html`, which the importer cannot map back
+ * to a page — silently breaking internal links on every export → re-import round trip.
+ */
+
+import { test, expect } from '../fixtures/auth.fixture';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { unzipSync, strFromU8 } from 'fflate';
+import {
+    waitForAppReady,
+    gotoWorkarea,
+    addPage,
+    selectNavNode,
+    addTextIdeviceWithContent,
+    downloadProject,
+    openElpFile,
+} from '../helpers/workarea-helpers';
+
+async function getFirstPageId(page: import('@playwright/test').Page): Promise<string> {
+    const id = await page.evaluate(() => {
+        const bridge = (window as any).eXeLearning?.app?.project?._yjsBridge;
+        const nav = bridge?.documentManager?.getNavigation?.();
+        if (!nav) return null;
+        for (let i = 0; i < nav.length; i++) {
+            const p = nav.get(i);
+            const pid = p.get('id') || p.get('pageId');
+            if (pid && pid !== 'root') return pid;
+        }
+        return null;
+    });
+    if (!id) throw new Error('Could not find first page ID');
+    return id;
+}
+
+test.describe('Internal link export → re-import round trip (#1927)', () => {
+    test('content.xml keeps exe-node: links and they survive re-import', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const uuid = await createProject(page, 'Internal Link Round Trip');
+
+        await gotoWorkarea(page, uuid);
+        await waitForAppReady(page);
+
+        const page1Id = await getFirstPageId(page);
+        const page2Id = await addPage(page, 'About');
+
+        // On the first page, add a text iDevice that links to the second page.
+        await selectNavNode(page, page1Id);
+        await page.waitForTimeout(400);
+        await addTextIdeviceWithContent(page, `<p>Go to <a href="exe-node:${page2Id}">About</a>.</p>`);
+
+        // Download the project as ELPX through the real browser export pipeline.
+        const download = await downloadProject(page);
+        const tmpElpx = path.join(os.tmpdir(), `roundtrip-1927-${Date.now()}.elpx`);
+        await download.saveAs(tmpElpx);
+
+        // 1. The re-editable content.xml must keep the exe-node: reference, not a static path.
+        const buffer = fs.readFileSync(tmpElpx);
+        const entries = unzipSync(new Uint8Array(buffer));
+        const contentXmlEntry = entries['content.xml'];
+        expect(contentXmlEntry).toBeDefined();
+        const contentXml = strFromU8(contentXmlEntry);
+        expect(contentXml).toContain(`exe-node:${page2Id}`);
+        expect(contentXml).not.toContain('href="html/');
+
+        // 2. Re-import the downloaded package and confirm the link is still exe-node:.
+        await openElpFile(page, tmpElpx, 1);
+        await page.waitForTimeout(500);
+
+        const importedHtml = await page.evaluate(() => {
+            const bridge = (window as any).eXeLearning?.app?.project?._yjsBridge;
+            if (!bridge) return '';
+            const nav = bridge.documentManager.getNavigation();
+            const parts: string[] = [];
+            for (let i = 0; i < nav.length; i++) {
+                const p = nav.get(i);
+                const pid = p.get('id') || p.get('pageId');
+                if (!pid) continue;
+                const blocks = bridge.structureBinding.getBlocks(pid) || [];
+                for (const block of blocks) {
+                    const comps = bridge.structureBinding.getComponents(pid, block.id) || [];
+                    for (const comp of comps) {
+                        if (comp.htmlContent) parts.push(comp.htmlContent);
+                    }
+                }
+            }
+            return parts.join('\n');
+        });
+
+        expect(importedHtml).toContain('exe-node:');
+        expect(importedHtml).not.toContain('href="html/');
+
+        fs.rmSync(tmpElpx, { force: true });
+    });
+});

--- a/test/integration/export/internal-links-roundtrip.spec.ts
+++ b/test/integration/export/internal-links-roundtrip.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * Integration round-trip tests for internal links (#1927).
+ *
+ * Proves the full export → re-import cycle: a project with an `exe-node:` internal link
+ * is exported (ELPX / HTML5 / IMS), the resulting package is fed back through the real
+ * ElpxImporter, and the imported document must still carry `exe-node:` references — not the
+ * static export path. Before the fix, content.xml persisted `html/about.html`, which the
+ * importer cannot map back, silently breaking the link.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import * as path from 'path';
+import * as Y from 'yjs';
+import { zipSync, strToU8 } from 'fflate';
+
+import { ElpxExporter } from '../../../src/shared/export/exporters/ElpxExporter';
+import { Html5Exporter } from '../../../src/shared/export/exporters/Html5Exporter';
+import { ImsExporter } from '../../../src/shared/export/exporters/ImsExporter';
+import type {
+    ExportDocument,
+    ExportMetadata,
+    ExportPage,
+    ResourceProvider,
+    AssetProvider,
+    ZipProvider,
+} from '../../../src/shared/export/interfaces';
+import { ElpxImporter } from '../../../src/shared/import/ElpxImporter';
+import { FileSystemAssetHandler } from '../../../src/shared/import/FileSystemAssetHandler';
+import type { Logger } from '../../../src/shared/import/interfaces';
+
+const silentLogger: Logger = { log: () => {}, warn: () => {}, error: () => {} };
+
+class MockDocument implements ExportDocument {
+    constructor(
+        private metadata: ExportMetadata,
+        private pages: ExportPage[],
+    ) {}
+    getMetadata(): ExportMetadata {
+        return this.metadata;
+    }
+    getNavigation(): ExportPage[] {
+        return this.pages;
+    }
+}
+
+class MockResourceProvider implements ResourceProvider {
+    async fetchTheme(): Promise<Map<string, Buffer>> {
+        return new Map([['style.css', Buffer.from('/* css */')]]);
+    }
+    async fetchIdeviceResources(): Promise<Map<string, Buffer>> {
+        return new Map();
+    }
+    async fetchBaseLibraries(): Promise<Map<string, Buffer>> {
+        return new Map();
+    }
+    async fetchLibraryFiles(): Promise<Map<string, Buffer>> {
+        return new Map();
+    }
+    async fetchScormFiles(): Promise<Map<string, Buffer>> {
+        return new Map();
+    }
+    normalizeIdeviceType(type: string): string {
+        return type.toLowerCase().replace(/idevice$/i, '');
+    }
+    async fetchExeLogo(): Promise<Buffer | null> {
+        return null;
+    }
+    async fetchContentCss(): Promise<Map<string, Buffer>> {
+        return new Map([['content/css/base.css', Buffer.from('/* base */')]]);
+    }
+    async fetchI18nFile(): Promise<string> {
+        return '';
+    }
+    async fetchI18nTranslations(): Promise<Map<string, string>> {
+        return new Map();
+    }
+}
+
+class MockAssetProvider implements AssetProvider {
+    async getAsset(): Promise<Buffer | null> {
+        return null;
+    }
+    async getAllAssets(): Promise<
+        Array<{ id: string; filename: string; path: string; mimeType: string; data: Buffer }>
+    > {
+        return [];
+    }
+}
+
+class MockZipProvider implements ZipProvider {
+    files = new Map<string, string | Buffer>();
+    addFile(p: string, c: string | Buffer): void {
+        this.files.set(p, c);
+    }
+    hasFile(p: string): boolean {
+        return this.files.has(p);
+    }
+    getFilePaths(): string[] {
+        return Array.from(this.files.keys());
+    }
+    async generateAsync(): Promise<Buffer> {
+        const data: Record<string, Uint8Array> = {};
+        for (const [p, c] of this.files) {
+            data[p] = typeof c === 'string' ? strToU8(c) : new Uint8Array(c);
+        }
+        return Buffer.from(zipSync(data));
+    }
+}
+
+function makeLinkedPages(): ExportPage[] {
+    return [
+        {
+            id: 'page-1',
+            title: 'Home',
+            parentId: null,
+            order: 0,
+            blocks: [
+                {
+                    id: 'block-1',
+                    name: 'Content Block',
+                    order: 0,
+                    components: [
+                        {
+                            id: 'comp-1',
+                            type: 'FreeTextIdevice',
+                            order: 0,
+                            content:
+                                '<p>Go to <a href="exe-node:page-2">About</a> and <a href="exe-node:page-2#sec">a section</a>.</p>',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: 'page-2',
+            title: 'About',
+            parentId: null,
+            order: 1,
+            blocks: [
+                {
+                    id: 'block-2',
+                    name: 'Content Block',
+                    order: 0,
+                    components: [
+                        {
+                            id: 'comp-2',
+                            type: 'FreeTextIdevice',
+                            order: 0,
+                            content: '<p>Back to <a href="exe-node:page-1">Home</a>.</p>',
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
+}
+
+function collectImportedHtml(ydoc: Y.Doc): string {
+    const parts: string[] = [];
+    const navigation = ydoc.getArray('navigation');
+    for (let i = 0; i < navigation.length; i++) {
+        const page = navigation.get(i) as Y.Map<unknown>;
+        const blocks = page.get('blocks') as Y.Array<unknown> | undefined;
+        if (!blocks) continue;
+        for (let b = 0; b < blocks.length; b++) {
+            const block = blocks.get(b) as Y.Map<unknown>;
+            const components = block.get('components') as Y.Array<unknown> | undefined;
+            if (!components) continue;
+            for (let c = 0; c < components.length; c++) {
+                const comp = components.get(c) as Y.Map<unknown>;
+                parts.push(JSON.stringify(comp.toJSON()));
+            }
+        }
+    }
+    return parts.join('\n');
+}
+
+const META: ExportMetadata = {
+    title: 'Round Trip Project',
+    author: 'Tester',
+    language: 'en',
+    description: 'round trip',
+    license: 'CC-BY-SA',
+    theme: 'base',
+};
+
+type ExporterCtor = new (
+    doc: ExportDocument,
+    resources: ResourceProvider,
+    assets: AssetProvider,
+    zip: ZipProvider,
+) => { export(): Promise<{ success: boolean; data?: Uint8Array }> };
+
+const FORMATS: Array<{ name: string; Exporter: ExporterCtor }> = [
+    { name: 'ELPX', Exporter: ElpxExporter },
+    { name: 'HTML5', Exporter: Html5Exporter },
+    { name: 'IMS', Exporter: ImsExporter },
+];
+
+describe('Internal link export → re-import round trip (#1927)', () => {
+    let testDir: string;
+
+    beforeEach(() => {
+        testDir = path.join('/tmp', `roundtrip-1927-${process.pid}-${Math.floor(performance.now())}`);
+        if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+    });
+
+    for (const { name, Exporter } of FORMATS) {
+        it(`restores exe-node: internal links after a ${name} round trip`, async () => {
+            // Export
+            const exporter = new Exporter(
+                new MockDocument(META, makeLinkedPages()),
+                new MockResourceProvider(),
+                new MockAssetProvider(),
+                new MockZipProvider(),
+            );
+            const result = await exporter.export();
+            expect(result.success).toBe(true);
+            expect(result.data).toBeDefined();
+
+            // Re-import the produced package through the real importer
+            const ydoc = new Y.Doc();
+            const assetHandler = new FileSystemAssetHandler(testDir);
+            const importer = new ElpxImporter(ydoc, assetHandler, silentLogger);
+            const imported = await importer.importFromBuffer(new Uint8Array(result.data!));
+            expect(imported.pages).toBe(2);
+
+            // The imported document must carry exe-node: references again, not static paths.
+            const html = collectImportedHtml(ydoc);
+            expect(html).toContain('exe-node:');
+            expect(html).not.toContain('html/about.html');
+            expect(html).not.toContain('../index.html');
+
+            ydoc.destroy();
+        });
+    }
+});


### PR DESCRIPTION
Fixes #1927

## Problem

`BaseExporter.preprocessPagesForExport()` rewrote every `href="exe-node:<pageId>[#anchor]"` into a **static export path** (`index.html`, `html/about.html`, `../index.html#x`) **in the source HTML**, and that same mutated source then fed `generateOdeXml()` → `content.xml`.

Since the importer (`ElpxImporter.remapInternalPageLinks`) and the editor (`a[href^='exe-node:']`) only understand the `exe-node:` form — and there is **no reverse mapping** from `html/*.html` back to `exe-node:` anywhere in the import pipeline — internal page links were **silently degraded on every export → re-import round trip**. They keep resolving until the target page is renamed/moved/reordered, then break in every subsequent export.

This is the same class of issue already fixed for `exe-package:elp` (moved to render time). The asset half of preprocessing (`{{context_path}}/content/resources/…`) **is** reversed on import, confirming the asymmetry — only the internal-link rewrite leaked into the persisted XML. SCORM 1.2/2004 + EPUB3 dodged it because they build `content.xml` from raw `getContentXml()`.

## Fix

Move the internal-link rewrite out of preprocessing and into **render time**, so it runs on the rendered HTML output and never mutates the source that feeds `content.xml`.

- **`PageRenderer`** — new `replaceInternalLinks()` (multi-page) reuses the existing `getPageLink()` helper, so internal links and navigation links share one source of truth. New `namespaceSinglePageAnchors()` + `replaceSinglePageInternalLinks()` handle single-page export (in-page anchors). Applied in `renderPageContent()` (multi-page) and `renderSinglePage()` (single-page).
- **`BaseExporter.preprocessPagesForExport()`** — no longer rewrites `exe-node:`; keeps only the XML-safe asset-URL rewrite. The dead `buildPageUrlMap` / `replaceInternalLinks` helpers are removed (single source of truth).
- **`PageExporter`** — drops its source-mutating overrides; the single-page rewrite now happens at render time too.

Net effect: `content.xml` retains `exe-node:` links (and anchors); exported HTML pages still resolve to the correct static paths / in-page anchors. ELPX, HTML5 and IMS are fixed; SCORM/EPUB are unaffected for `content.xml` and keep correct HTML links via the shared render path.

## How to reproduce / test

- [ ] Create a project with two pages, **Home** (index) and **About**.
- [ ] On Home, add a text iDevice with an internal link to About (produces `href="exe-node:<about-id>"`).
- [ ] Export as `.elpx` (or HTML5/IMS with source included) and open `content.xml` inside the package.
- [ ] **Before the fix:** the link is `href="html/about.html"` — the `exe-node:` reference is gone. **After the fix:** `content.xml` keeps `href="exe-node:<about-id>"`.
- [ ] Re-import that `.elpx` into a fresh project; the link is still recognized as an internal `exe-node:` link in the editor.
- [ ] Rename **About** and re-export — the link still tracks the page (no 404).
- [ ] Confirm the exported `index.html` still contains the resolved static path `href="html/about.html"` (rendering unchanged).

## Automated tests

- [x] **Unit (RED → GREEN):** `content.xml` keeps `exe-node:` links (incl. anchors) for ELPX / HTML5 / IMS / single-page, while exported HTML still resolves to static paths — `ElpxExporter.spec.ts`, `Html5Exporter.spec.ts`, `ImsExporter.spec.ts`, `PageExporter.spec.ts`.
- [x] **Unit (edge cases):** direct `PageRenderer` tests for `replaceInternalLinks`, `namespaceSinglePageAnchors`, `replaceSinglePageInternalLinks` — index/subpage, anchor preserved, unknown target left unchanged, empty content, multiple links.
- [x] **Integration round trip:** export → real `ElpxImporter` → assert `exe-node:` restored, for ELPX / HTML5 / IMS — `test/integration/export/internal-links-roundtrip.spec.ts`.
- [x] **E2E round trip:** build a project, download ELPX, assert `content.xml` keeps `exe-node:`, re-import, assert it survives — `test/e2e/playwright/specs/internal-links-roundtrip.spec.ts`.

### Verification run locally
- [x] `make fix` clean (one pre-existing `noExplicitAny` warning in `src/routes/export.ts`, untouched here)
- [x] Backend `bun test` — 7076 pass, 0 fail
- [x] Frontend `vitest` — pass
- [x] `make test-integration` — pass
- [x] New E2E spec (chromium) — pass
