### PR TITLE
1976 minor fixes for next release

### DIFF
--- a/public/files/perm/idevices/base/electrical-circuits/config.xml
+++ b/public/files/perm/idevices/base/electrical-circuits/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <idevice>
-    <title>Electrical circuits</title>
+    <title>Electrical Circuits</title>
     <css-class>electrical-circuits</css-class>
     <category>Science</category>
     <icon>

--- a/src/cli/commands/translations.ts
+++ b/src/cli/commands/translations.ts
@@ -58,27 +58,6 @@ const EXCLUDE_FILE_PATTERNS = [
  */
 const EXCLUDE_EXACT_KEYS = new Set([
     'P + \\\\tfrac12 \\\\rho v^2 + \\\\rho g h = \\\\text{constant}', // Bernoulli equation example in edicuatex lang file
-    // TO DO: screenshot tab strings (pending localization)
-    'Screenshot',
-    'Current project screenshot preview',
-    'No screenshot yet. It will be auto-generated when you save or export.',
-    'Upload custom image',
-    'Screenshot must be smaller than 2 MB.',
-    'Invalid image',
-    'The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.',
-    'Generate from content',
-    'Not available',
-    'Screenshot generation is not available.',
-    'Generation failed',
-    'Could not generate screenshot from content. Try uploading an image instead.',
-    'Replace screenshot',
-    'This will delete the current image. Do you want to continue?',
-    'Delete screenshot',
-    'Delete the current image? This action cannot be undone.',
-    'Recommendations',
-    'Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.',
-    'The image will be used as a preview of this educational resource across different platforms.',
-    // END TO DO
 ]);
 
 /**

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="4hqy9yx" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Captura de pantalla</target>
       </trans-unit>
       <trans-unit id="n01szqr" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Previsualització de la captura del projecte actual</target>
       </trans-unit>
       <trans-unit id="ig3vsn3" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Encara no hi ha captura de pantalla. Es generarà automàticament en guardar o exportar.</target>
       </trans-unit>
       <trans-unit id="tia5iym" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Puja una imatge personalitzada</target>
       </trans-unit>
       <trans-unit id="ki7ppkv" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~La captura de pantalla ha de ser inferior a 2 MB.</target>
       </trans-unit>
       <trans-unit id="2zod872" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Imatge no vàlida</target>
       </trans-unit>
       <trans-unit id="edelrnd" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~La imatge no compleix els requisits mínims: relació d'aspecte 16:9 i almenys 600 píxels d'amplada.</target>
       </trans-unit>
       <trans-unit id="hc7wxq0" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Genera des del contingut</target>
       </trans-unit>
       <trans-unit id="t764wel" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~No disponible</target>
       </trans-unit>
       <trans-unit id="7laifyy" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~La generació de captures de pantalla no està disponible.</target>
       </trans-unit>
       <trans-unit id="1897es4" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Error en la generació</target>
       </trans-unit>
       <trans-unit id="x67tpix" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~No s'ha pogut generar la captura des del contingut. Prova a pujar una imatge en lloc d'això.</target>
       </trans-unit>
       <trans-unit id="hnwvovl" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Substitueix la captura de pantalla</target>
       </trans-unit>
       <trans-unit id="4z35j0h" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Això eliminarà la imatge actual. Vols continuar?</target>
       </trans-unit>
       <trans-unit id="kc00t8o" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Elimina la captura de pantalla</target>
       </trans-unit>
       <trans-unit id="oe3qs3v" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Elimines la imatge actual? Aquesta acció no es pot desfer.</target>
       </trans-unit>
       <trans-unit id="8h7muhj" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Recomanacions</target>
       </trans-unit>
       <trans-unit id="u1higx5" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Utilitza una imatge 16:9 (es recomanen 1280×720 px) que representi clarament el contingut principal del recurs educatiu. Evita el desordre i el text petit, i assegura un bon contrast per a la llegibilitat en mides reduïdes.</target>
       </trans-unit>
       <trans-unit id="b6f9jmr" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~La imatge s'utilitzarà com a previsualització d'aquest recurs educatiu en diferents plataformes.</target>
       </trans-unit>
       <trans-unit id="tenzxb9" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Molècula 3D</target>
       </trans-unit>
       <trans-unit id="2dcde1v" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Molècules 3D</target>
       </trans-unit>
       <trans-unit id="1geizo9" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Amplada màx. (opcional)</target>
       </trans-unit>
       <trans-unit id="rj49fl4" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Alçada màx. (opcional)</target>
       </trans-unit>
       <trans-unit id="t75w3sp" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~p. ex. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="hjgffrh" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~L'amplada màx. ha de ser superior a 0 i usar px, em, rem o % (p. ex. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="qyxn0fw" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~L'alçada màx. ha de ser superior a 0 i usar px, em, rem o % (p. ex. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="ngdv6dc" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Ho sentim, és incorrecte... La resposta correcta és:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Genera la vista prèvia del circuit abans de desar</target>
       </trans-unit>
+      <trans-unit id="4hqy9yx" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="n01szqr" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ig3vsn3" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tia5iym" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ki7ppkv" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2zod872" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="edelrnd" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hc7wxq0" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="t764wel" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7laifyy" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1897es4" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="x67tpix" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hnwvovl" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4z35j0h" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kc00t8o" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="oe3qs3v" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8h7muhj" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="u1higx5" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="b6f9jmr" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tenzxb9" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2dcde1v" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1geizo9" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rj49fl4" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="t75w3sp" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hjgffrh" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qyxn0fw" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ngdv6dc" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="kvcquij" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Screenshot</target>
       </trans-unit>
       <trans-unit id="dfoqpnk" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Screenshot-Vorschau des aktuellen Projekts</target>
       </trans-unit>
       <trans-unit id="p0q7x97" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Noch kein Screenshot vorhanden. Er wird beim Speichern oder Exportieren automatisch generiert.</target>
       </trans-unit>
       <trans-unit id="q76zlui" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Benutzerdefiniertes Bild hochladen</target>
       </trans-unit>
       <trans-unit id="l4esmui" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~Der Screenshot muss kleiner als 2 MB sein.</target>
       </trans-unit>
       <trans-unit id="fi99axe" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Ungültiges Bild</target>
       </trans-unit>
       <trans-unit id="fxmu3mq" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~Das Bild erfüllt die Mindestanforderungen nicht: Seitenverhältnis 16:9 und mindestens 600 Pixel Breite.</target>
       </trans-unit>
       <trans-unit id="he35tlq" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Aus Inhalt generieren</target>
       </trans-unit>
       <trans-unit id="247657i" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Nicht verfügbar</target>
       </trans-unit>
       <trans-unit id="tc3s2tq" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~Die Screenshot-Generierung ist nicht verfügbar.</target>
       </trans-unit>
       <trans-unit id="kcavu1c" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Generierung fehlgeschlagen</target>
       </trans-unit>
       <trans-unit id="f4m0t3o" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Screenshot konnte nicht aus dem Inhalt generiert werden. Versuche stattdessen, ein Bild hochzuladen.</target>
       </trans-unit>
       <trans-unit id="nggl4sy" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Screenshot ersetzen</target>
       </trans-unit>
       <trans-unit id="xud1kjz" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Dadurch wird das aktuelle Bild gelöscht. Möchtest du fortfahren?</target>
       </trans-unit>
       <trans-unit id="d8gab66" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Screenshot löschen</target>
       </trans-unit>
       <trans-unit id="pg5gqsj" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Aktuelles Bild löschen? Diese Aktion kann nicht rückgängig gemacht werden.</target>
       </trans-unit>
       <trans-unit id="wzy44es" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Empfehlungen</target>
       </trans-unit>
       <trans-unit id="cue6ns6" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Verwende ein 16:9-Bild (1280×720 px empfohlen), das den Hauptinhalt der Lernressource klar darstellt. Vermeide Unübersichtlichkeit und kleinen Text, und sorge für guten Kontrast für die Lesbarkeit bei kleinen Größen.</target>
       </trans-unit>
       <trans-unit id="ncsab6s" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~Das Bild wird als Vorschau dieser Bildungsressource auf verschiedenen Plattformen verwendet.</target>
       </trans-unit>
       <trans-unit id="hqhr804" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~3D-Molekül</target>
       </trans-unit>
       <trans-unit id="eetajl5" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~3D-Moleküle</target>
       </trans-unit>
       <trans-unit id="kd2vt0n" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Max. Breite (optional)</target>
       </trans-unit>
       <trans-unit id="4zve5km" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Max. Höhe (optional)</target>
       </trans-unit>
       <trans-unit id="alm7ch8" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~z. B. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="djz138s" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~Die max. Breite muss größer als 0 sein und px, em, rem oder % verwenden (z. B. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="pjrwxk6" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~Die max. Höhe muss größer als 0 sein und px, em, rem oder % verwenden (z. B. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="ah201me" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Es tut uns leid, das ist falsch... Die richtige Antwort lautet:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Bitte erzeuge die Schaltungsvorschau vor dem Speichern</target>
       </trans-unit>
+      <trans-unit id="kvcquij" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="dfoqpnk" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="p0q7x97" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="q76zlui" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="l4esmui" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fi99axe" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fxmu3mq" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="he35tlq" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="247657i" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tc3s2tq" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kcavu1c" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="f4m0t3o" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="nggl4sy" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xud1kjz" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="d8gab66" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pg5gqsj" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wzy44es" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="cue6ns6" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ncsab6s" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hqhr804" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="eetajl5" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kd2vt0n" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4zve5km" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="alm7ch8" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="djz138s" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pjrwxk6" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ah201me" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="sacsso5" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="39sqhba" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zi2l4x5" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="f413keq" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ptp03dl" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0p730uu" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="lexsg71" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ex3bxga" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8jtqrz9" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3tz9hyz" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="u3kdtq3" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sbed23r" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pt7a1ii" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tduoe4f" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2v3drxe" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rlc0dlt" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="34xahej" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="a0sbzta" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="jf28vfy" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="47xk0wr" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="e9eyd0s" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0c5n3qd" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6alvagx" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2v9wv9g" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="o0du8vd" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0j4rd7x" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="lklo25x" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Bonvolu generi la antaŭrigardon de la cirkvito antaŭ ol konservi</target>
       </trans-unit>
+      <trans-unit id="y2fg8e5" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kbvvdgi" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yycim2g" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ozehezc" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="z4rfgd6" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hdlrwro" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="udyb9um" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kscxl0d" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="s98c6kv" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uwrpxot" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="m0ul6em" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="o7tgeey" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="b6b7fbm" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="bfogsw2" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="v1xulcp" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9hl1i3s" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="k2m7qyi" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="avbkh8c" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ca80gu5" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="es50bwi" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vhqs629" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9xkm21o" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="q5q2ln0" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="41tf78e" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="o4sioy0" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uf7uhfc" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y44ibxy" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="y2fg8e5" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Ekrankopio</target>
       </trans-unit>
       <trans-unit id="kbvvdgi" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Antaŭrigardo de ekrankopio de la aktuala projekto</target>
       </trans-unit>
       <trans-unit id="yycim2g" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Ankoraŭ neniu ekrankopio. Ĝi estos aŭtomate generita dum konservado aŭ eksportado.</target>
       </trans-unit>
       <trans-unit id="ozehezc" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Alŝuti propran bildon</target>
       </trans-unit>
       <trans-unit id="z4rfgd6" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~La ekrankopio devas esti malpli ol 2 MB.</target>
       </trans-unit>
       <trans-unit id="hdlrwro" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Nevalida bildo</target>
       </trans-unit>
       <trans-unit id="udyb9um" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~La bildo ne plenumas la minimumajn postulojn: proporciumo 16:9 kaj almenaŭ 600 pikseloj larĝe.</target>
       </trans-unit>
       <trans-unit id="kscxl0d" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Generi el enhavo</target>
       </trans-unit>
       <trans-unit id="s98c6kv" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Ne disponebla</target>
       </trans-unit>
       <trans-unit id="uwrpxot" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~La generado de ekrankopionoj ne estas disponebla.</target>
       </trans-unit>
       <trans-unit id="m0ul6em" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Generado malsukcesis</target>
       </trans-unit>
       <trans-unit id="o7tgeey" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Ne eblis generi ekrankopio el enhavo. Provu anstataŭe alŝuti bildon.</target>
       </trans-unit>
       <trans-unit id="b6b7fbm" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Anstataŭigi ekrankopio</target>
       </trans-unit>
       <trans-unit id="bfogsw2" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Ĉi tio forigos la aktualan bildon. Ĉu vi volas daŭrigi?</target>
       </trans-unit>
       <trans-unit id="v1xulcp" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Forigi ekrankopio</target>
       </trans-unit>
       <trans-unit id="9hl1i3s" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Forigi la aktualan bildon? Ĉi tiu ago ne povas esti nuligita.</target>
       </trans-unit>
       <trans-unit id="k2m7qyi" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Rekomendoj</target>
       </trans-unit>
       <trans-unit id="avbkh8c" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Uzu bildon 16:9 (rekomendate 1280×720 px) kiu klare reprezentas la ĉefan enhavon de la lernresurso. Evitu malordon kaj malgrandan tekston, kaj certigu bonan kontraston por legebleco ĉe malgrandaj grandecoj.</target>
       </trans-unit>
       <trans-unit id="ca80gu5" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~La bildo estos uzata kiel antaŭrigardo de ĉi tiu eduka resurso sur diversaj platformoj.</target>
       </trans-unit>
       <trans-unit id="es50bwi" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~3D-molekulo</target>
       </trans-unit>
       <trans-unit id="vhqs629" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~3D-molekuloj</target>
       </trans-unit>
       <trans-unit id="9xkm21o" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Maks. larĝo (laŭvola)</target>
       </trans-unit>
       <trans-unit id="q5q2ln0" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Maks. alto (laŭvola)</target>
       </trans-unit>
       <trans-unit id="41tf78e" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~eks. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="o4sioy0" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~La maks. larĝo devas esti pli granda ol 0 kaj uzi px, em, rem aŭ % (eks. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="uf7uhfc" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~La maks. alto devas esti pli granda ol 0 kaj uzi px, em, rem aŭ % (eks. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="y44ibxy" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Bedaŭrinde, tio estas malĝusta... La ĝusta respondo estas:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>Genera la vista previa del circuito antes de guardar</target>
       </trans-unit>
+      <trans-unit id="z8ugq75" resname="Screenshot">
+        <source>Screenshot</source>
+        <target>Captura de pantalla</target>
+      </trans-unit>
+      <trans-unit id="9psg4cy" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target>Vista previa de la captura del proyecto actual</target>
+      </trans-unit>
+      <trans-unit id="dot7hzc" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target>Aún no hay captura de pantalla. Se generará automáticamente al guardar o exportar.</target>
+      </trans-unit>
+      <trans-unit id="030c86c" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target>Subir imagen personalizada</target>
+      </trans-unit>
+      <trans-unit id="wix31pp" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target>La captura de pantalla debe tener un tamaño inferior a 2 MB.</target>
+      </trans-unit>
+      <trans-unit id="tza6h1a" resname="Invalid image">
+        <source>Invalid image</source>
+        <target>Imagen no válida</target>
+      </trans-unit>
+      <trans-unit id="ryr4omd" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target>La imagen no cumple los requisitos mínimos: relación de aspecto 16:9 y al menos 600 píxeles de ancho.</target>
+      </trans-unit>
+      <trans-unit id="6219smb" resname="Generate from content">
+        <source>Generate from content</source>
+        <target>Generar desde el contenido</target>
+      </trans-unit>
+      <trans-unit id="uk3h68y" resname="Not available">
+        <source>Not available</source>
+        <target>No disponible</target>
+      </trans-unit>
+      <trans-unit id="8wr6ns3" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target>La generación de capturas de pantalla no está disponible.</target>
+      </trans-unit>
+      <trans-unit id="8uu47r1" resname="Generation failed">
+        <source>Generation failed</source>
+        <target>Error en la generación</target>
+      </trans-unit>
+      <trans-unit id="zdz83z7" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target>No se pudo generar la captura desde el contenido. Intenta subir una imagen en su lugar.</target>
+      </trans-unit>
+      <trans-unit id="xcvh4sd" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target>Reemplazar captura de pantalla</target>
+      </trans-unit>
+      <trans-unit id="fm4oo08" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target>Esto eliminará la imagen actual. ¿Quieres continuar?</target>
+      </trans-unit>
+      <trans-unit id="cxju9z0" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target>Eliminar captura de pantalla</target>
+      </trans-unit>
+      <trans-unit id="s82hb3v" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target>¿Eliminar la imagen actual? Esta acción no se puede deshacer.</target>
+      </trans-unit>
+      <trans-unit id="q0xbg0a" resname="Recommendations">
+        <source>Recommendations</source>
+        <target>Recomendaciones</target>
+      </trans-unit>
+      <trans-unit id="zjymnxt" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target>Usa una imagen 16:9 (se recomiendan 1280×720 px) que represente claramente el contenido principal del recurso educativo. Evita el desorden y el texto pequeño, y asegura un buen contraste para su legibilidad en tamaños reducidos.</target>
+      </trans-unit>
+      <trans-unit id="prdopse" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target>La imagen se usará como vista previa de este recurso educativo en diferentes plataformas.</target>
+      </trans-unit>
+      <trans-unit id="927fxwd" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target>Molécula 3D</target>
+      </trans-unit>
+      <trans-unit id="ukl6iar" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target>Moléculas 3D</target>
+      </trans-unit>
+      <trans-unit id="2u64vv1" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target>Ancho máx. (opcional)</target>
+      </trans-unit>
+      <trans-unit id="yqdv18m" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target>Alto máx. (opcional)</target>
+      </trans-unit>
+      <trans-unit id="2p1dwxn" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target>p. ej. 800px, 50%, 40em, 30rem</target>
+      </trans-unit>
+      <trans-unit id="nr6x6of" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target>El ancho máx. debe ser mayor que 0 y usar px, em, rem o % (p. ej. 800px, 50%, 40em, 30rem).</target>
+      </trans-unit>
+      <trans-unit id="ajr6w22" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target>El alto máx. debe ser mayor que 0 y usar px, em, rem o % (p. ej. 600px, 70%, 30em, 20rem).</target>
+      </trans-unit>
+      <trans-unit id="hr9o37u" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target>Es incorrecto... La respuesta correcta es:</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="abw5d9e" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Pantaila-argazkia</target>
       </trans-unit>
       <trans-unit id="1sdabg7" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Uneko proiektuaren pantaila-argazkiaren aurrebista</target>
       </trans-unit>
       <trans-unit id="20clic6" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Oraindik ez dago pantaila-argazkirik. Automatikoki sortuko da gordetzean edo esportatzean.</target>
       </trans-unit>
       <trans-unit id="v39bmmd" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Kargatu irudi pertsonalizatua</target>
       </trans-unit>
       <trans-unit id="1chfds6" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~Pantaila-argazkia 2 MB baino txikiagoa izan behar da.</target>
       </trans-unit>
       <trans-unit id="1c1e8cz" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Irudi baliogabea</target>
       </trans-unit>
       <trans-unit id="k4keozg" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~Irudiak ez ditu gutxieneko eskakizunak betetzen: 16:9 alderdi-ratioa eta gutxienez 600 pixel zabalera.</target>
       </trans-unit>
       <trans-unit id="kzrxn2o" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Sortu edukitik</target>
       </trans-unit>
       <trans-unit id="wgx5u0z" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Ez dago erabilgarri</target>
       </trans-unit>
       <trans-unit id="tv4qcxb" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~Pantaila-argazkiak sortzea ez dago erabilgarri.</target>
       </trans-unit>
       <trans-unit id="vnfn22u" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Sorkuntza huts egin du</target>
       </trans-unit>
       <trans-unit id="8g7nfd9" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Ezin izan da pantaila-argazkia edukitik sortu. Saia zaitez irudi bat kargatzen.</target>
       </trans-unit>
       <trans-unit id="agdbvob" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Ordezkatu pantaila-argazkia</target>
       </trans-unit>
       <trans-unit id="swp3bly" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Honek uneko irudia ezabatuko du. Jarraitu nahi al duzu?</target>
       </trans-unit>
       <trans-unit id="wvqh61v" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Ezabatu pantaila-argazkia</target>
       </trans-unit>
       <trans-unit id="ndpnsli" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Uneko irudia ezabatu? Ekintza hau ezin da desegin.</target>
       </trans-unit>
       <trans-unit id="2xmr5dw" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Gomendioak</target>
       </trans-unit>
       <trans-unit id="qq69t0l" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Erabili 16:9 irudi bat (1280×720 px gomendatzen da) ikaskuntza-baliabidearen eduki nagusia argi irudikatzeko. Saihestu nahasketa eta testu txikia, eta ziurtatu kontraste ona tamaina txikietan irakurgarritasunerako.</target>
       </trans-unit>
       <trans-unit id="fv3rouy" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~Irudia hezkuntza-baliabide honen aurrebista gisa erabiliko da plataforma desberdinetan.</target>
       </trans-unit>
       <trans-unit id="gy8vvcd" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~3D molekula</target>
       </trans-unit>
       <trans-unit id="lf1xxbc" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~3D molekulak</target>
       </trans-unit>
       <trans-unit id="ixws64z" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Gehienezko zabalera (aukerakoa)</target>
       </trans-unit>
       <trans-unit id="gqy25hp" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Gehienezko altuera (aukerakoa)</target>
       </trans-unit>
       <trans-unit id="xqmdypi" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~adib. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="fah4ip8" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~Gehienezko zabaleak 0 baino handiagoa izan behar du eta px, em, rem edo % erabili (adib. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="rmd8e6b" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~Gehienezko altuerak 0 baino handiagoa izan behar du eta px, em, rem edo % erabili (adib. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="7tbw9yg" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Barkatu, hori okerra da... Erantzun zuzena hau da:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Sortu zirkuituaren aurrebista gorde aurretik</target>
       </trans-unit>
+      <trans-unit id="abw5d9e" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1sdabg7" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="20clic6" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="v39bmmd" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1chfds6" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1c1e8cz" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="k4keozg" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kzrxn2o" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wgx5u0z" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tv4qcxb" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vnfn22u" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8g7nfd9" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="agdbvob" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="swp3bly" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wvqh61v" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ndpnsli" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2xmr5dw" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qq69t0l" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fv3rouy" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gy8vvcd" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="lf1xxbc" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ixws64z" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gqy25hp" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xqmdypi" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fah4ip8" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rmd8e6b" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7tbw9yg" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Xera a vista previa do circuíto antes de gardar</target>
       </trans-unit>
+      <trans-unit id="y0zdlh4" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zlca539" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2ncvp8h" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8q309y3" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4b88rc0" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sjie3fu" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y90v18l" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="e015blm" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0h9wg2v" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="toghlps" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qag5yrf" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y1148zv" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ssoeto5" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wmwfsbc" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="iob2279" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="mcj8uyd" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="p3qert3" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c4i1yfl" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="g02kr7y" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fxba9gk" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="iryym8x" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vhh15cd" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yd8829t" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="k72g8dh" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="podawtr" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fk3eqiw" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xp2mwnx" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="y0zdlh4" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Captura de pantalla</target>
       </trans-unit>
       <trans-unit id="zlca539" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Vista previa da captura do proxecto actual</target>
       </trans-unit>
       <trans-unit id="2ncvp8h" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Aínda non hai captura de pantalla. Xerarase automaticamente ao gardar ou exportar.</target>
       </trans-unit>
       <trans-unit id="8q309y3" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Subir imaxe personalizada</target>
       </trans-unit>
       <trans-unit id="4b88rc0" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~A captura de pantalla debe ser inferior a 2 MB.</target>
       </trans-unit>
       <trans-unit id="sjie3fu" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Imaxe non válida</target>
       </trans-unit>
       <trans-unit id="y90v18l" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~A imaxe non cumpre os requisitos mínimos: relación de aspecto 16:9 e polo menos 600 píxeles de ancho.</target>
       </trans-unit>
       <trans-unit id="e015blm" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Xerar desde o contido</target>
       </trans-unit>
       <trans-unit id="0h9wg2v" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Non dispoñible</target>
       </trans-unit>
       <trans-unit id="toghlps" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~A xeración de capturas de pantalla non está dispoñible.</target>
       </trans-unit>
       <trans-unit id="qag5yrf" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Erro na xeración</target>
       </trans-unit>
       <trans-unit id="y1148zv" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Non se puido xerar a captura desde o contido. Proba a subir unha imaxe.</target>
       </trans-unit>
       <trans-unit id="ssoeto5" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Substituír captura de pantalla</target>
       </trans-unit>
       <trans-unit id="wmwfsbc" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Isto eliminará a imaxe actual. Queres continuar?</target>
       </trans-unit>
       <trans-unit id="iob2279" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Eliminar captura de pantalla</target>
       </trans-unit>
       <trans-unit id="mcj8uyd" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Eliminar a imaxe actual? Esta acción non se pode desfacer.</target>
       </trans-unit>
       <trans-unit id="p3qert3" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Recomendacións</target>
       </trans-unit>
       <trans-unit id="c4i1yfl" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Usa unha imaxe 16:9 (recoméndanse 1280×720 px) que represente claramente o contido principal do recurso educativo. Evita o desorde e o texto pequeno, e asegura un bo contraste para a lexibilidade en tamaños reducidos.</target>
       </trans-unit>
       <trans-unit id="g02kr7y" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~A imaxe utilizarase como vista previa deste recurso educativo en diferentes plataformas.</target>
       </trans-unit>
       <trans-unit id="fxba9gk" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Molécula 3D</target>
       </trans-unit>
       <trans-unit id="iryym8x" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Moléculas 3D</target>
       </trans-unit>
       <trans-unit id="vhh15cd" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Ancho máx. (opcional)</target>
       </trans-unit>
       <trans-unit id="yd8829t" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Alto máx. (opcional)</target>
       </trans-unit>
       <trans-unit id="k72g8dh" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~p. ex. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="podawtr" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~O ancho máx. debe ser maior que 0 e usar px, em, rem ou % (p. ex. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="fk3eqiw" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~O alto máx. debe ser maior que 0 e usar px, em, rem ou % (p. ex. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="xp2mwnx" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Sentímolo, é incorrecto... A resposta correcta é:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Genera l'anteprima del circuito prima di salvare</target>
       </trans-unit>
+      <trans-unit id="7yld477" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wm6h99r" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rhoia8j" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="81nz9k8" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="a1op1gs" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="silaac4" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9lt1r78" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ytq83l5" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="81g6cd4" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="avb7s0g" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="96pu2jt" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="j750z0w" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="19drqr7" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uq99owm" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zgr4mxx" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uhoxtlx" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="92x24yo" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y7snk3m" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yo1xz25" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1lt2rkz" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ban05bn" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kcdhukl" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zomf6jx" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="umky8mh" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sa0c2r8" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qkh1mdb" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="cajeqsh" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="7yld477" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Screenshot</target>
       </trans-unit>
       <trans-unit id="wm6h99r" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Anteprima dello screenshot del progetto corrente</target>
       </trans-unit>
       <trans-unit id="rhoia8j" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Nessuno screenshot ancora. Verrà generato automaticamente al salvataggio o all'esportazione.</target>
       </trans-unit>
       <trans-unit id="81nz9k8" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Carica immagine personalizzata</target>
       </trans-unit>
       <trans-unit id="a1op1gs" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~Lo screenshot deve essere inferiore a 2 MB.</target>
       </trans-unit>
       <trans-unit id="silaac4" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Immagine non valida</target>
       </trans-unit>
       <trans-unit id="9lt1r78" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~L'immagine non soddisfa i requisiti minimi: rapporto di aspetto 16:9 e almeno 600 pixel di larghezza.</target>
       </trans-unit>
       <trans-unit id="ytq83l5" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Genera dal contenuto</target>
       </trans-unit>
       <trans-unit id="81g6cd4" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Non disponibile</target>
       </trans-unit>
       <trans-unit id="avb7s0g" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~La generazione di screenshot non è disponibile.</target>
       </trans-unit>
       <trans-unit id="96pu2jt" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Generazione fallita</target>
       </trans-unit>
       <trans-unit id="j750z0w" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Impossibile generare lo screenshot dal contenuto. Prova a caricare un'immagine.</target>
       </trans-unit>
       <trans-unit id="19drqr7" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Sostituisci screenshot</target>
       </trans-unit>
       <trans-unit id="uq99owm" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Questa operazione eliminerà l'immagine corrente. Vuoi continuare?</target>
       </trans-unit>
       <trans-unit id="zgr4mxx" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Elimina screenshot</target>
       </trans-unit>
       <trans-unit id="uhoxtlx" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Eliminare l'immagine corrente? Questa azione non può essere annullata.</target>
       </trans-unit>
       <trans-unit id="92x24yo" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Raccomandazioni</target>
       </trans-unit>
       <trans-unit id="y7snk3m" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Usa un'immagine 16:9 (si consigliano 1280×720 px) che rappresenti chiaramente il contenuto principale della risorsa didattica. Evita disordine e testo piccolo, e garantisci un buon contrasto per la leggibilità a dimensioni ridotte.</target>
       </trans-unit>
       <trans-unit id="yo1xz25" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~L'immagine sarà utilizzata come anteprima di questa risorsa didattica su diverse piattaforme.</target>
       </trans-unit>
       <trans-unit id="1lt2rkz" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Molecola 3D</target>
       </trans-unit>
       <trans-unit id="ban05bn" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Molecole 3D</target>
       </trans-unit>
       <trans-unit id="kcdhukl" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Largh. max. (opzionale)</target>
       </trans-unit>
       <trans-unit id="zomf6jx" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Alt. max. (opzionale)</target>
       </trans-unit>
       <trans-unit id="umky8mh" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~es. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="sa0c2r8" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~La largh. max. deve essere maggiore di 0 e usare px, em, rem o % (es. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="qkh1mdb" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~L'alt. max. deve essere maggiore di 0 e usare px, em, rem o % (es. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="cajeqsh" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Ci dispiace, è sbagliato... La risposta corretta è:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="gds1937" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Captura de ecrã</target>
       </trans-unit>
       <trans-unit id="gvb6say" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Pré-visualização da captura de ecrã do projeto atual</target>
       </trans-unit>
       <trans-unit id="ar1o052" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Ainda não há captura de ecrã. Será gerada automaticamente ao guardar ou exportar.</target>
       </trans-unit>
       <trans-unit id="n7vm8cb" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Carregar imagem personalizada</target>
       </trans-unit>
       <trans-unit id="l2b7wyo" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~A captura de ecrã deve ser inferior a 2 MB.</target>
       </trans-unit>
       <trans-unit id="yhcb22t" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Imagem inválida</target>
       </trans-unit>
       <trans-unit id="px6z6vx" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~A imagem não cumpre os requisitos mínimos: proporção 16:9 e pelo menos 600 píxeis de largura.</target>
       </trans-unit>
       <trans-unit id="042pugn" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Gerar a partir do conteúdo</target>
       </trans-unit>
       <trans-unit id="p6wlihs" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Não disponível</target>
       </trans-unit>
       <trans-unit id="9kqifo3" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~A geração de capturas de ecrã não está disponível.</target>
       </trans-unit>
       <trans-unit id="mw2qggk" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Falha na geração</target>
       </trans-unit>
       <trans-unit id="zkwuqf2" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Não foi possível gerar a captura a partir do conteúdo. Tente carregar uma imagem.</target>
       </trans-unit>
       <trans-unit id="0yn1y64" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Substituir captura de ecrã</target>
       </trans-unit>
       <trans-unit id="40z1pkf" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Isto irá eliminar a imagem atual. Deseja continuar?</target>
       </trans-unit>
       <trans-unit id="j08r8f0" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Eliminar captura de ecrã</target>
       </trans-unit>
       <trans-unit id="e476g0j" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Eliminar a imagem atual? Esta ação não pode ser anulada.</target>
       </trans-unit>
       <trans-unit id="eoq2514" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Recomendações</target>
       </trans-unit>
       <trans-unit id="z9ct9zm" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Utilize uma imagem 16:9 (recomenda-se 1280×720 px) que represente claramente o conteúdo principal do recurso educativo. Evite desordem e texto pequeno, e garanta bom contraste para legibilidade em tamanhos reduzidos.</target>
       </trans-unit>
       <trans-unit id="4bjp14s" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~A imagem será utilizada como pré-visualização deste recurso educativo em diferentes plataformas.</target>
       </trans-unit>
       <trans-unit id="rlubesd" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Molécula 3D</target>
       </trans-unit>
       <trans-unit id="c1e91jm" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Moléculas 3D</target>
       </trans-unit>
       <trans-unit id="85w81po" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Largura máx. (opcional)</target>
       </trans-unit>
       <trans-unit id="23o1pdp" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Altura máx. (opcional)</target>
       </trans-unit>
       <trans-unit id="oxi6y24" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~ex. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="4v150w9" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~A largura máx. deve ser superior a 0 e usar px, em, rem ou % (ex. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="rblop30" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~A altura máx. deve ser superior a 0 e usar px, em, rem ou % (ex. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="qha8b5b" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Lamentamos, está incorreto... A resposta correta é:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Gera a pré-visualização do circuito antes de guardar</target>
       </trans-unit>
+      <trans-unit id="gds1937" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gvb6say" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ar1o052" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="n7vm8cb" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="l2b7wyo" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yhcb22t" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="px6z6vx" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="042pugn" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="p6wlihs" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9kqifo3" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="mw2qggk" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zkwuqf2" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0yn1y64" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="40z1pkf" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="j08r8f0" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="e476g0j" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="eoq2514" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="z9ct9zm" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4bjp14s" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rlubesd" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c1e91jm" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="85w81po" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="23o1pdp" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="oxi6y24" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4v150w9" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rblop30" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qha8b5b" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Generează previzualizarea circuitului înainte de salvare</target>
       </trans-unit>
+      <trans-unit id="67oeim1" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="egfkd32" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7gfncu2" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="j6qe17o" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="du7886u" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9ghh8cs" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fjtviff" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="jhvmhtj" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="32qsnol" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6x5jja9" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pa6zoby" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="u8lue0h" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8c2d6qj" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3eqbaf1" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qziik0s" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="72zdvo8" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pxch4ab" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="76w0thd" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="bt3odta" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3is1mdt" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="riup14d" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4bv02yj" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qohgl6u" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uyzr3cq" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7icorgp" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gxoq8hj" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="fbslxqe" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="67oeim1" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Captură de ecran</target>
       </trans-unit>
       <trans-unit id="egfkd32" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Previzualizare captură de ecran a proiectului curent</target>
       </trans-unit>
       <trans-unit id="7gfncu2" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Nu există încă o captură de ecran. Va fi generată automat la salvare sau export.</target>
       </trans-unit>
       <trans-unit id="j6qe17o" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Încarcă imagine personalizată</target>
       </trans-unit>
       <trans-unit id="du7886u" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~Captura de ecran trebuie să fie mai mică de 2 MB.</target>
       </trans-unit>
       <trans-unit id="9ghh8cs" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Imagine nevalidă</target>
       </trans-unit>
       <trans-unit id="fjtviff" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~Imaginea nu îndeplinește cerințele minime: raport de aspect 16:9 și cel puțin 600 de pixeli lățime.</target>
       </trans-unit>
       <trans-unit id="jhvmhtj" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Generează din conținut</target>
       </trans-unit>
       <trans-unit id="32qsnol" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~Indisponibil</target>
       </trans-unit>
       <trans-unit id="6x5jja9" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~Generarea capturii de ecran nu este disponibilă.</target>
       </trans-unit>
       <trans-unit id="pa6zoby" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Generare eșuată</target>
       </trans-unit>
       <trans-unit id="u8lue0h" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~Nu s-a putut genera captura din conținut. Încearcă să încarci o imagine în schimb.</target>
       </trans-unit>
       <trans-unit id="8c2d6qj" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Înlocuiește captura de ecran</target>
       </trans-unit>
       <trans-unit id="3eqbaf1" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Aceasta va șterge imaginea curentă. Dorești să continui?</target>
       </trans-unit>
       <trans-unit id="qziik0s" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Șterge captura de ecran</target>
       </trans-unit>
       <trans-unit id="72zdvo8" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Ștergi imaginea curentă? Această acțiune nu poate fi anulată.</target>
       </trans-unit>
       <trans-unit id="pxch4ab" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Recomandări</target>
       </trans-unit>
       <trans-unit id="76w0thd" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Folosește o imagine 16:9 (se recomandă 1280×720 px) care să reprezinte clar conținutul principal al resursei de învățare. Evită aglomerarea și textul mic și asigură un contrast bun pentru lizibilitate la dimensiuni mici.</target>
       </trans-unit>
       <trans-unit id="bt3odta" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~Imaginea va fi folosită ca previzualizare a acestei resurse educaționale pe diferite platforme.</target>
       </trans-unit>
       <trans-unit id="3is1mdt" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Moleculă 3D</target>
       </trans-unit>
       <trans-unit id="riup14d" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Molecule 3D</target>
       </trans-unit>
       <trans-unit id="4bv02yj" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Lăț. max. (opțional)</target>
       </trans-unit>
       <trans-unit id="qohgl6u" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Înălț. max. (opțional)</target>
       </trans-unit>
       <trans-unit id="uyzr3cq" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~ex. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="7icorgp" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~Lățimea max. trebuie să fie mai mare decât 0 și să folosească px, em, rem sau % (ex. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="gxoq8hj" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~Înălțimea max. trebuie să fie mai mare decât 0 și să folosească px, em, rem sau % (ex. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="fbslxqe" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Ne pare rău, este incorect... Răspunsul corect este:</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15357,6 +15357,114 @@
         <source>Please render the circuit preview before saving.</source>
         <target>~Genera la vista prèvia del circuit abans de guardar</target>
       </trans-unit>
+      <trans-unit id="nhub00v" resname="Screenshot">
+        <source>Screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5wutt35" resname="Current project screenshot preview">
+        <source>Current project screenshot preview</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="oxrcqlr" resname="No screenshot yet. It will be auto-generated when you save or export.">
+        <source>No screenshot yet. It will be auto-generated when you save or export.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wr21xae" resname="Upload custom image">
+        <source>Upload custom image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1itmfm4" resname="Screenshot must be smaller than 2 MB.">
+        <source>Screenshot must be smaller than 2 MB.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y0t2r4s" resname="Invalid image">
+        <source>Invalid image</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="brbv4og" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
+        <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ekn9t49" resname="Generate from content">
+        <source>Generate from content</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rdkimdz" resname="Not available">
+        <source>Not available</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="p85210k" resname="Screenshot generation is not available.">
+        <source>Screenshot generation is not available.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ztsqmyb" resname="Generation failed">
+        <source>Generation failed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="f1t4ifq" resname="Could not generate screenshot from content. Try uploading an image instead.">
+        <source>Could not generate screenshot from content. Try uploading an image instead.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sxx6qq2" resname="Replace screenshot">
+        <source>Replace screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3cjr4d1" resname="This will delete the current image. Do you want to continue?">
+        <source>This will delete the current image. Do you want to continue?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="uf2pvm8" resname="Delete screenshot">
+        <source>Delete screenshot</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6rlpmrf" resname="Delete the current image? This action cannot be undone.">
+        <source>Delete the current image? This action cannot be undone.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gy1tkjb" resname="Recommendations">
+        <source>Recommendations</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="j22o1ai" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
+        <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="x0ec2vs" resname="The image will be used as a preview of this educational resource across different platforms.">
+        <source>The image will be used as a preview of this educational resource across different platforms.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sanaf2j" resname="3D Molecule">
+        <source>3D Molecule</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kcc41ya" resname="3D Molecules">
+        <source>3D Molecules</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ijod1pb" resname="Max. width (optional)">
+        <source>Max. width (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2xhv5s3" resname="Max. height (optional)">
+        <source>Max. height (optional)</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zlp2t7q" resname="e.g. 800px, 50%, 40em, 30rem">
+        <source>e.g. 800px, 50%, 40em, 30rem</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4v8qkam" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
+        <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rb075qo" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
+        <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="k75vl4p" resname="Sorry, that&apos;s incorrect... The right answer is:">
+        <source>Sorry, that's incorrect... The right answer is:</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15359,111 +15359,111 @@
       </trans-unit>
       <trans-unit id="nhub00v" resname="Screenshot">
         <source>Screenshot</source>
-        <target></target>
+        <target>~Captura de pantalla</target>
       </trans-unit>
       <trans-unit id="5wutt35" resname="Current project screenshot preview">
         <source>Current project screenshot preview</source>
-        <target></target>
+        <target>~Previsualització de la captura del projecte actual</target>
       </trans-unit>
       <trans-unit id="oxrcqlr" resname="No screenshot yet. It will be auto-generated when you save or export.">
         <source>No screenshot yet. It will be auto-generated when you save or export.</source>
-        <target></target>
+        <target>~Encara no hi ha captura de pantalla. Es generarà automàticament en guardar o exportar.</target>
       </trans-unit>
       <trans-unit id="wr21xae" resname="Upload custom image">
         <source>Upload custom image</source>
-        <target></target>
+        <target>~Puja una imatge personalitzada</target>
       </trans-unit>
       <trans-unit id="1itmfm4" resname="Screenshot must be smaller than 2 MB.">
         <source>Screenshot must be smaller than 2 MB.</source>
-        <target></target>
+        <target>~La captura de pantalla ha de ser inferior a 2 MB.</target>
       </trans-unit>
       <trans-unit id="y0t2r4s" resname="Invalid image">
         <source>Invalid image</source>
-        <target></target>
+        <target>~Imatge no vàlida</target>
       </trans-unit>
       <trans-unit id="brbv4og" resname="The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.">
         <source>The image does not meet the minimum requirements: 16:9 aspect ratio and at least 600 pixels wide.</source>
-        <target></target>
+        <target>~La imatge no compleix els requisits mínims: relació d'aspecte 16:9 i almenys 600 píxels d'amplada.</target>
       </trans-unit>
       <trans-unit id="ekn9t49" resname="Generate from content">
         <source>Generate from content</source>
-        <target></target>
+        <target>~Genera des del contingut</target>
       </trans-unit>
       <trans-unit id="rdkimdz" resname="Not available">
         <source>Not available</source>
-        <target></target>
+        <target>~No disponible</target>
       </trans-unit>
       <trans-unit id="p85210k" resname="Screenshot generation is not available.">
         <source>Screenshot generation is not available.</source>
-        <target></target>
+        <target>~La generació de captures de pantalla no està disponible.</target>
       </trans-unit>
       <trans-unit id="ztsqmyb" resname="Generation failed">
         <source>Generation failed</source>
-        <target></target>
+        <target>~Error en la generació</target>
       </trans-unit>
       <trans-unit id="f1t4ifq" resname="Could not generate screenshot from content. Try uploading an image instead.">
         <source>Could not generate screenshot from content. Try uploading an image instead.</source>
-        <target></target>
+        <target>~No s'ha pogut generar la captura des del contingut. Prova a pujar una imatge.</target>
       </trans-unit>
       <trans-unit id="sxx6qq2" resname="Replace screenshot">
         <source>Replace screenshot</source>
-        <target></target>
+        <target>~Substituïx la captura de pantalla</target>
       </trans-unit>
       <trans-unit id="3cjr4d1" resname="This will delete the current image. Do you want to continue?">
         <source>This will delete the current image. Do you want to continue?</source>
-        <target></target>
+        <target>~Açò eliminarà la imatge actual. Vols continuar?</target>
       </trans-unit>
       <trans-unit id="uf2pvm8" resname="Delete screenshot">
         <source>Delete screenshot</source>
-        <target></target>
+        <target>~Elimina la captura de pantalla</target>
       </trans-unit>
       <trans-unit id="6rlpmrf" resname="Delete the current image? This action cannot be undone.">
         <source>Delete the current image? This action cannot be undone.</source>
-        <target></target>
+        <target>~Elimines la imatge actual? Esta acció no es pot desfer.</target>
       </trans-unit>
       <trans-unit id="gy1tkjb" resname="Recommendations">
         <source>Recommendations</source>
-        <target></target>
+        <target>~Recomanacions</target>
       </trans-unit>
       <trans-unit id="j22o1ai" resname="Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.">
         <source>Use a 16:9 image (1280×720 px recommended) that clearly represents the main content of the learning resource. Avoid clutter and small text, and ensure good contrast for readability at small sizes.</source>
-        <target></target>
+        <target>~Utilitza una imatge 16:9 (es recomanen 1280×720 px) que represente clarament el contingut principal del recurs educatiu. Evita el desordre i el text menut, i assegura un bon contrast per a la llegibilitat en grandàries reduïdes.</target>
       </trans-unit>
       <trans-unit id="x0ec2vs" resname="The image will be used as a preview of this educational resource across different platforms.">
         <source>The image will be used as a preview of this educational resource across different platforms.</source>
-        <target></target>
+        <target>~La imatge s'utilitzarà com a previsualització d'este recurs educatiu en diferents plataformes.</target>
       </trans-unit>
       <trans-unit id="sanaf2j" resname="3D Molecule">
         <source>3D Molecule</source>
-        <target></target>
+        <target>~Molècula 3D</target>
       </trans-unit>
       <trans-unit id="kcc41ya" resname="3D Molecules">
         <source>3D Molecules</source>
-        <target></target>
+        <target>~Molècules 3D</target>
       </trans-unit>
       <trans-unit id="ijod1pb" resname="Max. width (optional)">
         <source>Max. width (optional)</source>
-        <target></target>
+        <target>~Amplada màx. (opcional)</target>
       </trans-unit>
       <trans-unit id="2xhv5s3" resname="Max. height (optional)">
         <source>Max. height (optional)</source>
-        <target></target>
+        <target>~Alçada màx. (opcional)</target>
       </trans-unit>
       <trans-unit id="zlp2t7q" resname="e.g. 800px, 50%, 40em, 30rem">
         <source>e.g. 800px, 50%, 40em, 30rem</source>
-        <target></target>
+        <target>~p. ex. 800px, 50%, 40em, 30rem</target>
       </trans-unit>
       <trans-unit id="4v8qkam" resname="Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).">
         <source>Max. width must be greater than 0 and use px, em, rem, or % (e.g. 800px, 50%, 40em, 30rem).</source>
-        <target></target>
+        <target>~L'amplada màx. ha de ser superior a 0 i usar px, em, rem o % (p. ex. 800px, 50%, 40em, 30rem).</target>
       </trans-unit>
       <trans-unit id="rb075qo" resname="Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).">
         <source>Max. height must be greater than 0 and use px, em, rem, or % (e.g. 600px, 70%, 30em, 20rem).</source>
-        <target></target>
+        <target>~L'alçada màx. ha de ser superior a 0 i usar px, em, rem o % (p. ex. 600px, 70%, 30em, 20rem).</target>
       </trans-unit>
       <trans-unit id="k75vl4p" resname="Sorry, that&apos;s incorrect... The right answer is:">
         <source>Sorry, that's incorrect... The right answer is:</source>
-        <target></target>
+        <target>~Ho sentim, és incorrecte... La resposta correcta és:</target>
       </trans-unit>
     </body>
   </file>

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -50,7 +50,7 @@
                         {# Hidden to reduce Open/Import confusion (issue #1223) #}
                         <li class="d-none"><a id="navbar-button-import-elp" class="dropdown-item" href="#"><span class="small-icon import-icon-green"></span> {{ t.import_elpx or 'Import (.elpx…)' }}</a></li>
                         <li class="dropdown-divider"></li>
-                        <li><a class="dropdown-item" id="navbar-button-save-offline" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.save or 'Save' }}</a></li>
+                        <li><a class="dropdown-item" id="navbar-button-save-offline" href="#" data-shortcut="Mod+S" aria-keyshortcuts="Control+S Meta+S"><span class="small-icon save-icon-green"></span> {{ t.download or 'Download' }}</a></li>
                         {# Advanced: save the project as an unpacked folder. Hidden until Alt is held or feature flag is set. #}
                         <li class="d-none exe-folder-project-action"><a class="dropdown-item" id="navbar-button-save-folder-offline" href="#"><span class="small-icon save-icon-green"></span> {{ t.save_to_folder or 'Save to folder' }}</a></li>
                         <li class="dropdown dropend">


### PR DESCRIPTION
- Screenshot tab strings, including the Spanish translation.
- Electrical Circuits iDevice. Fix untranslated iDevice name.
- Added automated placeholder translations for new strings in incomplete translations.