### PR TITLE
fix(export): include accessibility toolbar in IMS, SCORM and EPUB exports

### DIFF
--- a/src/shared/export/exporters/Epub3Exporter.spec.ts
+++ b/src/shared/export/exporters/Epub3Exporter.spec.ts
@@ -254,6 +254,48 @@ describe('Epub3Exporter', () => {
         exporter = new Epub3Exporter(document, resources, assets, zip);
     });
 
+    describe('Accessibility toolbar (addAccessibilityToolbar)', () => {
+        // Regression test for #1978: when the author enables the accessibility toolbar,
+        // every exported page must load exe_atools (JS + CSS) in its <head>, and the
+        // files must be bundled and declared in the EPUB package.opf manifest.
+        const mockToolbarLibFiles = () => {
+            resources.fetchLibraryFiles = async files => new Map(files.map(file => [file, Buffer.from('// mock lib')]));
+        };
+
+        it('references the toolbar JS and CSS in the page head when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Epub3Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            const indexXhtml = zip.files.get('EPUB/index.xhtml') as string;
+            expect(indexXhtml).toContain('libs/exe_atools/exe_atools.js');
+            expect(indexXhtml).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('bundles the toolbar files and declares them in package.opf when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Epub3Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            expect(zip.files.has('EPUB/libs/exe_atools/exe_atools.js')).toBe(true);
+            expect(zip.files.has('EPUB/libs/exe_atools/exe_atools.css')).toBe(true);
+            const packageOpf = zip.files.get('EPUB/package.opf') as string;
+            expect(packageOpf).toContain('libs/exe_atools/exe_atools.js');
+            expect(packageOpf).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('does not reference the toolbar when disabled (default)', async () => {
+            await exporter.export();
+
+            const indexXhtml = zip.files.get('EPUB/index.xhtml') as string;
+            expect(indexXhtml).not.toContain('exe_atools');
+        });
+    });
+
     describe('Basic Properties', () => {
         it('should return correct file extension', () => {
             expect(exporter.getFileExtension()).toBe('.epub');

--- a/src/shared/export/exporters/Epub3Exporter.ts
+++ b/src/shared/export/exporters/Epub3Exporter.ts
@@ -695,6 +695,8 @@ export class Epub3Exporter extends BaseExporter {
             hideNavButtons: true,
             addExeLink: meta.addExeLink ?? true,
             addPagination: meta.addPagination === true,
+            // Accessibility toolbar (exe_atools) when enabled in project properties (#1978)
+            addAccessibilityToolbar: meta.addAccessibilityToolbar ?? false,
             totalPages: allPages.length,
             currentPageIndex: pageIndex,
             // Pre-translated labels (resolved from XLF at export time)

--- a/src/shared/export/exporters/ImsExporter.spec.ts
+++ b/src/shared/export/exporters/ImsExporter.spec.ts
@@ -268,6 +268,48 @@ describe('ImsExporter', () => {
         });
     });
 
+    describe('Accessibility toolbar (addAccessibilityToolbar)', () => {
+        // Regression test for #1978: when the author enables the accessibility toolbar,
+        // every exported page must load exe_atools (JS + CSS) in its <head>, and the
+        // files must be bundled and referenced in imsmanifest.xml.
+        const mockToolbarLibFiles = () => {
+            resources.fetchLibraryFiles = async files => new Map(files.map(file => [file, Buffer.from('// mock lib')]));
+        };
+
+        it('references the toolbar JS and CSS in the page head when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new ImsExporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.js');
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('bundles the toolbar files and references them in imsmanifest.xml when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new ImsExporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            expect(zip.files.has('libs/exe_atools/exe_atools.js')).toBe(true);
+            expect(zip.files.has('libs/exe_atools/exe_atools.css')).toBe(true);
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).toContain('libs/exe_atools/exe_atools.js');
+            expect(manifest).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('does not reference the toolbar when disabled (default)', async () => {
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).not.toContain('exe_atools');
+        });
+    });
+
     describe('Basic Properties', () => {
         it('should return correct file suffix', () => {
             expect(exporter.getFileSuffix()).toBe('_ims');

--- a/src/shared/export/exporters/ImsExporter.ts
+++ b/src/shared/export/exporters/ImsExporter.ts
@@ -440,6 +440,8 @@ export class ImsExporter extends Html5Exporter {
             addExeLink: meta.addExeLink ?? true,
             addPagination: meta.addPagination ?? false,
             addMathJax: meta.addMathJax === true,
+            // Accessibility toolbar (exe_atools) when enabled in project properties (#1978)
+            addAccessibilityToolbar: meta.addAccessibilityToolbar ?? false,
             totalPages: allPages.length,
             currentPageIndex: pageIndex ?? 0,
             bodyClass: bodyClass,

--- a/src/shared/export/exporters/PageExporter.spec.ts
+++ b/src/shared/export/exporters/PageExporter.spec.ts
@@ -362,6 +362,45 @@ describe('PageExporter', () => {
         });
     });
 
+    describe('Accessibility toolbar (addAccessibilityToolbar)', () => {
+        // Regression test for #1978: when the author enables the accessibility toolbar,
+        // the single-page export must load exe_atools (JS + CSS) in its <head> and
+        // bundle the files alongside the page.
+        const mockToolbarLibFiles = () => {
+            resources.fetchLibraryFiles = async files => new Map(files.map(file => [file, Buffer.from('// mock lib')]));
+        };
+
+        it('references the toolbar JS and CSS in the page head when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new PageExporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.js');
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('bundles the toolbar files when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new PageExporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            expect(zip.files.has('libs/exe_atools/exe_atools.js')).toBe(true);
+            expect(zip.files.has('libs/exe_atools/exe_atools.css')).toBe(true);
+        });
+
+        it('does not reference the toolbar when disabled (default)', async () => {
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).not.toContain('exe_atools');
+        });
+    });
+
     describe('Basic Properties', () => {
         it('should return correct file suffix', () => {
             expect(exporter.getFileSuffix()).toBe('_page');

--- a/src/shared/export/exporters/Scorm12Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.spec.ts
@@ -271,6 +271,48 @@ describe('Scorm12Exporter', () => {
         });
     });
 
+    describe('Accessibility toolbar (addAccessibilityToolbar)', () => {
+        // Regression test for #1978: when the author enables the accessibility toolbar,
+        // every exported page must load exe_atools (JS + CSS) in its <head>, and the
+        // files must be bundled and referenced in imsmanifest.xml.
+        const mockToolbarLibFiles = () => {
+            resources.fetchLibraryFiles = async files => new Map(files.map(file => [file, Buffer.from('// mock lib')]));
+        };
+
+        it('references the toolbar JS and CSS in the page head when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Scorm12Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.js');
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('bundles the toolbar files and references them in imsmanifest.xml when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Scorm12Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            expect(zip.files.has('libs/exe_atools/exe_atools.js')).toBe(true);
+            expect(zip.files.has('libs/exe_atools/exe_atools.css')).toBe(true);
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).toContain('libs/exe_atools/exe_atools.js');
+            expect(manifest).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('does not reference the toolbar when disabled (default)', async () => {
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).not.toContain('exe_atools');
+        });
+    });
+
     describe('Basic Properties', () => {
         it('should return correct file suffix', () => {
             expect(exporter.getFileSuffix()).toBe('_scorm');

--- a/src/shared/export/exporters/Scorm12Exporter.ts
+++ b/src/shared/export/exporters/Scorm12Exporter.ts
@@ -468,6 +468,8 @@ export class Scorm12Exporter extends Html5Exporter {
             addExeLink: meta.addExeLink ?? true,
             addPagination: meta.addPagination ?? false,
             addMathJax: meta.addMathJax === true,
+            // Accessibility toolbar (exe_atools) when enabled in project properties (#1978)
+            addAccessibilityToolbar: meta.addAccessibilityToolbar ?? false,
             totalPages: allPages.length,
             currentPageIndex: pageIndex ?? 0,
             // SCORM-specific options

--- a/src/shared/export/exporters/Scorm2004Exporter.spec.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.spec.ts
@@ -271,6 +271,48 @@ describe('Scorm2004Exporter', () => {
         });
     });
 
+    describe('Accessibility toolbar (addAccessibilityToolbar)', () => {
+        // Regression test for #1978: when the author enables the accessibility toolbar,
+        // every exported page must load exe_atools (JS + CSS) in its <head>, and the
+        // files must be bundled and referenced in imsmanifest.xml.
+        const mockToolbarLibFiles = () => {
+            resources.fetchLibraryFiles = async files => new Map(files.map(file => [file, Buffer.from('// mock lib')]));
+        };
+
+        it('references the toolbar JS and CSS in the page head when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Scorm2004Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.js');
+            expect(indexHtml).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('bundles the toolbar files and references them in imsmanifest.xml when enabled', async () => {
+            document = new MockDocument({ addAccessibilityToolbar: true }, samplePages);
+            exporter = new Scorm2004Exporter(document, resources, assets, zip);
+            mockToolbarLibFiles();
+
+            await exporter.export();
+
+            expect(zip.files.has('libs/exe_atools/exe_atools.js')).toBe(true);
+            expect(zip.files.has('libs/exe_atools/exe_atools.css')).toBe(true);
+            const manifest = zip.files.get('imsmanifest.xml') as string;
+            expect(manifest).toContain('libs/exe_atools/exe_atools.js');
+            expect(manifest).toContain('libs/exe_atools/exe_atools.css');
+        });
+
+        it('does not reference the toolbar when disabled (default)', async () => {
+            await exporter.export();
+
+            const indexHtml = zip.files.get('index.html') as string;
+            expect(indexHtml).not.toContain('exe_atools');
+        });
+    });
+
     describe('Basic Properties', () => {
         it('should return correct file suffix', () => {
             expect(exporter.getFileSuffix()).toBe('_scorm2004');

--- a/src/shared/export/exporters/Scorm2004Exporter.ts
+++ b/src/shared/export/exporters/Scorm2004Exporter.ts
@@ -452,6 +452,8 @@ export class Scorm2004Exporter extends Html5Exporter {
             addExeLink: meta.addExeLink ?? true,
             addPagination: meta.addPagination ?? false,
             addMathJax: meta.addMathJax === true,
+            // Accessibility toolbar (exe_atools) when enabled in project properties (#1978)
+            addAccessibilityToolbar: meta.addAccessibilityToolbar ?? false,
             totalPages: allPages.length,
             currentPageIndex: pageIndex ?? 0,
             isScorm: true,


### PR DESCRIPTION
## Problem

Fixes #1978.

The accessibility toolbar (`exe_atools`) was missing from **IMS**, **SCORM 1.2**, **SCORM 2004** and **EPUB3** exports. It worked in HTML5 and single-page exports.

## Root cause

Each of these exporters already did two of the three things needed:

1. Copied `exe_atools/exe_atools.js` + `exe_atools/exe_atools.css` into the package (via `includeAccessibilityToolbar`).
2. Referenced those files in `imsmanifest.xml` (IMS/SCORM) / `package.opf` (EPUB).

But they never passed `addAccessibilityToolbar` to `pageRenderer.render()`, so the `<script>`/`<link>` tags were **never emitted in the page `<head>`**. The files shipped in the package but the toolbar never loaded.

HTML5 works because `Html5Exporter.generatePageHtml` passes the flag; single-page works because it forwards the detected libraries (which include `exe_atools`) to `renderSinglePage`.

## Fix

Pass `addAccessibilityToolbar: meta.addAccessibilityToolbar ?? false` to the `render()` call in `ImsExporter`, `Scorm12Exporter`, `Scorm2004Exporter` and `Epub3Exporter`, mirroring `Html5Exporter`. One line each.

## Tests

Added a regression suite per exporter (`*.spec.ts`):

- **Head reference** — asserts the page `<head>` loads `exe_atools.js` + `exe_atools.css` when enabled. **These are the real regression guards**: they fail (4 fail / 232 pass) when the source fix is reverted.
- **Manifest/OPF reference** — asserts the toolbar files are bundled and referenced in `imsmanifest.xml` / `package.opf` (documents the issue's manifest requirement; already passed before the fix since bundling already worked).
- **Disabled (default)** — asserts no `exe_atools` reference when the toolbar is off.
- A regression guard was also added for the single-page exporter, which was already correct.

All 1967 `src/shared/export` tests pass; `make fix` is clean.
