### PR TITLE
feat(electron): add "File → Close" desktop menu option

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1534,6 +1534,18 @@ ipcMain.handle('app:getMemoryUsage', async (e) => {
     };
 });
 
+// Close the window that initiated the request (File > Close). The unsaved
+// changes confirmation is handled by the close guard attached in
+// attachEditorWindowCloseGuard(), so we only trigger the close here.
+ipcMain.handle('app:closeCurrentWindow', async (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    if (win && !win.isDestroyed()) {
+        win.close();
+        return true;
+    }
+    return false;
+});
+
 function normalizeBinaryPayload(bufferData, base64Data) {
     if (bufferData instanceof Uint8Array) {
         return Buffer.from(bufferData);

--- a/app/preload.js
+++ b/app/preload.js
@@ -44,6 +44,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
   },
   openElp: () => ipcRenderer.invoke('app:openElp'),
+  // Close the current window (File > Close). The existing close guard in the
+  // main process still prompts for unsaved changes.
+  closeCurrentWindow: () => ipcRenderer.invoke('app:closeCurrentWindow'),
   readFile: (filePath) => ipcRenderer.invoke('app:readFile', { filePath }),
   getMemoryUsage: () => ipcRenderer.invoke('app:getMemoryUsage'),
   notifyRendererReadyForOpenFile: () => ipcRenderer.send('app:renderer-ready-for-open-file'),

--- a/public/app/common/shortcuts.js
+++ b/public/app/common/shortcuts.js
@@ -174,7 +174,7 @@ get isStatic() {
 
 getComboRemap() {
   const isStatic = this.isStatic;
-  return {
+  const map = {
     'mod+alt+n'   : 'navbar-button-new',
     'mod+o'       : isStatic ? 'navbar-button-open-offline'    : 'navbar-button-openuserodefiles',
     'mod+s'       : isStatic ? 'navbar-button-save-offline'    : 'navbar-button-save',
@@ -184,6 +184,18 @@ getComboRemap() {
     'mod+p'       : 'navbar-button-preview',
     'mod+k'       : 'navbar-button-global-search',
   };
+
+  // File -> Close (Cmd/Ctrl+W). This closes the current window, so the
+  // standard accelerator is Cmd+W / Ctrl+W (not Q, which is reserved for
+  // quitting the app). macOS already provides a native Cmd+W via the Window
+  // menu role, so we only wire the in-app binding on Windows/Linux. Gating on
+  // the Electron bridge keeps the browser/PWA build from swallowing Ctrl+W
+  // (which natively closes the browser tab there).
+  if (!this.isMac && typeof window?.electronAPI?.closeCurrentWindow === 'function') {
+    map['mod+w'] = 'navbar-button-close-file';
+  }
+
+  return map;
 }
 
 resolveTarget(combo) {

--- a/public/app/common/shortcuts.test.js
+++ b/public/app/common/shortcuts.test.js
@@ -352,6 +352,68 @@ describe('Shortcuts', () => {
     });
   });
 
+  describe('getComboRemap (File -> Close, Electron-only)', () => {
+    afterEach(() => {
+      delete window.electronAPI;
+    });
+
+    it('maps mod+w to the close-file button under Electron on non-macOS', () => {
+      shortcuts.isMac = false;
+      window.electronAPI = { closeCurrentWindow: vi.fn() };
+      expect(shortcuts.getComboRemap()['mod+w']).toBe('navbar-button-close-file');
+    });
+
+    it('does not map mod+w on macOS (native Cmd+W already provided)', () => {
+      shortcuts.isMac = true;
+      window.electronAPI = { closeCurrentWindow: vi.fn() };
+      expect(shortcuts.getComboRemap()['mod+w']).toBeUndefined();
+    });
+
+    it('does not map mod+w in the browser/PWA build (no Electron bridge)', () => {
+      shortcuts.isMac = false;
+      delete window.electronAPI;
+      expect(shortcuts.getComboRemap()['mod+w']).toBeUndefined();
+    });
+  });
+
+  describe('onKeyDown (File -> Close, Ctrl+W)', () => {
+    let closeBtn;
+
+    beforeEach(() => {
+      closeBtn = document.createElement('button');
+      closeBtn.id = 'navbar-button-close-file';
+      closeBtn.click = vi.fn();
+      document.body.appendChild(closeBtn);
+      shortcuts.isMac = false;
+    });
+
+    afterEach(() => {
+      delete window.electronAPI;
+    });
+
+    it('clicks the close-file button on Ctrl+W under Electron (non-macOS)', () => {
+      window.electronAPI = { closeCurrentWindow: vi.fn() };
+      const event = new KeyboardEvent('keydown', { code: 'KeyW', ctrlKey: true });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      shortcuts.onKeyDown(event);
+
+      expect(closeBtn.click).toHaveBeenCalled();
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('does not intercept Ctrl+W in the browser/PWA build (no Electron bridge)', () => {
+      delete window.electronAPI;
+      const event = new KeyboardEvent('keydown', { code: 'KeyW', ctrlKey: true });
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      shortcuts.onKeyDown(event);
+
+      expect(closeBtn.click).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('observe', () => {
     it('should create MutationObserver on root element', () => {
       const root = document.createElement('div');

--- a/public/app/workarea/menus/navbar/items/navbarFile.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.js
@@ -758,6 +758,14 @@ export default class NavbarFile {
         const wrapper = this.closeFileButton.closest('li') || this.closeFileButton;
         wrapper.classList.remove('d-none');
 
+        // Reveal the preceding separator too. It shares the exe-electron-only
+        // marker and is hidden by default so the browser/PWA build never shows
+        // a stray divider above a missing entry.
+        const divider = wrapper.previousElementSibling;
+        if (divider && divider.classList.contains('exe-electron-only')) {
+            divider.classList.remove('d-none');
+        }
+
         this.closeFileButton.addEventListener('click', (event) => {
             event.preventDefault();
             if (eXeLearning.app.project.checkOpenIdevice()) return;

--- a/public/app/workarea/menus/navbar/items/navbarFile.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.js
@@ -38,6 +38,10 @@ export default class NavbarFile {
         this.saveOfflineButton = this.menu.navbar.querySelector(
             '#navbar-button-save-offline'
         );
+        // Electron-only "Close" entry (hidden by default in the offline markup).
+        this.closeFileButton = this.menu.navbar.querySelector(
+            '#navbar-button-close-file'
+        );
         this.recentProjectsButton = this.menu.navbar.querySelector(
             '#navbar-button-dropdown-recent-projects'
         );
@@ -132,6 +136,7 @@ export default class NavbarFile {
         this.setRecentProjectsEvent();
         this.setDownloadProjectEvent();
         this.setSaveProjectOfflineEvent();
+        this.setCloseFileEvent();
         this.setDownloadProjectAsEvent();
         this.setExportHTML5Event();
         this.setExportHTML5AsEvent();
@@ -725,6 +730,38 @@ export default class NavbarFile {
             if (eXeLearning.app.project.checkOpenIdevice()) return false;
             this.downloadProjectEvent();
             return false;
+        });
+    }
+
+    /**
+     * Close the current file/window.
+     * File -> Close (Electron desktop only)
+     *
+     * The static browser/PWA build and the Electron app both run in the same
+     * static/offline runtime, so `config.isOfflineInstallation` cannot tell
+     * them apart. We gate visibility on the Electron-only `window.electronAPI`
+     * bridge instead: the entry stays hidden in the browser and is revealed
+     * only when the desktop app exposes `closeCurrentWindow`.
+     *
+     * Closing goes through `BrowserWindow.close()` in the main process, so the
+     * existing close guard still prompts for unsaved changes.
+     */
+    setCloseFileEvent() {
+        if (!this.closeFileButton) return;
+
+        // Browser/PWA build: no Electron bridge, keep the entry hidden.
+        if (typeof window.electronAPI?.closeCurrentWindow !== 'function') {
+            return;
+        }
+
+        // Reveal the entry (its wrapper <li> is hidden by default).
+        const wrapper = this.closeFileButton.closest('li') || this.closeFileButton;
+        wrapper.classList.remove('d-none');
+
+        this.closeFileButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (eXeLearning.app.project.checkOpenIdevice()) return;
+            window.electronAPI.closeCurrentWindow();
         });
     }
 

--- a/public/app/workarea/menus/navbar/items/navbarFile.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.test.js
@@ -849,6 +849,61 @@ describe('NavbarFile', () => {
             expect(closeCurrentWindow).toHaveBeenCalled();
         });
 
+        it('should reveal the preceding electron-only divider when the bridge is present', () => {
+            // Mirror the real markup: a hidden divider sits right above the
+            // hidden <li> wrapper, both flagged exe-electron-only.
+            const divider = document.createElement('li');
+            divider.classList.add('dropdown-divider', 'd-none', 'exe-electron-only');
+            const li = document.createElement('li');
+            li.classList.add('d-none', 'exe-electron-only');
+            li.appendChild(mockButtons.closeFileButton);
+            navbarElement.appendChild(divider);
+            navbarElement.appendChild(li);
+
+            window.electronAPI = { closeCurrentWindow: vi.fn() };
+
+            navbarFile.setCloseFileEvent();
+
+            expect(li.classList.contains('d-none')).toBe(false);
+            expect(divider.classList.contains('d-none')).toBe(false);
+        });
+
+        it('should leave the preceding divider hidden when electronAPI is absent', () => {
+            const divider = document.createElement('li');
+            divider.classList.add('dropdown-divider', 'd-none', 'exe-electron-only');
+            const li = document.createElement('li');
+            li.classList.add('d-none', 'exe-electron-only');
+            li.appendChild(mockButtons.closeFileButton);
+            navbarElement.appendChild(divider);
+            navbarElement.appendChild(li);
+
+            window.electronAPI = null;
+
+            navbarFile.setCloseFileEvent();
+
+            expect(li.classList.contains('d-none')).toBe(true);
+            expect(divider.classList.contains('d-none')).toBe(true);
+        });
+
+        it('should not touch a preceding sibling that is not an electron-only divider', () => {
+            // A non-divider previous sibling (e.g. the Print item) must be left
+            // untouched even when the close entry is revealed.
+            const sibling = document.createElement('li');
+            const li = document.createElement('li');
+            li.classList.add('d-none', 'exe-electron-only');
+            li.appendChild(mockButtons.closeFileButton);
+            navbarElement.appendChild(sibling);
+            navbarElement.appendChild(li);
+
+            window.electronAPI = { closeCurrentWindow: vi.fn() };
+
+            navbarFile.setCloseFileEvent();
+
+            expect(li.classList.contains('d-none')).toBe(false);
+            expect(sibling.classList.contains('d-none')).toBe(false);
+            expect(sibling.classList.length).toBe(0);
+        });
+
         it('should not close when an idevice editor is open', () => {
             const closeCurrentWindow = vi.fn();
             window.electronAPI = { closeCurrentWindow };

--- a/public/app/workarea/menus/navbar/items/navbarFile.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarFile.test.js
@@ -39,6 +39,7 @@ describe('NavbarFile', () => {
             openUserOdeFilesButton: createButton('navbar-button-openuserodefiles'),
             openOfflineButton: createButton('navbar-button-open-offline'),
             saveOfflineButton: createButton('navbar-button-save-offline'),
+            closeFileButton: createButton('navbar-button-close-file'),
             recentProjectsButton: createButton('navbar-button-dropdown-recent-projects'),
             downloadProjectButton: createButton('navbar-button-download-project'),
             downloadProjectAsButton: createButton('navbar-button-download-project-as'),
@@ -212,6 +213,7 @@ describe('NavbarFile', () => {
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-openuserodefiles');
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-open-offline');
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-save-offline');
+            expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-close-file');
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-dropdown-recent-projects');
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-download-project');
             expect(mockMenu.navbar.querySelector).toHaveBeenCalledWith('#navbar-button-download-project-as');
@@ -249,6 +251,7 @@ describe('NavbarFile', () => {
             expect(navbarFile.openUserOdeFilesButton).toBe(mockButtons.openUserOdeFilesButton);
             expect(navbarFile.openOfflineButton).toBe(mockButtons.openOfflineButton);
             expect(navbarFile.saveOfflineButton).toBe(mockButtons.saveOfflineButton);
+            expect(navbarFile.closeFileButton).toBe(mockButtons.closeFileButton);
             expect(navbarFile.recentProjectsButton).toBe(mockButtons.recentProjectsButton);
             expect(navbarFile.downloadProjectButton).toBe(mockButtons.downloadProjectButton);
             expect(navbarFile.downloadProjectAsButton).toBe(mockButtons.downloadProjectAsButton);
@@ -290,6 +293,7 @@ describe('NavbarFile', () => {
                 setRecentProjectsEvent: vi.spyOn(navbarFile, 'setRecentProjectsEvent'),
                 setDownloadProjectEvent: vi.spyOn(navbarFile, 'setDownloadProjectEvent'),
                 setSaveProjectOfflineEvent: vi.spyOn(navbarFile, 'setSaveProjectOfflineEvent'),
+                setCloseFileEvent: vi.spyOn(navbarFile, 'setCloseFileEvent'),
                 setDownloadProjectAsEvent: vi.spyOn(navbarFile, 'setDownloadProjectAsEvent'),
                 setExportHTML5Event: vi.spyOn(navbarFile, 'setExportHTML5Event'),
                 setExportHTML5AsEvent: vi.spyOn(navbarFile, 'setExportHTML5AsEvent'),
@@ -811,6 +815,72 @@ describe('NavbarFile', () => {
         it('setImportElpEvent should add click listener when button exists', () => {
             navbarFile.setImportElpEvent();
             expect(mockButtons.importElpButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+        });
+    });
+
+    describe('setCloseFileEvent (Electron-only File -> Close)', () => {
+        beforeEach(() => {
+            navbarFile = new NavbarFile(mockMenu);
+        });
+
+        it('should reveal the entry and close the window when the Electron bridge is present', () => {
+            // Mirror the real markup: the <a> lives inside a hidden <li> wrapper.
+            const li = document.createElement('li');
+            li.classList.add('d-none', 'exe-electron-only');
+            li.appendChild(mockButtons.closeFileButton);
+            navbarElement.appendChild(li);
+
+            const closeCurrentWindow = vi.fn();
+            window.electronAPI = { closeCurrentWindow };
+
+            navbarFile.setCloseFileEvent();
+
+            expect(li.classList.contains('d-none')).toBe(false);
+            expect(mockButtons.closeFileButton.addEventListener).toHaveBeenCalledWith(
+                'click',
+                expect.any(Function)
+            );
+
+            const clickHandler = mockButtons.closeFileButton.addEventListener.mock.calls[0][1];
+            const preventDefault = vi.fn();
+            clickHandler({ preventDefault });
+
+            expect(preventDefault).toHaveBeenCalled();
+            expect(closeCurrentWindow).toHaveBeenCalled();
+        });
+
+        it('should not close when an idevice editor is open', () => {
+            const closeCurrentWindow = vi.fn();
+            window.electronAPI = { closeCurrentWindow };
+            eXeLearning.app.project.checkOpenIdevice = vi.fn(() => true);
+
+            navbarFile.setCloseFileEvent();
+            const clickHandler = mockButtons.closeFileButton.addEventListener.mock.calls[0][1];
+            clickHandler({ preventDefault: vi.fn() });
+
+            expect(eXeLearning.app.project.checkOpenIdevice).toHaveBeenCalled();
+            expect(closeCurrentWindow).not.toHaveBeenCalled();
+        });
+
+        it('should stay hidden and wire nothing in the static browser build (no electronAPI)', () => {
+            const li = document.createElement('li');
+            li.classList.add('d-none', 'exe-electron-only');
+            li.appendChild(mockButtons.closeFileButton);
+            navbarElement.appendChild(li);
+
+            window.electronAPI = null;
+
+            navbarFile.setCloseFileEvent();
+
+            expect(li.classList.contains('d-none')).toBe(true);
+            expect(mockButtons.closeFileButton.addEventListener).not.toHaveBeenCalled();
+        });
+
+        it('should do nothing when the close button is absent', () => {
+            navbarFile.closeFileButton = null;
+            window.electronAPI = { closeCurrentWindow: vi.fn() };
+
+            expect(() => navbarFile.setCloseFileEvent()).not.toThrow();
         });
     });
 

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -955,6 +955,7 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     import_elpx: trans('Import (.elpx...)', {}, locale),
                     save: trans('Save', {}, locale),
                     save_as: trans('Save as', {}, locale),
+                    close: trans('Close', {}, locale),
                     download_as: trans('Download as...', {}, locale),
                     export_as: trans('Export as...', {}, locale),
                     exelearning_content: trans('eXeLearning content (.elpx)', {}, locale),

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -53,6 +53,8 @@
                         <li><a class="dropdown-item" id="navbar-button-save-offline" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.save or 'Save' }}</a></li>
                         {# Advanced: save the project as an unpacked folder. Hidden until Alt is held or feature flag is set. #}
                         <li class="d-none exe-folder-project-action"><a class="dropdown-item" id="navbar-button-save-folder-offline" href="#"><span class="small-icon save-icon-green"></span> {{ t.save_to_folder or 'Save to folder' }}</a></li>
+                        {# Desktop only: close the current window. Revealed by navbarFile.js only when the Electron bridge (window.electronAPI) is present. #}
+                        <li class="d-none exe-electron-only"><a class="dropdown-item" id="navbar-button-close-file" href="#"><span class="small-icon close-icon"></span> {{ t.close or 'Close' }}</a></li>
                         <li class="dropdown dropend">
                             <a class="dropdown-item dropdown-toggle" href="#" id="dropdownExportAsOffline" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="small-icon download-icon-green"></span> {{ t.export_as or 'Export as...' }}</a>
                             <ul class="dropdown-menu" aria-labelledby="dropdownExportAsOffline">

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -53,8 +53,6 @@
                         <li><a class="dropdown-item" id="navbar-button-save-offline" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.download or 'Download' }}</a></li>
                         {# Advanced: save the project as an unpacked folder. Hidden until Alt is held or feature flag is set. #}
                         <li class="d-none exe-folder-project-action"><a class="dropdown-item" id="navbar-button-save-folder-offline" href="#"><span class="small-icon save-icon-green"></span> {{ t.save_to_folder or 'Save to folder' }}</a></li>
-                        {# Desktop only: close the current window. Revealed by navbarFile.js only when the Electron bridge (window.electronAPI) is present. #}
-                        <li class="d-none exe-electron-only"><a class="dropdown-item" id="navbar-button-close-file" href="#"><span class="small-icon close-icon"></span> {{ t.close or 'Close' }}</a></li>
                         <li class="dropdown dropend">
                             <a class="dropdown-item dropdown-toggle" href="#" id="dropdownExportAsOffline" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="small-icon download-icon-green"></span> {{ t.export_as or 'Export as...' }}</a>
                             <ul class="dropdown-menu" aria-labelledby="dropdownExportAsOffline">
@@ -73,6 +71,13 @@
                     <li><a class="dropdown-item" id="navbar-button-settings" href="#"><span class="small-icon settings-icon-green"></span> {{ t.project_properties or 'Project Properties' }}</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a id="navbar-button-export-print" class="dropdown-item" href="#"><span class="small-icon print-icon-green"></span> {{ t.print or 'Print' }}</a></li>
+                    {% if config.isOfflineInstallation %}
+                        {# Desktop only: close the current window (Cmd+W / Ctrl+W). The divider and
+                           entry are hidden by default and revealed by navbarFile.js only when the
+                           Electron bridge (window.electronAPI) is present. #}
+                        <li class="dropdown-divider d-none exe-electron-only"></li>
+                        <li class="d-none exe-electron-only"><a class="dropdown-item" id="navbar-button-close-file" href="#" data-shortcut="Mod+W" aria-keyshortcuts="Control+W Meta+W"><span class="small-icon close-icon"></span> {{ t.close or 'Close' }}</a></li>
+                    {% endif %}
                     {% if config.platformIntegration %}
                         <li class="dropdown-divider"></li>
                         <li><a class="dropdown-item" id="navbar-button-uploadtoplatform" href="#"><span class="small-icon upload-cloud-icon-green"></span> {{ 'Send to %s' | trans({ s: config.platformName }) }}</a></li>


### PR DESCRIPTION
## Summary

Restores the missing **File → Close** menu entry reported in #1847. It closes the current editor window in the packaged desktop (Electron) app.

## Why it is Electron-only (and how)

The static browser/PWA build and the Electron app both run in the same `static`/offline runtime, so `config.isOfflineInstallation`, `window.__EXE_STATIC_MODE__`, `runtimeConfig.isStaticMode()` and storage capabilities **cannot** distinguish them. The only reliable Electron signal is the presence of `window.electronAPI`.

So the entry is rendered **hidden** in the offline navbar markup (`d-none exe-electron-only`) and is revealed by `navbarFile.js` **only** when `window.electronAPI.closeCurrentWindow` is a function. In the browser/PWA build it stays hidden; the server (online) build never renders the offline block at all.

## Unsaved-changes handling

Close goes through a new `app:closeCurrentWindow` IPC handler that calls `BrowserWindow.close()` on the sender window. The existing `attachEditorWindowCloseGuard(win)` still intercepts the close and prompts for unsaved changes — no confirmation logic is duplicated.

## Changes

- `app/preload.js` — expose `closeCurrentWindow()` on the `electronAPI` bridge.
- `app/main.js` — add the `app:closeCurrentWindow` IPC handler (resolves the sender window via `BrowserWindow.fromWebContents`, returns `true`/`false`).
- `views/workarea/menus/menuNavbar.njk` — add the hidden `File → Close` item in the offline block, after *Save* and before *Export as…*.
- `src/routes/pages.ts` — register the `close` label in the navbar translation map.
- `public/app/workarea/menus/navbar/items/navbarFile.js` — query the button, add `setCloseFileEvent()` (reveal + wire click only under Electron; respects `checkOpenIdevice()`).
- `public/app/workarea/menus/navbar/items/navbarFile.test.js` — tests for the new behavior.

## Testing

- `make fix` — clean (only a pre-existing unrelated `any` warning in `export.ts`).
- Frontend (Vitest) — full suite green; `navbarFile.test.js` covers: button is queried/stored, `setEvents()` calls `setCloseFileEvent()`, entry shown + close invoked when the Electron bridge is present, idevice-open guard blocks the close, and the entry stays hidden with nothing wired when `electronAPI` is absent. Patch coverage on the changed file is 100%.
- Backend (Bun) — `src/routes/pages.spec.ts` green with the new `close` label.

Note: the Electron-only visibility is verified by unit tests. The Playwright E2E harness runs the web/static build where `window.electronAPI` is absent, so it cannot exercise the Electron path.

Closes #1847
