### PR TITLE
fix(magnifier): preserve exported image path so HTML export shows the image (#1953)

### DIFF
--- a/public/files/perm/idevices/base/magnifier/export/magnifier.js
+++ b/public/files/perm/idevices/base/magnifier/export/magnifier.js
@@ -82,25 +82,41 @@ var $magnifier = {
 
     changeDirectory(data) {
         const $node = $('#' + data.ideviceId),
-            isInExe = eXe.app.isInExe();
-        if (isInExe || $node.length == 0 || !data.imageResource)
-            return data.imageResource;
+            isInExe = eXe.app.isInExe(),
+            file = data.imageResource;
 
-        // Don't transform blob:, data:, or asset:// URLs - they're already valid or will be resolved
-        if (data.imageResource.startsWith('blob:') ||
-            data.imageResource.startsWith('data:') ||
-            data.imageResource.startsWith('asset://')) {
-            return data.imageResource;
+        if (isInExe || $node.length == 0 || !file) return file;
+
+        // Don't transform blob:, data:, or asset:// URLs - they're already
+        // valid display URLs or will be resolved by the asset resolver.
+        if (
+            file.startsWith('blob:') ||
+            file.startsWith('data:') ||
+            file.startsWith('asset://')
+        ) {
+            return file;
         }
 
-        const pathMedia = $('html').is('#exe-index')
-            ? 'content/resources/' + data.ideviceId + '/'
-            : '../content/resources/' + data.ideviceId + '/';
+        // The exporter already rewrites the stored asset URL to its final
+        // location under content/resources/<filename> (prefixing '../' for
+        // subpages). Preserve that path instead of rebuilding it: inserting the
+        // iDevice id as an intermediate folder points to a directory that does
+        // not exist in the export, breaking the image ("Image not available").
+        // See issue #1953.
+        const basePath = $('html').is('#exe-index') ? '' : '../';
 
-        const parts = data.imageResource.split(/[/\\]/),
-            name = parts.pop(),
-            dir = pathMedia.replace(/[/\\]+$/, '');
-        return dir + '/' + name;
+        if (file.startsWith('content/resources/')) {
+            // Collapse a duplicated "<filename>/<filename>" tail if present and
+            // prepend the page-relative base path.
+            const parts = file.split('/'),
+                name = parts.pop();
+            if (parts[parts.length - 1] === name) parts.pop();
+            return basePath + parts.join('/') + '/' + name;
+        }
+
+        // Already page-relative (e.g. '../content/resources/...') or any other
+        // absolute/remote URL: leave it untouched.
+        return file;
     },
 
     replaceResourceDirectoryPaths(data) {

--- a/public/files/perm/idevices/base/magnifier/export/magnifier.test.js
+++ b/public/files/perm/idevices/base/magnifier/export/magnifier.test.js
@@ -113,4 +113,94 @@ describe('magnifier iDevice export', () => {
       expect(typeof $magnifier.createInterfaceMagnifier).toBe('function');
     });
   });
+
+  describe('changeDirectory (export path resolution)', () => {
+    beforeEach(() => {
+      // changeDirectory relies on eXe.app.isInExe(); the shared setup mock
+      // does not define it, so provide a controllable stub (default: export).
+      global.eXe.app.isInExe = () => false;
+      document.documentElement.removeAttribute('id');
+      document.body.innerHTML = '';
+    });
+
+    function mountNode(id) {
+      document.body.innerHTML = `<div id="${id}" class="idevice_node magnifier"></div>`;
+    }
+
+    it('returns the resource unchanged inside the eXe editor', () => {
+      global.eXe.app.isInExe = () => true;
+      mountNode('idev-1');
+      const out = $magnifier.changeDirectory({
+        ideviceId: 'idev-1',
+        imageResource: 'content/resources/img.jpg',
+      });
+      expect(out).toBe('content/resources/img.jpg');
+    });
+
+    it('returns the resource unchanged when the iDevice node is missing', () => {
+      const out = $magnifier.changeDirectory({
+        ideviceId: 'absent',
+        imageResource: 'content/resources/img.jpg',
+      });
+      expect(out).toBe('content/resources/img.jpg');
+    });
+
+    it('returns a falsy resource untouched', () => {
+      mountNode('idev-1');
+      expect(
+        $magnifier.changeDirectory({ ideviceId: 'idev-1', imageResource: '' })
+      ).toBe('');
+    });
+
+    it.each(['blob:http://x/y', 'data:image/png;base64,AAA', 'asset://uuid.jpg'])(
+      'keeps %s URLs as-is',
+      (url) => {
+        mountNode('idev-1');
+        expect(
+          $magnifier.changeDirectory({ ideviceId: 'idev-1', imageResource: url })
+        ).toBe(url);
+      }
+    );
+
+    it('preserves content/resources path on the index page (regression #1953)', () => {
+      document.documentElement.id = 'exe-index';
+      const ideviceId = 'idevice-1780487482081-mnjl9i39r';
+      mountNode(ideviceId);
+      const out = $magnifier.changeDirectory({
+        ideviceId,
+        imageResource: 'content/resources/img_animales.jpg',
+      });
+      // Must NOT insert the iDevice id as an intermediate folder.
+      expect(out).toBe('content/resources/img_animales.jpg');
+      expect(out).not.toContain(ideviceId);
+    });
+
+    it('prepends ../ for a content/resources path on a subpage', () => {
+      mountNode('idev-1'); // no #exe-index id on <html> => subpage
+      const out = $magnifier.changeDirectory({
+        ideviceId: 'idev-1',
+        imageResource: 'content/resources/img_animales.jpg',
+      });
+      expect(out).toBe('../content/resources/img_animales.jpg');
+    });
+
+    it('collapses a duplicated <filename>/<filename> tail', () => {
+      document.documentElement.id = 'exe-index';
+      mountNode('idev-1');
+      const out = $magnifier.changeDirectory({
+        ideviceId: 'idev-1',
+        imageResource: 'content/resources/img.jpg/img.jpg',
+      });
+      expect(out).toBe('content/resources/img.jpg');
+    });
+
+    it('leaves an already page-relative ../content/resources path untouched', () => {
+      mountNode('idev-1');
+      const out = $magnifier.changeDirectory({
+        ideviceId: 'idev-1',
+        imageResource: '../content/resources/img.jpg',
+      });
+      expect(out).toBe('../content/resources/img.jpg');
+    });
+  });
 });


### PR DESCRIPTION
The Magnifier iDevice rendered fine in the editor but showed "Image not available" in HTML5/SCORM/IMS/EPUB exports (Fixes #1953).

The exporter already rewrites the iDevice's `imageResource` to its final exported location (`content/resources/<filename>` from `index.html`, `../content/resources/<filename>` from subpages). At runtime, `changeDirectory()` discarded that correct path, kept only the basename, and rebuilt it as `content/resources/<ideviceId>/<filename>`. The exporter never creates that per-iDevice folder, so the image 404'd.

## Fix

Align `changeDirectory()` with the image-gallery path handling pattern:

- keep `blob:`, `data:`, and `asset://` URLs untouched
- preserve already-rewritten `content/resources/...` paths
- apply the correct page-relative prefix: `content/resources/...` from `index.html`, `../content/resources/...` from subpages

This removes the invalid `ideviceId` subfolder from exported image paths.

## How to test

### Manual reproduction (issue #1953 flow)
1. Create a new **Magnifier** iDevice.
2. Select an image from the resource manager.
3. Save the project.
4. Export as **Website (HTML5)**.
5. Unzip the package and open `index.html` (and a subpage under `html/`).
6. ✅ The image is shown and the magnifier works (before: "Image not available").

