### PR TITLE
fix(export): show SCORM 1.2 version in export option

### DIFF
--- a/src/services/template.spec.ts
+++ b/src/services/template.spec.ts
@@ -311,4 +311,34 @@ describe('Template Service', () => {
             expect(typeof result).toBe('string');
         });
     });
+
+    describe('workarea navbar export menu labels (#1760)', () => {
+        // Extract the visible text of the anchor identified by `id` from rendered HTML.
+        const anchorText = (html: string, id: string): string | null => {
+            const match = html.match(new RegExp(`id="${id}"[^>]*>([^<]*)<`));
+            return match ? match[1].trim() : null;
+        };
+
+        it('shows the SCORM version on the "Download as" SCORM 1.2 option', () => {
+            const html = renderTemplate('workarea/menus/menuNavbar', { config: {}, t: {} });
+            expect(anchorText(html, 'navbar-button-export-scorm12')).toBe('SCORM (1.2)');
+        });
+
+        it('shows the SCORM version on the offline "Export as" SCORM 1.2 option', () => {
+            const html = renderTemplate('workarea/menus/menuNavbar', {
+                config: { isOfflineInstallation: true },
+                t: {},
+            });
+            expect(anchorText(html, 'navbar-button-exportas-scorm12')).toBe('SCORM (1.2)');
+        });
+
+        it('leaves the SCORM 2004 option labels unchanged', () => {
+            const html = renderTemplate('workarea/menus/menuNavbar', {
+                config: { isOfflineInstallation: true },
+                t: {},
+            });
+            expect(anchorText(html, 'navbar-button-export-scorm2004')).toBe('SCORM 2004');
+            expect(anchorText(html, 'navbar-button-exportas-scorm2004')).toBe('SCORM 2004');
+        });
+    });
 });

--- a/test/e2e/playwright/specs/export-scorm-label.spec.ts
+++ b/test/e2e/playwright/specs/export-scorm-label.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { gotoWorkarea, waitForAppReady } from '../helpers/workarea-helpers';
+import type { Page } from '@playwright/test';
+
+/**
+ * E2E: SCORM export option label (issue #1760)
+ *
+ * The export menu must show the SCORM version next to the option so users can
+ * tell SCORM 1.2 apart from SCORM 2004. The SCORM 1.2 entry must read
+ * "SCORM (1.2)". This is a label-only change: the option ids and export
+ * behavior are unchanged. The SCORM 2004 label is asserted separately in the
+ * fast server-render unit test (src/services/template.spec.ts).
+ */
+
+/**
+ * Open the File menu and reveal the export submenu so its options are visible.
+ * Works in both online (Download as…) and offline (Export as…) layouts.
+ */
+async function openExportSubmenu(page: Page): Promise<void> {
+    await page.locator('#dropdownFile').click();
+    await page
+        .locator('#dropdownFile[aria-expanded="true"], .dropdown-menu.show')
+        .first()
+        .waitFor({ state: 'visible', timeout: 5000 });
+
+    const exportSubmenuToggle = page.locator('#dropdownExportAs:visible, #dropdownExportAsOffline:visible').first();
+    await exportSubmenuToggle.waitFor({ state: 'visible', timeout: 5000 });
+    await exportSubmenuToggle.click();
+}
+
+test.describe('Export menu SCORM label (#1760)', () => {
+    test('shows the SCORM 1.2 export option as "SCORM (1.2)"', async ({ authenticatedPage, createProject }) => {
+        const page = authenticatedPage;
+
+        const projectUuid = await createProject(page, 'SCORM export label #1760');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        await openExportSubmenu(page);
+
+        const scorm12Option = page
+            .locator('#navbar-button-export-scorm12:visible, #navbar-button-exportas-scorm12:visible')
+            .first();
+        await scorm12Option.waitFor({ state: 'visible', timeout: 5000 });
+        await expect(scorm12Option).toHaveText('SCORM (1.2)');
+    });
+});

--- a/views/workarea/menus/menuNavbar.njk
+++ b/views/workarea/menus/menuNavbar.njk
@@ -35,7 +35,7 @@
                             <li><a class="dropdown-item exe-advanced" id="navbar-button-download-project" href="#">{{ t.exelearning_content or 'eXeLearning content (.elpx)' }}</a></li>
                             <li><a id="navbar-button-export-html5" class="dropdown-item" href="#">{{ t.website or 'Website' }}</a></li>
                             <li><a id="navbar-button-export-html5-sp" class="dropdown-item" href="#">{{ t.single_page or 'Single page' }}</a></li>
-                            <li><a id="navbar-button-export-scorm12" class="dropdown-item" href="#">SCORM 1.2</a></li>
+                            <li><a id="navbar-button-export-scorm12" class="dropdown-item" href="#">SCORM (1.2)</a></li>
                             <li class="d-none"><a id="navbar-button-export-scorm2004" class="dropdown-item" href="#">SCORM 2004</a></li>
                             <li><a id="navbar-button-export-ims" class="dropdown-item exe-advanced" href="#">IMS CP</a></li>
                             <li><a id="navbar-button-export-epub3" class="dropdown-item" href="#">ePub3</a></li>
@@ -59,7 +59,7 @@
                                 <li><a id="navbar-button-exportas-html5" class="dropdown-item" href="#">{{ t.website or 'Website' }}</a></li>
                                 <li><a id="navbar-button-exportas-html5-folder" class="dropdown-item" href="#">{{ t.export_to_folder or 'Export to Folder (Unzipped Website)' }}</a></li>
                                 <li><a id="navbar-button-exportas-html5-sp" class="dropdown-item" href="#">{{ t.single_page or 'Single page' }}</a></li>
-                                <li><a id="navbar-button-exportas-scorm12" class="dropdown-item" href="#">SCORM 1.2</a></li>
+                                <li><a id="navbar-button-exportas-scorm12" class="dropdown-item" href="#">SCORM (1.2)</a></li>
                                 <li class="d-none"><a id="navbar-button-exportas-scorm2004" class="dropdown-item" href="#">SCORM 2004</a></li>
                                 <li><a id="navbar-button-exportas-ims" class="dropdown-item exe-advanced" href="#">IMS CP</a></li>
                                 <li><a id="navbar-button-exportas-epub3" class="dropdown-item" href="#">ePub3</a></li>


### PR DESCRIPTION
## Summary
- Shows the SCORM version in the File → Export menu so users can tell SCORM 1.2 apart from SCORM 2004. The SCORM 1.2 export option now reads `SCORM (1.2)` (issue asked for `"SCORM (1.2)" instead of "SCORM"`). It previously rendered `SCORM 1.2`.
- Label-only change in `views/workarea/menus/menuNavbar.njk` (both the "Download as…" and offline "Export as…" menus). Option ids (`navbar-button-export-scorm12`, `navbar-button-exportas-scorm12`), internal export type keys, routes, exporters and export behavior are all unchanged.
- The hidden SCORM 2004 entries (`SCORM 2004`) are intentionally left untouched.
- Adds regression coverage for the visible export option label.

## Testing
Developed with TDD (failing test first, then the minimal template change).

Commands run:

- `bun test src/services/template.spec.ts` → **45 pass, 0 fail**
  Renders the real `menuNavbar.njk` server-side and asserts the SCORM 1.2 options read `SCORM (1.2)` while the SCORM 2004 options stay `SCORM 2004`. Watched it go red (`Expected: "SCORM (1.2)" / Received: "SCORM 1.2"`) before the fix, green after.
- `npx vitest run public/app/workarea/menus/navbar/menuNavbar.test.js public/app/workarea/menus/navbar/items/navbarFile.test.js` → **212 pass** (navbar menu JS unaffected).
- `bun test test/integration/export/scorm12-exporter.spec.ts test/integration/export/scorm2004-exporter.spec.ts` → **33 pass, 0 fail** (export behavior unchanged).
- `bun test src/services/template.spec.ts src/routes/pages.spec.ts` → **131 pass, 0 fail** (full workarea page render including the menu still works).
- `make fix` → clean (only one pre-existing, unrelated `noExplicitAny` warning in `src/routes/export.ts`, not part of this change).

E2E spec added: `test/e2e/playwright/specs/export-scorm-label.spec.ts` opens File → Export and asserts the visible option reads `SCORM (1.2)`. It could not be executed in the local sandbox (the Playwright chromium binary extracts incompletely here — the Chrome framework binary is missing), so it is expected to run in CI:

```
bun x playwright test --project=chromium test/e2e/playwright/specs/export-scorm-label.spec.ts
```

Fixes #1760
