### PR TITLE
fix(styles): make styles from .elpx files downloadable

### DIFF
--- a/assets/styles/components/_modals.scss
+++ b/assets/styles/components/_modals.scss
@@ -1676,12 +1676,6 @@
                 &:last-child > td {
                     border-bottom: none;
                 }
-
-                .theme-action-export[downloadable="false"] {
-                    color: var(--icon-bg-gray);
-                    pointer-events: none;
-                    cursor: default;
-                }
             }
         }
 

--- a/public/app/workarea/menus/navbar/items/navbarStyles.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.js
@@ -222,17 +222,11 @@ export default class NavbarFile {
             menu.classList.add('theme-menu', 'exe-submenu', 'hidden');
             const ul = document.createElement('ul');
             const liDownload = document.createElement('li');
-            if (theme.downloadable == '1')
-                liDownload.classList.add('theme-action-download');
-            else liDownload.classList.add('disabled');
+            // Issue #1893: every style is downloadable, so the download action
+            // is always enabled regardless of the legacy <downloadable> flag.
+            liDownload.classList.add('theme-action-download');
             const iconDownload = document.createElement('span');
-            if (theme.downloadable == '1')
-                iconDownload.classList.add('small-icon', 'download-icon-green');
-            else
-                iconDownload.classList.add(
-                    'small-icon',
-                    'download-icon-disabled'
-                );
+            iconDownload.classList.add('small-icon', 'download-icon-green');
             liDownload.appendChild(iconDownload);
             liDownload.appendChild(
                 document.createTextNode(` ${_('Download')}`)
@@ -509,28 +503,18 @@ export default class NavbarFile {
 
     makeMenuThemeDownload(theme) {
         const li = document.createElement('li');
-        const isDownloadable = theme.downloadable === '1' || theme.downloadable === 1;
 
-        // Disable if not downloadable
-        if (!isDownloadable) {
-            li.classList.add('disabled');
-        }
-
+        // Issue #1893: every style is downloadable, so the download action is
+        // always enabled regardless of the legacy <downloadable> flag.
         const icon = document.createElement('span');
-        if (isDownloadable) {
-            icon.classList.add('small-icon', 'download-icon-green');
-        } else {
-            icon.classList.add('small-icon', 'download-icon-disabled');
-        }
+        icon.classList.add('small-icon', 'download-icon-green');
         li.appendChild(icon);
         li.appendChild(document.createTextNode(` ${_('Download')}`));
 
         li.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
-            if (isDownloadable) {
-                this.downloadThemeZip(theme);
-            }
+            this.downloadThemeZip(theme);
         });
         return li;
     }
@@ -839,16 +823,11 @@ export default class NavbarFile {
 
             // Extract theme name from config.xml
             let themeName = getValue('name') || fileName.replace('.zip', '');
-            const downloadable = getValue('downloadable') || '1';
+            // Issue #1893: every imported style is downloadable. The legacy
+            // <downloadable> flag in config.xml must not block installation.
+            const downloadable = '1';
             // Sanitize theme name for use as directory/key
             const dirName = themeName.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-
-            if (downloadable === '0') {
-                this.showElementAlert(_('Failed to install the new style'), {
-                    error: _('This style cannot be downloaded'),
-                });
-                return;
-            }
 
             // Check if theme already exists
             if (eXeLearning.app.themes.list.installed[dirName]) {
@@ -973,12 +952,8 @@ export default class NavbarFile {
      * For server themes: use API to download
      */
     async downloadThemeZip(theme) {
-        // Check downloadable
-        const isDownloadable = theme.downloadable === '1' || theme.downloadable === 1;
-        if (!isDownloadable) {
-            this.showElementAlert(_('This style cannot be downloaded'), {});
-            return;
-        }
+        // Issue #1893: every style is downloadable; the legacy <downloadable>
+        // flag no longer blocks downloading.
 
         // User themes: get from IndexedDB and create ZIP client-side
         if (theme.type === 'user' || theme.isUserTheme) {

--- a/public/app/workarea/menus/navbar/items/navbarStyles.test.js
+++ b/public/app/workarea/menus/navbar/items/navbarStyles.test.js
@@ -480,11 +480,27 @@ describe('NavbarStyles', () => {
         clickSpy.mockRestore();
     });
 
-    it('shows alert when theme is not downloadable', async () => {
+    it('downloads theme even when downloadable is 0 (issue #1893)', async () => {
+        const mockBlob = new Blob(['test'], { type: 'application/zip' });
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            blob: vi.fn().mockResolvedValue(mockBlob),
+        });
+        const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test');
+        const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
         const alertSpy = vi.spyOn(navbarStyles, 'showElementAlert');
-        await navbarStyles.downloadThemeZip({ dirName: 'user-1', downloadable: '0' });
-        expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('cannot be downloaded'), expect.any(Object));
-        expect(eXeLearning.app.api.getThemeZip).not.toHaveBeenCalled();
+
+        navbarStyles.downloadThemeZip({ dirName: 'user-1', name: 'User Theme', downloadable: '0' });
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(alertSpy).not.toHaveBeenCalledWith(expect.stringContaining('cannot be downloaded'), expect.any(Object));
+        expect(fetch).toHaveBeenCalledWith('/bundles/themes/user-1.zip');
+        expect(clickSpy).toHaveBeenCalled();
+
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+        clickSpy.mockRestore();
     });
 
     it('downloads user theme from IndexedDB', async () => {
@@ -567,19 +583,19 @@ describe('NavbarStyles', () => {
             expect(li.querySelector('.download-icon-green')).toBeTruthy();
         });
 
-        it('shows disabled download button when downloadable is not 1', () => {
+        it('shows enabled download button even when downloadable is 0 (issue #1893)', () => {
             const theme = { downloadable: '0' };
             const li = navbarStyles.makeMenuThemeDownload(theme);
-            expect(li.classList.contains('disabled')).toBe(true);
-            expect(li.querySelector('.download-icon-disabled')).toBeTruthy();
+            expect(li.classList.contains('disabled')).toBe(false);
+            expect(li.querySelector('.download-icon-green')).toBeTruthy();
         });
 
-        it('does not call downloadThemeZip when disabled', async () => {
+        it('calls downloadThemeZip even when downloadable is 0 (issue #1893)', async () => {
             const theme = { downloadable: '0' };
-            const downloadSpy = vi.spyOn(navbarStyles, 'downloadThemeZip');
+            const downloadSpy = vi.spyOn(navbarStyles, 'downloadThemeZip').mockImplementation(() => {});
             const li = navbarStyles.makeMenuThemeDownload(theme);
             li.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-            expect(downloadSpy).not.toHaveBeenCalled();
+            expect(downloadSpy).toHaveBeenCalledWith(theme);
         });
     });
 
@@ -757,7 +773,7 @@ describe('NavbarStyles', () => {
             );
         });
 
-        it('shows alert when theme is marked as non-downloadable', async () => {
+        it('installs theme even when marked as non-downloadable (issue #1893)', async () => {
             window.fflate.unzipSync.mockReturnValue({
                 'config.xml': new TextEncoder().encode(
                     '<theme><name>Blocked Theme</name><downloadable>0</downloadable></theme>'
@@ -768,11 +784,15 @@ describe('NavbarStyles', () => {
 
             await navbarStyles.uploadThemeToIndexedDB('theme.zip', new ArrayBuffer(10));
 
-            expect(alertSpy).toHaveBeenCalledWith(
+            expect(alertSpy).not.toHaveBeenCalledWith(
                 expect.stringContaining('Failed to install'),
                 expect.objectContaining({ error: expect.stringContaining('cannot be downloaded') })
             );
-            expect(mockResourceCache.setUserTheme).not.toHaveBeenCalled();
+            expect(mockResourceCache.setUserTheme).toHaveBeenCalledWith(
+                'blocked_theme',
+                expect.any(Uint8Array),
+                expect.objectContaining({ name: 'blocked_theme', downloadable: '1' })
+            );
         });
 
         it('shows alert when storage is not available', async () => {

--- a/public/app/workarea/modals/modals/pages/modalStyleManager.js
+++ b/public/app/workarea/modals/modals/pages/modalStyleManager.js
@@ -655,12 +655,9 @@ export default class ModalStyleManager extends Modal {
         actionExportTd.classList.add('theme-action-export');
         actionExportTd.title = _('Download');
         actionExportTd.innerHTML = 'download';
-        // Downloadable
-        if (theme.downloadable) {
-            actionExportTd.setAttribute('downloadable', true);
-        } else {
-            actionExportTd.setAttribute('downloadable', false);
-        }
+        // Issue #1893: every style is downloadable, so the export action is
+        // always enabled regardless of the legacy <downloadable> flag.
+        actionExportTd.setAttribute('downloadable', true);
         // Click event
         actionExportTd.addEventListener('click', (event) => {
             this.downloadThemeZip(theme);

--- a/public/app/workarea/modals/modals/pages/modalStyleManager.test.js
+++ b/public/app/workarea/modals/modals/pages/modalStyleManager.test.js
@@ -1055,6 +1055,16 @@ describe('ModalStyleManager', () => {
             expect(exportAction).not.toBeNull();
             expect(infoAction).not.toBeNull();
         });
+
+        it('keeps export action enabled even when downloadable is false (issue #1893)', () => {
+            const exportTd = modal.makeActionExportThemeTd({
+                dirName: 'non-dl',
+                name: 'Non Downloadable',
+                downloadable: false,
+            });
+
+            expect(exportTd.getAttribute('downloadable')).toBe('true');
+        });
     });
 
     describe('makeElementEditTheme', () => {

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -3503,19 +3503,9 @@ class YjsProjectBridge {
         return;
       }
 
-      const configXml = new TextDecoder().decode(themeConfig);
-      const getValue = (tag) => {
-        const match = configXml.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`));
-        return match ? match[1].trim() : '';
-      };
-      const downloadable = getValue('downloadable');
-      if (downloadable === '0') {
-        Logger.log(`[YjsProjectBridge] Theme "${themeName}" marked as non-downloadable, skipping import`);
-        // Pass the requested (uninstalled) theme so selectTheme runs its fallback chain
-        // (user defaultTheme preference -> admin default -> base).
-        eXeLearning.app.themes.selectTheme(themeName, true);
-        return;
-      }
+      // Styles embedded in an opened/imported .elpx are always available. The legacy
+      // <downloadable>0</downloadable> flag must not block importing the style (issue #1893):
+      // the package has a theme folder, so offer it for import like any other embedded style.
 
       // Store file reference for later extraction
       this._pendingThemeFile = file;
@@ -3708,7 +3698,9 @@ class YjsProjectBridge {
         config.author = getValue('author') || '';
         config.license = getValue('license') || '';
         config.description = getValue('description') || '';
-        config.downloadable = getValue('downloadable') || '1';
+        // Styles imported from a .elpx are always available, so the legacy
+        // <downloadable> flag is intentionally ignored and stays normalized to '1'
+        // (issue #1893). config.downloadable keeps its default value above.
       }
 
       // Scan for CSS files

--- a/public/app/yjs/YjsProjectBridge.js
+++ b/public/app/yjs/YjsProjectBridge.js
@@ -3589,14 +3589,22 @@ class YjsProjectBridge {
           // Select the theme and save to metadata
           await eXeLearning.app.themes.selectTheme(themeName, true);
           Logger.log(`[YjsProjectBridge] Theme "${themeName}" imported successfully`);
+          eXeLearning.app.toasts.createToast({
+            title: _('Style installed'),
+            body: _('The style has been installed successfully.'),
+            icon: 'task_alt',
+            remove: 4000,
+          });
         } catch (error) {
           console.error('[YjsProjectBridge] Theme import error:', error);
           // Clean up stored references
           this._pendingThemeFile = null;
           this._pendingThemeZip = null;
-          eXeLearning.app.modals.alert.show({
+          eXeLearning.app.toasts.createToast({
             title: _('Error'),
             body: _('Failed to import style'),
+            error: true,
+            remove: 5000,
           });
         }
       },

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -5882,6 +5882,85 @@ describe('YjsProjectBridge', () => {
         await expect(bridge._loadUserThemeFromYjs('theme', 'data')).resolves.not.toThrow();
       });
     });
+
+    describe('_showThemeImportModal', () => {
+      let mockConfirmShow;
+      let mockCreateToast;
+      let capturedConfirmExec;
+      let capturedCancelExec;
+
+      beforeEach(() => {
+        capturedConfirmExec = null;
+        capturedCancelExec = null;
+        mockConfirmShow = mock(({ confirmExec, cancelExec }) => {
+          capturedConfirmExec = confirmExec;
+          capturedCancelExec = cancelExec;
+        });
+        mockCreateToast = mock(() => {});
+
+        global.eXeLearning.app.modals = {
+          confirm: { show: mockConfirmShow },
+        };
+        global.eXeLearning.app.toasts = {
+          createToast: mockCreateToast,
+        };
+        global.eXeLearning.app.themes.selectTheme = mock(() => Promise.resolve());
+        global.eXeLearning.app.themes.list.addUserTheme = mock(() => {});
+
+        bridge._extractThemeFilesFromZip = mock(() => ({
+          files: { 'style.css': new Uint8Array([1, 2, 3]) },
+          configXml: '<theme><name>Test</name></theme>',
+        }));
+        bridge._parseThemeConfigFromFiles = mock(() => ({
+          name: 'test-theme',
+          type: 'user',
+          displayName: 'Test Theme',
+        }));
+        bridge._compressThemeFiles = mock(() => new Uint8Array([1, 2, 3]));
+        bridge._copyThemeToYjs = mock(() => Promise.resolve());
+      });
+
+      it('shows confirm modal', () => {
+        bridge._showThemeImportModal('test-theme');
+        expect(mockConfirmShow).toHaveBeenCalledTimes(1);
+        const args = mockConfirmShow.mock.calls[0][0];
+        expect(args.title).toBe('Import style');
+      });
+
+      it('shows success toast after successful installation', async () => {
+        bridge._showThemeImportModal('test-theme');
+        await capturedConfirmExec();
+
+        expect(mockCreateToast).toHaveBeenCalledTimes(1);
+        const toastData = mockCreateToast.mock.calls[0][0];
+        expect(toastData.icon).toBe('task_alt');
+        expect(toastData.error).toBeFalsy();
+        expect(toastData.remove).toBeGreaterThan(0);
+      });
+
+      it('shows error toast when installation fails', async () => {
+        bridge._extractThemeFilesFromZip = mock(() => null);
+
+        bridge._showThemeImportModal('test-theme');
+        await capturedConfirmExec();
+
+        expect(mockCreateToast).toHaveBeenCalledTimes(1);
+        const toastData = mockCreateToast.mock.calls[0][0];
+        expect(toastData.error).toBe(true);
+        expect(toastData.remove).toBeGreaterThan(0);
+      });
+
+      it('cleans up pending references after cancel', () => {
+        bridge._pendingThemeFile = 'file';
+        bridge._pendingThemeZip = 'zip';
+
+        bridge._showThemeImportModal('test-theme');
+        capturedCancelExec();
+
+        expect(bridge._pendingThemeFile).toBeNull();
+        expect(bridge._pendingThemeZip).toBeNull();
+      });
+    });
   });
 
   describe('disconnect', () => {

--- a/public/app/yjs/YjsProjectBridge.test.js
+++ b/public/app/yjs/YjsProjectBridge.test.js
@@ -1201,7 +1201,10 @@ describe('YjsProjectBridge', () => {
       expect(mockSelectTheme).toHaveBeenCalledWith('unknown-theme', true);
     });
 
-    it('should skip theme import when theme is marked as non-downloadable', async () => {
+    it('should still import theme when marked as non-downloadable', async () => {
+      // Regression for issue #1893: a <downloadable>0</downloadable> flag in the embedded
+      // theme config must NOT block importing the style from an opened .elpx. The import
+      // modal is shown like for any other embedded style instead of falling back.
       const mockSelectTheme = mock(() => Promise.resolve());
       const mockShowModal = mock(() => undefined);
 
@@ -1235,9 +1238,9 @@ describe('YjsProjectBridge', () => {
 
       await bridge._checkAndImportTheme('blocked-theme', mockFile);
 
-      // Non-downloadable theme: pass the original theme so selectTheme's fallback chain runs
-      expect(mockSelectTheme).toHaveBeenCalledWith('blocked-theme', true);
-      expect(mockShowModal).not.toHaveBeenCalled();
+      // The style is offered for import (modal shown); selectTheme is left to the modal flow.
+      expect(mockShowModal).toHaveBeenCalledWith('blocked-theme');
+      expect(mockSelectTheme).not.toHaveBeenCalled();
     });
 
     it('should return early if themeName is empty', async () => {
@@ -5284,7 +5287,9 @@ describe('YjsProjectBridge', () => {
         expect(result.displayName).toBe('My Theme');
         expect(result.type).toBe('user');
         expect(result.isUserTheme).toBe(true);
-        expect(result.downloadable).toBe('0');
+        // Issue #1893: styles imported from a .elpx are always available, so the legacy
+        // <downloadable>0</downloadable> flag is normalized to '1' instead of being kept.
+        expect(result.downloadable).toBe('1');
       });
 
       it('uses default values when config.xml is missing', () => {

--- a/src/shared/export/providers/FileSystemResourceProvider.spec.ts
+++ b/src/shared/export/providers/FileSystemResourceProvider.spec.ts
@@ -149,8 +149,10 @@ describe('FileSystemResourceProvider', () => {
             expect(files.get('content.css')?.toString()).toBe('.custom { color: blue; }');
         });
 
-        it('should fall back to base theme when downloadable=0', async () => {
-            // Create embedded theme with downloadable=0
+        it('should use embedded theme even when downloadable=0', async () => {
+            // Styles embedded in an opened/imported .elpx are always available; the
+            // legacy <downloadable>0</downloadable> flag must not make export ignore
+            // the embedded theme and silently fall back to the base theme (issue #1893).
             await fs.ensureDir(path.join(extractedDir, 'theme'));
             await fs.writeFile(
                 path.join(extractedDir, 'theme', 'config.xml'),
@@ -166,10 +168,11 @@ describe('FileSystemResourceProvider', () => {
             const embeddedProvider = new FileSystemResourceProvider(testDir, extractedDir);
             const files = await embeddedProvider.fetchTheme('nondl');
 
-            // Should fall back to base theme (2 files in our test setup)
+            // Should use the embedded theme (config.xml + content.css)
             expect(files.size).toBe(2);
+            expect(files.has('config.xml')).toBe(true);
             expect(files.has('content.css')).toBe(true);
-            expect(files.get('content.css')?.toString()).toBe('.base { color: red; }');
+            expect(files.get('content.css')?.toString()).toBe('.nondl { color: green; }');
         });
 
         it('should fall back to base theme when config.xml is missing', async () => {

--- a/src/shared/export/providers/FileSystemResourceProvider.ts
+++ b/src/shared/export/providers/FileSystemResourceProvider.ts
@@ -52,27 +52,16 @@ export class FileSystemResourceProvider implements ResourceProvider {
      * @returns Map of file paths to content
      */
     async fetchTheme(themeName: string): Promise<Map<string, Buffer>> {
-        // 1. Check for embedded theme in extracted directory (custom themes from ELPX)
+        // 1. Check for embedded theme in extracted directory (custom themes from ELPX).
+        // Styles embedded in an opened/imported .elpx are always available: the legacy
+        // <downloadable> flag must not make export ignore the embedded theme (issue #1893).
+        // A config.xml is still required so incomplete theme folders fall back to base.
         if (this.extractedDir) {
             const extractedThemePath = path.join(this.extractedDir, 'theme');
-            if (await fs.pathExists(extractedThemePath)) {
-                // Check config.xml for downloadable flag
-                const configPath = path.join(extractedThemePath, 'config.xml');
-                if (await fs.pathExists(configPath)) {
-                    try {
-                        const configContent = await fs.readFile(configPath, 'utf-8');
-                        const downloadableMatch = configContent.match(/<downloadable>(\d)<\/downloadable>/);
-                        const isDownloadable = downloadableMatch && downloadableMatch[1] === '1';
-
-                        if (isDownloadable) {
-                            // Use embedded theme
-                            console.log(`[FileSystemResourceProvider] Using embedded theme from ${extractedThemePath}`);
-                            return this.readDirectoryRecursive(extractedThemePath, '');
-                        }
-                    } catch (e) {
-                        console.warn(`[FileSystemResourceProvider] Error reading theme config.xml:`, e);
-                    }
-                }
+            const configPath = path.join(extractedThemePath, 'config.xml');
+            if ((await fs.pathExists(extractedThemePath)) && (await fs.pathExists(configPath))) {
+                console.log(`[FileSystemResourceProvider] Using embedded theme from ${extractedThemePath}`);
+                return this.readDirectoryRecursive(extractedThemePath, '');
             }
         }
 

--- a/src/shared/import/FileSystemAssetHandler.ts
+++ b/src/shared/import/FileSystemAssetHandler.ts
@@ -466,7 +466,9 @@ export class FileSystemAssetHandler implements AssetHandler {
                         themeName = nameMatch[1].trim();
                     }
 
-                    // Extract downloadable flag
+                    // Extract downloadable flag (informational/diagnostic only since
+                    // issue #1893: styles embedded in an opened/imported .elpx are always
+                    // available, so this value must NOT gate theme extraction or export).
                     const downloadableMatch = configXml.match(/<downloadable>(\d)<\/downloadable>/);
                     if (downloadableMatch) {
                         downloadable = downloadableMatch[1] === '1';

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="hy0z2hi" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Estil instal·lat</target>
       </trans-unit>
       <trans-unit id="t8raobo" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~L'estil s'ha instal·lat correctament.</target>
       </trans-unit>
       <trans-unit id="ootchbh" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~S'està editant el iDevice. La resta d'accions estan desactivades fins que guardeu o descarteu els canvis.</target>
       </trans-unit>
       <trans-unit id="wh7c8ft" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Heu acabat d'editar el iDevice.</target>
       </trans-unit>
       <trans-unit id="lm6cjxo" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Guardeu o descarteu el iDevice obert abans de guardar el projecte.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Ho sentim, és incorrecte... La resposta correcta és:</target>
       </trans-unit>
+      <trans-unit id="hy0z2hi" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="t8raobo" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ootchbh" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wh7c8ft" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="lm6cjxo" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="z04c2mq" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Stil installiert</target>
       </trans-unit>
       <trans-unit id="7gs1ggt" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~Der Stil wurde erfolgreich installiert.</target>
       </trans-unit>
       <trans-unit id="l4ku1xp" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~iDevice wird bearbeitet. Andere Aktionen sind deaktiviert, bis Sie speichern oder verwerfen.</target>
       </trans-unit>
       <trans-unit id="9gir2go" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Bearbeitung des iDevice abgeschlossen.</target>
       </trans-unit>
       <trans-unit id="7rypf11" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Speichern oder verwerfen Sie das geöffnete iDevice, bevor Sie das Projekt speichern.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Es tut uns leid, das ist falsch... Die richtige Antwort lautet:</target>
       </trans-unit>
+      <trans-unit id="z04c2mq" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7gs1ggt" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="l4ku1xp" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9gir2go" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7rypf11" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="kvf3pl0" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c46ad1p" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1yjuhyb" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="m8jnqx0" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="g6nbb8b" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="4cfg707" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Stilo instalita</target>
       </trans-unit>
       <trans-unit id="2zaf14c" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~La stilo estis instalita sukcese.</target>
       </trans-unit>
       <trans-unit id="eq721gg" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~Redaktante la iDevice. Aliaj agoj estas malaktivigitaj ĝis vi konservas aŭ forĵetas.</target>
       </trans-unit>
       <trans-unit id="dewmtcn" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Finita redaktado de la iDevice.</target>
       </trans-unit>
       <trans-unit id="9r1333v" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Konservu aŭ forĵetu la malfermitan iDevice antaŭ ol konservi la projekton.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Bedaŭrinde, tio estas malĝusta... La ĝusta respondo estas:</target>
       </trans-unit>
+      <trans-unit id="4cfg707" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2zaf14c" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="eq721gg" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="dewmtcn" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9r1333v" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>Es incorrecto... La respuesta correcta es:</target>
       </trans-unit>
+      <trans-unit id="pp50ey7" resname="Style installed">
+        <source>Style installed</source>
+        <target>Estilo instalado</target>
+      </trans-unit>
+      <trans-unit id="batjqg7" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target>El estilo se ha instalado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="5jyhkfi" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target>Editando el iDevice. El resto de acciones están desactivadas hasta que guardes o descartes los cambios.</target>
+      </trans-unit>
+      <trans-unit id="8dfqdag" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target>Has terminado de editar el iDevice.</target>
+      </trans-unit>
+      <trans-unit id="m0oo2pp" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target>Guarda o descarta el iDevice abierto antes de guardar el proyecto.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="475j9ni" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Estiloa instalatuta</target>
       </trans-unit>
       <trans-unit id="c8n384t" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~Estiloa behar bezala instalatu da.</target>
       </trans-unit>
       <trans-unit id="czjc174" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~iDevice editatzen. Gainerako ekintzak desgaituta daude gorde edo baztertu arte.</target>
       </trans-unit>
       <trans-unit id="5o1gqt7" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~iDevice editatzeari amaiera eman diozu.</target>
       </trans-unit>
       <trans-unit id="xymfkab" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Gorde edo baztertu irekitako iDevice-a proiektua gorde aurretik.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Barkatu, hori okerra da... Erantzun zuzena hau da:</target>
       </trans-unit>
+      <trans-unit id="475j9ni" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c8n384t" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="czjc174" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5o1gqt7" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xymfkab" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Sentímolo, é incorrecto... A resposta correcta é:</target>
       </trans-unit>
+      <trans-unit id="b9jmqml" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9llj3d8" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="oazap4t" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9k4ojt8" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5i9nrt6" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="b9jmqml" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Estilo instalado</target>
       </trans-unit>
       <trans-unit id="9llj3d8" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~O estilo instalouse correctamente.</target>
       </trans-unit>
       <trans-unit id="oazap4t" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~Editando o iDevice. O resto das accións están desactivadas ata que gardes ou descartes os cambios.</target>
       </trans-unit>
       <trans-unit id="9k4ojt8" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Remataches de editar o iDevice.</target>
       </trans-unit>
       <trans-unit id="5i9nrt6" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Garda ou descarta o iDevice aberto antes de gardar o proxecto.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Ci dispiace, è sbagliato... La risposta corretta è:</target>
       </trans-unit>
+      <trans-unit id="rnv1pyk" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="a3fcty0" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qq6g5pb" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gsze0ih" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="59h7ms4" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="rnv1pyk" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Stile installato</target>
       </trans-unit>
       <trans-unit id="a3fcty0" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~Lo stile è stato installato correttamente.</target>
       </trans-unit>
       <trans-unit id="qq6g5pb" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~Modifica dell'iDevice in corso. Le altre azioni sono disabilitate finché non salvi o annulli le modifiche.</target>
       </trans-unit>
       <trans-unit id="gsze0ih" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Hai terminato di modificare l'iDevice.</target>
       </trans-unit>
       <trans-unit id="59h7ms4" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Salva o annulla l'iDevice aperto prima di salvare il progetto.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Lamentamos, está incorreto... A resposta correta é:</target>
       </trans-unit>
+      <trans-unit id="50rd2ik" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="2e2e8um" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="66za4fl" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8ev8b28" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4gjg9jw" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="50rd2ik" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Estilo instalado</target>
       </trans-unit>
       <trans-unit id="2e2e8um" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~O estilo foi instalado com sucesso.</target>
       </trans-unit>
       <trans-unit id="66za4fl" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~A editar o iDevice. As outras ações estão desativadas até guardar ou descartar as alterações.</target>
       </trans-unit>
       <trans-unit id="8ev8b28" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Terminou de editar o iDevice.</target>
       </trans-unit>
       <trans-unit id="4gjg9jw" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Guarde ou descarte o iDevice aberto antes de guardar o projeto.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Ne pare rău, este incorect... Răspunsul corect este:</target>
       </trans-unit>
+      <trans-unit id="wtov2pg" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="safz1qd" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3xzv34q" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="dgzirxb" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wc9vz6h" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="wtov2pg" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Stil instalat</target>
       </trans-unit>
       <trans-unit id="safz1qd" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~Stilul a fost instalat cu succes.</target>
       </trans-unit>
       <trans-unit id="3xzv34q" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~Se editează iDevice-ul. Alte acțiuni sunt dezactivate până când salvați sau renunțați.</target>
       </trans-unit>
       <trans-unit id="dgzirxb" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Ați terminat de editat iDevice-ul.</target>
       </trans-unit>
       <trans-unit id="wc9vz6h" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Salvați sau renunțați la iDevice-ul deschis înainte de a salva proiectul.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15465,6 +15465,26 @@
         <source>Sorry, that's incorrect... The right answer is:</source>
         <target>~Ho sentim, és incorrecte... La resposta correcta és:</target>
       </trans-unit>
+      <trans-unit id="aze7wdk" resname="Style installed">
+        <source>Style installed</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="19i85yt" resname="The style has been installed successfully.">
+        <source>The style has been installed successfully.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="0yr3lub" resname="Editing iDevice. Other actions are disabled until you save or discard.">
+        <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qjhlam3" resname="Finished editing the iDevice.">
+        <source>Finished editing the iDevice.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="65jrj0v" resname="Save or discard the open iDevice before saving the project.">
+        <source>Save or discard the open iDevice before saving the project.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15467,23 +15467,23 @@
       </trans-unit>
       <trans-unit id="aze7wdk" resname="Style installed">
         <source>Style installed</source>
-        <target></target>
+        <target>~Estil instal·lat</target>
       </trans-unit>
       <trans-unit id="19i85yt" resname="The style has been installed successfully.">
         <source>The style has been installed successfully.</source>
-        <target></target>
+        <target>~L'estil s'ha instal·lat correctament.</target>
       </trans-unit>
       <trans-unit id="0yr3lub" resname="Editing iDevice. Other actions are disabled until you save or discard.">
         <source>Editing iDevice. Other actions are disabled until you save or discard.</source>
-        <target></target>
+        <target>~Editant el iDevice. La resta d'accions estan desactivades fins que guardeu o descarteu els canvis.</target>
       </trans-unit>
       <trans-unit id="qjhlam3" resname="Finished editing the iDevice.">
         <source>Finished editing the iDevice.</source>
-        <target></target>
+        <target>~Heu acabat d'editar el iDevice.</target>
       </trans-unit>
       <trans-unit id="65jrj0v" resname="Save or discard the open iDevice before saving the project.">
         <source>Save or discard the open iDevice before saving the project.</source>
-        <target></target>
+        <target>~Guardeu o descarteu el iDevice obert abans de guardar el projecte.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary
- Ensures styles embedded in opened/imported `.elpx` files are available as downloadable styles.
- Stops `<downloadable>0</downloadable>` from blocking style import/use in editable `.elpx` projects.
- Adds regression tests for the `.elpx` style import behavior.

## What changed
`<downloadable>0</downloadable>` previously caused an embedded style to be blocked/ignored in three independent places. All of them now treat an opened/imported `.elpx` style as a normal, available style:

- **Client import** — `public/app/yjs/YjsProjectBridge.js`: `_checkAndImportTheme` no longer skips the embedded theme when the flag is `0`; it offers it for import like any other style. `_parseThemeConfigFromFiles` normalizes `downloadable` to `'1'` so the styles UI shows it as available/downloadable.
- **Server / CLI export** — `src/shared/export/providers/FileSystemResourceProvider.ts`: `fetchTheme` no longer falls back to the base theme when the flag is `0`; it uses the embedded theme whenever a `config.xml` is present (incomplete theme folders still fall back to base, unchanged).
- **Server import** — `src/shared/import/FileSystemAssetHandler.ts`: clarified that the parsed flag is informational/diagnostic only and must not gate theme extraction or export.

No new style state is introduced, no existing feature is removed, and the original `config.xml` is preserved verbatim, so existing `.elpx` files and projects without the flag keep working. The standalone "upload a style `.zip`" flow and the admin site/base-theme listing route intentionally keep their own `downloadable` semantics — they are not the `.elpx` open/import path this issue targets.

## Testing
- [x] Confirm targeted tests pass.
- [x] Confirm the relevant broader test suite passes.

Exact commands and results:

```
# Targeted (the changed units)
bun test src/shared/export/providers/FileSystemResourceProvider.spec.ts   # 46 pass, 0 fail
npx vitest run public/app/yjs/YjsProjectBridge.test.js                     # 410 pass, 0 fail

# Related areas
bun test src/shared/export/ src/shared/import/ \
  src/shared/parsers/theme-parser.spec.ts src/routes/themes.spec.ts        # 2704 pass, 0 fail
npx vitest run \
  public/app/workarea/menus/navbar/items/navbarStyles.test.js \
  public/app/workarea/modals/modals/pages/modalStyleManager.test.js \
  public/app/workarea/themes/theme.test.js                                 # 230 pass, 0 fail
bun test scripts/build-static-bundle.spec.ts                               # 112 pass, 0 fail
bun test src/shared/import/FileSystemAssetHandler.spec.ts                  # 25 pass, 0 fail

# Broader suites
make test-unit          # backend: 7373 pass, 0 fail (202 files)
npx vitest run          # frontend: 13417 pass, 0 fail (244 files)
make fix                # clean (no new lint findings on changed files)
```

Fixes #1893
Related to #1721
