### PR TITLE
fix(three-d-viewer): hide empty-state overlay over a loaded model in export (#1957)

### DIFF
--- a/public/files/perm/idevices/base/three-d-viewer/export/three-d-viewer.js
+++ b/public/files/perm/idevices/base/three-d-viewer/export/three-d-viewer.js
@@ -769,6 +769,31 @@
     }
 
     /**
+     * Decide whether the empty-state overlay ("Select a 3D model to display")
+     * should be shown.
+     *
+     * A model is present when the iDevice has a configured source (single
+     * source of truth, mirroring edition's `[data-empty-state]` logic) OR the
+     * `<model-viewer>` already resolved a `src`. The configured source may be
+     * a relative `content/resources/...` path (static export + the preview
+     * URL-rewrite pipeline), an `asset://` handle (live editor / preview), a
+     * `blob:` URL, or an absolute http(s) URL — all mean "model selected".
+     * The previous blob:/http:/asset:// allowlist missed the relative export
+     * path and left the overlay covering a rendered model (issue #1957).
+     *
+     * @param {string} configSrc - the configured model source
+     * @param {string} viewerSrc - the current `<model-viewer>` src, if any
+     * @returns {'none'|'grid'} CSS display value for the overlay
+     */
+    function computeEmptyStateDisplay(configSrc, viewerSrc) {
+        const hasModel = !!(
+            (configSrc && String(configSrc).trim()) ||
+            (viewerSrc && String(viewerSrc).trim())
+        );
+        return hasModel ? 'none' : 'grid';
+    }
+
+    /**
      * Runtime controller for each wrapper.
      */
     class ThreeDViewerRuntime {
@@ -976,6 +1001,14 @@
                     this._threeJSControls = inst.controls;
                     this._threeJSCamera = inst.camera;
                 }
+
+                // Hide the empty-state overlay now that a model is configured
+                // and the STL renderer has booted. The shared runtime also
+                // clears it after a successful parse (three-d-viewer-runtime.js),
+                // but doing it here makes the result deterministic regardless of
+                // the async parse timing — and keeps STL aligned with the
+                // GLB/GLTF path (issue #1957).
+                this.toggleEmpty();
             } catch (err) {
                 console.error('[3D Viewer] Failed to render STL:', err);
                 this.toggleEmpty();
@@ -1111,13 +1144,8 @@
          */
         toggleEmpty() {
             if (!this.emptyState) return;
-            // Check for any valid src (including blob: URLs from asset resolution)
-            const src = this.modelViewer?.getAttribute('src') || this.modelViewer?.src || '';
-            // Show model if we have a valid src (blob: or http:) or if config has asset:// that will be resolved
-            const hasValidSrc = src && (src.startsWith('blob:') || src.startsWith('http'));
-            const hasConfigSrc = this.config.src && this.config.src.startsWith('asset://');
-            const hasModel = hasValidSrc || hasConfigSrc;
-            this.emptyState.style.display = hasModel ? 'none' : 'grid';
+            const viewerSrc = this.modelViewer?.getAttribute('src') || this.modelViewer?.src || '';
+            this.emptyState.style.display = computeEmptyStateDisplay(this.config.src, viewerSrc);
         }
 
         /**
@@ -1348,4 +1376,6 @@
     globalScope.$threedviewer.__migrateLegacyConfig = migrateLegacyConfig;
     globalScope.$threedviewer.__detectModelTypeFromSrc = detectModelTypeFromSrc;
     globalScope.$threedviewer.__resolveRuntimeSrc = resolveRuntimeSrc;
+    globalScope.$threedviewer.__computeEmptyStateDisplay = computeEmptyStateDisplay;
+    globalScope.$threedviewer.__ThreeDViewerRuntime = ThreeDViewerRuntime;
 })();

--- a/public/files/perm/idevices/base/three-d-viewer/export/three-d-viewer.test.js
+++ b/public/files/perm/idevices/base/three-d-viewer/export/three-d-viewer.test.js
@@ -996,3 +996,147 @@ describe('three-d-viewer renderBehaviour — strips stale model-viewer src for S
         expect(mv.getAttribute('src')).toBe('asset://abc.glb');
     });
 });
+
+// Issue #1957 — in exported / preview content the ".viewer-empty" overlay
+// ("Select a 3D model to display") stayed on top of a rendered model because
+// toggleEmpty() only recognised blob:/http:/asset:// sources and missed the
+// relative `content/resources/...` path produced by the static export and the
+// preview URL-rewrite pipeline. The decision now lives in a pure helper.
+describe('three-d-viewer empty-state visibility (#1957)', () => {
+    let $threedviewer;
+    beforeEach(() => {
+        global.eXeLearning = { config: null, symfony: {}, app: { project: {} } };
+        global._ = (s) => s;
+        global.$threedviewer = undefined;
+        global.customElements = { get: () => undefined, whenDefined: () => Promise.resolve() };
+        const code = readFileSync(join(__dirname, 'three-d-viewer.js'), 'utf-8');
+        // eslint-disable-next-line no-eval
+        (0, eval)(code);
+        $threedviewer = global.$threedviewer;
+    });
+
+    describe('__computeEmptyStateDisplay (pure decision)', () => {
+        it('is exposed for testing', () => {
+            expect(typeof $threedviewer.__computeEmptyStateDisplay).toBe('function');
+        });
+
+        it('hides the overlay for a relative content/resources/...glb export path (the bug)', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('content/resources/abc.glb', '')).toBe('none');
+        });
+
+        it('hides the overlay for a ../content/resources/...glb subpage export path', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('../content/resources/abc.glb', '')).toBe('none');
+        });
+
+        it('hides the overlay for a relative content/resources/...stl export path', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('content/resources/abc.stl', '')).toBe('none');
+        });
+
+        it('hides the overlay for an asset:// source (live editor / preview)', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('asset://abc.glb', '')).toBe('none');
+        });
+
+        it('hides the overlay when the model-viewer already resolved a blob: src', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('', 'blob:http://h/xyz')).toBe('none');
+        });
+
+        it('hides the overlay when the model-viewer already resolved an http(s) src', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('', 'http://h/m.glb')).toBe('none');
+        });
+
+        it('shows the overlay when no source is configured', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('', '')).toBe('grid');
+        });
+
+        it('shows the overlay for whitespace-only sources', () => {
+            expect($threedviewer.__computeEmptyStateDisplay('   ', '   ')).toBe('grid');
+        });
+
+        it('shows the overlay for null/undefined sources', () => {
+            expect($threedviewer.__computeEmptyStateDisplay(undefined, null)).toBe('grid');
+        });
+    });
+
+    describe('ThreeDViewerRuntime.toggleEmpty()', () => {
+        function makeInstance(configSrc, viewerSrcAttr) {
+            const RuntimeClass = $threedviewer.__ThreeDViewerRuntime;
+            const inst = Object.create(RuntimeClass.prototype);
+            inst.emptyState = { style: {} };
+            inst.modelViewer = { getAttribute: () => viewerSrcAttr ?? null, src: viewerSrcAttr || '' };
+            inst.config = { src: configSrc };
+            return inst;
+        }
+
+        it('exposes the runtime class for testing', () => {
+            expect(typeof $threedviewer.__ThreeDViewerRuntime).toBe('function');
+        });
+
+        it('hides the overlay for a relative content/resources export path', () => {
+            const inst = makeInstance('content/resources/x.glb', null);
+            inst.toggleEmpty();
+            expect(inst.emptyState.style.display).toBe('none');
+        });
+
+        it('shows the overlay when no model is configured', () => {
+            const inst = makeInstance('', null);
+            inst.toggleEmpty();
+            expect(inst.emptyState.style.display).toBe('grid');
+        });
+
+        it('is a no-op when there is no empty-state element', () => {
+            const RuntimeClass = $threedviewer.__ThreeDViewerRuntime;
+            const inst = Object.create(RuntimeClass.prototype);
+            inst.emptyState = null;
+            inst.config = { src: 'content/resources/x.glb' };
+            expect(() => inst.toggleEmpty()).not.toThrow();
+        });
+    });
+
+    describe('renderSTL hides the overlay after booting the shared runtime', () => {
+        let prevThree;
+        let prevViewer;
+        beforeEach(() => {
+            prevThree = global.THREE;
+            prevViewer = global.eXe3DViewer;
+            // Short-circuit the async loaders so renderSTL reaches the boot path.
+            global.THREE = { STLLoader: function () {}, OrbitControls: function () {} };
+        });
+        afterEach(() => {
+            global.THREE = prevThree;
+            global.eXe3DViewer = prevViewer;
+        });
+
+        it('clears the empty-state overlay once eXe3DViewer.init has run (#1957)', async () => {
+            let inited = false;
+            global.eXe3DViewer = {
+                destroy() {},
+                init() {
+                    inited = true;
+                },
+                getInstance() {
+                    return null;
+                },
+            };
+
+            const RuntimeClass = $threedviewer.__ThreeDViewerRuntime;
+            const inst = Object.create(RuntimeClass.prototype);
+            inst.wrapper = document.createElement('div');
+            inst.ideviceId = 'stl-x';
+            inst.emptyState = { style: {} };
+            inst.modelViewer = null;
+            inst.config = {
+                src: 'content/resources/x.stl',
+                modelColor: '#888888',
+                backgroundColor: '#f5f5f5',
+                cameraControls: true,
+                autoRotate: false,
+                autoRotateSpeed: 30,
+            };
+
+            await inst.renderSTL();
+
+            expect(inited).toBe(true);
+            expect(inst.emptyState.style.display).toBe('none');
+        });
+    });
+});

--- a/test/e2e/playwright/specs/idevices/three-d-viewer.spec.ts
+++ b/test/e2e/playwright/specs/idevices/three-d-viewer.spec.ts
@@ -7,7 +7,11 @@ import {
     saveProject,
     reloadPage,
 } from '../../helpers/workarea-helpers';
-import type { Page } from '@playwright/test';
+import { unzipSync } from '../../../../../src/shared/export';
+import type { Download, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 /**
  * E2E Tests for 3D Viewer iDevice
@@ -101,6 +105,43 @@ async function save3DViewerIdevice(page: Page): Promise<void> {
         .catch(() => {});
 
     await page.waitForTimeout(500);
+}
+
+/**
+ * Trigger an HTML5 (offline website) export and return the Playwright download.
+ */
+async function exportHtml5Website(page: Page): Promise<Download> {
+    await page.locator('#dropdownFile').click();
+    await page.waitForTimeout(300);
+    const exportSubmenuToggle = page.locator('#dropdownExportAs:visible, #dropdownExportAsOffline:visible').first();
+    if ((await exportSubmenuToggle.count()) > 0) {
+        await exportSubmenuToggle.click();
+        await page.waitForTimeout(300);
+    }
+    const exportOption = page
+        .locator('#navbar-button-export-html5:visible, #navbar-button-exportas-html5:visible')
+        .first();
+    await exportOption.waitFor({ state: 'visible', timeout: 10000 });
+    const downloadPromise = page.waitForEvent('download', { timeout: 90000 });
+    await exportOption.click();
+    return downloadPromise;
+}
+
+/** Best-effort content type for serving the unzipped export over page.route(). */
+function exportContentType(p: string): string {
+    if (p.endsWith('.html')) return 'text/html; charset=utf-8';
+    if (p.endsWith('.js') || p.endsWith('.mjs')) return 'text/javascript; charset=utf-8';
+    if (p.endsWith('.css')) return 'text/css; charset=utf-8';
+    if (p.endsWith('.json')) return 'application/json; charset=utf-8';
+    if (p.endsWith('.glb')) return 'model/gltf-binary';
+    if (p.endsWith('.stl')) return 'model/stl';
+    if (p.endsWith('.svg')) return 'image/svg+xml';
+    if (p.endsWith('.wasm')) return 'application/wasm';
+    if (p.endsWith('.png')) return 'image/png';
+    if (p.endsWith('.jpg') || p.endsWith('.jpeg')) return 'image/jpeg';
+    if (p.endsWith('.woff2')) return 'font/woff2';
+    if (p.endsWith('.woff')) return 'font/woff';
+    return 'application/octet-stream';
 }
 
 test.describe('3D Viewer iDevice', () => {
@@ -696,6 +737,86 @@ test.describe('3D Viewer iDevice', () => {
             });
             const src = await previewModelViewer.getAttribute('src');
             expect(src).toBeTruthy();
+
+            // #1957: once a model is shown the "Select a 3D model to display"
+            // empty-state overlay must be hidden — it used to stay on top of
+            // the rendered model in exported / preview content.
+            const emptyOverlay = iframe.locator('.three-d-viewer-wrapper [data-empty]').first();
+            await expect(emptyOverlay).toBeHidden({ timeout: 10000 });
+        });
+
+        test('hides the empty-state overlay in a real HTML5 export (#1957)', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, '3D Viewer Export Overlay Test');
+            await gotoWorkarea(page, projectUuid);
+            await waitForAppReady(page);
+
+            await selectFirstPage(page);
+            await add3DViewerIdevice(page);
+            await uploadModelViaFilePicker(page, 'test/fixtures/sample-model.glb');
+            await page.waitForFunction(
+                () => {
+                    const mv = document.querySelector('#threeDViewerPreview model-viewer') as any;
+                    return mv && (mv.loaded || mv.src);
+                },
+                { timeout: 30000 },
+            );
+            await save3DViewerIdevice(page);
+            await saveProject(page);
+
+            // Generate a real offline HTML5 export. This is the faithful bug
+            // condition: the exporter rewrites the model source to a relative
+            // `content/resources/<file>` path and the standalone page has no
+            // AssetManager, so the runtime's empty-state decision must work for
+            // that relative path. Before the fix the ".viewer-empty" overlay
+            // stayed on top of the rendered model.
+            const download = await exportHtml5Website(page);
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdv-export-'));
+            const zipPath = path.join(tmpDir, download.suggestedFilename());
+            await download.saveAs(zipPath);
+            const zip = unzipSync(fs.readFileSync(zipPath));
+
+            // Sanity-check the export shape so a failure points at the right cause.
+            expect(zip['index.html']).toBeTruthy();
+            expect(Object.keys(zip).some(k => k.startsWith('content/resources/') && k.endsWith('.glb'))).toBe(true);
+
+            // Serve the exact exported bytes from a clean origin (no service
+            // worker, no dev-server caching) and load the offline page.
+            const origin = 'http://tdv-export.local';
+            await page.route(`${origin}/**`, async route => {
+                const url = new URL(route.request().url());
+                let key = decodeURIComponent(url.pathname.replace(/^\//, ''));
+                if (key === '') key = 'index.html';
+                const bytes = zip[key];
+                if (bytes) {
+                    await route.fulfill({ status: 200, contentType: exportContentType(key), body: Buffer.from(bytes) });
+                } else {
+                    await route.fulfill({ status: 404, contentType: 'text/plain', body: `not in export: ${key}` });
+                }
+            });
+
+            await page.goto(`${origin}/index.html`);
+
+            // The rendered wrapper carries the empty-state overlay; the runtime
+            // must hide it once the configured model is shown.
+            await page.locator('.three-d-viewer-wrapper [data-empty]').first().waitFor({
+                state: 'attached',
+                timeout: 20000,
+            });
+            await page.waitForFunction(
+                () => {
+                    const e = document.querySelector('.three-d-viewer-wrapper [data-empty]') as HTMLElement | null;
+                    return !!e && e.style.display === 'none';
+                },
+                null,
+                { timeout: 20000 },
+            );
+
+            await page.unroute(`${origin}/**`);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #1957. In exported content (and the preview panel), the **3D Viewer** iDevice kept the `.viewer-empty` layer — the semi-transparent gradient with the text *"Select a 3D model to display"* — on top of an already rendered model, so the model looked washed out behind a misleading message. This only happened outside edition mode; the editor was unaffected because it uses different runtime logic.

## Root cause

The export runtime's `ThreeDViewerRuntime.toggleEmpty()` decided overlay visibility from a narrow scheme allowlist:

```js
const hasValidSrc = src && (src.startsWith('blob:') || src.startsWith('http'));
const hasConfigSrc = this.config.src && this.config.src.startsWith('asset://');
```

- **Live editor / preview iframe:** the preview reaches the parent window's `AssetManager`, so the configured source stays an `asset://` handle, `hasConfigSrc` is true and the overlay is hidden.
- **Static HTML5 export:** there is no `AssetManager`, and `IdeviceRenderer.fixAssetUrls` rewrites the source to a **relative** `content/resources/<file>` path. That value starts with neither `blob:`/`http` nor `asset://`, so `hasModel` was `false` and the overlay stayed on top of the model. This is the bug.

STL was unaffected (the shared runtime hides the overlay after parsing) and edition was unaffected (it owns `[data-empty-state]` and keys off `state.src`).

## Fix

Decide overlay visibility from whether a model source is configured **at all** — the same single-source-of-truth rule edition already uses — instead of an allowlist of URL schemes. The decision is extracted into a pure, edge-case-tested helper:

```js
function computeEmptyStateDisplay(configSrc, viewerSrc) {
    const hasModel = !!(
        (configSrc && String(configSrc).trim()) ||
        (viewerSrc && String(viewerSrc).trim())
    );
    return hasModel ? 'none' : 'grid';
}
```

`toggleEmpty()` now delegates to it, so a relative `content/resources/...` path, an `asset://` handle, a `blob:` URL or an absolute URL all correctly mean "model selected". The overlay is also hidden right after the shared STL runtime boots, so STL matches the GLB/GLTF path deterministically.

Only the export runtime is touched — no edition, CSS or markup changes, and no existing behaviour is removed.

## Tests

- **Unit (Vitest)** — `three-d-viewer.test.js`: pure-function edge cases (including the relative `content/resources/...glb` regression, `asset://`, `blob:`, `http`, empty/whitespace/null), the `toggleEmpty()` method, and the STL boot path. Verified red before the fix and green after.
- **E2E (Playwright)** — `three-d-viewer.spec.ts`: generates a **real HTML5 export**, serves the unzipped bytes byte-for-byte from a clean origin (no service worker / dev-server cache) and loads the offline page, asserting the `.viewer-empty` overlay is hidden over the rendered model. Verified failing before the fix and passing after. A preview-panel overlay assertion was also added.

## Verification

- `make fix` clean
- `npx vitest run .../three-d-viewer` → 200 passed
- `bun x playwright test --project=chromium .../three-d-viewer.spec.ts` → 20 passed
- Every changed source line is covered by a unit test.