### PR TITLE
# fix(electrical-circuits): fix AI prompt identifier and correctly render Ω and Greek/math symbols in circuits

### DIFF
--- a/public/files/perm/idevices/base/electrical-circuits/edition/electrical-circuits.js
+++ b/public/files/perm/idevices/base/electrical-circuits/edition/electrical-circuits.js
@@ -27,6 +27,7 @@ var $exeDevice = {
     version: 3.1,
     renderedTikzPreview: null,
     tikzFinishedHandler: null,
+    tikzCapturePromise: null,
 
     init: function (element, previousData, path) {
         this.ideviceBody = element;
@@ -467,12 +468,153 @@ var $exeDevice = {
         return new XMLSerializer().serializeToString(parsedSvg);
     },
 
+    // Unicode symbols TikZJax's bundled LaTeX cannot parse (its inputenc is not
+    // set up for utf8), mapped to their LaTeX commands. Authors routinely type
+    // these glyphs directly — e.g. the ohm sign Ω in "R=1 kΩ" or micro µ in
+    // "1 µF" — which otherwise aborts compilation with
+    // "Unicode character ... not set up for use with LaTeX" and leaves the
+    // circuit unrendered.
+    tikzUnicodeReplacements: {
+        // Uppercase Greek letters
+        Ω: '\\Omega',
+        Γ: '\\Gamma',
+        Δ: '\\Delta',
+        Θ: '\\Theta',
+        Λ: '\\Lambda',
+        Π: '\\Pi',
+        Σ: '\\Sigma',
+        Φ: '\\Phi',
+        Ψ: '\\Psi',
+        // Lowercase Greek letters
+        α: '\\alpha',
+        β: '\\beta',
+        γ: '\\gamma',
+        δ: '\\delta',
+        ε: '\\varepsilon',
+        η: '\\eta',
+        θ: '\\theta',
+        λ: '\\lambda',
+        µ: '\\mu', // U+00B5 micro sign
+        μ: '\\mu', // U+03BC greek small letter mu
+        ν: '\\nu',
+        π: '\\pi',
+        ρ: '\\rho',
+        σ: '\\sigma',
+        τ: '\\tau',
+        φ: '\\varphi',
+        χ: '\\chi',
+        ψ: '\\psi',
+        ω: '\\omega',
+        // Operators and units
+        '×': '\\times',
+        '÷': '\\div',
+        '±': '\\pm',
+        '∓': '\\mp',
+        '·': '\\cdot',
+        '≤': '\\leq',
+        '≥': '\\geq',
+        '≠': '\\neq',
+        '≈': '\\approx',
+        '∞': '\\infty',
+        '√': '\\surd',
+        '∝': '\\propto',
+        '∠': '\\angle',
+        '°': '^\\circ',
+        // Arrows
+        '→': '\\rightarrow',
+        '←': '\\leftarrow',
+        '↔': '\\leftrightarrow',
+        '⇒': '\\Rightarrow',
+    },
+
+    /**
+     * Replace bare Unicode symbols with their LaTeX equivalents wrapped in
+     * \ensuremath{} so they compile under TikZJax regardless of whether they
+     * appear in text or math context. Pure helper consumed by normalizeTikzCode
+     * (the single source of truth), so the rendered LaTeX, the cache key and the
+     * saved code all stay LaTeX-safe.
+     */
+    sanitizeTikzUnicode: function (code) {
+        if (!code) {
+            return '';
+        }
+
+        let result = '';
+        for (const char of code) {
+            const replacement = $exeDevice.tikzUnicodeReplacements[char];
+            result += replacement ? '\\ensuremath{' + replacement + '}' : char;
+        }
+        return result;
+    },
+
+    sanitizeTikzRendererSyntax: function (code) {
+        if (!code) {
+            return '';
+        }
+
+        const formatNumber = (value) =>
+            String(value).trim().replace(/(\d),(\d)/g, '$1{,}$2');
+
+        return code
+            .replace(/\\\\,/g, '\\,')
+            .replace(/\bto\s*\[\s*lD\b/g, 'to[leD')
+            .replace(
+                /\bto\s*\[\s*(battery1|battery2)\s*,\s*l\s*=\s*([0-9]+(?:\{,\}[0-9]+|[.,][0-9]+)?)\s*V\s*\]/g,
+                (_match, component, value) =>
+                    `to[${component},l={$${formatNumber(value)}\\,\\mathrm{V}$}]`
+            )
+            .replace(
+                /\bto\s*\[\s*R\s*=\s*([0-9]+(?:\{,\}[0-9]+|[.,][0-9]+)?)\s*(k?)\s*(?:Ω|\\Omega)\s*\]/g,
+                (_match, value, prefix) => {
+                    const unit = prefix ? '\\mathrm{k}\\Omega' : '\\Omega';
+                    return `to[R,l={$${formatNumber(value)}\\,${unit}$}]`;
+                }
+            )
+            .replace(
+                /\bto\s*\[\s*C\s*=\s*([0-9]+(?:\{,\}[0-9]+|[.,][0-9]+)?)\s*(?:\\mu|µ|μ|u)\s*F\s*\]/g,
+                (_match, value) =>
+                    `to[C,l={$${formatNumber(value)}\\,\\mu\\mathrm{F}$}]`
+            )
+            .replace(/(^|[^\\]),\s*(?=\\(?:mathrm|Omega|mu)\b)/g, '$1\\,');
+    },
+
     normalizeTikzCode: function (code) {
         // Single source of truth: collapse line breaks (and the surrounding
-        // indentation) into single spaces. TikZJax fails on multi-line input,
-        // and using this everywhere keeps the rendered-SVG cache key aligned
-        // with what validateQuestion/save look up.
-        return (code || '').trim().replace(/\s*\r?\n\s*/g, ' ');
+        // indentation), repair known AI-generated CircuiTikZ patterns, then
+        // replace Unicode symbols TikZJax cannot parse. TikZJax fails on
+        // multi-line input, and using this everywhere keeps the rendered-SVG
+        // cache key aligned with what validateQuestion/save look up.
+        const collapsed = (code || '').trim().replace(/\s*\r?\n\s*/g, ' ');
+        return $exeDevice.sanitizeTikzUnicode(
+            $exeDevice.sanitizeTikzRendererSyntax(collapsed)
+        );
+    },
+
+    normalizeVisibleCircuitText: function (text) {
+        if (!text) {
+            return '';
+        }
+
+        return String(text)
+            .trim()
+            .replace(/^\\\((.*)\\\)$/g, '$1')
+            .replace(/^\{\$(.*)\$\}$/g, '$1')
+            .replace(/^\$(.*)\$$/g, '$1')
+            .replace(/\{,\}/g, ',')
+            .replace(/(^|[^\\]),\s*(?=\\(?:mathrm|Omega|mu)\b)/g, '$1 ')
+            .replace(/\\mathrm\{([^{}]*)\}/g, '$1')
+            .replace(/\\\\,/g, ' ')
+            .replace(/\\,/g, ' ')
+            .replace(/\\Omega/g, 'Ω')
+            .replace(/\\mu/g, 'µ')
+            .replace(/\\times\b/g, '×')
+            .replace(/\\cdot\b/g, '·')
+            .replace(/\\pm\b/g, '±')
+            .replace(/\^\{?\\circ\}?/g, '°')
+            .replace(/\\degree\b/g, '°')
+            .replace(/[{}$]/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
     },
 
     setRenderedTikzSvg: function (code, svg) {
@@ -507,6 +649,351 @@ var $exeDevice = {
 
     invalidateTikzSvgPreview: function () {
         $exeDevice.renderedTikzPreview = null;
+    },
+
+    // Parsed Computer Modern fonts, keyed by font-family, reused across renders.
+    tikzFontCache: {},
+
+    // TikZJax emits one Unicode code point per glyph from its own font-encoding
+    // table. That mapping for the operators-font uppercase Omega is off by one:
+    // it emits U+00AC (¬) although the Computer Modern fonts carry the Omega
+    // glyph at U+00AD. Correct it before looking the glyph up — otherwise the
+    // ohm sign is the not-sign, the code point the browser also refuses to draw.
+    tikzGlyphCodepointFixups: new Map([[0x00ac, 0x00ad]]),
+
+    /**
+     * Minimal big-endian TrueType reader: just enough to turn the Computer
+     * Modern glyphs TikZJax references into vector outlines. Returns a font
+     * object exposing unitsPerEm, a code-point -> glyph-index Map, per-glyph
+     * advance widths and the contours of a glyph, or null when a required table
+     * is missing or the buffer is not a recognizable font.
+     */
+    parseTikzFont: function (buffer) {
+        const view = new DataView(
+            buffer instanceof ArrayBuffer ? buffer : buffer.buffer
+        );
+        if (view.byteLength < 12) return null;
+
+        const u8 = (offset) => view.getUint8(offset);
+        const u16 = (offset) => view.getUint16(offset);
+        const i16 = (offset) => view.getInt16(offset);
+        const u32 = (offset) => view.getUint32(offset);
+
+        const tables = {};
+        const numTables = u16(4);
+        for (let i = 0; i < numTables; i++) {
+            const record = 12 + i * 16;
+            const tag = String.fromCharCode(
+                u8(record),
+                u8(record + 1),
+                u8(record + 2),
+                u8(record + 3)
+            );
+            tables[tag] = u32(record + 8);
+        }
+
+        if (
+            tables.head == null ||
+            tables.maxp == null ||
+            tables.loca == null ||
+            tables.glyf == null ||
+            tables.cmap == null
+        ) {
+            return null;
+        }
+
+        const cmap = $exeDevice.parseTikzCmap(view, tables.cmap);
+        if (!cmap) return null;
+
+        const unitsPerEm = u16(tables.head + 18);
+        const longLoca = i16(tables.head + 50) === 1;
+        const numGlyphs = u16(tables.maxp + 4);
+        const numberOfHMetrics =
+            tables.hhea != null ? u16(tables.hhea + 34) : 0;
+
+        const glyphOffsets = new Array(numGlyphs + 1);
+        for (let i = 0; i <= numGlyphs; i++) {
+            glyphOffsets[i] = longLoca
+                ? u32(tables.loca + i * 4)
+                : u16(tables.loca + i * 2) * 2;
+        }
+
+        const advanceWidth = (glyphIndex) => {
+            if (tables.hmtx == null || numberOfHMetrics === 0) return 0;
+            const index =
+                glyphIndex < numberOfHMetrics
+                    ? glyphIndex
+                    : numberOfHMetrics - 1;
+            return u16(tables.hmtx + index * 4);
+        };
+
+        const glyphContours = (glyphIndex) => {
+            if (glyphIndex < 0 || glyphIndex >= numGlyphs) return [];
+            if (glyphOffsets[glyphIndex] === glyphOffsets[glyphIndex + 1]) {
+                return [];
+            }
+
+            const start = tables.glyf + glyphOffsets[glyphIndex];
+            const numberOfContours = i16(start);
+            // The shipped Computer Modern fonts use only simple glyphs; composite
+            // glyphs (negative contour count) never occur, so leave them empty.
+            if (numberOfContours < 0) return [];
+
+            let pointer = start + 10;
+            const endPoints = [];
+            for (let i = 0; i < numberOfContours; i++) {
+                endPoints.push(u16(pointer));
+                pointer += 2;
+            }
+            const pointCount = numberOfContours
+                ? endPoints[numberOfContours - 1] + 1
+                : 0;
+            pointer += 2 + u16(pointer); // skip hinting instructions
+
+            const flags = [];
+            while (flags.length < pointCount) {
+                const flag = u8(pointer++);
+                flags.push(flag);
+                if (flag & 0x08) {
+                    let repeat = u8(pointer++);
+                    while (repeat-- > 0) flags.push(flag);
+                }
+            }
+
+            const readDeltas = (shortBit, sameBit) => {
+                const values = [];
+                let value = 0;
+                for (let i = 0; i < pointCount; i++) {
+                    const flag = flags[i];
+                    if (flag & shortBit) {
+                        const delta = u8(pointer++);
+                        value += flag & sameBit ? delta : -delta;
+                    } else if (!(flag & sameBit)) {
+                        value += i16(pointer);
+                        pointer += 2;
+                    }
+                    values.push(value);
+                }
+                return values;
+            };
+            const xs = readDeltas(0x02, 0x10);
+            const ys = readDeltas(0x04, 0x20);
+
+            const contours = [];
+            let from = 0;
+            for (let c = 0; c < numberOfContours; c++) {
+                const to = endPoints[c];
+                const points = [];
+                for (let i = from; i <= to; i++) {
+                    points.push({
+                        x: xs[i],
+                        y: ys[i],
+                        on: !!(flags[i] & 0x01),
+                    });
+                }
+                contours.push(points);
+                from = to + 1;
+            }
+            return contours;
+        };
+
+        return {
+            unitsPerEm: unitsPerEm,
+            cmap: cmap,
+            advanceWidth: advanceWidth,
+            glyphContours: glyphContours,
+        };
+    },
+
+    // Parse a TrueType `cmap` table, returning a code-point -> glyph-index Map.
+    // Only the Windows Unicode BMP subtable (platform 3, encoding 1, format 4)
+    // is needed for the bundled Computer Modern fonts.
+    parseTikzCmap: function (view, cmapOffset) {
+        const u16 = (offset) => view.getUint16(offset);
+        const u32 = (offset) => view.getUint32(offset);
+
+        const subtableCount = u16(cmapOffset + 2);
+        let subtable = -1;
+        for (let i = 0; i < subtableCount; i++) {
+            const record = cmapOffset + 4 + i * 8;
+            if (u16(record) === 3 && u16(record + 2) === 1) {
+                subtable = cmapOffset + u32(record + 4);
+                break;
+            }
+        }
+        if (subtable < 0 || u16(subtable) !== 4) return null;
+
+        const map = new Map();
+        const segCount = u16(subtable + 6) / 2;
+        const endCodes = subtable + 14;
+        const startCodes = endCodes + segCount * 2 + 2;
+        const deltas = startCodes + segCount * 2;
+        const ranges = deltas + segCount * 2;
+        for (let s = 0; s < segCount; s++) {
+            const end = u16(endCodes + s * 2);
+            const start = u16(startCodes + s * 2);
+            const delta = u16(deltas + s * 2);
+            const rangeOffset = u16(ranges + s * 2);
+            for (let code = start; code <= end && code !== 0xffff; code++) {
+                let glyph;
+                if (rangeOffset === 0) {
+                    glyph = (code + delta) & 0xffff;
+                } else {
+                    glyph = u16(ranges + s * 2 + rangeOffset + (code - start) * 2);
+                    if (glyph !== 0) glyph = (glyph + delta) & 0xffff;
+                }
+                if (glyph) map.set(code, glyph);
+            }
+        }
+        return map;
+    },
+
+    // Turn a glyph's TrueType contours (quadratic on/off-curve points, font
+    // units, Y axis up) into SVG path data placed at the baseline origin
+    // (penX, baselineY), matching how the original <text> element sat.
+    tikzContoursToPathData: function (contours, penX, baselineY, scale) {
+        const tx = (value) => Number((penX + value * scale).toFixed(2));
+        const ty = (value) => Number((baselineY - value * scale).toFixed(2));
+        let data = '';
+
+        for (const contour of contours) {
+            const count = contour.length;
+            if (count === 0) continue;
+
+            let current = contour[count - 1];
+            let next = contour[0];
+            if (current.on) {
+                data += 'M' + tx(current.x) + ' ' + ty(current.y);
+            } else if (next.on) {
+                data += 'M' + tx(next.x) + ' ' + ty(next.y);
+            } else {
+                data +=
+                    'M' +
+                    tx((current.x + next.x) / 2) +
+                    ' ' +
+                    ty((current.y + next.y) / 2);
+            }
+
+            for (let i = 0; i < count; i++) {
+                current = next;
+                next = contour[(i + 1) % count];
+                if (current.on) {
+                    data += 'L' + tx(current.x) + ' ' + ty(current.y);
+                    continue;
+                }
+                let endX = next.x;
+                let endY = next.y;
+                if (!next.on) {
+                    endX = (current.x + next.x) / 2;
+                    endY = (current.y + next.y) / 2;
+                }
+                data +=
+                    'Q' +
+                    tx(current.x) +
+                    ' ' +
+                    ty(current.y) +
+                    ' ' +
+                    tx(endX) +
+                    ' ' +
+                    ty(endY);
+            }
+            data += 'Z';
+        }
+        return data;
+    },
+
+    // Build the SVG path data for `text` rendered with `font` at baseline origin
+    // (x, y) and the given font size, advancing the pen per glyph.
+    tikzGlyphStringToPath: function (font, text, x, y, fontSize) {
+        const scale = fontSize / font.unitsPerEm;
+        let penX = x;
+        let data = '';
+        for (const character of text) {
+            const codePoint = character.codePointAt(0);
+            const fixedCodePoint =
+                $exeDevice.tikzGlyphCodepointFixups.get(codePoint) ?? codePoint;
+            const glyphIndex = font.cmap.get(fixedCodePoint);
+            if (glyphIndex) {
+                data += $exeDevice.tikzContoursToPathData(
+                    font.glyphContours(glyphIndex),
+                    penX,
+                    y,
+                    scale
+                );
+                penX += font.advanceWidth(glyphIndex) * scale;
+            }
+        }
+        return data;
+    },
+
+    // Fetch and parse a Computer Modern font shipped next to this iDevice,
+    // caching the (promise of the) result. Overridable in tests.
+    loadTikzFont: function (family) {
+        if (!$exeDevice.tikzFontCache[family]) {
+            const url = ($exeDevice.idevicePath || '') + 'fonts/' + family + '.ttf';
+            $exeDevice.tikzFontCache[family] = fetch(url)
+                .then((response) => (response.ok ? response.arrayBuffer() : null))
+                .then((buffer) =>
+                    buffer ? $exeDevice.parseTikzFont(buffer) : null
+                )
+                .catch(() => null);
+        }
+        return $exeDevice.tikzFontCache[family];
+    },
+
+    /**
+     * Replace every <text> TikZJax produced with a self-contained <path> built
+     * from the real glyph outlines. This makes the stored/exported SVG render
+     * correctly without the Computer Modern web fonts (which are never
+     * registered as @font-face) and draws the ohm sign — whose code point the
+     * browser otherwise refuses to render. Falls back to leaving a <text>
+     * untouched when its font cannot be loaded.
+     */
+    convertTikzTextToPaths: function (svg) {
+        if (!svg) return Promise.resolve();
+        const texts = [...svg.querySelectorAll('text')];
+        if (texts.length === 0) return Promise.resolve();
+
+        const families = [
+            ...new Set(
+                texts.map((text) => text.getAttribute('font-family')).filter(Boolean)
+            ),
+        ];
+
+        return Promise.all(
+            families.map((family) =>
+                $exeDevice
+                    .loadTikzFont(family)
+                    .then((font) => [family, font])
+            )
+        ).then((entries) => {
+            const fonts = Object.fromEntries(entries);
+            texts.forEach((text) => {
+                const font = fonts[text.getAttribute('font-family')];
+                if (!font) return;
+
+                const x = parseFloat(text.getAttribute('x')) || 0;
+                const y = parseFloat(text.getAttribute('y')) || 0;
+                const fontSize = parseFloat(text.getAttribute('font-size')) || 10;
+                const data = $exeDevice.tikzGlyphStringToPath(
+                    font,
+                    text.textContent,
+                    x,
+                    y,
+                    fontSize
+                );
+                if (!data) return;
+
+                const path = document.createElementNS(
+                    'http://www.w3.org/2000/svg',
+                    'path'
+                );
+                path.setAttribute('d', data);
+                const fill = text.getAttribute('fill');
+                if (fill) path.setAttribute('fill', fill);
+                text.replaceWith(path);
+            });
+        });
     },
 
     captureRenderedTikzPreview: function (code, preview) {
@@ -576,7 +1063,16 @@ var $exeDevice = {
         const onFinished = () => {
             preview.removeEventListener('tikzjax-load-finished', onFinished);
             $exeDevice.tikzFinishedHandler = null;
-            $exeDevice.captureRenderedTikzPreview(code, preview);
+            // TikZJax renders glyphs as <text> referencing Computer Modern fonts
+            // that are never registered, so convert them to self-contained
+            // <path>s before capturing. Conversion is async (it fetches fonts);
+            // expose the promise so the rest of the flow (and tests) can await.
+            const renderedSvg = preview.querySelector('svg');
+            $exeDevice.tikzCapturePromise = Promise.resolve(
+                renderedSvg ? $exeDevice.convertTikzTextToPaths(renderedSvg) : null
+            )
+                .catch(() => {})
+                .then(() => $exeDevice.captureRenderedTikzPreview(code, preview));
         };
         $exeDevice.tikzFinishedHandler = onFinished;
         preview.addEventListener('tikzjax-load-finished', onFinished);
@@ -1721,7 +2217,7 @@ var $exeDevice = {
 
         $exeDevicesEdition.iDevice.gamification.itinerary.addEvents();
         $exeDevicesEdition.iDevice.gamification.share.addEvents(
-            10,
+            11,
             $exeDevice.insertQuestions
         );
 
@@ -2000,14 +2496,14 @@ var $exeDevice = {
                         solutionChar = letters.charAt(index);
                     }
                 }
-                p.description = description;
-                p.tikzCode = tikzCode;
+                p.description = $exeDevice.normalizeVisibleCircuitText(description);
+                p.tikzCode = $exeDevice.normalizeTikzCode(tikzCode);
                 p.solution = solutionChar;
-                p.quextion = linarray[3];
-                p.options[0] = linarray[4] || '';
-                p.options[1] = linarray[5] || '';
-                p.options[2] = linarray[6] || '';
-                p.options[3] = linarray[7] || '';
+                p.quextion = $exeDevice.normalizeVisibleCircuitText(linarray[3]);
+                p.options[0] = $exeDevice.normalizeVisibleCircuitText(linarray[4]);
+                p.options[1] = $exeDevice.normalizeVisibleCircuitText(linarray[5]);
+                p.options[2] = $exeDevice.normalizeVisibleCircuitText(linarray[6]);
+                p.options[3] = $exeDevice.normalizeVisibleCircuitText(linarray[7]);
                 p.numberOptions = linarray.length - 4;
                 questions.push(p);
             } else if (lineFormat1.test(line)) {

--- a/public/files/perm/idevices/base/electrical-circuits/edition/electrical-circuits.test.js
+++ b/public/files/perm/idevices/base/electrical-circuits/edition/electrical-circuits.test.js
@@ -123,13 +123,19 @@ describe('electrical-circuits iDevice edition', () => {
             '#elceTikzPreview script[type="text/tikz"]'
         );
         expect(script).not.toBeNull();
+        expect(JSON.parse(script.dataset.texPackages)).toEqual({
+            circuitikz: '',
+            amsmath: '',
+            amssymb: '',
+        });
+        expect(script.dataset.showConsole).toBe('true');
         expect(script.textContent).not.toContain('\n');
         expect(script.textContent).toBe(
             '\\begin{document}\\begin{circuitikz} \\draw (0,0) to[R, l=$R_1$] (3,0); \\end{circuitikz}\\end{document}'
         );
     });
 
-    it('ignores the loading spinner and captures only after tikzjax-load-finished', () => {
+    it('ignores the loading spinner and captures only after tikzjax-load-finished', async () => {
         document.body.innerHTML = `
             <textarea id="elceTikzCode"></textarea>
             <div id="elceTikzPreview"></div>
@@ -150,12 +156,16 @@ describe('electrical-circuits iDevice edition', () => {
         expect($exeDevice.getRenderedTikzSvgForCode(code)).toBe('');
 
         // TikZJax then swaps in the real circuit and fires the finished event.
+        // Capture now happens after the (async) <text>-to-<path> conversion, so
+        // wait for the exposed promise before asserting. This SVG has no <text>,
+        // so conversion is a no-op and no fonts are fetched.
         preview.innerHTML = '<svg viewBox="0 0 10 10"><path d="M0 0"></path></svg>';
         preview
             .querySelector('svg')
             .dispatchEvent(
                 new Event('tikzjax-load-finished', { bubbles: true })
             );
+        await $exeDevice.tikzCapturePromise;
 
         expect($exeDevice.getRenderedTikzSvgForCode(code)).toContain('<svg');
     });
@@ -168,6 +178,87 @@ describe('electrical-circuits iDevice edition', () => {
         ).toBe('\\begin{circuitikz} \\draw (0,0); \\end{circuitikz}');
         expect($exeDevice.normalizeTikzCode('')).toBe('');
         expect($exeDevice.normalizeTikzCode(null)).toBe('');
+    });
+
+    it('sanitizeTikzUnicode rewrites the ohm sign that crashed inputenc', () => {
+        // The exact label from the reported bug: a literal Ω (U+03A9) aborted
+        // TikZJax with "Unicode character ^^ce^^a9 not set up for use with
+        // LaTeX" and no DVI was produced.
+        expect(
+            $exeDevice.sanitizeTikzUnicode('to[R=1 kΩ] (4,2) to[R=2 kΩ]')
+        ).toBe(
+            'to[R=1 k\\ensuremath{\\Omega}] (4,2) to[R=2 k\\ensuremath{\\Omega}]'
+        );
+    });
+
+    it('sanitizeTikzUnicode maps Greek letters, operators, units and arrows', () => {
+        expect($exeDevice.sanitizeTikzUnicode('1 µF')).toBe(
+            '1 \\ensuremath{\\mu}F'
+        );
+        expect($exeDevice.sanitizeTikzUnicode('1 μF')).toBe(
+            '1 \\ensuremath{\\mu}F'
+        );
+        expect($exeDevice.sanitizeTikzUnicode('2×3±1')).toBe(
+            '2\\ensuremath{\\times}3\\ensuremath{\\pm}1'
+        );
+        expect($exeDevice.sanitizeTikzUnicode('45°')).toBe(
+            '45\\ensuremath{^\\circ}'
+        );
+        expect($exeDevice.sanitizeTikzUnicode('α→β')).toBe(
+            '\\ensuremath{\\alpha}\\ensuremath{\\rightarrow}\\ensuremath{\\beta}'
+        );
+    });
+
+    it('sanitizeTikzUnicode leaves plain LaTeX and empty input untouched', () => {
+        const plain = '\\begin{circuitikz}\\draw (0,0) to[R, l=$R_1$] (3,0);\\end{circuitikz}';
+        expect($exeDevice.sanitizeTikzUnicode(plain)).toBe(plain);
+        expect($exeDevice.sanitizeTikzUnicode('')).toBe('');
+        expect($exeDevice.sanitizeTikzUnicode(null)).toBe('');
+    });
+
+    it('sanitizeTikzUnicode is idempotent so repeated normalization is safe', () => {
+        const once = $exeDevice.sanitizeTikzUnicode('R=1 kΩ');
+        expect($exeDevice.sanitizeTikzUnicode(once)).toBe(once);
+    });
+
+    it('sanitizeTikzRendererSyntax repairs AI-generated labels that break TikZJax', () => {
+        const code = String.raw`\begin{circuitikz}\draw (0,0) to[battery1,l={$5,\mathrm{V}$}] (0,2) to[R,l={$1,\mathrm{k}\Omega$}] (3,2) to[R,l={$220,\Omega$}] (3,0) to[C,l={$100,\mu\mathrm{F}$}] (0,0) to[lD] (1,0);\end{circuitikz}`;
+
+        expect($exeDevice.sanitizeTikzRendererSyntax(code)).toBe(
+            String.raw`\begin{circuitikz}\draw (0,0) to[battery1,l={$5\,\mathrm{V}$}] (0,2) to[R,l={$1\,\mathrm{k}\Omega$}] (3,2) to[R,l={$220\,\Omega$}] (3,0) to[C,l={$100\,\mu\mathrm{F}$}] (0,0) to[leD] (1,0);\end{circuitikz}`
+        );
+    });
+
+    it('sanitizeTikzRendererSyntax expands shorthand labels with units', () => {
+        const code = '\\begin{circuitikz}\\draw (0,0) to[battery1,l=5 V] (0,2) to[R=1 kΩ] (3,2) to[R=220 Ω] (3,0) to[C=100 \\mu F] (0,0);\\end{circuitikz}';
+
+        expect($exeDevice.sanitizeTikzRendererSyntax(code)).toBe(
+            String.raw`\begin{circuitikz}\draw (0,0) to[battery1,l={$5\,\mathrm{V}$}] (0,2) to[R,l={$1\,\mathrm{k}\Omega$}] (3,2) to[R,l={$220\,\Omega$}] (3,0) to[C,l={$100\,\mu\mathrm{F}$}] (0,0);\end{circuitikz}`
+        );
+    });
+
+    it('sanitizeTikzRendererSyntax collapses double-escaped thin spaces', () => {
+        const code = String.raw`\begin{circuitikz}\draw (0,0) to[battery1,l={$5\\,\mathrm{V}$}] (0,2) to[fuse] (2,2) -- (4,2) -- (4,0) -- (0,0);\end{circuitikz}`;
+
+        expect($exeDevice.sanitizeTikzRendererSyntax(code)).toBe(
+            String.raw`\begin{circuitikz}\draw (0,0) to[battery1,l={$5\,\mathrm{V}$}] (0,2) to[fuse] (2,2) -- (4,2) -- (4,0) -- (0,0);\end{circuitikz}`
+        );
+    });
+
+    it('normalizeTikzCode collapses whitespace and sanitizes Unicode together', () => {
+        expect(
+            $exeDevice.normalizeTikzCode(
+                '\\begin{circuitikz}\n  \\draw (0,0) to[R=1 kΩ] (3,0);\n\\end{circuitikz}'
+            )
+        ).toBe(
+            '\\begin{circuitikz} \\draw (0,0) to[R,l={$1\\,\\mathrm{k}\\Omega$}] (3,0); \\end{circuitikz}'
+        );
+    });
+
+    it('normalizeVisibleCircuitText converts TeX units to Unicode for visible fields', () => {
+        expect($exeDevice.normalizeVisibleCircuitText('{$1{,}22,\\mathrm{k}\\Omega$}')).toBe('1,22 kΩ');
+        expect($exeDevice.normalizeVisibleCircuitText('$100\\,\\mu\\mathrm{F}$')).toBe('100 µF');
+        expect($exeDevice.normalizeVisibleCircuitText('5\\,\\mathrm{V} \\pm 1\\degree')).toBe('5 V ± 1°');
     });
 
     it('finds the cached SVG whether the code is queried multi-line or single-line', () => {
@@ -188,6 +279,54 @@ describe('electrical-circuits iDevice edition', () => {
         expect($exeDevice.getRenderedTikzSvgForCode(singleLine)).toBe(stored);
     });
 
+    it('wires the AI question generator with the electric-circuits format (gameId 11)', () => {
+        // The AI tab is built with getTabIA(11), the electric-circuits format
+        // (Description#TikZ#Solution#Question#Options...). addEvents() must
+        // register the SAME gameId, otherwise questions generated or pasted by
+        // the user are validated against the wrong (adaptative-quiz, id 10)
+        // format and silently rejected. Guards the 10 -> 11 fix.
+        const shareAddEvents = vi.fn();
+        $exeDevicesEdition.iDevice.gamification.itinerary = { addEvents: vi.fn() };
+        $exeDevicesEdition.iDevice.gamification.share = { addEvents: shareAddEvents };
+
+        $exeDevice.addEvents();
+
+        expect(shareAddEvents).toHaveBeenCalledWith(11, $exeDevice.insertQuestions);
+    });
+
+    it('insertQuestions normalizes AI-generated TikZ before adding questions', () => {
+        const addQuestions = vi.spyOn($exeDevice, 'addQuestions').mockImplementation(() => {});
+        const line =
+            'Circuito#\\begin{circuitikz}\\draw (0,0) to[battery1,l={$5,\\mathrm{V}$}] (0,2) to[R,l={$220,\\Omega$}] (2,2) to[lD] (2,0) -- (0,0);\\end{circuitikz}#A#Question#Correct#Wrong';
+
+        $exeDevice.insertQuestions([line]);
+
+        expect(addQuestions).toHaveBeenCalledWith([
+            expect.objectContaining({
+                tikzCode:
+                    '\\begin{circuitikz}\\draw (0,0) to[battery1,l={$5\\,\\mathrm{V}$}] (0,2) to[R,l={$220\\,\\Omega$}] (2,2) to[leD] (2,0) -- (0,0);\\end{circuitikz}',
+            }),
+        ]);
+    });
+
+    it('insertQuestions converts visible TeX units to Unicode without changing TikZ rules', () => {
+        const addQuestions = vi.spyOn($exeDevice, 'addQuestions').mockImplementation(() => {});
+        const line =
+            'Circuito \\Omega#\\begin{circuitikz}\\draw (0,0) to[R,l={$220\\,\\Omega$}] (2,0);\\end{circuitikz}#A#Valor de \\Omega#{$1{,}22,\\mathrm{k}\\Omega$}#220 \\Omega#100\\,\\mu\\mathrm{F}';
+
+        $exeDevice.insertQuestions([line]);
+
+        expect(addQuestions).toHaveBeenCalledWith([
+            expect.objectContaining({
+                description: 'Circuito Ω',
+                tikzCode:
+                    '\\begin{circuitikz}\\draw (0,0) to[R,l={$220\\,\\Omega$}] (2,0);\\end{circuitikz}',
+                quextion: 'Valor de Ω',
+                options: ['1,22 kΩ', '220 Ω', '100 µF', ''],
+            }),
+        ]);
+    });
+
     it('round-trips tikzCode and tikzSvg without tikzSvgHash', () => {
         setQuestionForm();
         $('#elceTikzCode').val('\\draw (0,0);');
@@ -205,5 +344,121 @@ describe('electrical-circuits iDevice edition', () => {
         expect(reloaded.tikzCode).toBe('\\draw (0,0);');
         expect(reloaded.tikzSvg).toBe(svg);
         expect(reloaded).not.toHaveProperty('tikzSvgHash');
+    });
+
+    function loadFont(family) {
+        const file = readFileSync(join(__dirname, 'fonts', `${family}.ttf`));
+        const buffer = file.buffer.slice(
+            file.byteOffset,
+            file.byteOffset + file.byteLength
+        );
+        return $exeDevice.parseTikzFont(buffer);
+    }
+
+    function makeTikzSvg(textContent, attrs = {}) {
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        const text = document.createElementNS(ns, 'text');
+        const merged = { 'font-family': 'cmr10', x: '5', y: '10', 'font-size': '10', ...attrs };
+        Object.entries(merged).forEach(([name, value]) => text.setAttribute(name, value));
+        text.textContent = textContent;
+        svg.appendChild(text);
+        return svg;
+    }
+
+    it('parseTikzFont reads cmr10 and exposes the Omega glyph at U+00AD', () => {
+        const font = loadFont('cmr10');
+
+        expect(font).not.toBeNull();
+        expect(font.unitsPerEm).toBeGreaterThan(0);
+        // Computer Modern carries uppercase Omega at U+00AD (not the real Greek
+        // block), which is exactly where TikZJax's encoding table points.
+        const omegaGlyph = font.cmap.get(0x00ad);
+        expect(omegaGlyph).toBeGreaterThan(0);
+        const contours = font.glyphContours(omegaGlyph);
+        expect(contours.length).toBeGreaterThan(0);
+        expect(contours[0][0]).toHaveProperty('on');
+        // Glyphs without an outline (e.g. space) yield no contours.
+        expect(font.glyphContours(font.cmap.get(0x20))).toEqual([]);
+    });
+
+    it('parseTikzFont returns null for a buffer that is not a font', () => {
+        expect($exeDevice.parseTikzFont(new ArrayBuffer(4))).toBeNull();
+        expect($exeDevice.parseTikzFont(new Uint8Array([1, 2, 3, 4, 5, 6]))).toBeNull();
+    });
+
+    it('tikzGlyphStringToPath draws the ohm sign and applies the U+00AC fixup', () => {
+        const font = loadFont('cmr10');
+
+        // The not-sign U+00AC TikZJax emits for Omega must resolve to the same
+        // outline as the real Omega code point U+00AD.
+        const fromNotSign = $exeDevice.tikzGlyphStringToPath(font, '¬', 0, 0, 10);
+        const fromOmega = $exeDevice.tikzGlyphStringToPath(font, '­', 0, 0, 10);
+        expect(fromNotSign).toBe(fromOmega);
+        expect(fromNotSign.startsWith('M')).toBe(true);
+
+        // A code point the font does not map contributes nothing.
+        expect($exeDevice.tikzGlyphStringToPath(font, '☃', 0, 0, 10)).toBe('');
+    });
+
+    it('convertTikzTextToPaths replaces <text> with a self-contained <path>', async () => {
+        const font = loadFont('cmr10');
+        vi.spyOn($exeDevice, 'loadTikzFont').mockResolvedValue(font);
+        const svg = makeTikzSvg('¬', { fill: 'black' });
+
+        await $exeDevice.convertTikzTextToPaths(svg);
+
+        expect(svg.querySelector('text')).toBeNull();
+        const path = svg.querySelector('path');
+        expect(path).not.toBeNull();
+        expect(path.getAttribute('d').startsWith('M')).toBe(true);
+        expect(path.getAttribute('fill')).toBe('black');
+    });
+
+    it('convertTikzTextToPaths leaves <text> untouched when the font fails to load', async () => {
+        vi.spyOn($exeDevice, 'loadTikzFont').mockResolvedValue(null);
+        const svg = makeTikzSvg('¬');
+
+        await $exeDevice.convertTikzTextToPaths(svg);
+
+        expect(svg.querySelector('text')).not.toBeNull();
+        expect(svg.querySelector('path')).toBeNull();
+    });
+
+    it('convertTikzTextToPaths is a no-op when there is no text to convert', async () => {
+        const loadSpy = vi.spyOn($exeDevice, 'loadTikzFont');
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        svg.appendChild(document.createElementNS(ns, 'path'));
+
+        await $exeDevice.convertTikzTextToPaths(svg);
+        await $exeDevice.convertTikzTextToPaths(null);
+
+        expect(loadSpy).not.toHaveBeenCalled();
+    });
+
+    it('loadTikzFont fetches, parses and caches a font, returning null on failure', async () => {
+        const file = readFileSync(join(__dirname, 'fonts', 'cmr10.ttf'));
+        const okFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () =>
+                file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength),
+        });
+        global.fetch = okFetch;
+        $exeDevice.tikzFontCache = {};
+        $exeDevice.idevicePath = '/idevice/';
+
+        const font = await $exeDevice.loadTikzFont('cmr10');
+        expect(font.unitsPerEm).toBeGreaterThan(0);
+        expect(okFetch).toHaveBeenCalledWith('/idevice/fonts/cmr10.ttf');
+
+        // Second call is served from cache (no extra fetch).
+        await $exeDevice.loadTikzFont('cmr10');
+        expect(okFetch).toHaveBeenCalledTimes(1);
+
+        // A failed response resolves to null.
+        global.fetch = vi.fn().mockResolvedValue({ ok: false });
+        $exeDevice.tikzFontCache = {};
+        expect(await $exeDevice.loadTikzFont('cmmi10')).toBeNull();
     });
 });


### PR DESCRIPTION
Closes #1964

This PR fixes two issues in the **Electrical Circuits** iDevice:

* **The iDevice AI prompt now generates questions compatible with the activity.
* **Greek and mathematical glyph rendering**: TikZJax emits SVG `<text>` elements without registering `@font-face`, causing browsers to fall back to system fonts. As a result, symbols such as Ω, Σ, and ω were rendered incorrectly (`Ω → ¬`, `Σ → §`, `ω → !`). Additionally, an off-by-one issue affected omega rendering because TikZJax emits U+00AC while the Computer Modern font stores the glyph at U+00AD.


## How to Test

### 1. Insert AI-generated questions

1. Open a project and add the **Electrical Circuits** iDevice (Science category).
2. Use the **AI Generator** to create several questions.
3. Copy the generated questions into the questions dialog.
4. Verify that the questions are inserted into the activity, each with its corresponding circuit code and statement.
5. Navigate through the questions and confirm that each circuit preview is displayed correctly.

### 2. Circuit code containing the Ω symbol

1. In a question, enter a circuit containing a literal Ω symbol, for example:

   ```latex
   \begin{circuitikz}
   \draw (0,0) to[battery1,l=6 V] (0,2) -- (2,2) to[R=1 kΩ] (4,2) to[R=2 kΩ] (4,0) -- (0,0);
   \end{circuitikz}
   ```

2. Click **Preview** and verify that Ω is rendered correctly (not as `¬`). The same should apply to symbols such as Σ and ω.

3. Save the iDevice and open the activity preview.

4. Verify that the circuit still renders correctly, using the self-contained SVG without requiring a re-render.

## Tests

* Added unit tests for Unicode-to-LaTeX normalization.
* Added unit tests for SVG text-to-path conversion.
