### PR TITLE
feat(ai): add configurable providers for game generation

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -261,3 +261,41 @@ CLEANUP_UNSAVED_AGE_HOURS=24
 # Age in days after which guest user projects are deleted (default: 7)
 CLEANUP_GUEST_AGE_DAYS=7
 ###< Project Cleanup Settings ###
+
+###> AI Configuration ###
+# Controls how AI assistance is offered in game-generation activities.
+# These values are DEFAULTS; administrators can override them at runtime from
+# the admin panel "AI" tab (stored in app_settings, which takes precedence).
+# API keys are never exposed to the frontend.
+
+# Master switch. When false, all AI buttons and AI preferences are hidden.
+AI_FEATURES_ENABLED=true
+
+# Provider mode: external | azure | ollama | openai_compat
+#  - external      : keep the public AI assistant links (ChatGPT, Claude, ...).
+#  - azure/ollama/openai_compat : eXeLearning generates questions server-side
+#    through the configured provider; the public AI options are hidden.
+# Invalid values fall back to "external" (fail-safe).
+AI_PROVIDER=external
+
+# Azure OpenAI (used when AI_PROVIDER=azure)
+AI_AZURE_ENDPOINT=
+AI_AZURE_API_KEY=
+AI_AZURE_DEPLOYMENT=
+AI_AZURE_API_VERSION=
+
+# Ollama (used when AI_PROVIDER=ollama). Endpoint defaults to a local instance.
+AI_OLLAMA_ENDPOINT=http://localhost:11434
+AI_OLLAMA_MODEL=
+
+# OpenAI-compatible endpoint (used when AI_PROVIDER=openai_compat).
+# AI_COMPAT_API_KEY is optional (some self-hosted gateways are unauthenticated).
+AI_COMPAT_ENDPOINT=
+AI_COMPAT_API_KEY=
+AI_COMPAT_MODEL=
+
+# Generation options (managed providers only)
+AI_REQUEST_TIMEOUT_MS=60000
+AI_MAX_OUTPUT_TOKENS=4096
+AI_TEMPERATURE=0.2
+###< AI Configuration ###

--- a/.env.dist
+++ b/.env.dist
@@ -268,7 +268,9 @@ CLEANUP_GUEST_AGE_DAYS=7
 # the admin panel "AI" tab (stored in app_settings, which takes precedence).
 # API keys are never exposed to the frontend.
 
-# Master switch. When false, all AI buttons and AI preferences are hidden.
+# Master switch. When false, the AI tab stays visible in copy-only form (prompt +
+# Copy) but the provider selector, "Send to AI", the managed Generate surface and
+# the defaultAI preference are all hidden, and the server endpoint refuses to run.
 AI_FEATURES_ENABLED=true
 
 # Provider mode: external | azure | ollama | openai_compat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,7 @@ Domain-specific guidance lives in `.agents/skills/*/SKILL.md`.
 | Real-time/Yjs | [doc/development/real-time.md](doc/development/real-time.md) |
 | REST API v1 | [doc/development/rest-api.md](doc/development/rest-api.md) |
 | Embedding in LMS | [doc/development/embedding.md](doc/development/embedding.md) |
+| AI configuration | [doc/development/ai-configuration.md](doc/development/ai-configuration.md) |
 | Profiling | [doc/development/profiling.md](doc/development/profiling.md) |
 | Styles/Themes | [doc/development/styles.md](doc/development/styles.md) |
 | Conventions | [doc/conventions.md](doc/conventions.md) |

--- a/doc/development/ai-configuration.md
+++ b/doc/development/ai-configuration.md
@@ -1,0 +1,136 @@
+# AI Configuration
+
+eXeLearning offers AI assistance when authoring **game-generation iDevices**
+(quizzes, identify, classify, ...). This page explains how to control which AI
+options users see and, optionally, how to route generation through your own
+server-side AI provider instead of public assistants.
+
+The design follows the separation of concerns of Moodle's AI subsystem (without
+reusing its code):
+
+- **Placement** — where AI appears in the UI (the game-generation editor).
+- **Action** — what is requested (generate questions).
+- **Provider** — who executes the request (Azure OpenAI, Ollama, an
+  OpenAI-compatible endpoint, or the user's chosen public assistant).
+- **Manager** — selects the configured provider and runs the action.
+
+## Where settings live
+
+AI settings are read from the `app_settings` database table first, falling back
+to the matching environment variable. This means:
+
+- Environment variables (`.env`) provide the **initial defaults** for a
+  deployment.
+- Administrators can **override them at runtime** from the admin panel **AI**
+  tab, with no redeploy.
+
+API keys are stored **server-side only**. They are never returned by any API,
+never embedded in the static bundle, and never exposed to the frontend.
+
+## Default behaviour
+
+With no configuration, AI features are **enabled** and the provider is
+**`external`**, preserving the historical behaviour:
+
+- The game editor offers a prompt and a public AI assistant selector
+  (ChatGPT, Claude, Perplexity, Le Chat, Grok, Qwen).
+- The **Send to AI** button opens the selected assistant with the prompt.
+- Users can pick their preferred assistant via the `defaultAI` preference.
+
+## Behaviour matrix
+
+| `AI_FEATURES_ENABLED` | `AI_PROVIDER` | Game editor | `defaultAI` preference |
+|-----------------------|---------------|-------------|------------------------|
+| `false`               | (any)         | No AI tab, no AI buttons | Hidden |
+| `true`                | `external`    | Prompt + assistant selector + **Send to AI** | Shown |
+| `true`                | `azure` / `ollama` / `openai_compat` | **Generate** tab with a server-side **Create** button; no external selector | Hidden |
+
+In managed mode the editor calls `POST /api/ai/generate-text`; the server runs
+the configured provider and returns generated text, which the editor turns into
+questions. eXeLearning **never falls back** to a public AI service when a
+managed provider is selected but misconfigured — it shows a clear error.
+
+## Disabling all AI features
+
+```env
+AI_FEATURES_ENABLED=false
+```
+
+This hides every AI button, the AI tab, and the `defaultAI` preference. The
+server endpoint also responds with a safe `AI_DISABLED` error if called
+directly.
+
+## Configuring a managed provider
+
+Set `AI_PROVIDER` and the matching fields. After deployment, the same values can
+be edited from the admin panel **AI** tab (API keys are write-only there: leave
+the field blank to keep the stored key).
+
+### Azure OpenAI
+
+```env
+AI_PROVIDER=azure
+AI_AZURE_ENDPOINT=https://my-resource.openai.azure.com
+AI_AZURE_API_KEY=...                # server-side only
+AI_AZURE_DEPLOYMENT=gpt-4o
+AI_AZURE_API_VERSION=2024-02-01
+```
+
+Calls `{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={apiVersion}`
+with the `api-key` header.
+
+### Ollama
+
+```env
+AI_PROVIDER=ollama
+AI_OLLAMA_ENDPOINT=http://localhost:11434   # default
+AI_OLLAMA_MODEL=llama3
+```
+
+Calls `{endpoint}/api/chat` (non-streaming). No API key is required; a local or
+institutional endpoint is expected.
+
+### OpenAI-compatible
+
+```env
+AI_PROVIDER=openai_compat
+AI_COMPAT_ENDPOINT=https://api.example.com/v1
+AI_COMPAT_API_KEY=...               # optional, server-side only
+AI_COMPAT_MODEL=gpt-4o-mini
+```
+
+Calls `{endpoint}/chat/completions` with a `Bearer` token when a key is set.
+
+### Generation options (managed providers)
+
+```env
+AI_REQUEST_TIMEOUT_MS=60000
+AI_MAX_OUTPUT_TOKENS=4096
+AI_TEMPERATURE=0.2
+```
+
+## Security notes
+
+- Provider credentials stay on the server. `/api/config`,
+  `/api/parameter-management/parameters/data/list`, the admin settings API and
+  the static bundle expose only safe flags: `{ enabled, provider, mode,
+  configured }`.
+- `AI_PROVIDER` is validated against an allow-list; managed endpoint URLs are
+  validated as `http(s)` URLs on save.
+- The endpoint is administrator-configured (a trusted value) and the browser
+  only ever sends the prompt text — it cannot choose the provider URL.
+- Managed AI generation is **online only**. Static/offline builds never require
+  provider secrets and only ever offer the external (or disabled) mode.
+
+## Where this lives in the code
+
+- Service layer: `src/services/ai/` (`config.ts`, `manager.ts`, `types.ts`,
+  `providers/`).
+- Route: `src/routes/ai.ts` (`POST /api/ai/generate-text`,
+  `POST /api/ai/test-connection`).
+- Public config: `src/routes/config.ts` + `src/routes/parameter-response.ts`
+  (`ai` object) and `src/routes/config-params.ts` (`defaultAI` gating).
+- Admin settings: `src/routes/admin.ts` (allow-list + secret masking) and the
+  admin **AI** tab (`views/admin/index.njk`, `public/app/admin/ai.js`).
+- Editor UI: `public/app/common/common_edition.js` (`getTabIA`, `aiSettings`)
+  and `public/app/rest/apiCallManager.js` (`getGenerateQuestions`).

--- a/doc/development/ai-configuration.md
+++ b/doc/development/ai-configuration.md
@@ -41,7 +41,7 @@ With no configuration, AI features are **enabled** and the provider is
 
 | `AI_FEATURES_ENABLED` | `AI_PROVIDER` | Game editor | `defaultAI` preference |
 |-----------------------|---------------|-------------|------------------------|
-| `false`               | (any)         | No AI tab, no AI buttons | Hidden |
+| `false`               | (any)         | Copy-only AI tab: prompt + **Copy**, no provider selector / **Send to AI** / **Generate** | Hidden |
 | `true`                | `external`    | Prompt + assistant selector + **Send to AI** | Shown |
 | `true`                | `azure` / `ollama` / `openai_compat` | **Generate** tab with a server-side **Create** button; no external selector | Hidden |
 
@@ -56,9 +56,16 @@ managed provider is selected but misconfigured — it shows a clear error.
 AI_FEATURES_ENABLED=false
 ```
 
-This hides every AI button, the AI tab, and the `defaultAI` preference. The
-server endpoint also responds with a safe `AI_DISABLED` error if called
-directly.
+This removes every AI **provider** integration — the assistant selector, the
+**Send to AI** button, the managed **Generate**/**Create** surface and the
+`defaultAI` preference all disappear, and the server endpoint responds with a
+safe `AI_DISABLED` error if called directly.
+
+The AI tab itself **stays visible** in a copy-only form: teachers can still read
+and **Copy** the auto-built prompt, take it to any AI tool of their choice, and
+paste the result back into the **Questions** tab. This keeps the
+heavily-used game-authoring workflow available without eXeLearning ever calling
+an AI provider.
 
 ## Configuring a managed provider
 
@@ -108,6 +115,32 @@ AI_REQUEST_TIMEOUT_MS=60000
 AI_MAX_OUTPUT_TOKENS=4096
 AI_TEMPERATURE=0.2
 ```
+
+## Troubleshooting a managed provider
+
+When a managed provider request fails, the editor shows a safe message such as
+*"The AI provider returned an error (HTTP 500)"*. The underlying cause is logged
+**server-side** with provider, endpoint host, HTTP status and a truncated body
+snippet, for example:
+
+```
+[ai] provider "ollama" at localhost:11434 returned HTTP 500: {"error":"model 'llama3' not found, try pulling it first"}
+```
+
+Check the application/container logs for `[ai]` lines first. Administrators can
+also use **Test connection** in the admin **AI** tab: that admin-only diagnostic
+returns the upstream `details` snippet directly, so the exact provider error is
+visible without reading logs. (The public `POST /api/ai/generate-text` response
+never includes this snippet.)
+
+Common causes of an upstream `HTTP 500`:
+
+- **Ollama** — the model named in `AI_OLLAMA_MODEL` has not been pulled
+  (`ollama pull <model>`), so Ollama answers with *model not found*.
+- **Azure / OpenAI-compatible** — a wrong deployment name, API version or key,
+  or an endpoint that is not actually reachable from the server (e.g. a
+  `localhost` Ollama is not reachable from inside the Docker container started by
+  `make up`; use a host-reachable address there).
 
 ## Security notes
 

--- a/public/app/admin/ai.js
+++ b/public/app/admin/ai.js
@@ -1,0 +1,136 @@
+/**
+ * Admin panel — AI settings tab.
+ *
+ * Drives the "AI" section of the admin panel:
+ *  - shows only the field groups relevant to the selected provider,
+ *  - saves the AI settings (scoped to the #ai section) via PUT /api/admin/settings,
+ *  - runs an optional "Test connection" against the managed provider.
+ *
+ * Secrets (API keys) are never rendered with a value; blank key fields are
+ * sent as-is and the backend treats a blank value as "keep the stored key".
+ *
+ * Uses the globals `API_BASE` and `T` declared by the admin template, mirroring
+ * dashboard.js. All accesses are defensive so the module is unit-testable.
+ */
+
+/** Resolve a translation with a fallback, tolerating a missing global `T`. */
+function tr(key, fallback) {
+    return (typeof T !== 'undefined' && T && T[key]) || fallback;
+}
+
+/** Base URL for the admin settings API (global declared by the template). */
+function adminApiBase() {
+    return typeof API_BASE !== 'undefined' && API_BASE ? API_BASE : '';
+}
+
+/** Base URL for the AI API (sibling of the admin API: .../api/ai). */
+export function aiApiBase() {
+    return adminApiBase().replace(/\/admin$/, '/ai');
+}
+
+function setStatus(el, text, state) {
+    if (!el) return;
+    el.textContent = text;
+    el.className = `admin-settings-status${state ? ` ${state}` : ''}`;
+}
+
+/**
+ * Show only the field groups relevant to the selected provider. The shared
+ * "managed" group (generation options) is shown for any non-external provider.
+ *
+ * @param {string} provider
+ */
+export function applyProviderVisibility(provider) {
+    const managed = Boolean(provider) && provider !== 'external';
+    document.querySelectorAll('[data-ai-provider-group]').forEach(group => {
+        const target = group.getAttribute('data-ai-provider-group');
+        const show = target === 'managed' ? managed : target === provider;
+        group.style.display = show ? '' : 'none';
+    });
+}
+
+/**
+ * Collect the AI settings inputs scoped to the #ai section into the
+ * { key, value, type } shape expected by PUT /api/admin/settings.
+ *
+ * @returns {Array<{key: string, value: string, type: string}>}
+ */
+export function collectAiSettings() {
+    const section = document.getElementById('ai');
+    if (!section) return [];
+    const settings = [];
+    section.querySelectorAll('[data-setting-key]').forEach(input => {
+        const key = input.dataset.settingKey;
+        const type = input.dataset.settingType || 'string';
+        const value = type === 'boolean' ? (input.checked ? 'true' : 'false') : input.value;
+        settings.push({ key, value: String(value == null ? '' : value), type });
+    });
+    return settings;
+}
+
+/** Persist the AI settings. Returns true on success. */
+export async function saveAiSettings() {
+    const statusEl = document.getElementById('aiSaveStatus');
+    setStatus(statusEl, tr('saving', 'Saving...'), '');
+    try {
+        const res = await fetch(`${adminApiBase()}/settings`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ settings: collectAiSettings() }),
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            setStatus(statusEl, err.message || tr('error_saving', 'Error saving'), 'error');
+            return false;
+        }
+        setStatus(statusEl, tr('saved', 'Saved'), 'success');
+        return true;
+    } catch (_e) {
+        setStatus(statusEl, tr('error_saving', 'Error saving'), 'error');
+        return false;
+    }
+}
+
+/** Run a managed-provider connection test and report the outcome. Returns true on success. */
+export async function testAiConnection() {
+    const statusEl = document.getElementById('aiSaveStatus');
+    setStatus(statusEl, tr('ai_testing', 'Testing...'), '');
+    try {
+        const res = await fetch(`${aiApiBase()}/test-connection`, { method: 'POST', credentials: 'include' });
+        const data = await res.json().catch(() => ({}));
+        if (res.ok && data.ok) {
+            setStatus(statusEl, tr('ai_test_ok', 'Connection successful'), 'success');
+            return true;
+        }
+        const detail = data.message || data.error || res.status;
+        setStatus(statusEl, `${tr('ai_test_failed', 'Connection failed')}: ${detail}`, 'error');
+        return false;
+    } catch (_e) {
+        setStatus(statusEl, tr('ai_test_failed', 'Connection failed'), 'error');
+        return false;
+    }
+}
+
+/** Wire up the AI tab controls. Safe to call when the section is absent. */
+export function initAiTab() {
+    const select = document.getElementById('aiProviderSelect');
+    if (select) {
+        applyProviderVisibility(select.value);
+        select.addEventListener('change', () => applyProviderVisibility(select.value));
+    }
+    const saveBtn = document.getElementById('aiSaveBtn');
+    if (saveBtn) saveBtn.addEventListener('click', saveAiSettings);
+    const testBtn = document.getElementById('aiTestBtn');
+    if (testBtn) testBtn.addEventListener('click', testAiConnection);
+}
+
+// Auto-initialize in the browser. In tests the module is imported with an empty
+// DOM (init becomes a no-op) and the exported functions are called directly.
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initAiTab);
+    } else {
+        initAiTab();
+    }
+}

--- a/public/app/admin/ai.test.js
+++ b/public/app/admin/ai.test.js
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    aiApiBase,
+    applyProviderVisibility,
+    collectAiSettings,
+    initAiTab,
+    saveAiSettings,
+    testAiConnection,
+} from './ai.js';
+
+const AI_SECTION_HTML = `
+<section id="ai">
+  <select id="aiProviderSelect" data-setting-key="AI_PROVIDER" data-setting-type="string">
+    <option value="external">external</option>
+    <option value="azure">azure</option>
+    <option value="ollama" selected>ollama</option>
+    <option value="openai_compat">compat</option>
+  </select>
+  <input id="enabled" type="checkbox" data-setting-key="AI_FEATURES_ENABLED" data-setting-type="boolean" checked>
+  <input id="model" data-setting-key="AI_OLLAMA_MODEL" data-setting-type="string" value="llama3">
+  <input id="timeout" type="number" data-setting-key="AI_REQUEST_TIMEOUT_MS" data-setting-type="number" value="60000">
+  <input id="key" type="password" data-setting-key="AI_AZURE_API_KEY" data-setting-type="string" value="">
+  <div data-ai-provider-group="azure">azure</div>
+  <div data-ai-provider-group="ollama">ollama</div>
+  <div data-ai-provider-group="openai_compat">compat</div>
+  <div data-ai-provider-group="managed">managed</div>
+  <button id="aiSaveBtn"></button>
+  <button id="aiTestBtn"></button>
+  <span id="aiSaveStatus"></span>
+</section>`;
+
+function groupDisplay(name) {
+    return document.querySelector(`[data-ai-provider-group="${name}"]`).style.display;
+}
+
+beforeEach(() => {
+    globalThis.API_BASE = '/base/api/admin';
+    globalThis.T = {
+        saving: 'Saving...',
+        saved: 'Saved',
+        error_saving: 'Error saving',
+        ai_testing: 'Testing...',
+        ai_test_ok: 'Connection successful',
+        ai_test_failed: 'Connection failed',
+    };
+    document.body.innerHTML = AI_SECTION_HTML;
+    // Set the selected provider explicitly (happy-dom does not always reflect the
+    // `selected` attribute into select.value); mirrors the server-rendered state.
+    document.getElementById('aiProviderSelect').value = 'ollama';
+});
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    delete globalThis.API_BASE;
+    delete globalThis.T;
+    vi.restoreAllMocks();
+});
+
+describe('aiApiBase', () => {
+    it('derives the /api/ai base from the admin base', () => {
+        expect(aiApiBase()).toBe('/base/api/ai');
+    });
+});
+
+describe('applyProviderVisibility', () => {
+    it('hides all provider groups in external mode', () => {
+        applyProviderVisibility('external');
+        expect(groupDisplay('azure')).toBe('none');
+        expect(groupDisplay('ollama')).toBe('none');
+        expect(groupDisplay('openai_compat')).toBe('none');
+        expect(groupDisplay('managed')).toBe('none');
+    });
+
+    it('shows only the selected managed provider plus the shared options', () => {
+        applyProviderVisibility('ollama');
+        expect(groupDisplay('ollama')).toBe('');
+        expect(groupDisplay('managed')).toBe('');
+        expect(groupDisplay('azure')).toBe('none');
+        expect(groupDisplay('openai_compat')).toBe('none');
+    });
+
+    it('shows the azure group for azure', () => {
+        applyProviderVisibility('azure');
+        expect(groupDisplay('azure')).toBe('');
+        expect(groupDisplay('managed')).toBe('');
+        expect(groupDisplay('ollama')).toBe('none');
+    });
+});
+
+describe('collectAiSettings', () => {
+    it('collects scoped #ai inputs with normalized types', () => {
+        const settings = collectAiSettings();
+        const byKey = Object.fromEntries(settings.map(s => [s.key, s]));
+        expect(byKey.AI_PROVIDER).toEqual({ key: 'AI_PROVIDER', value: 'ollama', type: 'string' });
+        expect(byKey.AI_FEATURES_ENABLED).toEqual({ key: 'AI_FEATURES_ENABLED', value: 'true', type: 'boolean' });
+        expect(byKey.AI_OLLAMA_MODEL.value).toBe('llama3');
+        expect(byKey.AI_REQUEST_TIMEOUT_MS).toEqual({ key: 'AI_REQUEST_TIMEOUT_MS', value: '60000', type: 'number' });
+        // Blank secret is sent as an empty string (backend treats it as "keep").
+        expect(byKey.AI_AZURE_API_KEY.value).toBe('');
+    });
+});
+
+describe('saveAiSettings', () => {
+    it('PUTs the collected settings and reports success', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+
+        const ok = await saveAiSettings();
+
+        expect(ok).toBe(true);
+        const [url, init] = fetchSpy.mock.calls[0];
+        expect(url).toBe('/base/api/admin/settings');
+        expect(init.method).toBe('PUT');
+        expect(init.credentials).toBe('include');
+        expect(JSON.parse(init.body).settings.some(s => s.key === 'AI_PROVIDER')).toBe(true);
+        expect(document.getElementById('aiSaveStatus').textContent).toBe('Saved');
+    });
+
+    it('shows the server error message on failure', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue({
+            ok: false,
+            json: async () => ({ message: 'AI_PROVIDER must be one of: external, azure, ollama, openai_compat' }),
+        });
+
+        const ok = await saveAiSettings();
+        expect(ok).toBe(false);
+        expect(document.getElementById('aiSaveStatus').textContent).toContain('AI_PROVIDER must be one of');
+    });
+});
+
+describe('testAiConnection', () => {
+    it('reports success when the provider responds ok', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+
+        const ok = await testAiConnection();
+
+        expect(ok).toBe(true);
+        expect(fetchSpy.mock.calls[0][0]).toBe('/base/api/ai/test-connection');
+        expect(document.getElementById('aiSaveStatus').textContent).toBe('Connection successful');
+    });
+
+    it('reports a clear error when the provider is misconfigured', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue({
+            ok: false,
+            json: async () => ({ ok: false, error: 'AI_NOT_CONFIGURED', message: 'The AI provider is not fully configured.' }),
+        });
+
+        const ok = await testAiConnection();
+        expect(ok).toBe(false);
+        expect(document.getElementById('aiSaveStatus').textContent).toContain('not fully configured');
+    });
+});
+
+describe('initAiTab', () => {
+    it('applies provider visibility on init and on provider change', () => {
+        initAiTab();
+        // Initial select value is "ollama".
+        expect(groupDisplay('ollama')).toBe('');
+        expect(groupDisplay('azure')).toBe('none');
+
+        const select = document.getElementById('aiProviderSelect');
+        select.value = 'azure';
+        select.dispatchEvent(new Event('change'));
+        expect(groupDisplay('azure')).toBe('');
+        expect(groupDisplay('ollama')).toBe('none');
+    });
+});

--- a/public/app/common/common_edition.js
+++ b/public/app/common/common_edition.js
@@ -551,11 +551,13 @@ var $exeDevicesEdition = {
 
                 getTabIA: function (type = 0, options = {}) {
                     const ai = $exeDevicesEdition.iDevice.gamification.share.aiSettings();
-                    // AI features disabled by the administrator: render no AI tab at all.
-                    if (!ai.enabled) {
-                        return '';
-                    }
-                    const managed = ai.mode === 'managed';
+                    // Managed (server-side generation) only when AI is enabled in managed mode.
+                    const managed = ai.enabled && ai.mode === 'managed';
+                    // The public-assistant selector + "Send to AI" only when AI is enabled
+                    // in external mode. When AI is fully disabled the tab still renders so
+                    // teachers can copy the prompt and paste questions generated elsewhere,
+                    // but without any provider selector, "Send to AI" or "Generate" surface.
+                    const showExternalControls = ai.enabled && ai.mode === 'external';
                     const msgAddText = _("You can easily generate multiple questions for the activity using AI.");
                     const promptText = $exeDevicesEdition.iDevice.gamification.share.buildIAPromptText(type, options);
 
@@ -576,7 +578,7 @@ var $exeDevicesEdition = {
                                     </div>`
                         : '';
                     // External public-assistant selector + "Send to AI" button only in external mode.
-                    const externalControls = managed
+                    const externalControls = !showExternalControls
                         ? ''
                         : `<select id="eXeEIASelect" name="eXeEIASelect" class="form-select form-select-sm w-auto ms-2">
                                         <option selected value="https://chatgpt.com/?q=">ChatGPT</option>
@@ -948,8 +950,13 @@ var $exeDevicesEdition = {
                     const $eXeGameAddQuestion = $('#eXeGameAddQuestion');
                     const $eXeEAddArea = $('#eXeEAddArea');
 
+                    // The public-assistant selector + "Send to AI" button only exist when
+                    // AI is enabled in external mode (see getTabIA). Guard the logic that
+                    // depends on them so disabled/managed mode does no dead work.
+                    const hasExternalControls = $iaSelect.length > 0 && $openChatGPTButton.length > 0;
+
                     // Load user's default AI preference and select it
-                    if (window.eXeLearning?.app?.user?.preferences?.preferences?.defaultAI?.value) {
+                    if (hasExternalControls && window.eXeLearning?.app?.user?.preferences?.preferences?.defaultAI?.value) {
                         const defaultAI = eXeLearning.app.user.preferences.preferences.defaultAI.value;
                         if ($iaSelect.find(`option[value="${defaultAI}"]`).length) {
                             $iaSelect.val(defaultAI);
@@ -1037,22 +1044,25 @@ var $exeDevicesEdition = {
                         $iaSelect.hide();
                     });
 
-                    $openChatGPTButton.on('click', function () {
-                        $tabQuestions.trigger('click');
-                        let prompt = $textPrompt.val();
-                        if (!prompt || !prompt.trim()) {
-                            eXe.app.alert(_('There is no query to send to the assistant.'));
-                            return;
-                        }
-                        const encodedPrompt = encodeURIComponent(prompt.trim());
-                        const baseUrl = $iaSelect.val();
-                        if (!baseUrl) {
-                            eXe.app.alert(_('Please select an AI assistant.'));
-                            return;
-                        }
-                        const url = `${baseUrl}${encodedPrompt}`;
-                        window.open(url, '_blank');
-                    });
+                    // "Send to AI" only exists in external mode; bind it only then.
+                    if (hasExternalControls) {
+                        $openChatGPTButton.on('click', function () {
+                            $tabQuestions.trigger('click');
+                            let prompt = $textPrompt.val();
+                            if (!prompt || !prompt.trim()) {
+                                eXe.app.alert(_('There is no query to send to the assistant.'));
+                                return;
+                            }
+                            const encodedPrompt = encodeURIComponent(prompt.trim());
+                            const baseUrl = $iaSelect.val();
+                            if (!baseUrl) {
+                                eXe.app.alert(_('Please select an AI assistant.'));
+                                return;
+                            }
+                            const url = `${baseUrl}${encodedPrompt}`;
+                            window.open(url, '_blank');
+                        });
+                    }
 
                     $saveButton.on('click', function () {
                         const content = $textQuestionsArea.val().trim();

--- a/public/app/common/common_edition.js
+++ b/public/app/common/common_edition.js
@@ -525,9 +525,68 @@ var $exeDevicesEdition = {
                     return tab.replace(/[ \t]+/g, ' ').trim();
                 },
 
+                /**
+                 * Resolve the AI behaviour for the editor UI from the safe public
+                 * config served by the backend (window.eXeLearning.app.api.parameters.ai).
+                 *
+                 * When the config is absent (static/offline build or legacy server),
+                 * the historical behaviour is preserved: external assistants enabled.
+                 *
+                 * @returns {{enabled: boolean, mode: 'external'|'managed'}}
+                 */
+                aiSettings: function () {
+                    const root =
+                        (typeof window !== 'undefined' && window.eXeLearning) ||
+                        (typeof globalThis !== 'undefined' && globalThis.eXeLearning) ||
+                        null;
+                    const ai = root?.app?.api?.parameters?.ai || null;
+                    if (!ai) {
+                        return { enabled: true, mode: 'external' };
+                    }
+                    return {
+                        enabled: ai.enabled !== false,
+                        mode: ai.mode === 'managed' ? 'managed' : 'external',
+                    };
+                },
+
                 getTabIA: function (type = 0, options = {}) {
+                    const ai = $exeDevicesEdition.iDevice.gamification.share.aiSettings();
+                    // AI features disabled by the administrator: render no AI tab at all.
+                    if (!ai.enabled) {
+                        return '';
+                    }
+                    const managed = ai.mode === 'managed';
                     const msgAddText = _("You can easily generate multiple questions for the activity using AI.");
                     const promptText = $exeDevicesEdition.iDevice.gamification.share.buildIAPromptText(type, options);
+
+                    // The "Generate" tab and its Create surface only exist in managed
+                    // mode (server-side generation). In external mode the user copies
+                    // the prompt and opens a public assistant instead.
+                    const generateTab = managed
+                        ? `<li class="nav-item">
+                                        <a id="eXeETabIA" class="nav-link bg-light border-end" href="#">
+                                        ${_('Generate')}
+                                        </a>
+                                    </li>`
+                        : '';
+                    const iaDiv = managed
+                        ? `<div  class="form-control font-monospace fs-6" id="eXeEIADiv"  style="display:none">
+                                        ${$exeDevicesEdition.iDevice.gamification.share.createIAButtonsHtml()}
+                                        <textarea class="form-control font-monospace fs-6" style="display:none" id="eXeEQuestionsIA"> </textarea>
+                                    </div>`
+                        : '';
+                    // External public-assistant selector + "Send to AI" button only in external mode.
+                    const externalControls = managed
+                        ? ''
+                        : `<select id="eXeEIASelect" name="eXeEIASelect" class="form-select form-select-sm w-auto ms-2">
+                                        <option selected value="https://chatgpt.com/?q=">ChatGPT</option>
+                                        <option value="https://claude.ai/new?q=">Claude</option>
+                                        <option value="https://www.perplexity.ai/search?q=">Perplexity</option>
+                                        <option value="https://chat.mistral.ai/chat/?q=">Le Chat (Mistral)</option>
+                                        <option value="https://grok.com/?q=">Grok</option>
+                                        <option value="https://chat.qwen.ai/?text=">Qwen</option>
+                                    </select>
+                                   <button id="eXeEOpenChatGPTButton"  class="btn btn-primary ms-2"/>${_('Send to AI')}</button>`;
                     const tab = `
                         <div class="exe-form-tab" title="${_('AI')}">
                             <p class="exe-block-info">${msgAddText}</p>
@@ -544,33 +603,18 @@ var $exeDevicesEdition = {
                                          ${_('Questions')}
                                         </a>
                                     </li>
-                                    <li class="nav-item" style="display:none">
-                                        <a id="eXeETabIA" class="nav-link bg-light border-end" href="#">
-                                        ${_('Generate')}
-                                        </a>
-                                    </li>
+                                    ${generateTab}
                                 </ul>
                                 <div class="eXeE-LightboxContent p-2">
                                     <textarea class="form-control font-monospace fs-6" style="min-height:350px;" id="eXeEPromptArea">${promptText}</textarea>
                                     <textarea id="eXeEQuestionsArea" class="form-control font-monospace fs-6" style="min-height:350px;display:none"></textarea>
-                                    <div  class="form-control font-monospace fs-6" id="eXeEIADiv"  style="display:none">
-                                        ${$exeDevicesEdition.iDevice.gamification.share.createIAButtonsHtml()}
-                                        <textarea class="form-control font-monospace fs-6" style="display:none" id="eXeEQuestionsIA"> </textarea>
-                                    </div>
+                                    ${iaDiv}
                                 </div>
                                 <div class="d-flex justify-content-end  border-secondary p-2">
                                    <button id="eXeESaveButton"  class="btn  btn-primary ms-2"/>${_('Save')}</button>
                                    <button id="eXeECopyButton"  class="btn btn-primary ms-2"/>${_('Copy')}</button>
-                                   <select id="eXeEIASelect" name="eXeEIASelect" class="form-select form-select-sm w-auto ms-2">
-                                        <option selected value="https://chatgpt.com/?q=">ChatGPT</option>
-                                        <option value="https://claude.ai/new?q=">Claude</option>
-                                        <option value="https://www.perplexity.ai/search?q=">Perplexity</option>
-                                        <option value="https://chat.mistral.ai/chat/?q=">Le Chat (Mistral)</option>
-                                        <option value="https://grok.com/?q=">Grok</option>
-                                        <option value="https://chat.qwen.ai/?text=">Qwen</option>
-                                    </select>
-                                   <button id="eXeEOpenChatGPTButton"  class="btn btn-primary ms-2"/>${_('Send to AI')}</button>
-                                   <button id="eXeEIAButton"  class="btn btn-primary"/>${_('Add questions')}</button>
+                                   ${externalControls}
+                                   <button id="eXeEIAButton"  class="btn btn-primary" style="display:none"/>${_('Add questions')}</button>
                                 </div>
                             </div>
                         </div>`;
@@ -1136,8 +1180,14 @@ var $exeDevicesEdition = {
                                 $('#eXeIAMessage').text(_(sdata)).show();
                             }
                         } else {
-                            sdata = _('The questions could not be generated. Incorrect format');
-                            $('#eXeIAMessage').text(_(sdata)).show();
+                            // Managed-provider failures arrive as { error, message } (no
+                            // questions). Surface the backend's safe message when present
+                            // so the teacher gets a useful diagnostic instead of a generic one.
+                            const detail = data.message || data.error;
+                            sdata = detail
+                                ? `${_('The questions could not be generated')}: ${detail}`
+                                : _('The questions could not be generated. Incorrect format');
+                            $('#eXeIAMessage').text(sdata).show();
                         }
                         $('#eXeFormIAContainer').find('input, textarea, button, select').prop('disabled', false);
                     } catch (error) {

--- a/public/app/common/common_edition.test.js
+++ b/public/app/common/common_edition.test.js
@@ -1055,9 +1055,20 @@ describe('common_edition.js', () => {
         expect(share().aiSettings().enabled).toBe(false);
       });
 
-      it('getTabIA renders nothing when AI is disabled', () => {
+      it('getTabIA keeps a copy-only tab when AI is disabled (no selector / Send to AI / Generate)', () => {
         setAi({ enabled: false, provider: 'external', mode: 'external', configured: true });
-        expect(share().getTabIA(0)).toBe('');
+        const html = share().getTabIA(0);
+        // The tab itself and the prompt/copy/questions surface remain so teachers
+        // can still copy the prompt and paste questions generated elsewhere.
+        expect(html).not.toBe('');
+        expect(html).toContain('eXeEPromptArea');
+        expect(html).toContain('eXeECopyButton');
+        expect(html).toContain('eXeEQuestionsArea');
+        // But no AI provider controls of any kind.
+        expect(html).not.toContain('eXeEIASelect');
+        expect(html).not.toContain('eXeEOpenChatGPTButton');
+        expect(html).not.toContain('eXeETabIA');
+        expect(html).not.toContain('eXeEIADiv');
       });
 
       it('external mode renders the assistant selector and "Send to AI", not the Generate tab', () => {
@@ -1578,6 +1589,31 @@ describe('common_edition.js', () => {
           'https://chatgpt.com/?q=test%20prompt%20with%20spaces',
           '_blank'
         );
+      });
+
+      it('disabled mode: addEvents wires the Save flow without binding absent external controls', () => {
+        const saveQuestionsMock = vi.fn();
+        // Copy-only disabled-mode DOM: no #eXeEIASelect, no #eXeEOpenChatGPTButton.
+        document.body.innerHTML = `
+          <textarea id="eXeEQuestionsArea"></textarea>
+          <textarea id="eXeEPromptArea"></textarea>
+          <button id="eXeESaveButton"></button>
+          <button id="eXeECopyButton"></button>
+          <a id="eXeETabQuestions" class="active"></a>
+          <a id="eXeETabPrompt"></a>
+        `;
+        $('#eXeEQuestionsArea').val('Word1#Definition1\nWord2#Definition2');
+
+        // hasExternalControls is false here; addEvents must not throw and must not
+        // try to bind the Send-to-AI handler against a non-existent element.
+        expect(() =>
+          globalThis.$exeDevicesEdition.iDevice.gamification.share.addEvents(0, saveQuestionsMock)
+        ).not.toThrow();
+
+        // The manual copy/paste-back Save flow still works when AI is disabled.
+        $('#eXeESaveButton').trigger('click');
+        expect(saveQuestionsMock).toHaveBeenCalled();
+        expect(globalThis.eXe.app.alert).toHaveBeenCalledWith('The questions have been added successfully');
       });
 
       it('saveButton click shows alert when questions textarea is empty', () => {

--- a/public/app/common/common_edition.test.js
+++ b/public/app/common/common_edition.test.js
@@ -1028,6 +1028,98 @@ describe('common_edition.js', () => {
       expect(result).toContain('eXeSpecialtyIA');
     });
 
+    describe('AI behaviour matrix (aiSettings / getTabIA)', () => {
+      const share = () => globalThis.$exeDevicesEdition.iDevice.gamification.share;
+      function setAi(ai) {
+        globalThis.eXeLearning.app.api.parameters = ai ? { ai } : undefined;
+      }
+      afterEach(() => {
+        // Reset so other tests observe the external-default behaviour.
+        if (globalThis.eXeLearning?.app?.api) {
+          delete globalThis.eXeLearning.app.api.parameters;
+        }
+      });
+
+      it('aiSettings defaults to enabled/external when no config is present', () => {
+        setAi(null);
+        expect(share().aiSettings()).toEqual({ enabled: true, mode: 'external' });
+      });
+
+      it('aiSettings reflects a managed provider', () => {
+        setAi({ enabled: true, provider: 'ollama', mode: 'managed', configured: true });
+        expect(share().aiSettings()).toEqual({ enabled: true, mode: 'managed' });
+      });
+
+      it('aiSettings reflects disabled AI', () => {
+        setAi({ enabled: false, provider: 'external', mode: 'external', configured: true });
+        expect(share().aiSettings().enabled).toBe(false);
+      });
+
+      it('getTabIA renders nothing when AI is disabled', () => {
+        setAi({ enabled: false, provider: 'external', mode: 'external', configured: true });
+        expect(share().getTabIA(0)).toBe('');
+      });
+
+      it('external mode renders the assistant selector and "Send to AI", not the Generate tab', () => {
+        setAi({ enabled: true, provider: 'external', mode: 'external', configured: true });
+        const html = share().getTabIA(0);
+        expect(html).toContain('eXeEIASelect');
+        expect(html).toContain('eXeEOpenChatGPTButton');
+        expect(html).not.toContain('eXeETabIA');
+        expect(html).not.toContain('eXeEIADiv');
+      });
+
+      it('managed mode renders the Generate tab + Create surface, not the external selector', () => {
+        setAi({ enabled: true, provider: 'ollama', mode: 'managed', configured: true });
+        const html = share().getTabIA(0);
+        expect(html).toContain('eXeETabIA');
+        expect(html).toContain('eXeEIADiv');
+        expect(html).toContain('eXeFormIAContainer');
+        expect(html).not.toContain('eXeEIASelect');
+        expect(html).not.toContain('eXeEOpenChatGPTButton');
+      });
+    });
+
+    describe('genarateIAQuestons (managed mode result handling)', () => {
+      let savedEXe;
+      beforeEach(() => {
+        savedEXe = globalThis.eXeLearning;
+        document.body.innerHTML = `
+          <div id="eXeFormIAContainer"><input id="eXeNumberOfQuestionsIA" value="3"></div>
+          <p id="eXeIAMessage"></p>`;
+      });
+      afterEach(() => {
+        globalThis.eXeLearning = savedEXe;
+        document.body.innerHTML = '';
+      });
+
+      it('surfaces the backend error message instead of a generic "Incorrect format"', async () => {
+        globalThis.eXeLearning = {
+          app: {
+            api: {
+              getGenerateQuestions: vi.fn().mockResolvedValue({
+                error: 'AI_NOT_CONFIGURED',
+                message: 'The AI provider is not fully configured.',
+              }),
+            },
+          },
+        };
+        const saveQuestions = vi.fn();
+        await globalThis.$exeDevicesEdition.iDevice.gamification.share.genarateIAQuestons(0, saveQuestions, {});
+        expect(saveQuestions).not.toHaveBeenCalled();
+        expect(document.getElementById('eXeIAMessage').textContent).toContain('not fully configured');
+      });
+
+      it('saves questions returned by the managed provider', async () => {
+        globalThis.eXeLearning = {
+          app: { api: { getGenerateQuestions: vi.fn().mockResolvedValue({ questions: ['q1', 'q2'] }) } },
+        };
+        const saveQuestions = vi.fn();
+        await globalThis.$exeDevicesEdition.iDevice.gamification.share.genarateIAQuestons(0, saveQuestions, {});
+        expect(saveQuestions).toHaveBeenCalled();
+      });
+    });
+
     it('getAllowedFormats returns formats for each gameId', () => {
       // Test each game type
       for (let i = 0; i <= 9; i++) {

--- a/public/app/rest/apiCallManager.js
+++ b/public/app/rest/apiCallManager.js
@@ -332,6 +332,72 @@ export default class ApiCallManager {
     }
 
     /**
+     * Generate questions for game iDevices using the server-managed AI provider.
+     *
+     * Online + managed mode only: the browser sends the fully-built prompt and
+     * the server runs the configured provider, returning plain text. We
+     * normalize that text into an array of question lines that the gamification
+     * editor validates per game format. In external mode the UI never calls this
+     * (it opens the selected public AI assistant instead).
+     *
+     * @param {string} prompt Fully-composed prompt string.
+     * @returns {Promise<{questions: string[]}|{error: string, message?: string}>}
+     */
+    async getGenerateQuestions(prompt) {
+        if (this._isStaticMode()) {
+            return { error: 'AI_OFFLINE', message: 'AI generation is not available offline.' };
+        }
+
+        const url = `${this.apiUrlBase}${this.apiUrlBasePath}/api/ai/generate-text`;
+        const authToken =
+            eXeLearning?.app?.project?._yjsBridge?.authToken ||
+            eXeLearning?.app?.auth?.getToken?.() ||
+            eXeLearning?.config?.token ||
+            localStorage.getItem('authToken');
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+            },
+            credentials: 'include',
+            body: JSON.stringify({ prompt }),
+        });
+
+        if (!response.ok) {
+            let payload = {};
+            try {
+                payload = await response.json();
+            } catch (_e) {
+                // Non-JSON error body: fall back to a generic provider error code.
+            }
+            return { error: payload.error || 'AI_PROVIDER_ERROR', message: payload.message };
+        }
+
+        const data = await response.json();
+        return { questions: this._normalizeAiQuestions(data.text) };
+    }
+
+    /**
+     * Normalize a model's plain-text answer into question lines: strip Markdown
+     * code fences and blank lines so the gamification editor receives one
+     * question per array entry.
+     *
+     * @param {string} text
+     * @returns {string[]}
+     */
+    _normalizeAiQuestions(text) {
+        if (typeof text !== 'string') return [];
+        return text
+            .replace(/```[a-zA-Z0-9]*\n?/g, '')
+            .replace(/```/g, '')
+            .split(/\r?\n/)
+            .map(line => line.trim())
+            .filter(line => line.length > 0);
+    }
+
+    /**
      * Get recent user odefiles (projects)
      * Uses NestJS endpoint for Yjs-based projects
      * Returns the 3 most recently updated projects

--- a/public/app/rest/apiCallManager.test.js
+++ b/public/app/rest/apiCallManager.test.js
@@ -152,6 +152,69 @@ describe('ApiCallManager', () => {
     });
   });
 
+  describe('getGenerateQuestions', () => {
+    it('posts the prompt to the AI endpoint and normalizes the text into questions', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ text: '```text\nq1|a|b\n\nq2|c|d\n```' }),
+      });
+      localStorage.setItem('authToken', 'ai-token');
+
+      const result = await apiManager.getGenerateQuestions('PROMPT');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/ai/generate-text'),
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+          body: JSON.stringify({ prompt: 'PROMPT' }),
+          headers: expect.objectContaining({ Authorization: 'Bearer ai-token' }),
+        })
+      );
+      // Code fences and blank lines are stripped; one question per array entry.
+      expect(result).toEqual({ questions: ['q1|a|b', 'q2|c|d'] });
+      localStorage.removeItem('authToken');
+    });
+
+    it('returns the server error code without throwing on a non-ok response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: vi.fn().mockResolvedValue({ error: 'AI_NOT_CONFIGURED', message: 'not configured' }),
+      });
+
+      const result = await apiManager.getGenerateQuestions('PROMPT');
+      expect(result).toEqual({ error: 'AI_NOT_CONFIGURED', message: 'not configured' });
+    });
+
+    it('does not call the server in static/offline mode', async () => {
+      mockApp.capabilities = { storage: { remote: false } };
+      global.fetch = vi.fn();
+
+      const result = await apiManager.getGenerateQuestions('PROMPT');
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result.error).toBe('AI_OFFLINE');
+    });
+
+    it('falls back to AI_PROVIDER_ERROR when the error body is not JSON', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: vi.fn().mockRejectedValue(new Error('not json')),
+      });
+
+      const result = await apiManager.getGenerateQuestions('PROMPT');
+      expect(result).toEqual({ error: 'AI_PROVIDER_ERROR', message: undefined });
+    });
+
+    it('_normalizeAiQuestions returns [] for non-string input', () => {
+      expect(apiManager._normalizeAiQuestions(undefined)).toEqual([]);
+      expect(apiManager._normalizeAiQuestions(null)).toEqual([]);
+      expect(apiManager._normalizeAiQuestions('  a \n\n b ')).toEqual(['a', 'b']);
+    });
+  });
+
   describe('getCurrentUserOdeSessionId', () => {
     it('should return project id from URL', async () => {
       const oldLocation = window.location;

--- a/scripts/build-static-bundle.spec.ts
+++ b/scripts/build-static-bundle.spec.ts
@@ -629,6 +629,29 @@ describe('buildApiParameters', () => {
         expect(params.userPreferencesConfig.versionControl).toBeDefined();
     });
 
+    it('exposes a safe external-only AI capability object with no secrets', () => {
+        // Static/offline builds can only offer external assistants and must never
+        // embed provider secrets/endpoints. toEqual guarantees exactly these 4 keys.
+        expect(params.ai).toEqual({ enabled: true, provider: 'external', mode: 'external', configured: true });
+    });
+
+    it('disables AI and omits defaultAI when AI_FEATURES_ENABLED=false at build time', () => {
+        const prev = process.env.AI_FEATURES_ENABLED;
+        process.env.AI_FEATURES_ENABLED = 'false';
+        try {
+            const disabled = buildApiParameters();
+            expect(disabled.ai.enabled).toBe(false);
+            expect(disabled.ai.mode).toBe('external');
+            expect(disabled.userPreferencesConfig.defaultAI).toBeUndefined();
+        } finally {
+            if (prev === undefined) {
+                delete process.env.AI_FEATURES_ENABLED;
+            } else {
+                process.env.AI_FEATURES_ENABLED = prev;
+            }
+        }
+    });
+
     it('should include iDevice info fields config', () => {
         expect(params.ideviceInfoFieldsConfig).toBeDefined();
         expect(params.ideviceInfoFieldsConfig.title).toBeDefined();

--- a/scripts/build-static-bundle.ts
+++ b/scripts/build-static-bundle.ts
@@ -32,6 +32,7 @@ import { LOCALES, LOCALE_NAMES, PACKAGE_LOCALES, LICENSES } from './static-bundl
 import { buildConfigParams } from '../src/routes/config-params';
 import { STATIC_ROUTES } from '../src/routes/api-routes';
 import { buildParameterResponse } from '../src/routes/parameter-response';
+import { parseAiConfig, toPublicAiConfig } from '../src/services/ai';
 import { VOID_ELEMENTS } from '../src/shared/utils/html-constants';
 
 // Re-export config for external use
@@ -855,18 +856,27 @@ export function buildApiParameters() {
         THEMES[theme.dirName] = theme.title || theme.dirName;
     }
 
+    // Static/offline builds cannot run a managed (server-side) provider, so AI is
+    // forced to the external mode and reflects only the build-time enable flag.
+    // No secrets are ever embedded in the bundle.
+    const staticAi = toPublicAiConfig(
+        parseAiConfig({ AI_FEATURES_ENABLED: process.env.AI_FEATURES_ENABLED, AI_PROVIDER: 'external' }),
+    );
+
     const configParams = buildConfigParams({
         TRANS_PREFIX: '',
         LICENSES,
         PACKAGE_LOCALES,
         LOCALES: LOCALE_NAMES,
         THEMES,
+        INCLUDE_DEFAULT_AI: staticAi.enabled,
     });
 
     return buildParameterResponse({
         configParams,
         routes: STATIC_ROUTES,
         disableThemeEdition: true,
+        ai: staticAi,
     });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { themesRoutes } from './routes/themes';
 import { resourcesRoutes } from './routes/resources';
 import { userRoutes } from './routes/user';
 import { adminRoutes } from './routes/admin';
+import { aiRoutes } from './routes/ai';
 import { adminThemesRoutes } from './routes/admin-themes';
 import { adminTemplatesRoutes } from './routes/admin-templates';
 import { yjsRoutes } from './routes/yjs';
@@ -578,6 +579,7 @@ if (registerRootRoutes) {
         .use(resourcesRoutes)
         .use(userRoutes)
         .use(adminRoutes)
+        .use(aiRoutes)
         .use(adminThemesRoutes)
         .use(adminTemplatesRoutes)
         .use(yjsRoutes)
@@ -614,6 +616,7 @@ if (routePrefix) {
             .use(resourcesRoutes)
             .use(userRoutes)
             .use(adminRoutes)
+            .use(aiRoutes)
             .use(adminThemesRoutes)
             .use(adminTemplatesRoutes)
             .use(yjsRoutes)

--- a/src/routes/admin.spec.ts
+++ b/src/routes/admin.spec.ts
@@ -1484,6 +1484,167 @@ describe('Admin Routes', () => {
         });
     });
 
+    describe('AI settings — secret masking and write-only behaviour', () => {
+        it('never returns the AI API key value, only whether it is set', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        getAllSettings: async () => [
+                            { key: 'AI_AZURE_API_KEY', value: 'stored-secret', type: 'string' },
+                        ],
+                    }),
+                ),
+            );
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'GET',
+                    headers: { Authorization: `Bearer ${token}` },
+                }),
+            );
+
+            const data = await response.json();
+            expect(data.settings.AI_AZURE_API_KEY.value).toBe('');
+            expect(data.settings.AI_AZURE_API_KEY.isSet).toBe(true);
+            expect(JSON.stringify(data)).not.toContain('stored-secret');
+        });
+
+        it('reports isSet=false when no AI key is stored', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(createAdminRoutes(createMockDeps({ getAllSettings: async () => [] })));
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'GET',
+                    headers: { Authorization: `Bearer ${token}` },
+                }),
+            );
+
+            const data = await response.json();
+            expect(data.settings.AI_COMPAT_API_KEY.value).toBe('');
+            expect(data.settings.AI_COMPAT_API_KEY.isSet).toBe(false);
+        });
+
+        it('skips saving a blank AI API key (keeps the stored secret)', async () => {
+            const token = await generateAdminToken();
+            const saved: Array<{ key: string; value: string }> = [];
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        setSetting: async (_db, key, value) => {
+                            saved.push({ key, value });
+                        },
+                    }),
+                ),
+            );
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'PUT',
+                    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        settings: [
+                            { key: 'AI_AZURE_API_KEY', value: '', type: 'string' },
+                            { key: 'AI_PROVIDER', value: 'azure', type: 'string' },
+                        ],
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            expect(saved.some(s => s.key === 'AI_AZURE_API_KEY')).toBe(false);
+            expect(saved.some(s => s.key === 'AI_PROVIDER')).toBe(true);
+        });
+
+        it('saves a non-blank AI API key', async () => {
+            const token = await generateAdminToken();
+            const saved: Array<{ key: string; value: string }> = [];
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        setSetting: async (_db, key, value) => {
+                            saved.push({ key, value });
+                        },
+                    }),
+                ),
+            );
+
+            await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'PUT',
+                    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        settings: [{ key: 'AI_COMPAT_API_KEY', value: 'new-key', type: 'string' }],
+                    }),
+                }),
+            );
+
+            expect(saved).toEqual([{ key: 'AI_COMPAT_API_KEY', value: 'new-key' }]);
+        });
+
+        it('rejects an AI_PROVIDER outside the allow-list', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(createAdminRoutes(createMockDeps()));
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'PUT',
+                    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ settings: [{ key: 'AI_PROVIDER', value: 'skynet', type: 'string' }] }),
+                }),
+            );
+
+            expect(response.status).toBe(400);
+            expect((await response.json()).message).toContain('AI_PROVIDER');
+        });
+
+        it('rejects an invalid AI endpoint URL', async () => {
+            const token = await generateAdminToken();
+            const app = new Elysia().use(createAdminRoutes(createMockDeps()));
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'PUT',
+                    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        settings: [{ key: 'AI_OLLAMA_ENDPOINT', value: 'not-a-url', type: 'string' }],
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(400);
+            expect((await response.json()).message).toContain('AI_OLLAMA_ENDPOINT');
+        });
+
+        it('accepts a valid AI endpoint URL', async () => {
+            const token = await generateAdminToken();
+            const saved: Array<{ key: string; value: string }> = [];
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps({
+                        setSetting: async (_db, key, value) => {
+                            saved.push({ key, value });
+                        },
+                    }),
+                ),
+            );
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/settings', {
+                    method: 'PUT',
+                    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        settings: [{ key: 'AI_OLLAMA_ENDPOINT', value: 'http://localhost:11434', type: 'string' }],
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            expect(saved).toEqual([{ key: 'AI_OLLAMA_ENDPOINT', value: 'http://localhost:11434' }]);
+        });
+    });
+
     describe('PUT /api/admin/settings', () => {
         it('should update settings successfully', async () => {
             const token = await generateAdminToken();

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -52,6 +52,7 @@ import {
 } from '../db/queries/admin-analytics';
 import { getConnectedClientsDetail } from '../websocket/yjs-websocket';
 import { createFileHelper, type FileHelper } from '../services/file-helper';
+import { AI_PROVIDERS, AI_SECRET_KEYS, isAiProvider } from '../services/ai';
 import * as pathModule from 'path';
 import {
     ElpxExporter,
@@ -367,6 +368,49 @@ export function buildAdminTranslations(locale: string): Record<string, string> {
             {},
             locale,
         ),
+        // AI configuration
+        ai: trans('AI', {}, locale),
+        ai_settings: trans('AI Settings', {}, locale),
+        ai_intro: trans(
+            'Configure how AI assistance is offered in game-generation activities. With the external provider, users pick a public AI assistant (ChatGPT, Claude...). With a managed provider, eXeLearning generates questions through your own server-side AI and no public AI options are shown.',
+            {},
+            locale,
+        ),
+        ai_features_enabled: trans('Enable AI features', {}, locale),
+        ai_features_enabled_help: trans(
+            'When disabled, all AI buttons and AI preferences are hidden everywhere.',
+            {},
+            locale,
+        ),
+        ai_provider: trans('Provider', {}, locale),
+        ai_provider_help: trans(
+            'External keeps the public AI assistant links. Azure, Ollama and OpenAI-compatible route generation through your configured server-side provider.',
+            {},
+            locale,
+        ),
+        ai_provider_external: trans('External public assistants', {}, locale),
+        ai_provider_azure: trans('Azure OpenAI', {}, locale),
+        ai_provider_ollama: trans('Ollama', {}, locale),
+        ai_provider_openai_compat: trans('OpenAI-compatible', {}, locale),
+        ai_azure_group: trans('Azure OpenAI', {}, locale),
+        ai_ollama_group: trans('Ollama', {}, locale),
+        ai_compat_group: trans('OpenAI-compatible', {}, locale),
+        ai_common_group: trans('Generation options', {}, locale),
+        ai_endpoint: trans('Endpoint', {}, locale),
+        ai_api_key: trans('API key', {}, locale),
+        ai_api_key_help: trans('Stored on the server only. Leave blank to keep the current key.', {}, locale),
+        ai_api_key_set: trans('A key is currently configured.', {}, locale),
+        ai_api_key_unset: trans('No key configured.', {}, locale),
+        ai_deployment: trans('Deployment', {}, locale),
+        ai_api_version: trans('API version', {}, locale),
+        ai_model: trans('Model', {}, locale),
+        ai_request_timeout_ms: trans('Request timeout (ms)', {}, locale),
+        ai_max_output_tokens: trans('Max output tokens', {}, locale),
+        ai_temperature: trans('Temperature', {}, locale),
+        ai_test_connection: trans('Test connection', {}, locale),
+        ai_test_ok: trans('Connection successful', {}, locale),
+        ai_test_failed: trans('Connection failed', {}, locale),
+        ai_testing: trans('Testing...', {}, locale),
     };
 }
 
@@ -626,7 +670,37 @@ const ADMIN_SETTINGS_DEFAULTS: Record<
     APP_NAME: { value: '', type: 'string' },
     APP_FAVICON_PATH: { value: '', type: 'string' },
     MAINTENANCE_MODE: { value: process.env.MAINTENANCE_MODE ?? 'false', type: 'boolean' },
+    // AI (server-managed generation). Secrets (API keys) are write-only: never
+    // returned by GET (masked) and a blank value on PUT keeps the stored secret.
+    AI_FEATURES_ENABLED: { value: process.env.AI_FEATURES_ENABLED ?? 'true', type: 'boolean' },
+    AI_PROVIDER: { value: process.env.AI_PROVIDER || 'external', type: 'string' },
+    AI_AZURE_ENDPOINT: { value: process.env.AI_AZURE_ENDPOINT || '', type: 'string' },
+    AI_AZURE_API_KEY: { value: process.env.AI_AZURE_API_KEY || '', type: 'string' },
+    AI_AZURE_DEPLOYMENT: { value: process.env.AI_AZURE_DEPLOYMENT || '', type: 'string' },
+    AI_AZURE_API_VERSION: { value: process.env.AI_AZURE_API_VERSION || '', type: 'string' },
+    AI_OLLAMA_ENDPOINT: { value: process.env.AI_OLLAMA_ENDPOINT || 'http://localhost:11434', type: 'string' },
+    AI_OLLAMA_MODEL: { value: process.env.AI_OLLAMA_MODEL || '', type: 'string' },
+    AI_COMPAT_ENDPOINT: { value: process.env.AI_COMPAT_ENDPOINT || '', type: 'string' },
+    AI_COMPAT_API_KEY: { value: process.env.AI_COMPAT_API_KEY || '', type: 'string' },
+    AI_COMPAT_MODEL: { value: process.env.AI_COMPAT_MODEL || '', type: 'string' },
+    AI_REQUEST_TIMEOUT_MS: { value: process.env.AI_REQUEST_TIMEOUT_MS ?? '60000', type: 'number' },
+    AI_MAX_OUTPUT_TOKENS: { value: process.env.AI_MAX_OUTPUT_TOKENS ?? '4096', type: 'number' },
+    // Stored as a string so fractional temperatures (e.g. 0.2) survive round-trips.
+    AI_TEMPERATURE: { value: process.env.AI_TEMPERATURE ?? '0.2', type: 'string' },
 };
+
+/** AI endpoint keys validated as http(s) URLs on save. */
+const AI_ENDPOINT_KEYS = new Set<string>(['AI_AZURE_ENDPOINT', 'AI_OLLAMA_ENDPOINT', 'AI_COMPAT_ENDPOINT']);
+
+/** True when `value` parses as an absolute http(s) URL. */
+export function isValidHttpUrl(value: string): boolean {
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
 
 // ============================================================================
 // FACTORY FUNCTION
@@ -762,13 +836,24 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
                 const stored = await queries.getAllSettings(db as unknown as AppSettingsDb);
                 const storedMap = new Map(stored.map(item => [item.key, item]));
 
-                const settings: Record<string, { value: string | number | boolean; type: string }> = {};
+                const settings: Record<string, { value: string | number | boolean; type: string; isSet?: boolean }> =
+                    {};
                 for (const [key, def] of Object.entries(ADMIN_SETTINGS_DEFAULTS)) {
                     const override = storedMap.get(key);
-                    settings[key] = {
-                        value: override ? override.value : def.value,
-                        type: override ? override.type : def.type,
-                    };
+                    const rawValue = override ? override.value : def.value;
+                    const type = override ? override.type : def.type;
+
+                    // Secrets are never returned. Expose only whether a value is set.
+                    if (AI_SECRET_KEYS.has(key)) {
+                        settings[key] = {
+                            value: '',
+                            type,
+                            isSet: Boolean(rawValue !== undefined && rawValue !== null && String(rawValue) !== ''),
+                        };
+                        continue;
+                    }
+
+                    settings[key] = { value: rawValue, type };
                 }
 
                 return { settings };
@@ -814,6 +899,31 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
                                     message: `APP_AUTH_METHODS has invalid values: ${invalid.join(', ')}`,
                                 };
                             }
+                        }
+
+                        // Write-only secrets: a blank value means "keep the stored secret".
+                        if (AI_SECRET_KEYS.has(setting.key) && setting.value.trim() === '') {
+                            continue;
+                        }
+
+                        if (setting.key === 'AI_PROVIDER' && !isAiProvider(setting.value.trim())) {
+                            set.status = 400;
+                            return {
+                                error: 'Bad Request',
+                                message: `AI_PROVIDER must be one of: ${AI_PROVIDERS.join(', ')}`,
+                            };
+                        }
+
+                        if (
+                            AI_ENDPOINT_KEYS.has(setting.key) &&
+                            setting.value.trim() !== '' &&
+                            !isValidHttpUrl(setting.value.trim())
+                        ) {
+                            set.status = 400;
+                            return {
+                                error: 'Bad Request',
+                                message: `${setting.key} must be a valid http(s) URL`,
+                            };
                         }
 
                         try {

--- a/src/routes/ai.spec.ts
+++ b/src/routes/ai.spec.ts
@@ -89,18 +89,27 @@ describe('POST /api/ai/generate-text', () => {
         expect((await res.json()).text).toBe('Q for: biology');
     });
 
-    it('maps provider failures to a useful error without leaking secrets', async () => {
+    it('maps provider failures to a useful error without leaking secrets or upstream details', async () => {
         const app = buildApp({
             loadAiConfig: async () => azureConfig,
             generateText: async () => {
-                throw new AiError('AI_PROVIDER_ERROR', 'The AI provider returned an error (HTTP 500).', 502);
+                // The error carries an upstream `details` snippet for admin diagnostics;
+                // the public generate-text response must NOT expose it.
+                throw new AiError(
+                    'AI_PROVIDER_ERROR',
+                    'The AI provider returned an error (HTTP 500).',
+                    502,
+                    'upstream stack trace with secret-key',
+                );
             },
         });
         const res = await app.handle(postGenerate(await userToken(), { prompt: 'p' }));
         expect(res.status).toBe(502);
         const body = await res.json();
         expect(body.error).toBe('AI_PROVIDER_ERROR');
+        expect(body.details).toBeUndefined();
         expect(JSON.stringify(body)).not.toContain('secret-key');
+        expect(JSON.stringify(body)).not.toContain('upstream stack trace');
     });
 
     it('validates the request body (empty prompt rejected)', async () => {
@@ -144,5 +153,25 @@ describe('POST /api/ai/test-connection', () => {
         const body = await res.json();
         expect(body.ok).toBe(false);
         expect(body.error).toBe('AI_NOT_CONFIGURED');
+    });
+
+    it('surfaces the upstream `details` snippet to an admin so a provider failure is debuggable', async () => {
+        const app = buildApp({
+            loadAiConfig: async () => azureConfig,
+            generateText: async () => {
+                throw new AiError(
+                    'AI_PROVIDER_ERROR',
+                    'The AI provider returned an error (HTTP 500).',
+                    502,
+                    "model 'llama3' not found, try pulling it first",
+                );
+            },
+        });
+        const res = await app.handle(postTest(await adminToken()));
+        expect(res.status).toBe(502);
+        const body = await res.json();
+        expect(body.ok).toBe(false);
+        expect(body.error).toBe('AI_PROVIDER_ERROR');
+        expect(body.details).toContain("model 'llama3' not found");
     });
 });

--- a/src/routes/ai.spec.ts
+++ b/src/routes/ai.spec.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import { jwt } from '@elysiajs/jwt';
+import type { Kysely } from 'kysely';
+import type { Database } from '../db/types';
+import { createAiRoutes, type AiRoutesDeps } from './ai';
+import { parseAiConfig } from '../services/ai/config';
+import { generateText as realGenerateText } from '../services/ai/manager';
+import { AiError, type AiConfig } from '../services/ai/types';
+
+const TEST_JWT_SECRET = 'ai-route-test-secret';
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+    process.env.API_JWT_SECRET = TEST_JWT_SECRET;
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+});
+
+afterEach(() => {
+    process.env = { ...originalEnv };
+});
+
+async function signToken(payload: Record<string, unknown>): Promise<string> {
+    const tempApp = new Elysia().use(jwt({ name: 'jwt', secret: TEST_JWT_SECRET }));
+    // @ts-expect-error decorator typing is loose in tests
+    return tempApp.decorator.jwt.sign(payload);
+}
+
+function buildApp(overrides: Partial<AiRoutesDeps> = {}) {
+    const deps: AiRoutesDeps = {
+        db: {} as Kysely<Database>,
+        loadAiConfig: async () => parseAiConfig({ AI_PROVIDER: 'external' }),
+        generateText: realGenerateText,
+        ...overrides,
+    };
+    return new Elysia().use(createAiRoutes(deps));
+}
+
+function postGenerate(token: string | null, body: unknown) {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return new Request('http://localhost/api/ai/generate-text', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+    });
+}
+
+const userToken = () => signToken({ sub: 7, email: 'u@e.net', roles: ['ROLE_USER'], isGuest: false });
+const adminToken = () => signToken({ sub: 1, email: 'a@e.net', roles: ['ROLE_USER', 'ROLE_ADMIN'], isGuest: false });
+
+const azureConfig = parseAiConfig({
+    AI_PROVIDER: 'azure',
+    AI_AZURE_ENDPOINT: 'https://x.openai.azure.com',
+    AI_AZURE_API_KEY: 'secret-key',
+    AI_AZURE_DEPLOYMENT: 'd',
+    AI_AZURE_API_VERSION: '2024-02-01',
+});
+
+describe('POST /api/ai/generate-text', () => {
+    it('requires authentication', async () => {
+        const app = buildApp();
+        const res = await app.handle(postGenerate(null, { prompt: 'hello' }));
+        expect(res.status).toBe(401);
+    });
+
+    it('returns a safe disabled response when AI is disabled', async () => {
+        const app = buildApp({ loadAiConfig: async () => parseAiConfig({ AI_FEATURES_ENABLED: 'false' }) });
+        const res = await app.handle(postGenerate(await userToken(), { prompt: 'hello' }));
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('AI_DISABLED');
+    });
+
+    it('rejects external mode (no server-side generation)', async () => {
+        const app = buildApp({ loadAiConfig: async () => parseAiConfig({ AI_PROVIDER: 'external' }) });
+        const res = await app.handle(postGenerate(await userToken(), { prompt: 'hello' }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('AI_EXTERNAL_MODE');
+    });
+
+    it('returns generated text for a configured managed provider', async () => {
+        const app = buildApp({
+            loadAiConfig: async () => azureConfig,
+            generateText: async (_config: AiConfig, prompt: string) => ({ text: `Q for: ${prompt}` }),
+        });
+        const res = await app.handle(postGenerate(await userToken(), { prompt: 'biology' }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).text).toBe('Q for: biology');
+    });
+
+    it('maps provider failures to a useful error without leaking secrets', async () => {
+        const app = buildApp({
+            loadAiConfig: async () => azureConfig,
+            generateText: async () => {
+                throw new AiError('AI_PROVIDER_ERROR', 'The AI provider returned an error (HTTP 500).', 502);
+            },
+        });
+        const res = await app.handle(postGenerate(await userToken(), { prompt: 'p' }));
+        expect(res.status).toBe(502);
+        const body = await res.json();
+        expect(body.error).toBe('AI_PROVIDER_ERROR');
+        expect(JSON.stringify(body)).not.toContain('secret-key');
+    });
+
+    it('validates the request body (empty prompt rejected)', async () => {
+        const app = buildApp();
+        const res = await app.handle(postGenerate(await userToken(), { prompt: '' }));
+        expect(res.status).toBe(422);
+    });
+});
+
+describe('POST /api/ai/test-connection', () => {
+    function postTest(token: string | null) {
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
+        return new Request('http://localhost/api/ai/test-connection', { method: 'POST', headers });
+    }
+
+    it('rejects non-admin users', async () => {
+        const app = buildApp({ loadAiConfig: async () => azureConfig });
+        const res = await app.handle(postTest(await userToken()));
+        expect(res.status).toBe(403);
+        expect((await res.json()).ok).toBe(false);
+    });
+
+    it('reports success when the provider responds for an admin', async () => {
+        const app = buildApp({
+            loadAiConfig: async () => azureConfig,
+            generateText: async () => ({ text: 'OK' }),
+        });
+        const res = await app.handle(postTest(await adminToken()));
+        expect(res.status).toBe(200);
+        expect((await res.json()).ok).toBe(true);
+    });
+
+    it('reports a clear error when the managed provider is misconfigured', async () => {
+        const app = buildApp({
+            loadAiConfig: async () => parseAiConfig({ AI_PROVIDER: 'ollama' }),
+            generateText: realGenerateText,
+        });
+        const res = await app.handle(postTest(await adminToken()));
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.ok).toBe(false);
+        expect(body.error).toBe('AI_NOT_CONFIGURED');
+    });
+});

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -84,7 +84,11 @@ export function createAiRoutes(deps: AiRoutesDeps = defaultDeps) {
                 } catch (error) {
                     if (error instanceof AiError) {
                         set.status = error.status;
-                        return { ok: false, error: error.code, message: error.message };
+                        // Admin-only diagnostic: include the upstream `details` snippet
+                        // (e.g. Ollama's "model not found" body) so an administrator can
+                        // see exactly why the managed provider failed. This endpoint is
+                        // guarded by requireAdmin, so the snippet is never exposed publicly.
+                        return { ok: false, error: error.code, message: error.message, details: error.details };
                     }
                     set.status = 502;
                     return { ok: false, error: 'AI_PROVIDER_ERROR', message: 'The AI request failed.' };

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -1,0 +1,96 @@
+/**
+ * AI Routes for Elysia.
+ *
+ * Online-only, authenticated endpoint that runs the configured managed AI
+ * provider on the user's behalf. It is intentionally absent from STATIC_ROUTES
+ * so static/offline builds neither ship it nor require provider secrets.
+ *
+ * Security:
+ *  - Requires a valid session (requireAuth).
+ *  - Returns a safe, typed error (never provider URLs/keys/payloads).
+ *  - When AI is disabled or set to the external provider it fails closed with a
+ *    clear error and never calls a public AI service.
+ */
+import { Elysia, t } from 'elysia';
+import type { Kysely } from 'kysely';
+import { db as defaultDb } from '../db/client';
+import type { Database } from '../db/types';
+import { withJwtAuth } from '../utils/route-auth';
+import { requireAdmin, requireAuth } from '../utils/guards';
+import { AiError, generateText as generateTextDefault, loadAiConfig as loadAiConfigDefault } from '../services/ai';
+
+export interface AiRoutesDeps {
+    db: Kysely<Database>;
+    loadAiConfig: typeof loadAiConfigDefault;
+    generateText: typeof generateTextDefault;
+}
+
+const defaultDeps: AiRoutesDeps = {
+    db: defaultDb,
+    loadAiConfig: loadAiConfigDefault,
+    generateText: generateTextDefault,
+};
+
+const generateTextSchema = t.Object({
+    prompt: t.String({ minLength: 1, maxLength: 20000 }),
+});
+
+/**
+ * Factory to create the AI routes with dependency injection (used by tests).
+ */
+export function createAiRoutes(deps: AiRoutesDeps = defaultDeps) {
+    const { db, loadAiConfig, generateText } = deps;
+
+    return (
+        new Elysia({ name: 'ai-routes' })
+            .use(withJwtAuth())
+            .onBeforeHandle(({ jwtPayload, set }) => {
+                const err = requireAuth(jwtPayload);
+                if (err) {
+                    set.status = err.status;
+                    return { error: err.error, message: err.message };
+                }
+            })
+            .post(
+                '/api/ai/generate-text',
+                async ({ body, set }) => {
+                    const { prompt } = body as { prompt: string };
+                    const config = await loadAiConfig(db);
+                    try {
+                        const result = await generateText(config, prompt);
+                        return { text: result.text };
+                    } catch (error) {
+                        if (error instanceof AiError) {
+                            set.status = error.status;
+                            return { error: error.code, message: error.message };
+                        }
+                        set.status = 502;
+                        return { error: 'AI_PROVIDER_ERROR', message: 'The AI request failed.' };
+                    }
+                },
+                { body: generateTextSchema },
+            )
+            // Admin-only diagnostic: verify the configured managed provider responds.
+            .post('/api/ai/test-connection', async ({ jwtPayload, set }) => {
+                const adminErr = requireAdmin(jwtPayload);
+                if (adminErr) {
+                    set.status = adminErr.status;
+                    return { ok: false, error: adminErr.error, message: adminErr.message };
+                }
+                const config = await loadAiConfig(db);
+                try {
+                    await generateText(config, 'Reply with the single word: OK.');
+                    return { ok: true };
+                } catch (error) {
+                    if (error instanceof AiError) {
+                        set.status = error.status;
+                        return { ok: false, error: error.code, message: error.message };
+                    }
+                    set.status = 502;
+                    return { ok: false, error: 'AI_PROVIDER_ERROR', message: 'The AI request failed.' };
+                }
+            })
+    );
+}
+
+export const aiRoutes = createAiRoutes();

--- a/src/routes/api-routes.ts
+++ b/src/routes/api-routes.ts
@@ -127,6 +127,9 @@ export const API_ROUTES: RouteMap = {
     // Config
     api_config_upload_limits: { path: '/api/config/upload-limits', methods: ['GET'] },
     api_config_parameters: { path: '/api/config/parameters', methods: ['GET'] },
+
+    // AI (online-only managed generation; intentionally NOT in STATIC_ROUTES)
+    api_ai_generate_text: { path: '/api/ai/generate-text', methods: ['POST'] },
 };
 
 /**

--- a/src/routes/config-params.spec.ts
+++ b/src/routes/config-params.spec.ts
@@ -125,4 +125,26 @@ describe('buildConfigParams', () => {
             expect(result.USER_PREFERENCES_CONFIG.theme.type).toBe('text');
         });
     });
+
+    describe('INCLUDE_DEFAULT_AI dependency', () => {
+        it('includes defaultAI by default (external mode)', () => {
+            const result = buildConfigParams({ TRANS_PREFIX: '', LICENSES, PACKAGE_LOCALES, LOCALES });
+            expect(result.USER_PREFERENCES_CONFIG.defaultAI).toBeDefined();
+        });
+
+        it('omits defaultAI when INCLUDE_DEFAULT_AI is false (managed/disabled)', () => {
+            const result = buildConfigParams({
+                TRANS_PREFIX: '',
+                LICENSES,
+                PACKAGE_LOCALES,
+                LOCALES,
+                INCLUDE_DEFAULT_AI: false,
+            });
+            expect(result.USER_PREFERENCES_CONFIG.defaultAI).toBeUndefined();
+            // Other preferences remain intact.
+            expect(result.USER_PREFERENCES_CONFIG.locale).toBeDefined();
+            expect(result.USER_PREFERENCES_CONFIG.defaultTheme).toBeDefined();
+            expect(result.USER_PREFERENCES_CONFIG.versionControl).toBeDefined();
+        });
+    });
 });

--- a/src/routes/config-params.ts
+++ b/src/routes/config-params.ts
@@ -21,12 +21,20 @@ export interface ConfigParamsDeps {
      * callers keep working until they pass the new dependency.
      */
     THEMES?: Record<string, string>;
+    /**
+     * Whether to include the `defaultAI` user preference (the public AI
+     * assistant selector). It is shown only when AI features are enabled AND
+     * the provider is `external`. Defaults to true so existing callers keep
+     * the historical behaviour.
+     */
+    INCLUDE_DEFAULT_AI?: boolean;
 }
 
 export function buildConfigParams(deps: ConfigParamsDeps) {
     // Named TRANS_PREFIX so the translation extractor can detect strings in this file.
     const TRANS_PREFIX = deps.TRANS_PREFIX;
     const { LICENSES, PACKAGE_LOCALES, LOCALES } = deps;
+    const includeDefaultAI = deps.INCLUDE_DEFAULT_AI !== false;
     // The first option (empty value) means "use the server/site default theme".
     const THEMES: Record<string, string> = {
         '': `${TRANS_PREFIX}Use the default style of the site`,
@@ -71,21 +79,27 @@ export function buildConfigParams(deps: ConfigParamsDeps) {
             options: THEMES,
             category: `${TRANS_PREFIX}General settings`,
         },
-        defaultAI: {
-            title: `${TRANS_PREFIX}Default AI Assistant`,
-            help: `${TRANS_PREFIX}Select the AI that will be selected by default when editing iDevices.`,
-            value: 'https://chatgpt.com/?q=',
-            type: 'select',
-            options: {
-                'https://chatgpt.com/?q=': 'ChatGPT',
-                'https://claude.ai/new?q=': 'Claude',
-                'https://www.perplexity.ai/search?q=': 'Perplexity',
-                'https://chat.mistral.ai/chat/?q=': 'Le Chat (Mistral)',
-                'https://grok.com/?q=': 'Grok',
-                'https://chat.qwen.ai/?text=': 'Qwen',
-            },
-            category: `${TRANS_PREFIX}General settings`,
-        },
+        // The public AI assistant selector is only offered in external mode; a
+        // managed/disabled AI configuration omits it (see INCLUDE_DEFAULT_AI).
+        ...(includeDefaultAI
+            ? {
+                  defaultAI: {
+                      title: `${TRANS_PREFIX}Default AI Assistant`,
+                      help: `${TRANS_PREFIX}Select the AI that will be selected by default when editing iDevices.`,
+                      value: 'https://chatgpt.com/?q=',
+                      type: 'select',
+                      options: {
+                          'https://chatgpt.com/?q=': 'ChatGPT',
+                          'https://claude.ai/new?q=': 'Claude',
+                          'https://www.perplexity.ai/search?q=': 'Perplexity',
+                          'https://chat.mistral.ai/chat/?q=': 'Le Chat (Mistral)',
+                          'https://grok.com/?q=': 'Grok',
+                          'https://chat.qwen.ai/?text=': 'Qwen',
+                      },
+                      category: `${TRANS_PREFIX}General settings`,
+                  },
+              }
+            : {}),
         // Legacy 'theme' key is kept hidden for backward compatibility so projects
         // that still read user.preferences.preferences.theme keep working until
         // they migrate to the new defaultTheme key.

--- a/src/routes/config.spec.ts
+++ b/src/routes/config.spec.ts
@@ -626,4 +626,78 @@ describe('Config Routes', () => {
             }
         });
     });
+
+    describe('AI capability config (public, no secrets)', () => {
+        async function clearAiSettings() {
+            await db
+                .deleteFrom('app_settings')
+                .where('key', 'in', [
+                    'AI_FEATURES_ENABLED',
+                    'AI_PROVIDER',
+                    'AI_OLLAMA_MODEL',
+                    'AI_AZURE_ENDPOINT',
+                    'AI_AZURE_API_KEY',
+                    'AI_AZURE_DEPLOYMENT',
+                    'AI_AZURE_API_VERSION',
+                ])
+                .execute();
+        }
+
+        async function fetchParams() {
+            const response = await app.handle(
+                new Request('http://localhost/api/parameter-management/parameters/data/list'),
+            );
+            return response.json();
+        }
+
+        it('defaults to enabled external mode and includes defaultAI', async () => {
+            await clearAiSettings();
+            const data = await fetchParams();
+            expect(data.ai).toEqual({ enabled: true, provider: 'external', mode: 'external', configured: true });
+            expect(data.userPreferencesConfig.defaultAI).toBeDefined();
+        });
+
+        it('hides defaultAI and reports managed mode for a configured managed provider', async () => {
+            await clearAiSettings();
+            await setSetting(db, 'AI_PROVIDER', 'ollama', 'string');
+            await setSetting(db, 'AI_OLLAMA_MODEL', 'llama3', 'string');
+            try {
+                const data = await fetchParams();
+                expect(data.ai.provider).toBe('ollama');
+                expect(data.ai.mode).toBe('managed');
+                expect(data.ai.configured).toBe(true);
+                expect(data.userPreferencesConfig.defaultAI).toBeUndefined();
+            } finally {
+                await clearAiSettings();
+            }
+        });
+
+        it('disables AI and hides defaultAI when features are turned off', async () => {
+            await clearAiSettings();
+            await setSetting(db, 'AI_FEATURES_ENABLED', 'false', 'boolean');
+            try {
+                const data = await fetchParams();
+                expect(data.ai.enabled).toBe(false);
+                expect(data.userPreferencesConfig.defaultAI).toBeUndefined();
+            } finally {
+                await clearAiSettings();
+            }
+        });
+
+        it('never leaks provider secrets in the response', async () => {
+            await clearAiSettings();
+            await setSetting(db, 'AI_PROVIDER', 'azure', 'string');
+            await setSetting(db, 'AI_AZURE_ENDPOINT', 'https://x.openai.azure.com', 'string');
+            await setSetting(db, 'AI_AZURE_API_KEY', 'leaky-secret-value', 'string');
+            await setSetting(db, 'AI_AZURE_DEPLOYMENT', 'gpt4o', 'string');
+            await setSetting(db, 'AI_AZURE_API_VERSION', '2024-02-01', 'string');
+            try {
+                const data = await fetchParams();
+                expect(data.ai.configured).toBe(true);
+                expect(JSON.stringify(data)).not.toContain('leaky-secret-value');
+            } finally {
+                await clearAiSettings();
+            }
+        });
+    });
 });

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -36,6 +36,8 @@ import { ALLOWED_EXTENSIONS } from '../config';
 import { buildConfigParams } from './config-params';
 import { API_ROUTES, prefixRoutesWithBasePath } from './api-routes';
 import { buildParameterResponse } from './parameter-response';
+import { loadAiConfig, toPublicAiConfig } from '../services/ai';
+import type { PublicAiConfig } from '../services/ai';
 
 /**
  * Available licenses for content dropdown
@@ -74,9 +76,28 @@ async function buildThemesMap(): Promise<Record<string, string>> {
  * (admin uploads/disables), so we resolve them at request time instead of
  * caching at module load.
  */
-async function getConfigParams() {
+async function getConfigParams(includeDefaultAI = true) {
     const THEMES = await buildThemesMap();
-    return buildConfigParams({ TRANS_PREFIX, LICENSES, PACKAGE_LOCALES, LOCALES, THEMES });
+    return buildConfigParams({
+        TRANS_PREFIX,
+        LICENSES,
+        PACKAGE_LOCALES,
+        LOCALES,
+        THEMES,
+        INCLUDE_DEFAULT_AI: includeDefaultAI,
+    });
+}
+
+/**
+ * Resolve the safe public AI capability object and whether the public AI
+ * assistant selector (`defaultAI`) should be offered. `defaultAI` is shown only
+ * when AI features are enabled AND the provider is `external`.
+ */
+async function getAiState(): Promise<{ publicAi: PublicAiConfig; includeDefaultAI: boolean }> {
+    const aiConfig = await loadAiConfig(defaultDb);
+    const publicAi = toPublicAiConfig(aiConfig);
+    const includeDefaultAI = publicAi.enabled && publicAi.mode === 'external';
+    return { publicAi, includeDefaultAI };
 }
 
 /**
@@ -211,8 +232,11 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
             parseNumber(process.env.PERMANENT_SAVE_AUTOSAVE_TIME_INTERVAL, 600),
         );
 
+        // Resolve AI capability flags and whether the public AI selector is offered.
+        const { publicAi, includeDefaultAI } = await getAiState();
+
         // Translate all config params for the requested locale
-        const translatedParams = translateObject(await getConfigParams(), locale);
+        const translatedParams = translateObject(await getConfigParams(includeDefaultAI), locale);
 
         return buildParameterResponse({
             configParams: translatedParams,
@@ -224,6 +248,7 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
                 autosaveIntervalTime,
                 generateNewItemKey: `item_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
             },
+            ai: publicAi,
         });
     })
 
@@ -285,10 +310,12 @@ export const configRoutes = new Elysia({ name: 'config-routes' })
 
         // Return the parameters with TRANSLATABLE_TEXT: values translated
         // Return translated config params only (no routes or app settings)
-        const translatedParams = translateObject(await getConfigParams(), locale);
+        const { publicAi, includeDefaultAI } = await getAiState();
+        const translatedParams = translateObject(await getConfigParams(includeDefaultAI), locale);
         return buildParameterResponse({
             configParams: translatedParams,
             routes: {},
+            ai: publicAi,
         });
     })
 

--- a/src/routes/pages.spec.ts
+++ b/src/routes/pages.spec.ts
@@ -2030,6 +2030,61 @@ describe('Pages Routes', () => {
             expect(res.headers.get('content-type')).toContain('text/html');
         });
 
+        it('masks stored AI API keys in the admin view-model (never the raw value)', async () => {
+            mockUsers.set(12, {
+                id: 12,
+                email: 'admin3@test.com',
+                roles: '["ROLE_USER", "ROLE_ADMIN"]',
+            });
+
+            // db mock whose getAllSettings (app_settings) returns stored AI secrets.
+            const aiSecretDb = {
+                selectFrom: (table: string) => ({
+                    selectAll: () => ({
+                        execute: async () =>
+                            table === 'app_settings'
+                                ? [
+                                      { key: 'AI_AZURE_API_KEY', value: 'stored-secret-value', type: 'string' },
+                                      { key: 'AI_COMPAT_API_KEY', value: 'stored-secret-value', type: 'string' },
+                                  ]
+                                : [],
+                    }),
+                }),
+            } as any;
+
+            let templateData: any = null;
+            const customTemplate: PagesTemplateDeps = {
+                renderTemplate: (_template: string, data: any) => {
+                    templateData = data;
+                    return '<html></html>';
+                },
+                setRenderLocale: () => {},
+            };
+            const customApp = new Elysia().use(
+                createPagesRoutes({ ...mockDeps, db: aiSecretDb, template: customTemplate }),
+            );
+
+            const jwt = await import('@elysiajs/jwt');
+            const tempApp = new Elysia().use(jwt.jwt({ name: 'jwt', secret: 'test-secret-for-testing-only' }));
+            const token = await tempApp.decorator.jwt.sign({
+                sub: 12,
+                email: 'admin3@test.com',
+                roles: ['ROLE_USER', 'ROLE_ADMIN'],
+                isGuest: false,
+            });
+
+            const res = await customApp.handle(
+                new Request('http://localhost/admin', { headers: { Cookie: `auth=${token}` } }),
+            );
+
+            expect(res.status).toBe(200);
+            expect(templateData).not.toBeNull();
+            expect(templateData.adminSettings.ai.azure_api_key_set).toBe(true);
+            expect(templateData.adminSettings.ai.compat_api_key_set).toBe(true);
+            // The raw secret must never reach the template/browser.
+            expect(JSON.stringify(templateData.adminSettings.ai)).not.toContain('stored-secret-value');
+        });
+
         it('should detect locale from Accept-Language header', async () => {
             let templateData: any = null;
             const customTemplate: PagesTemplateDeps = {

--- a/src/routes/pages.ts
+++ b/src/routes/pages.ts
@@ -1175,6 +1175,24 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     maintenance: {
                         maintenance_mode: false,
                     },
+                    // AI settings. Secrets are rendered as *_set booleans only — the
+                    // raw API keys are NEVER sent to the admin template/browser.
+                    ai: {
+                        features_enabled: parseBoolean(process.env.AI_FEATURES_ENABLED, true),
+                        provider: process.env.AI_PROVIDER || 'external',
+                        azure_endpoint: process.env.AI_AZURE_ENDPOINT || '',
+                        azure_api_key_set: Boolean(process.env.AI_AZURE_API_KEY),
+                        azure_deployment: process.env.AI_AZURE_DEPLOYMENT || '',
+                        azure_api_version: process.env.AI_AZURE_API_VERSION || '',
+                        ollama_endpoint: process.env.AI_OLLAMA_ENDPOINT || 'http://localhost:11434',
+                        ollama_model: process.env.AI_OLLAMA_MODEL || '',
+                        compat_endpoint: process.env.AI_COMPAT_ENDPOINT || '',
+                        compat_api_key_set: Boolean(process.env.AI_COMPAT_API_KEY),
+                        compat_model: process.env.AI_COMPAT_MODEL || '',
+                        request_timeout_ms: parseNumber(process.env.AI_REQUEST_TIMEOUT_MS, 60000),
+                        max_output_tokens: parseNumber(process.env.AI_MAX_OUTPUT_TOKENS, 4096),
+                        temperature: process.env.AI_TEMPERATURE || '0.2',
+                    },
                 };
 
                 const adminSettingsMap: Record<
@@ -1222,11 +1240,32 @@ export function createPagesRoutes(deps: PagesDependencies = defaultDependencies)
                     APP_NAME: { path: ['presentation', 'app_name'], type: 'string' },
                     APP_FAVICON_PATH: { path: ['presentation', 'app_favicon_path'], type: 'string' },
                     MAINTENANCE_MODE: { path: ['maintenance', 'maintenance_mode'], type: 'boolean' },
+                    // AI (non-secret keys only; AI_*_API_KEY are handled as *_set flags below).
+                    AI_FEATURES_ENABLED: { path: ['ai', 'features_enabled'], type: 'boolean' },
+                    AI_PROVIDER: { path: ['ai', 'provider'], type: 'string' },
+                    AI_AZURE_ENDPOINT: { path: ['ai', 'azure_endpoint'], type: 'string' },
+                    AI_AZURE_DEPLOYMENT: { path: ['ai', 'azure_deployment'], type: 'string' },
+                    AI_AZURE_API_VERSION: { path: ['ai', 'azure_api_version'], type: 'string' },
+                    AI_OLLAMA_ENDPOINT: { path: ['ai', 'ollama_endpoint'], type: 'string' },
+                    AI_OLLAMA_MODEL: { path: ['ai', 'ollama_model'], type: 'string' },
+                    AI_COMPAT_ENDPOINT: { path: ['ai', 'compat_endpoint'], type: 'string' },
+                    AI_COMPAT_MODEL: { path: ['ai', 'compat_model'], type: 'string' },
+                    AI_REQUEST_TIMEOUT_MS: { path: ['ai', 'request_timeout_ms'], type: 'number' },
+                    AI_MAX_OUTPUT_TOKENS: { path: ['ai', 'max_output_tokens'], type: 'number' },
+                    AI_TEMPERATURE: { path: ['ai', 'temperature'], type: 'string' },
                 };
 
                 try {
                     const storedSettings = await getAllSettingsDefault(db as unknown as AppSettingsDb);
                     for (const setting of storedSettings) {
+                        // Secrets: never expose the value, only whether one is set.
+                        if (setting.key === 'AI_AZURE_API_KEY') {
+                            adminSettings.ai.azure_api_key_set =
+                                adminSettings.ai.azure_api_key_set || Boolean(setting.value);
+                        } else if (setting.key === 'AI_COMPAT_API_KEY') {
+                            adminSettings.ai.compat_api_key_set =
+                                adminSettings.ai.compat_api_key_set || Boolean(setting.value);
+                        }
                         const mapping = adminSettingsMap[setting.key];
                         if (!mapping) continue;
 

--- a/src/routes/parameter-response.ts
+++ b/src/routes/parameter-response.ts
@@ -11,6 +11,7 @@
 
 import type { buildConfigParams } from './config-params';
 import type { RouteMap } from './api-routes';
+import type { PublicAiConfig } from '../services/ai/types';
 
 /**
  * Server-only application settings.
@@ -33,6 +34,11 @@ export interface ParameterResponseOptions {
     appSettings?: AppSettings;
     /** When true, returns empty themeEditionFieldsConfig (static/offline mode). */
     disableThemeEdition?: boolean;
+    /**
+     * Safe, client-facing AI capability flags. Contains no secrets. Omitted when
+     * absent so callers that do not compute it (e.g. legacy paths) stay valid.
+     */
+    ai?: PublicAiConfig;
 }
 
 /**
@@ -40,7 +46,7 @@ export interface ParameterResponseOptions {
  * Both server and static call this with their respective inputs.
  */
 export function buildParameterResponse(opts: ParameterResponseOptions) {
-    const { configParams, routes, appSettings = {}, disableThemeEdition = false } = opts;
+    const { configParams, routes, appSettings = {}, disableThemeEdition = false, ai } = opts;
 
     return {
         userPreferencesConfig: configParams.USER_PREFERENCES_CONFIG,
@@ -54,5 +60,6 @@ export function buildParameterResponse(opts: ParameterResponseOptions) {
         odeProjectSyncCataloguingConfig: configParams.ODE_PROJECT_SYNC_CATALOGUING_CONFIG,
         routes,
         ...appSettings,
+        ...(ai ? { ai } : {}),
     };
 }

--- a/src/services/ai/config.spec.ts
+++ b/src/services/ai/config.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'bun:test';
+import type { Kysely } from 'kysely';
+import type { Database } from '../../db/types';
+import {
+    AI_SECRET_KEYS,
+    DEFAULT_OLLAMA_ENDPOINT,
+    isAiProvider,
+    isProviderConfigured,
+    loadAiConfig,
+    parseAiConfig,
+    parseProvider,
+    toPublicAiConfig,
+} from './config';
+
+describe('parseProvider', () => {
+    it('accepts known providers', () => {
+        expect(parseProvider('external')).toBe('external');
+        expect(parseProvider('azure')).toBe('azure');
+        expect(parseProvider('ollama')).toBe('ollama');
+        expect(parseProvider('openai_compat')).toBe('openai_compat');
+    });
+
+    it('is case-insensitive and trims', () => {
+        expect(parseProvider('  AZURE ')).toBe('azure');
+    });
+
+    it('falls back to external for unknown or empty values', () => {
+        expect(parseProvider('gpt-9000')).toBe('external');
+        expect(parseProvider('')).toBe('external');
+        expect(parseProvider(undefined)).toBe('external');
+    });
+});
+
+describe('isAiProvider', () => {
+    it('validates against the allow-list', () => {
+        expect(isAiProvider('ollama')).toBe(true);
+        expect(isAiProvider('nope')).toBe(false);
+    });
+});
+
+describe('parseAiConfig', () => {
+    it('uses safe defaults (enabled + external) when nothing is set', () => {
+        const config = parseAiConfig({});
+        expect(config.enabled).toBe(true);
+        expect(config.provider).toBe('external');
+        expect(config.mode).toBe('external');
+        expect(config.ollama.endpoint).toBe(DEFAULT_OLLAMA_ENDPOINT);
+        expect(config.requestTimeoutMs).toBe(60000);
+        expect(config.maxOutputTokens).toBe(4096);
+        expect(config.temperature).toBeCloseTo(0.2);
+    });
+
+    it('disables AI when AI_FEATURES_ENABLED is falsey', () => {
+        expect(parseAiConfig({ AI_FEATURES_ENABLED: 'false' }).enabled).toBe(false);
+        expect(parseAiConfig({ AI_FEATURES_ENABLED: '0' }).enabled).toBe(false);
+        expect(parseAiConfig({ AI_FEATURES_ENABLED: 'off' }).enabled).toBe(false);
+    });
+
+    it('derives managed mode for non-external providers', () => {
+        expect(parseAiConfig({ AI_PROVIDER: 'azure' }).mode).toBe('managed');
+        expect(parseAiConfig({ AI_PROVIDER: 'ollama' }).mode).toBe('managed');
+        expect(parseAiConfig({ AI_PROVIDER: 'openai_compat' }).mode).toBe('managed');
+    });
+
+    it('falls back to external for an invalid provider', () => {
+        const config = parseAiConfig({ AI_PROVIDER: 'bogus' });
+        expect(config.provider).toBe('external');
+        expect(config.mode).toBe('external');
+    });
+
+    it('parses a fractional temperature and falls back on invalid input', () => {
+        expect(parseAiConfig({ AI_TEMPERATURE: '0.7' }).temperature).toBeCloseTo(0.7);
+        expect(parseAiConfig({ AI_TEMPERATURE: 'hot' }).temperature).toBeCloseTo(0.2);
+    });
+
+    it('clamps non-positive timeout and max-output-tokens to the defaults', () => {
+        expect(parseAiConfig({ AI_REQUEST_TIMEOUT_MS: '0' }).requestTimeoutMs).toBe(60000);
+        expect(parseAiConfig({ AI_REQUEST_TIMEOUT_MS: '-5' }).requestTimeoutMs).toBe(60000);
+        expect(parseAiConfig({ AI_MAX_OUTPUT_TOKENS: '0' }).maxOutputTokens).toBe(4096);
+        // Positive overrides are respected.
+        expect(parseAiConfig({ AI_REQUEST_TIMEOUT_MS: '5000' }).requestTimeoutMs).toBe(5000);
+        expect(parseAiConfig({ AI_MAX_OUTPUT_TOKENS: '256' }).maxOutputTokens).toBe(256);
+    });
+
+    it('keeps a configured Ollama endpoint but defaults a blank one', () => {
+        expect(parseAiConfig({ AI_OLLAMA_ENDPOINT: 'http://ollama:11434' }).ollama.endpoint).toBe(
+            'http://ollama:11434',
+        );
+        expect(parseAiConfig({ AI_OLLAMA_ENDPOINT: '   ' }).ollama.endpoint).toBe(DEFAULT_OLLAMA_ENDPOINT);
+    });
+});
+
+describe('isProviderConfigured', () => {
+    it('is always true for external', () => {
+        expect(isProviderConfigured(parseAiConfig({ AI_PROVIDER: 'external' }))).toBe(true);
+    });
+
+    it('requires endpoint, key, deployment and api version for azure', () => {
+        const incomplete = parseAiConfig({ AI_PROVIDER: 'azure', AI_AZURE_ENDPOINT: 'https://x.openai.azure.com' });
+        expect(isProviderConfigured(incomplete)).toBe(false);
+        const complete = parseAiConfig({
+            AI_PROVIDER: 'azure',
+            AI_AZURE_ENDPOINT: 'https://x.openai.azure.com',
+            AI_AZURE_API_KEY: 'key',
+            AI_AZURE_DEPLOYMENT: 'gpt4o',
+            AI_AZURE_API_VERSION: '2024-02-01',
+        });
+        expect(isProviderConfigured(complete)).toBe(true);
+    });
+
+    it('requires a model for ollama (endpoint has a default)', () => {
+        expect(isProviderConfigured(parseAiConfig({ AI_PROVIDER: 'ollama' }))).toBe(false);
+        expect(isProviderConfigured(parseAiConfig({ AI_PROVIDER: 'ollama', AI_OLLAMA_MODEL: 'llama3' }))).toBe(true);
+    });
+
+    it('requires endpoint and model for openai_compat; api key optional', () => {
+        expect(isProviderConfigured(parseAiConfig({ AI_PROVIDER: 'openai_compat', AI_COMPAT_MODEL: 'gpt' }))).toBe(
+            false,
+        );
+        const ok = parseAiConfig({
+            AI_PROVIDER: 'openai_compat',
+            AI_COMPAT_ENDPOINT: 'https://api.example.com/v1',
+            AI_COMPAT_MODEL: 'gpt',
+        });
+        expect(isProviderConfigured(ok)).toBe(true);
+    });
+});
+
+describe('toPublicAiConfig', () => {
+    it('exposes only capability flags and never secrets', () => {
+        const config = parseAiConfig({
+            AI_PROVIDER: 'azure',
+            AI_AZURE_ENDPOINT: 'https://x.openai.azure.com',
+            AI_AZURE_API_KEY: 'super-secret',
+            AI_AZURE_DEPLOYMENT: 'gpt4o',
+            AI_AZURE_API_VERSION: '2024-02-01',
+        });
+        const pub = toPublicAiConfig(config);
+        expect(pub).toEqual({ enabled: true, provider: 'azure', mode: 'managed', configured: true });
+        expect(JSON.stringify(pub)).not.toContain('super-secret');
+    });
+
+    it('reports not-configured for an incomplete managed provider', () => {
+        const pub = toPublicAiConfig(parseAiConfig({ AI_PROVIDER: 'azure' }));
+        expect(pub.configured).toBe(false);
+    });
+});
+
+describe('AI_SECRET_KEYS', () => {
+    it('marks the provider API keys as secrets', () => {
+        expect(AI_SECRET_KEYS.has('AI_AZURE_API_KEY')).toBe(true);
+        expect(AI_SECRET_KEYS.has('AI_COMPAT_API_KEY')).toBe(true);
+        expect(AI_SECRET_KEYS.has('AI_PROVIDER')).toBe(false);
+    });
+});
+
+describe('loadAiConfig', () => {
+    it('reads each key via the injected settings reader (db overrides env)', async () => {
+        const stored: Record<string, string> = {
+            AI_FEATURES_ENABLED: 'true',
+            AI_PROVIDER: 'ollama',
+            AI_OLLAMA_MODEL: 'llama3',
+        };
+        const getSettingString = async (_db: Kysely<Database>, key: string, fallback: string) =>
+            stored[key] ?? fallback;
+
+        const config = await loadAiConfig({} as Kysely<Database>, { getSettingString });
+        expect(config.provider).toBe('ollama');
+        expect(config.mode).toBe('managed');
+        expect(config.ollama.model).toBe('llama3');
+        expect(isProviderConfigured(config)).toBe(true);
+    });
+});

--- a/src/services/ai/config.ts
+++ b/src/services/ai/config.ts
@@ -1,0 +1,158 @@
+/**
+ * AI configuration parsing and loading.
+ *
+ * `parseAiConfig` is a pure function over a flat record of raw string values so
+ * it can be unit-tested without a database. `loadAiConfig` is a thin async
+ * wrapper that reads each key from `app_settings` (admin overrides) falling back
+ * to the matching `process.env` value, then delegates to `parseAiConfig`.
+ *
+ * Defaults: AI features are ENABLED and the provider is `external`, which
+ * preserves the historical behaviour (public AI assistant links) for
+ * installations that do not configure anything.
+ */
+import type { Kysely } from 'kysely';
+import type { Database } from '../../db/types';
+import { getSettingString as getSettingStringDefault, parseBoolean, parseNumber } from '../app-settings';
+import { AI_PROVIDERS, type AiConfig, type AiProvider, type PublicAiConfig } from './types';
+
+/** Every setting key the AI subsystem reads. Shared by the admin allow-list. */
+export const AI_SETTING_KEYS = [
+    'AI_FEATURES_ENABLED',
+    'AI_PROVIDER',
+    'AI_AZURE_ENDPOINT',
+    'AI_AZURE_API_KEY',
+    'AI_AZURE_DEPLOYMENT',
+    'AI_AZURE_API_VERSION',
+    'AI_OLLAMA_ENDPOINT',
+    'AI_OLLAMA_MODEL',
+    'AI_COMPAT_ENDPOINT',
+    'AI_COMPAT_API_KEY',
+    'AI_COMPAT_MODEL',
+    'AI_REQUEST_TIMEOUT_MS',
+    'AI_MAX_OUTPUT_TOKENS',
+    'AI_TEMPERATURE',
+] as const;
+
+/** AI setting keys whose value is a secret and must never be returned to a client. */
+export const AI_SECRET_KEYS = new Set<string>(['AI_AZURE_API_KEY', 'AI_COMPAT_API_KEY']);
+
+/** Default Ollama endpoint when none is configured. */
+export const DEFAULT_OLLAMA_ENDPOINT = 'http://localhost:11434';
+
+const DEFAULT_TIMEOUT_MS = 60000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+const DEFAULT_TEMPERATURE = 0.2;
+
+/** Returns true when `raw` is a recognised provider. */
+export function isAiProvider(raw: string): raw is AiProvider {
+    return (AI_PROVIDERS as readonly string[]).includes(raw);
+}
+
+/**
+ * Parse a provider string against the allow-list. Unknown values fall back to
+ * `external` (fail-safe: we never silently activate a managed provider).
+ */
+export function parseProvider(raw: string | undefined): AiProvider {
+    const value = (raw ?? '').trim().toLowerCase();
+    return isAiProvider(value) ? value : 'external';
+}
+
+function parseFloatOr(value: string | undefined, fallback: number): number {
+    if (value === undefined || value === null || String(value).trim() === '') return fallback;
+    const parsed = Number.parseFloat(String(value));
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
+ * Parse a strictly positive integer setting. Non-positive values (0 or
+ * negative) fall back to the default so a misconfiguration cannot, for example,
+ * set a 0ms timeout that aborts every request immediately.
+ */
+function positiveNumber(value: string | undefined, fallback: number): number {
+    const parsed = parseNumber(value, fallback);
+    return parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Build a typed {@link AiConfig} from a flat record of raw string values.
+ * Pure and synchronous — the canonical place to unit-test parsing rules.
+ */
+export function parseAiConfig(raw: Record<string, string | undefined>): AiConfig {
+    const provider = parseProvider(raw.AI_PROVIDER);
+    const mode = provider === 'external' ? 'external' : 'managed';
+    return {
+        enabled: parseBoolean(raw.AI_FEATURES_ENABLED, true),
+        provider,
+        mode,
+        azure: {
+            endpoint: (raw.AI_AZURE_ENDPOINT ?? '').trim(),
+            apiKey: (raw.AI_AZURE_API_KEY ?? '').trim(),
+            deployment: (raw.AI_AZURE_DEPLOYMENT ?? '').trim(),
+            apiVersion: (raw.AI_AZURE_API_VERSION ?? '').trim(),
+        },
+        ollama: {
+            endpoint: (raw.AI_OLLAMA_ENDPOINT ?? '').trim() || DEFAULT_OLLAMA_ENDPOINT,
+            model: (raw.AI_OLLAMA_MODEL ?? '').trim(),
+        },
+        compat: {
+            endpoint: (raw.AI_COMPAT_ENDPOINT ?? '').trim(),
+            apiKey: (raw.AI_COMPAT_API_KEY ?? '').trim(),
+            model: (raw.AI_COMPAT_MODEL ?? '').trim(),
+        },
+        requestTimeoutMs: positiveNumber(raw.AI_REQUEST_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+        maxOutputTokens: positiveNumber(raw.AI_MAX_OUTPUT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS),
+        temperature: parseFloatOr(raw.AI_TEMPERATURE, DEFAULT_TEMPERATURE),
+    };
+}
+
+/**
+ * Whether the configured managed provider has all required fields. For the
+ * `external` provider this is always true (no server-side configuration needed).
+ */
+export function isProviderConfigured(config: AiConfig): boolean {
+    switch (config.provider) {
+        case 'external':
+            return true;
+        case 'azure':
+            return Boolean(
+                config.azure.endpoint && config.azure.apiKey && config.azure.deployment && config.azure.apiVersion,
+            );
+        case 'ollama':
+            // Endpoint always has a default; only the model is mandatory.
+            return Boolean(config.ollama.endpoint && config.ollama.model);
+        case 'openai_compat':
+            // API key is optional (e.g. self-hosted gateways); endpoint + model required.
+            return Boolean(config.compat.endpoint && config.compat.model);
+        default:
+            return false;
+    }
+}
+
+/** Derive the safe, client-facing capability object. Never includes secrets. */
+export function toPublicAiConfig(config: AiConfig): PublicAiConfig {
+    return {
+        enabled: config.enabled,
+        provider: config.provider,
+        mode: config.mode,
+        configured: isProviderConfigured(config),
+    };
+}
+
+export interface LoadAiConfigDeps {
+    getSettingString: typeof getSettingStringDefault;
+}
+
+const defaultLoadDeps: LoadAiConfigDeps = { getSettingString: getSettingStringDefault };
+
+/**
+ * Read every AI setting from the database (with `process.env` as the fallback)
+ * and return the parsed configuration. Values are read as strings and parsed by
+ * {@link parseAiConfig} so there is a single source of truth for parsing.
+ */
+export async function loadAiConfig(db: Kysely<Database>, deps: LoadAiConfigDeps = defaultLoadDeps): Promise<AiConfig> {
+    const raw: Record<string, string | undefined> = {};
+    for (const key of AI_SETTING_KEYS) {
+        raw[key] = await deps.getSettingString(db, key, process.env[key] ?? '');
+    }
+    return parseAiConfig(raw);
+}

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Public entry point for the server-managed AI subsystem.
+ */
+export * from './types';
+export {
+    AI_SECRET_KEYS,
+    AI_SETTING_KEYS,
+    DEFAULT_OLLAMA_ENDPOINT,
+    isAiProvider,
+    isProviderConfigured,
+    loadAiConfig,
+    parseAiConfig,
+    parseProvider,
+    toPublicAiConfig,
+} from './config';
+export { assertCanGenerate, generateText, type GenerateTextResult, type ManagerDeps } from './manager';

--- a/src/services/ai/manager.spec.ts
+++ b/src/services/ai/manager.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test';
+import { parseAiConfig } from './config';
+import { assertCanGenerate, generateText, type ManagerDeps } from './manager';
+import { AiError, type AiConfig, type GenerateTextOptions } from './types';
+
+function recordingDeps() {
+    const calls: Array<{ provider: string; prompt: string; options: GenerateTextOptions }> = [];
+    const make = (provider: string) => async (_config: AiConfig, prompt: string, options: GenerateTextOptions) => {
+        calls.push({ provider, prompt, options });
+        return `from-${provider}`;
+    };
+    const deps: ManagerDeps = {
+        providers: { azure: make('azure'), ollama: make('ollama'), openai_compat: make('openai_compat') },
+    };
+    return { calls, deps };
+}
+
+const azureConfig = parseAiConfig({
+    AI_PROVIDER: 'azure',
+    AI_AZURE_ENDPOINT: 'https://x.openai.azure.com',
+    AI_AZURE_API_KEY: 'k',
+    AI_AZURE_DEPLOYMENT: 'd',
+    AI_AZURE_API_VERSION: '2024-02-01',
+});
+
+function expectAiError(fn: () => void, code: string, status: number) {
+    let caught: unknown;
+    try {
+        fn();
+    } catch (error) {
+        caught = error;
+    }
+    expect(caught).toBeInstanceOf(AiError);
+    expect((caught as AiError).code).toBe(code as AiError['code']);
+    expect((caught as AiError).status).toBe(status);
+}
+
+describe('assertCanGenerate', () => {
+    it('rejects disabled AI', () => {
+        expectAiError(() => assertCanGenerate(parseAiConfig({ AI_FEATURES_ENABLED: 'false' })), 'AI_DISABLED', 403);
+    });
+
+    it('rejects external mode (no server-side generation)', () => {
+        expectAiError(() => assertCanGenerate(parseAiConfig({ AI_PROVIDER: 'external' })), 'AI_EXTERNAL_MODE', 400);
+    });
+
+    it('rejects a misconfigured managed provider (fail closed)', () => {
+        expectAiError(() => assertCanGenerate(parseAiConfig({ AI_PROVIDER: 'azure' })), 'AI_NOT_CONFIGURED', 503);
+    });
+
+    it('passes for a fully configured managed provider', () => {
+        expect(() => assertCanGenerate(azureConfig)).not.toThrow();
+    });
+});
+
+describe('generateText', () => {
+    it('does not call any provider in external mode', async () => {
+        const { calls, deps } = recordingDeps();
+        await expect(generateText(parseAiConfig({ AI_PROVIDER: 'external' }), 'p', {}, deps)).rejects.toMatchObject({
+            code: 'AI_EXTERNAL_MODE',
+        });
+        expect(calls).toHaveLength(0);
+    });
+
+    it('selects the configured provider and returns its text', async () => {
+        const { calls, deps } = recordingDeps();
+        const result = await generateText(azureConfig, 'make questions', {}, deps);
+        expect(result).toEqual({ text: 'from-azure' });
+        expect(calls).toHaveLength(1);
+        expect(calls[0].provider).toBe('azure');
+        // The manager wires a timeout-driven AbortSignal through to the provider.
+        expect(calls[0].options.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('selects ollama when configured', async () => {
+        const { calls, deps } = recordingDeps();
+        const config = parseAiConfig({ AI_PROVIDER: 'ollama', AI_OLLAMA_MODEL: 'llama3' });
+        await generateText(config, 'p', {}, deps);
+        expect(calls[0].provider).toBe('ollama');
+    });
+
+    it('fails closed when the managed provider is not configured', async () => {
+        const { deps } = recordingDeps();
+        await expect(generateText(parseAiConfig({ AI_PROVIDER: 'ollama' }), 'p', {}, deps)).rejects.toMatchObject({
+            code: 'AI_NOT_CONFIGURED',
+        });
+    });
+
+    it('passes through AiError thrown by the provider', async () => {
+        const deps: ManagerDeps = {
+            providers: {
+                azure: async () => {
+                    throw new AiError('AI_PROVIDER_ERROR', 'boom', 502);
+                },
+                ollama: async () => 'x',
+                openai_compat: async () => 'x',
+            },
+        };
+        await expect(generateText(azureConfig, 'p', {}, deps)).rejects.toMatchObject({ code: 'AI_PROVIDER_ERROR' });
+    });
+
+    it('wraps an unexpected provider error as AI_PROVIDER_ERROR', async () => {
+        const deps: ManagerDeps = {
+            providers: {
+                azure: async () => {
+                    throw new Error('kaboom');
+                },
+                ollama: async () => 'x',
+                openai_compat: async () => 'x',
+            },
+        };
+        await expect(generateText(azureConfig, 'p', {}, deps)).rejects.toMatchObject({
+            code: 'AI_PROVIDER_ERROR',
+            status: 502,
+        });
+    });
+
+    it('maps a provider AbortError to AI_TIMEOUT', async () => {
+        const deps: ManagerDeps = {
+            providers: {
+                azure: async () => {
+                    const err = new Error('aborted');
+                    err.name = 'AbortError';
+                    throw err;
+                },
+                ollama: async () => 'x',
+                openai_compat: async () => 'x',
+            },
+        };
+        await expect(generateText(azureConfig, 'p', {}, deps)).rejects.toMatchObject({ code: 'AI_TIMEOUT' });
+    });
+});

--- a/src/services/ai/manager.spec.ts
+++ b/src/services/ai/manager.spec.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { parseAiConfig } from './config';
 import { assertCanGenerate, generateText, type ManagerDeps } from './manager';
 import { AiError, type AiConfig, type GenerateTextOptions } from './types';
+
+// The manager logs a diagnostic when wrapping an unexpected provider error.
+let errorSpy: ReturnType<typeof spyOn>;
+beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+    errorSpy.mockRestore();
+});
 
 function recordingDeps() {
     const calls: Array<{ provider: string; prompt: string; options: GenerateTextOptions }> = [];
@@ -109,10 +118,11 @@ describe('generateText', () => {
                 openai_compat: async () => 'x',
             },
         };
-        await expect(generateText(azureConfig, 'p', {}, deps)).rejects.toMatchObject({
-            code: 'AI_PROVIDER_ERROR',
-            status: 502,
-        });
+        const err = (await generateText(azureConfig, 'p', {}, deps).catch(e => e)) as AiError;
+        expect(err).toMatchObject({ code: 'AI_PROVIDER_ERROR', status: 502 });
+        // The unexpected reason is captured for diagnostics and logged server-side.
+        expect(err.details).toBe('kaboom');
+        expect(String(errorSpy.mock.calls[0][0])).toContain('kaboom');
     });
 
     it('maps a provider AbortError to AI_TIMEOUT', async () => {

--- a/src/services/ai/manager.ts
+++ b/src/services/ai/manager.ts
@@ -1,0 +1,96 @@
+/**
+ * AI manager: selects the configured provider and runs the generate-text action.
+ *
+ * Fail-closed semantics:
+ *  - disabled            -> AI_DISABLED
+ *  - external provider   -> AI_EXTERNAL_MODE (no server-side generation)
+ *  - managed but missing required fields -> AI_NOT_CONFIGURED
+ * The manager never falls back to a public/external AI service.
+ *
+ * A per-request timeout is enforced with an AbortController driven by
+ * `config.requestTimeoutMs`.
+ */
+import { AiError, type AiConfig, type GenerateTextOptions } from './types';
+import { isProviderConfigured } from './config';
+import * as azure from './providers/azure';
+import * as ollama from './providers/ollama';
+import * as openaiCompatible from './providers/openai-compatible';
+
+export type ProviderGenerate = (config: AiConfig, prompt: string, options: GenerateTextOptions) => Promise<string>;
+
+export interface ManagerDeps {
+    providers: Record<'azure' | 'ollama' | 'openai_compat', ProviderGenerate>;
+}
+
+const defaultDeps: ManagerDeps = {
+    providers: {
+        azure: azure.generate,
+        ollama: ollama.generate,
+        openai_compat: openaiCompatible.generate,
+    },
+};
+
+/**
+ * Throw the appropriate {@link AiError} when the configuration does not allow a
+ * server-side generation. Exposed so the route can fail fast before doing work.
+ */
+export function assertCanGenerate(config: AiConfig): void {
+    if (!config.enabled) {
+        throw new AiError('AI_DISABLED', 'AI features are disabled.', 403);
+    }
+    if (config.mode === 'external') {
+        throw new AiError(
+            'AI_EXTERNAL_MODE',
+            'Server-side generation is not available with the external provider.',
+            400,
+        );
+    }
+    if (!isProviderConfigured(config)) {
+        throw new AiError('AI_NOT_CONFIGURED', 'The AI provider is not fully configured.', 503);
+    }
+}
+
+export interface GenerateTextResult {
+    text: string;
+}
+
+/**
+ * Generate plain text from a prompt using the configured managed provider.
+ * Always throws an {@link AiError} (never leaks provider internals) on failure.
+ */
+export async function generateText(
+    config: AiConfig,
+    prompt: string,
+    options: GenerateTextOptions = {},
+    deps: ManagerDeps = defaultDeps,
+): Promise<GenerateTextResult> {
+    assertCanGenerate(config);
+
+    const provider = deps.providers[config.provider as 'azure' | 'ollama' | 'openai_compat'];
+    if (!provider) {
+        // Defensive: parseProvider only yields known managed providers past assertCanGenerate.
+        throw new AiError('AI_NOT_CONFIGURED', 'No AI provider is available.', 503);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), config.requestTimeoutMs);
+    try {
+        const text = await provider(config, prompt, {
+            maxOutputTokens: options.maxOutputTokens,
+            temperature: options.temperature,
+            fetchImpl: options.fetchImpl,
+            signal: controller.signal,
+        });
+        return { text };
+    } catch (error) {
+        if (error instanceof AiError) {
+            throw error;
+        }
+        if (error instanceof Error && error.name === 'AbortError') {
+            throw new AiError('AI_TIMEOUT', 'The AI provider did not respond in time.', 504);
+        }
+        throw new AiError('AI_PROVIDER_ERROR', 'The AI provider request failed.', 502);
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/src/services/ai/manager.ts
+++ b/src/services/ai/manager.ts
@@ -89,7 +89,9 @@ export async function generateText(
         if (error instanceof Error && error.name === 'AbortError') {
             throw new AiError('AI_TIMEOUT', 'The AI provider did not respond in time.', 504);
         }
-        throw new AiError('AI_PROVIDER_ERROR', 'The AI provider request failed.', 502);
+        const reason = error instanceof Error ? error.message : String(error);
+        console.error(`[ai] provider "${config.provider}" generation failed: ${reason}`);
+        throw new AiError('AI_PROVIDER_ERROR', 'The AI provider request failed.', 502, reason);
     } finally {
         clearTimeout(timer);
     }

--- a/src/services/ai/providers/azure.spec.ts
+++ b/src/services/ai/providers/azure.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import { parseAiConfig } from '../config';
+import { generate } from './azure';
+
+function captureFetch(responseData: unknown) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true, status: 200, json: async () => responseData } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+}
+
+const azureConfig = parseAiConfig({
+    AI_PROVIDER: 'azure',
+    AI_AZURE_ENDPOINT: 'https://my-resource.openai.azure.com',
+    AI_AZURE_API_KEY: 'azure-secret-key',
+    AI_AZURE_DEPLOYMENT: 'gpt-4o',
+    AI_AZURE_API_VERSION: '2024-02-01',
+    AI_MAX_OUTPUT_TOKENS: '1000',
+    AI_TEMPERATURE: '0.3',
+});
+
+describe('azure provider', () => {
+    it('calls the deployment chat-completions URL with the api-key header', async () => {
+        const { calls, fetchImpl } = captureFetch({ choices: [{ message: { content: 'q1\nq2' } }] });
+
+        const text = await generate(azureConfig, 'make questions', { fetchImpl });
+
+        expect(text).toBe('q1\nq2');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe(
+            'https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-02-01',
+        );
+        const headers = calls[0].init.headers as Record<string, string>;
+        expect(headers['api-key']).toBe('azure-secret-key');
+        expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('sends a chat-completions payload using config max_tokens/temperature', async () => {
+        const { calls, fetchImpl } = captureFetch({ choices: [{ message: { content: 'ok' } }] });
+        await generate(azureConfig, 'prompt text', { fetchImpl });
+
+        const body = JSON.parse(calls[0].init.body as string);
+        expect(body.messages).toEqual([{ role: 'user', content: 'prompt text' }]);
+        expect(body.max_tokens).toBe(1000);
+        expect(body.temperature).toBeCloseTo(0.3);
+    });
+
+    it('honours per-call option overrides', async () => {
+        const { calls, fetchImpl } = captureFetch({ choices: [{ message: { content: 'ok' } }] });
+        await generate(azureConfig, 'p', { fetchImpl, maxOutputTokens: 7, temperature: 0.9 });
+        const body = JSON.parse(calls[0].init.body as string);
+        expect(body.max_tokens).toBe(7);
+        expect(body.temperature).toBeCloseTo(0.9);
+    });
+
+    it('throws a provider error on an empty completion', async () => {
+        const { fetchImpl } = captureFetch({ choices: [{ message: { content: '' } }] });
+        await expect(generate(azureConfig, 'p', { fetchImpl })).rejects.toMatchObject({ code: 'AI_PROVIDER_ERROR' });
+    });
+});

--- a/src/services/ai/providers/azure.ts
+++ b/src/services/ai/providers/azure.ts
@@ -1,0 +1,29 @@
+/**
+ * Azure OpenAI provider.
+ *
+ * Calls the chat-completions deployment endpoint:
+ *   {endpoint}/openai/deployments/{deployment}/chat/completions?api-version={apiVersion}
+ * authenticating with the `api-key` header expected by Azure OpenAI.
+ */
+import type { AiConfig, GenerateTextOptions } from '../types';
+import { extractChatCompletionText, joinUrl, postJson } from './http';
+
+export async function generate(config: AiConfig, prompt: string, options: GenerateTextOptions = {}): Promise<string> {
+    const { endpoint, deployment, apiVersion, apiKey } = config.azure;
+    const base = joinUrl(endpoint, `openai/deployments/${encodeURIComponent(deployment)}/chat/completions`);
+    const url = `${base}?api-version=${encodeURIComponent(apiVersion)}`;
+
+    const data = await postJson({
+        url,
+        headers: { 'api-key': apiKey },
+        body: {
+            messages: [{ role: 'user', content: prompt }],
+            max_tokens: options.maxOutputTokens ?? config.maxOutputTokens,
+            temperature: options.temperature ?? config.temperature,
+        },
+        signal: options.signal,
+        fetchImpl: options.fetchImpl,
+    });
+
+    return extractChatCompletionText(data);
+}

--- a/src/services/ai/providers/azure.ts
+++ b/src/services/ai/providers/azure.ts
@@ -15,6 +15,7 @@ export async function generate(config: AiConfig, prompt: string, options: Genera
 
     const data = await postJson({
         url,
+        provider: 'azure',
         headers: { 'api-key': apiKey },
         body: {
             messages: [{ role: 'user', content: prompt }],

--- a/src/services/ai/providers/http.spec.ts
+++ b/src/services/ai/providers/http.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'bun:test';
+import { AiError } from '../types';
+import { extractChatCompletionText, joinUrl, postJson, requireText } from './http';
+
+function jsonResponse(data: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+    return {
+        ok: init.ok ?? true,
+        status: init.status ?? 200,
+        json: async () => data,
+    } as unknown as Response;
+}
+
+describe('joinUrl', () => {
+    it('joins with exactly one slash regardless of trailing/leading slashes', () => {
+        expect(joinUrl('http://h:1234', 'api/chat')).toBe('http://h:1234/api/chat');
+        expect(joinUrl('http://h:1234/', '/api/chat')).toBe('http://h:1234/api/chat');
+        expect(joinUrl('https://x/v1///', '///chat/completions')).toBe('https://x/v1/chat/completions');
+    });
+});
+
+describe('postJson', () => {
+    it('sends a JSON body with merged headers and returns the parsed response', async () => {
+        let captured: { url: string; init: RequestInit } | null = null;
+        const fetchImpl = (async (url: string, init: RequestInit) => {
+            captured = { url, init };
+            return jsonResponse({ ok: 1 });
+        }) as unknown as typeof fetch;
+
+        const result = await postJson({
+            url: 'https://api.example.com/chat',
+            headers: { Authorization: 'Bearer k' },
+            body: { a: 1 },
+            fetchImpl,
+        });
+
+        expect(result).toEqual({ ok: 1 });
+        expect(captured!.url).toBe('https://api.example.com/chat');
+        expect(captured!.init.method).toBe('POST');
+        expect(captured!.init.body).toBe(JSON.stringify({ a: 1 }));
+        expect((captured!.init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+        expect((captured!.init.headers as Record<string, string>).Authorization).toBe('Bearer k');
+    });
+
+    it('maps a non-2xx response to a provider error (no details leaked)', async () => {
+        const fetchImpl = (async () =>
+            jsonResponse({ error: 'secret detail' }, { ok: false, status: 401 })) as unknown as typeof fetch;
+        const promise = postJson({ url: 'https://x/chat', body: {}, fetchImpl });
+        await expect(promise).rejects.toMatchObject({ code: 'AI_PROVIDER_ERROR', status: 502 });
+        await expect(promise).rejects.toBeInstanceOf(AiError);
+    });
+
+    it('maps an AbortError to a timeout error', async () => {
+        const fetchImpl = (async () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            throw err;
+        }) as unknown as typeof fetch;
+        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
+            code: 'AI_TIMEOUT',
+            status: 504,
+        });
+    });
+
+    it('maps a generic network failure to a provider error', async () => {
+        const fetchImpl = (async () => {
+            throw new Error('ECONNREFUSED');
+        }) as unknown as typeof fetch;
+        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
+            code: 'AI_PROVIDER_ERROR',
+            status: 502,
+        });
+    });
+
+    it('maps an invalid JSON body to a provider error', async () => {
+        const fetchImpl = (async () =>
+            ({
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new Error('not json');
+                },
+            }) as unknown as Response) as unknown as typeof fetch;
+        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
+            code: 'AI_PROVIDER_ERROR',
+        });
+    });
+});
+
+describe('requireText', () => {
+    it('returns non-empty strings', () => {
+        expect(requireText('hello')).toBe('hello');
+    });
+
+    it('throws a provider error for empty/non-string values', () => {
+        expect(() => requireText('')).toThrow(AiError);
+        expect(() => requireText('   ')).toThrow(AiError);
+        expect(() => requireText(null)).toThrow(AiError);
+        expect(() => requireText(42)).toThrow(AiError);
+    });
+});
+
+describe('extractChatCompletionText', () => {
+    it('extracts the assistant message content', () => {
+        expect(extractChatCompletionText({ choices: [{ message: { content: 'answer' } }] })).toBe('answer');
+    });
+
+    it('throws when the payload is malformed', () => {
+        expect(() => extractChatCompletionText({})).toThrow(AiError);
+        expect(() => extractChatCompletionText({ choices: [] })).toThrow(AiError);
+    });
+});

--- a/src/services/ai/providers/http.spec.ts
+++ b/src/services/ai/providers/http.spec.ts
@@ -1,14 +1,32 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { AiError } from '../types';
-import { extractChatCompletionText, joinUrl, postJson, requireText } from './http';
+import {
+    endpointHost,
+    extractChatCompletionText,
+    joinUrl,
+    PROVIDER_DETAILS_MAX_LENGTH,
+    postJson,
+    readDetails,
+    requireText,
+} from './http';
 
 function jsonResponse(data: unknown, init: { ok?: boolean; status?: number } = {}): Response {
     return {
         ok: init.ok ?? true,
         status: init.status ?? 200,
         json: async () => data,
+        text: async () => (typeof data === 'string' ? data : JSON.stringify(data)),
     } as unknown as Response;
 }
+
+// Silence and capture the diagnostic logs the provider layer now emits.
+let errorSpy: ReturnType<typeof spyOn>;
+beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+    errorSpy.mockRestore();
+});
 
 describe('joinUrl', () => {
     it('joins with exactly one slash regardless of trailing/leading slashes', () => {
@@ -41,37 +59,64 @@ describe('postJson', () => {
         expect((captured!.init.headers as Record<string, string>).Authorization).toBe('Bearer k');
     });
 
-    it('maps a non-2xx response to a provider error (no details leaked)', async () => {
+    it('maps a non-2xx response to a provider error whose public message omits the body', async () => {
         const fetchImpl = (async () =>
-            jsonResponse({ error: 'secret detail' }, { ok: false, status: 401 })) as unknown as typeof fetch;
-        const promise = postJson({ url: 'https://x/chat', body: {}, fetchImpl });
+            jsonResponse({ error: 'upstream detail' }, { ok: false, status: 500 })) as unknown as typeof fetch;
+        const promise = postJson({ url: 'https://x/chat', body: {}, fetchImpl, provider: 'ollama' });
         await expect(promise).rejects.toMatchObject({ code: 'AI_PROVIDER_ERROR', status: 502 });
         await expect(promise).rejects.toBeInstanceOf(AiError);
+        // The public message states the status only; the body is never inlined into it.
+        const err = (await promise.catch(e => e)) as AiError;
+        expect(err.message).toBe('The AI provider returned an error (HTTP 500).');
+        expect(err.message).not.toContain('upstream detail');
     });
 
-    it('maps an AbortError to a timeout error', async () => {
+    it('captures the upstream body as `details` and logs it for diagnostics', async () => {
+        const fetchImpl = (async () =>
+            jsonResponse({ error: "model 'llama3' not found" }, { ok: false, status: 500 })) as unknown as typeof fetch;
+        const err = (await postJson({
+            url: 'http://localhost:11434/api/chat',
+            body: {},
+            fetchImpl,
+            provider: 'ollama',
+        }).catch(e => e)) as AiError;
+        expect(err.details).toContain("model 'llama3' not found");
+        // Logged with provider + host context so it shows up in the container logs.
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const logged = String(errorSpy.mock.calls[0][0]);
+        expect(logged).toContain('ollama');
+        expect(logged).toContain('localhost:11434');
+        expect(logged).toContain('HTTP 500');
+    });
+
+    it('maps an AbortError to a timeout error and logs it', async () => {
         const fetchImpl = (async () => {
             const err = new Error('aborted');
             err.name = 'AbortError';
             throw err;
         }) as unknown as typeof fetch;
-        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
-            code: 'AI_TIMEOUT',
-            status: 504,
-        });
+        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl, provider: 'azure' })).rejects.toMatchObject(
+            {
+                code: 'AI_TIMEOUT',
+                status: 504,
+            },
+        );
+        expect(String(errorSpy.mock.calls[0][0])).toContain('timed out');
     });
 
-    it('maps a generic network failure to a provider error', async () => {
+    it('maps a generic network failure to a provider error and records the reason', async () => {
         const fetchImpl = (async () => {
             throw new Error('ECONNREFUSED');
         }) as unknown as typeof fetch;
-        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
-            code: 'AI_PROVIDER_ERROR',
-            status: 502,
-        });
+        const err = (await postJson({ url: 'https://x/chat', body: {}, fetchImpl, provider: 'ollama' }).catch(
+            e => e,
+        )) as AiError;
+        expect(err).toMatchObject({ code: 'AI_PROVIDER_ERROR', status: 502 });
+        expect(err.details).toBe('ECONNREFUSED');
+        expect(String(errorSpy.mock.calls[0][0])).toContain('ECONNREFUSED');
     });
 
-    it('maps an invalid JSON body to a provider error', async () => {
+    it('maps an invalid JSON body to a provider error and logs it', async () => {
         const fetchImpl = (async () =>
             ({
                 ok: true,
@@ -80,9 +125,47 @@ describe('postJson', () => {
                     throw new Error('not json');
                 },
             }) as unknown as Response) as unknown as typeof fetch;
-        await expect(postJson({ url: 'https://x/chat', body: {}, fetchImpl })).rejects.toMatchObject({
+        await expect(
+            postJson({ url: 'https://x/chat', body: {}, fetchImpl, provider: 'openai_compat' }),
+        ).rejects.toMatchObject({
             code: 'AI_PROVIDER_ERROR',
         });
+        expect(String(errorSpy.mock.calls[0][0])).toContain('non-JSON');
+    });
+});
+
+describe('endpointHost', () => {
+    it('returns the host of a valid URL', () => {
+        expect(endpointHost('http://localhost:11434/api/chat')).toBe('localhost:11434');
+        expect(endpointHost('https://my-resource.openai.azure.com/openai')).toBe('my-resource.openai.azure.com');
+    });
+
+    it('returns a placeholder for an unparseable URL', () => {
+        expect(endpointHost('not a url')).toBe('unknown-host');
+    });
+});
+
+describe('readDetails', () => {
+    it('returns the trimmed body text', async () => {
+        const response = { text: async () => '  boom  ' } as unknown as Response;
+        expect(await readDetails(response)).toBe('boom');
+    });
+
+    it('truncates an over-long body', async () => {
+        const long = 'x'.repeat(PROVIDER_DETAILS_MAX_LENGTH + 50);
+        const response = { text: async () => long } as unknown as Response;
+        const result = await readDetails(response);
+        expect(result.length).toBe(PROVIDER_DETAILS_MAX_LENGTH + 1); // +1 for the ellipsis
+        expect(result.endsWith('…')).toBe(true);
+    });
+
+    it('returns an empty string when the body cannot be read', async () => {
+        const response = {
+            text: mock(async () => {
+                throw new Error('stream consumed');
+            }),
+        } as unknown as Response;
+        expect(await readDetails(response)).toBe('');
     });
 });
 

--- a/src/services/ai/providers/http.ts
+++ b/src/services/ai/providers/http.ts
@@ -17,20 +17,56 @@ export function joinUrl(base: string, path: string): string {
     return `${trimmedBase}/${trimmedPath}`;
 }
 
+/** Max length of an upstream body snippet captured for diagnostics/logging. */
+export const PROVIDER_DETAILS_MAX_LENGTH = 500;
+
+/** Host (never the full URL/secret query) of a provider endpoint, for log context. */
+export function endpointHost(url: string): string {
+    try {
+        return new URL(url).host;
+    } catch {
+        return 'unknown-host';
+    }
+}
+
+/**
+ * Read and truncate an upstream response body for diagnostics. Best-effort:
+ * a body that cannot be read yields an empty string rather than throwing.
+ */
+export async function readDetails(response: Response): Promise<string> {
+    try {
+        const text = (await response.text()).trim();
+        return text.length > PROVIDER_DETAILS_MAX_LENGTH ? `${text.slice(0, PROVIDER_DETAILS_MAX_LENGTH)}…` : text;
+    } catch {
+        return '';
+    }
+}
+
 export interface PostJsonOptions {
     url: string;
     headers?: Record<string, string>;
     body: unknown;
     signal?: AbortSignal;
     fetchImpl?: typeof fetch;
+    /** Provider label (e.g. `ollama`) used only for server-side log context. */
+    provider?: string;
 }
 
 /**
  * POST a JSON body and parse a JSON response, mapping transport/HTTP failures to
- * a typed {@link AiError} that never leaks request details (URL, key, payload).
+ * a typed {@link AiError}.
+ *
+ * The public error message never leaks request details (URL, key, payload), but
+ * the failure is logged server-side (provider, endpoint host, HTTP status and a
+ * truncated body snippet) and the snippet is attached to the error's `details`
+ * so the admin-only test-connection diagnostic can surface why a managed
+ * provider failed. This is what makes `HTTP 500`-style failures debuggable from
+ * the container logs instead of silently opaque.
  */
 export async function postJson<T = unknown>(opts: PostJsonOptions): Promise<T> {
     const fetchImpl = opts.fetchImpl ?? fetch;
+    const label = opts.provider ?? 'unknown';
+    const host = endpointHost(opts.url);
     let response: Response;
     try {
         response = await fetchImpl(opts.url, {
@@ -41,18 +77,31 @@ export async function postJson<T = unknown>(opts: PostJsonOptions): Promise<T> {
         });
     } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
+            console.error(`[ai] provider "${label}" request to ${host} timed out.`);
             throw new AiError('AI_TIMEOUT', 'The AI provider did not respond in time.', 504);
         }
-        throw new AiError('AI_PROVIDER_ERROR', 'Could not reach the AI provider.', 502);
+        const reason = error instanceof Error ? error.message : String(error);
+        console.error(`[ai] provider "${label}" request to ${host} failed: ${reason}`);
+        throw new AiError('AI_PROVIDER_ERROR', 'Could not reach the AI provider.', 502, reason);
     }
 
     if (!response.ok) {
-        throw new AiError('AI_PROVIDER_ERROR', `The AI provider returned an error (HTTP ${response.status}).`, 502);
+        const details = await readDetails(response);
+        console.error(
+            `[ai] provider "${label}" at ${host} returned HTTP ${response.status}${details ? `: ${details}` : ''}`,
+        );
+        throw new AiError(
+            'AI_PROVIDER_ERROR',
+            `The AI provider returned an error (HTTP ${response.status}).`,
+            502,
+            details || undefined,
+        );
     }
 
     try {
         return (await response.json()) as T;
     } catch {
+        console.error(`[ai] provider "${label}" at ${host} returned a non-JSON response.`);
         throw new AiError('AI_PROVIDER_ERROR', 'The AI provider returned an invalid response.', 502);
     }
 }

--- a/src/services/ai/providers/http.ts
+++ b/src/services/ai/providers/http.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared HTTP helpers for AI providers.
+ *
+ * Outbound calls use the injected `fetchImpl` (defaults to global `fetch`) so
+ * tests stay hermetic. We deliberately do NOT route these through the SSRF
+ * guard: the endpoint is configured server-side by an administrator (a trusted
+ * value) and the browser only supplies the prompt text — never the URL. The
+ * SSRF guard also blocks loopback/RFC1918 addresses, which would break the
+ * primary managed use case (a local Ollama on http://localhost:11434).
+ */
+import { AiError } from '../types';
+
+/** Join a base URL and a path with exactly one slash between them. */
+export function joinUrl(base: string, path: string): string {
+    const trimmedBase = base.replace(/\/+$/, '');
+    const trimmedPath = path.replace(/^\/+/, '');
+    return `${trimmedBase}/${trimmedPath}`;
+}
+
+export interface PostJsonOptions {
+    url: string;
+    headers?: Record<string, string>;
+    body: unknown;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST a JSON body and parse a JSON response, mapping transport/HTTP failures to
+ * a typed {@link AiError} that never leaks request details (URL, key, payload).
+ */
+export async function postJson<T = unknown>(opts: PostJsonOptions): Promise<T> {
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    let response: Response;
+    try {
+        response = await fetchImpl(opts.url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...(opts.headers ?? {}) },
+            body: JSON.stringify(opts.body),
+            signal: opts.signal,
+        });
+    } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+            throw new AiError('AI_TIMEOUT', 'The AI provider did not respond in time.', 504);
+        }
+        throw new AiError('AI_PROVIDER_ERROR', 'Could not reach the AI provider.', 502);
+    }
+
+    if (!response.ok) {
+        throw new AiError('AI_PROVIDER_ERROR', `The AI provider returned an error (HTTP ${response.status}).`, 502);
+    }
+
+    try {
+        return (await response.json()) as T;
+    } catch {
+        throw new AiError('AI_PROVIDER_ERROR', 'The AI provider returned an invalid response.', 502);
+    }
+}
+
+/** Validate that a provider produced non-empty text, else raise a provider error. */
+export function requireText(value: unknown): string {
+    if (typeof value === 'string' && value.trim() !== '') {
+        return value;
+    }
+    throw new AiError('AI_PROVIDER_ERROR', 'The AI provider returned an empty response.', 502);
+}
+
+/** Extract the assistant message from an OpenAI/Azure chat-completions payload. */
+export function extractChatCompletionText(data: unknown): string {
+    const content = (data as { choices?: Array<{ message?: { content?: unknown } }> })?.choices?.[0]?.message?.content;
+    return requireText(content);
+}

--- a/src/services/ai/providers/ollama.spec.ts
+++ b/src/services/ai/providers/ollama.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import { parseAiConfig } from '../config';
+import { generate } from './ollama';
+
+function captureFetch(responseData: unknown) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true, status: 200, json: async () => responseData } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+}
+
+const ollamaConfig = parseAiConfig({
+    AI_PROVIDER: 'ollama',
+    AI_OLLAMA_ENDPOINT: 'http://localhost:11434',
+    AI_OLLAMA_MODEL: 'llama3',
+    AI_MAX_OUTPUT_TOKENS: '512',
+    AI_TEMPERATURE: '0.1',
+});
+
+describe('ollama provider', () => {
+    it('calls the non-streaming chat endpoint without an auth header', async () => {
+        const { calls, fetchImpl } = captureFetch({ message: { content: 'a\nb' } });
+
+        const text = await generate(ollamaConfig, 'make questions', { fetchImpl });
+
+        expect(text).toBe('a\nb');
+        expect(calls[0].url).toBe('http://localhost:11434/api/chat');
+        const headers = calls[0].init.headers as Record<string, string>;
+        expect(headers.Authorization).toBeUndefined();
+        expect(headers['api-key']).toBeUndefined();
+    });
+
+    it('sends model, non-streaming flag and options', async () => {
+        const { calls, fetchImpl } = captureFetch({ message: { content: 'ok' } });
+        await generate(ollamaConfig, 'prompt', { fetchImpl });
+
+        const body = JSON.parse(calls[0].init.body as string);
+        expect(body.model).toBe('llama3');
+        expect(body.stream).toBe(false);
+        expect(body.messages).toEqual([{ role: 'user', content: 'prompt' }]);
+        expect(body.options.temperature).toBeCloseTo(0.1);
+        expect(body.options.num_predict).toBe(512);
+    });
+
+    it('throws a provider error when the response has no message content', async () => {
+        const { fetchImpl } = captureFetch({ message: {} });
+        await expect(generate(ollamaConfig, 'p', { fetchImpl })).rejects.toMatchObject({ code: 'AI_PROVIDER_ERROR' });
+    });
+});

--- a/src/services/ai/providers/ollama.ts
+++ b/src/services/ai/providers/ollama.ts
@@ -1,0 +1,34 @@
+/**
+ * Ollama provider.
+ *
+ * Uses the non-streaming chat endpoint ({endpoint}/api/chat) so the whole
+ * answer is returned in a single JSON response. No API key is required —
+ * Ollama is typically a local or institutional service.
+ */
+import type { AiConfig, GenerateTextOptions } from '../types';
+import { joinUrl, postJson, requireText } from './http';
+
+interface OllamaChatResponse {
+    message?: { content?: unknown };
+}
+
+export async function generate(config: AiConfig, prompt: string, options: GenerateTextOptions = {}): Promise<string> {
+    const url = joinUrl(config.ollama.endpoint, 'api/chat');
+
+    const data = await postJson<OllamaChatResponse>({
+        url,
+        body: {
+            model: config.ollama.model,
+            messages: [{ role: 'user', content: prompt }],
+            stream: false,
+            options: {
+                temperature: options.temperature ?? config.temperature,
+                num_predict: options.maxOutputTokens ?? config.maxOutputTokens,
+            },
+        },
+        signal: options.signal,
+        fetchImpl: options.fetchImpl,
+    });
+
+    return requireText(data?.message?.content);
+}

--- a/src/services/ai/providers/ollama.ts
+++ b/src/services/ai/providers/ollama.ts
@@ -17,6 +17,7 @@ export async function generate(config: AiConfig, prompt: string, options: Genera
 
     const data = await postJson<OllamaChatResponse>({
         url,
+        provider: 'ollama',
         body: {
             model: config.ollama.model,
             messages: [{ role: 'user', content: prompt }],

--- a/src/services/ai/providers/openai-compatible.spec.ts
+++ b/src/services/ai/providers/openai-compatible.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { parseAiConfig } from '../config';
+import { generate } from './openai-compatible';
+
+function captureFetch(responseData: unknown) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true, status: 200, json: async () => responseData } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+}
+
+describe('openai-compatible provider', () => {
+    it('calls {endpoint}/chat/completions with a Bearer token when a key is set', async () => {
+        const config = parseAiConfig({
+            AI_PROVIDER: 'openai_compat',
+            AI_COMPAT_ENDPOINT: 'https://api.example.com/v1',
+            AI_COMPAT_API_KEY: 'compat-secret',
+            AI_COMPAT_MODEL: 'gpt-4o-mini',
+        });
+        const { calls, fetchImpl } = captureFetch({ choices: [{ message: { content: 'x' } }] });
+
+        const text = await generate(config, 'prompt', { fetchImpl });
+
+        expect(text).toBe('x');
+        expect(calls[0].url).toBe('https://api.example.com/v1/chat/completions');
+        const headers = calls[0].init.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer compat-secret');
+        const body = JSON.parse(calls[0].init.body as string);
+        expect(body.model).toBe('gpt-4o-mini');
+        expect(body.messages).toEqual([{ role: 'user', content: 'prompt' }]);
+    });
+
+    it('omits the Authorization header when no key is configured', async () => {
+        const config = parseAiConfig({
+            AI_PROVIDER: 'openai_compat',
+            AI_COMPAT_ENDPOINT: 'https://gateway.local/v1',
+            AI_COMPAT_MODEL: 'local-model',
+        });
+        const { calls, fetchImpl } = captureFetch({ choices: [{ message: { content: 'x' } }] });
+
+        await generate(config, 'p', { fetchImpl });
+
+        const headers = calls[0].init.headers as Record<string, string>;
+        expect(headers.Authorization).toBeUndefined();
+    });
+});

--- a/src/services/ai/providers/openai-compatible.ts
+++ b/src/services/ai/providers/openai-compatible.ts
@@ -17,6 +17,7 @@ export async function generate(config: AiConfig, prompt: string, options: Genera
 
     const data = await postJson({
         url,
+        provider: 'openai_compat',
         headers,
         body: {
             model: config.compat.model,

--- a/src/services/ai/providers/openai-compatible.ts
+++ b/src/services/ai/providers/openai-compatible.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenAI-compatible provider.
+ *
+ * Targets any endpoint exposing the OpenAI chat-completions API
+ * ({endpoint}/chat/completions), e.g. self-hosted gateways (LiteLLM, vLLM) or
+ * OpenAI itself. The API key is optional — some gateways are unauthenticated.
+ */
+import type { AiConfig, GenerateTextOptions } from '../types';
+import { extractChatCompletionText, joinUrl, postJson } from './http';
+
+export async function generate(config: AiConfig, prompt: string, options: GenerateTextOptions = {}): Promise<string> {
+    const url = joinUrl(config.compat.endpoint, 'chat/completions');
+    const headers: Record<string, string> = {};
+    if (config.compat.apiKey) {
+        headers.Authorization = `Bearer ${config.compat.apiKey}`;
+    }
+
+    const data = await postJson({
+        url,
+        headers,
+        body: {
+            model: config.compat.model,
+            messages: [{ role: 'user', content: prompt }],
+            max_tokens: options.maxOutputTokens ?? config.maxOutputTokens,
+            temperature: options.temperature ?? config.temperature,
+        },
+        signal: options.signal,
+        fetchImpl: options.fetchImpl,
+    });
+
+    return extractChatCompletionText(data);
+}

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -83,15 +83,23 @@ export type AiErrorCode = 'AI_DISABLED' | 'AI_EXTERNAL_MODE' | 'AI_NOT_CONFIGURE
 /**
  * Error raised by the AI manager/providers. Carries a stable {@link AiErrorCode}
  * and an HTTP status so the route can respond without leaking provider details.
+ *
+ * `details` is an optional, truncated diagnostic snippet of the upstream
+ * provider's response/failure (e.g. Ollama's `model 'x' not found` body). It is
+ * captured for server-side logging and the **admin-only** test-connection
+ * diagnostic. It is NEVER included in the public `/api/ai/generate-text`
+ * response, so it cannot leak provider internals to ordinary users.
  */
 export class AiError extends Error {
     readonly code: AiErrorCode;
     readonly status: number;
+    readonly details?: string;
 
-    constructor(code: AiErrorCode, message: string, status: number) {
+    constructor(code: AiErrorCode, message: string, status: number, details?: string) {
         super(message);
         this.name = 'AiError';
         this.code = code;
         this.status = status;
+        this.details = details;
     }
 }

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared types for the server-managed AI subsystem.
+ *
+ * The design separates concerns the way Moodle's AI subsystem does (without
+ * copying its code):
+ *  - Placement: where AI is offered in the UI (game-generation iDevices).
+ *  - Action: what is requested (generate text / questions).
+ *  - Provider: who executes the request (Azure, Ollama, OpenAI-compatible).
+ *  - Manager: selects the configured provider and runs the action.
+ *
+ * Secrets (API keys) live only inside {@link AiConfig} on the server. The
+ * frontend only ever receives {@link PublicAiConfig}, which exposes capability
+ * flags but never endpoints, keys, deployment names or model names.
+ */
+
+/** Accepted values for the `AI_PROVIDER` setting (allow-list). */
+export const AI_PROVIDERS = ['external', 'azure', 'ollama', 'openai_compat'] as const;
+export type AiProvider = (typeof AI_PROVIDERS)[number];
+
+/**
+ * High-level mode derived from the provider:
+ *  - `external`: the user is offered public AI assistants (ChatGPT, Claude...)
+ *    and the prompt is opened in their web UI. No server call happens.
+ *  - `managed`: eXeLearning calls a server-side provider on the user's behalf.
+ */
+export type AiMode = 'external' | 'managed';
+
+export interface AzureConfig {
+    endpoint: string;
+    apiKey: string;
+    deployment: string;
+    apiVersion: string;
+}
+
+export interface OllamaConfig {
+    endpoint: string;
+    model: string;
+}
+
+export interface OpenAiCompatConfig {
+    endpoint: string;
+    apiKey: string;
+    model: string;
+}
+
+/** Full, server-only AI configuration. Contains secrets — never serialize to the client. */
+export interface AiConfig {
+    enabled: boolean;
+    provider: AiProvider;
+    mode: AiMode;
+    azure: AzureConfig;
+    ollama: OllamaConfig;
+    compat: OpenAiCompatConfig;
+    requestTimeoutMs: number;
+    maxOutputTokens: number;
+    temperature: number;
+}
+
+/**
+ * Safe subset of the AI configuration sent to the browser.
+ * Exposes only capability flags — no endpoints, keys, deployments or models.
+ */
+export interface PublicAiConfig {
+    enabled: boolean;
+    provider: AiProvider;
+    mode: AiMode;
+    configured: boolean;
+}
+
+/** Per-call overrides + injectable transport (for hermetic tests). */
+export interface GenerateTextOptions {
+    maxOutputTokens?: number;
+    temperature?: number;
+    /** Abort signal (the manager wires a timeout-driven controller here). */
+    signal?: AbortSignal;
+    /** Injectable fetch implementation. Defaults to the global `fetch`. */
+    fetchImpl?: typeof fetch;
+}
+
+/** Stable error codes mapped to HTTP responses by the route layer. */
+export type AiErrorCode = 'AI_DISABLED' | 'AI_EXTERNAL_MODE' | 'AI_NOT_CONFIGURED' | 'AI_PROVIDER_ERROR' | 'AI_TIMEOUT';
+
+/**
+ * Error raised by the AI manager/providers. Carries a stable {@link AiErrorCode}
+ * and an HTTP status so the route can respond without leaking provider details.
+ */
+export class AiError extends Error {
+    readonly code: AiErrorCode;
+    readonly status: number;
+
+    constructor(code: AiErrorCode, message: string, status: number) {
+        super(message);
+        this.name = 'AiError';
+        this.code = code;
+        this.status = status;
+    }
+}

--- a/test/e2e/playwright/specs/ai-configuration.spec.ts
+++ b/test/e2e/playwright/specs/ai-configuration.spec.ts
@@ -8,7 +8,7 @@ import type { Page } from '@playwright/test';
  * The game-generation editor (here the Form iDevice, which renders getTabIA)
  * shows different AI controls depending on the safe public AI config served by
  * the backend at window.eXeLearning.app.api.parameters.ai:
- *   - disabled  -> no AI tab at all
+ *   - disabled  -> copy-only tab (prompt + Copy), no provider selector/Send to AI
  *   - external  -> public assistant selector + "Send to AI" (default behaviour)
  *   - managed   -> server-side "Generate"/"Create" surface, no external selector
  *
@@ -58,7 +58,10 @@ test.describe('AI configuration behaviour matrix', () => {
         await expect(page.locator('#eXeETabIA')).toHaveCount(0);
     });
 
-    test('disabled mode renders no AI tab', async ({ authenticatedPage, createProject }) => {
+    test('disabled mode keeps a copy-only tab (prompt + Copy) without provider controls', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
         const page = authenticatedPage;
         const projectUuid = await createProject(page, 'AI Disabled Test');
         await gotoWorkarea(page, projectUuid);
@@ -67,10 +70,13 @@ test.describe('AI configuration behaviour matrix', () => {
         await setAiConfig(page, { enabled: false, provider: 'external', mode: 'external', configured: true });
         await addFormGameIdevice(page);
 
-        // getTabIA returns '' when disabled: no AI tab content anywhere.
-        await expect(page.locator('#eXeEPromptArea')).toHaveCount(0);
+        // The prompt + Copy surface stays so teachers can still copy the prompt and
+        // paste questions generated elsewhere; no AI provider controls are rendered.
+        await expect(page.locator('#eXeEPromptArea')).toBeAttached({ timeout: 10000 });
+        await expect(page.locator('#eXeECopyButton')).toBeAttached();
         await expect(page.locator('#eXeEIASelect')).toHaveCount(0);
         await expect(page.locator('#eXeEOpenChatGPTButton')).toHaveCount(0);
+        await expect(page.locator('#eXeETabIA')).toHaveCount(0);
     });
 
     test('managed mode shows the Generate/Create surface and hides the external selector', async ({

--- a/test/e2e/playwright/specs/ai-configuration.spec.ts
+++ b/test/e2e/playwright/specs/ai-configuration.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { waitForAppReady, gotoWorkarea, selectFirstPage, addIdevice } from '../helpers/workarea-helpers';
+import type { Page } from '@playwright/test';
+
+/**
+ * E2E tests for the server-managed AI configuration behaviour matrix.
+ *
+ * The game-generation editor (here the Form iDevice, which renders getTabIA)
+ * shows different AI controls depending on the safe public AI config served by
+ * the backend at window.eXeLearning.app.api.parameters.ai:
+ *   - disabled  -> no AI tab at all
+ *   - external  -> public assistant selector + "Send to AI" (default behaviour)
+ *   - managed   -> server-side "Generate"/"Create" surface, no external selector
+ *
+ * The managed/disabled rows are driven by overriding the public config client
+ * side (the server only sends safe flags; this just exercises the UI branches
+ * without requiring a configured provider).
+ */
+
+/** Override the public AI config before the iDevice editor renders. */
+async function setAiConfig(page: Page, ai: Record<string, unknown> | null): Promise<void> {
+    await page.evaluate(value => {
+        const api = (window as any).eXeLearning?.app?.api;
+        if (!api) return;
+        api.parameters = api.parameters || {};
+        if (value) api.parameters.ai = value;
+        else delete api.parameters.ai;
+    }, ai);
+}
+
+async function addFormGameIdevice(page: Page): Promise<void> {
+    await selectFirstPage(page);
+    await addIdevice(page, 'form');
+    // The Form iDevice enters edition on add; its AI tab content (getTabIA) is
+    // rendered into the editor DOM (hidden unless the AI tab is active).
+    await page.waitForSelector('#node-content article .idevice_node.form', { timeout: 15000 });
+}
+
+test.describe('AI configuration behaviour matrix', () => {
+    test('external mode shows the public assistant selector and "Send to AI"', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'AI External Test');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        // Default server config in the E2E env is enabled + external; assert it,
+        // then add the iDevice so getTabIA renders the external controls.
+        await setAiConfig(page, { enabled: true, provider: 'external', mode: 'external', configured: true });
+        await addFormGameIdevice(page);
+
+        await expect(page.locator('#eXeEPromptArea')).toBeAttached({ timeout: 10000 });
+        await expect(page.locator('#eXeEIASelect')).toBeAttached();
+        await expect(page.locator('#eXeEOpenChatGPTButton')).toBeAttached();
+        // No managed Generate tab in external mode.
+        await expect(page.locator('#eXeETabIA')).toHaveCount(0);
+    });
+
+    test('disabled mode renders no AI tab', async ({ authenticatedPage, createProject }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'AI Disabled Test');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        await setAiConfig(page, { enabled: false, provider: 'external', mode: 'external', configured: true });
+        await addFormGameIdevice(page);
+
+        // getTabIA returns '' when disabled: no AI tab content anywhere.
+        await expect(page.locator('#eXeEPromptArea')).toHaveCount(0);
+        await expect(page.locator('#eXeEIASelect')).toHaveCount(0);
+        await expect(page.locator('#eXeEOpenChatGPTButton')).toHaveCount(0);
+    });
+
+    test('managed mode shows the Generate/Create surface and hides the external selector', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'AI Managed Test');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        await setAiConfig(page, { enabled: true, provider: 'ollama', mode: 'managed', configured: true });
+        await addFormGameIdevice(page);
+
+        await expect(page.locator('#eXeEPromptArea')).toBeAttached({ timeout: 10000 });
+        await expect(page.locator('#eXeETabIA')).toBeAttached();
+        await expect(page.locator('#eXeFormIAContainer')).toBeAttached();
+        // External assistant controls are hidden in managed mode.
+        await expect(page.locator('#eXeEIASelect')).toHaveCount(0);
+        await expect(page.locator('#eXeEOpenChatGPTButton')).toHaveCount(0);
+    });
+});

--- a/views/admin/index.njk
+++ b/views/admin/index.njk
@@ -1289,6 +1289,10 @@
                 <span class="mi">tune</span>
                 {{ t.customization or 'Customization' }}
             </a>
+            <a href="#ai" class="admin-nav-link" data-section="ai">
+                <span class="mi">smart_toy</span>
+                {{ t.ai or 'AI' }}
+            </a>
             <a href="#maintenance" class="admin-nav-link" data-section="maintenance">
                 <span class="mi">engineering</span>
                 {{ t.maintenance or 'Maintenance' }}
@@ -2007,6 +2011,130 @@ window.$eXeLearningCustom = {
                 </div>
             </section>
 
+            <!-- AI Section -->
+            <section id="ai" class="admin-section">
+                <div class="admin-card">
+                    <div class="admin-card-header">
+                        <h5>
+                            <span class="mi mi-sm">smart_toy</span>
+                            {{ t.ai_settings or 'AI Settings' }}
+                        </h5>
+                    </div>
+                    <div class="admin-card-body">
+                        <p class="admin-help">{{ t.ai_intro or 'Configure how AI assistance is offered in game-generation activities.' }}</p>
+                        <div class="admin-settings-actions">
+                            <button id="aiSaveBtn" class="btn-admin-primary">
+                                <span class="mi mi-sm">save</span>
+                                {{ t.save or 'Save' }}
+                            </button>
+                            <button id="aiTestBtn" class="btn-admin-secondary" type="button">
+                                <span class="mi mi-sm">network_check</span>
+                                {{ t.ai_test_connection or 'Test connection' }}
+                            </button>
+                            <span id="aiSaveStatus" class="admin-settings-status"></span>
+                        </div>
+
+                        <div class="admin-settings-group">
+                            <h6>{{ t.ai_settings or 'AI Settings' }}</h6>
+                            <div class="admin-settings-grid">
+                                <div class="admin-field">
+                                    <label>AI_FEATURES_ENABLED</label>
+                                    <div class="form-check-custom">
+                                        <input type="checkbox" data-setting-key="AI_FEATURES_ENABLED" data-setting-type="boolean" {% if adminSettings.ai.features_enabled %}checked{% endif %}>
+                                        <span>{{ t.ai_features_enabled or 'Enable AI features' }}</span>
+                                    </div>
+                                    <small>{{ t.ai_features_enabled_help or 'When disabled, all AI buttons and AI preferences are hidden everywhere.' }}</small>
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_PROVIDER</label>
+                                    <select id="aiProviderSelect" class="admin-input" data-setting-key="AI_PROVIDER" data-setting-type="string">
+                                        <option value="external" {% if adminSettings.ai.provider == 'external' %}selected{% endif %}>{{ t.ai_provider_external or 'External public assistants' }}</option>
+                                        <option value="azure" {% if adminSettings.ai.provider == 'azure' %}selected{% endif %}>{{ t.ai_provider_azure or 'Azure OpenAI' }}</option>
+                                        <option value="ollama" {% if adminSettings.ai.provider == 'ollama' %}selected{% endif %}>{{ t.ai_provider_ollama or 'Ollama' }}</option>
+                                        <option value="openai_compat" {% if adminSettings.ai.provider == 'openai_compat' %}selected{% endif %}>{{ t.ai_provider_openai_compat or 'OpenAI-compatible' }}</option>
+                                    </select>
+                                    <small>{{ t.ai_provider_help or 'External keeps the public AI assistant links. Azure, Ollama and OpenAI-compatible route generation through your configured server-side provider.' }}</small>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="admin-settings-group" data-ai-provider-group="azure">
+                            <h6>{{ t.ai_azure_group or 'Azure OpenAI' }}</h6>
+                            <div class="admin-settings-grid">
+                                <div class="admin-field">
+                                    <label>AI_AZURE_ENDPOINT</label>
+                                    <input class="admin-input" data-setting-key="AI_AZURE_ENDPOINT" data-setting-type="string" value="{{ adminSettings.ai.azure_endpoint }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_AZURE_API_KEY</label>
+                                    <input type="password" class="admin-input" data-setting-key="AI_AZURE_API_KEY" data-setting-type="string" autocomplete="new-password" placeholder="{% if adminSettings.ai.azure_api_key_set %}••••••••{% endif %}">
+                                    <small>{{ t.ai_api_key_help or 'Stored on the server only. Leave blank to keep the current key.' }} {% if adminSettings.ai.azure_api_key_set %}{{ t.ai_api_key_set or 'A key is currently configured.' }}{% else %}{{ t.ai_api_key_unset or 'No key configured.' }}{% endif %}</small>
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_AZURE_DEPLOYMENT</label>
+                                    <input class="admin-input" data-setting-key="AI_AZURE_DEPLOYMENT" data-setting-type="string" value="{{ adminSettings.ai.azure_deployment }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_AZURE_API_VERSION</label>
+                                    <input class="admin-input" data-setting-key="AI_AZURE_API_VERSION" data-setting-type="string" value="{{ adminSettings.ai.azure_api_version }}">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="admin-settings-group" data-ai-provider-group="ollama">
+                            <h6>{{ t.ai_ollama_group or 'Ollama' }}</h6>
+                            <div class="admin-settings-grid">
+                                <div class="admin-field">
+                                    <label>AI_OLLAMA_ENDPOINT</label>
+                                    <input class="admin-input" data-setting-key="AI_OLLAMA_ENDPOINT" data-setting-type="string" value="{{ adminSettings.ai.ollama_endpoint }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_OLLAMA_MODEL</label>
+                                    <input class="admin-input" data-setting-key="AI_OLLAMA_MODEL" data-setting-type="string" value="{{ adminSettings.ai.ollama_model }}">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="admin-settings-group" data-ai-provider-group="openai_compat">
+                            <h6>{{ t.ai_compat_group or 'OpenAI-compatible' }}</h6>
+                            <div class="admin-settings-grid">
+                                <div class="admin-field">
+                                    <label>AI_COMPAT_ENDPOINT</label>
+                                    <input class="admin-input" data-setting-key="AI_COMPAT_ENDPOINT" data-setting-type="string" value="{{ adminSettings.ai.compat_endpoint }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_COMPAT_API_KEY</label>
+                                    <input type="password" class="admin-input" data-setting-key="AI_COMPAT_API_KEY" data-setting-type="string" autocomplete="new-password" placeholder="{% if adminSettings.ai.compat_api_key_set %}••••••••{% endif %}">
+                                    <small>{{ t.ai_api_key_help or 'Stored on the server only. Leave blank to keep the current key.' }} {% if adminSettings.ai.compat_api_key_set %}{{ t.ai_api_key_set or 'A key is currently configured.' }}{% else %}{{ t.ai_api_key_unset or 'No key configured.' }}{% endif %}</small>
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_COMPAT_MODEL</label>
+                                    <input class="admin-input" data-setting-key="AI_COMPAT_MODEL" data-setting-type="string" value="{{ adminSettings.ai.compat_model }}">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="admin-settings-group" data-ai-provider-group="managed">
+                            <h6>{{ t.ai_common_group or 'Generation options' }}</h6>
+                            <div class="admin-settings-grid">
+                                <div class="admin-field">
+                                    <label>AI_REQUEST_TIMEOUT_MS</label>
+                                    <input type="number" class="admin-input" data-setting-key="AI_REQUEST_TIMEOUT_MS" data-setting-type="number" value="{{ adminSettings.ai.request_timeout_ms }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_MAX_OUTPUT_TOKENS</label>
+                                    <input type="number" class="admin-input" data-setting-key="AI_MAX_OUTPUT_TOKENS" data-setting-type="number" value="{{ adminSettings.ai.max_output_tokens }}">
+                                </div>
+                                <div class="admin-field">
+                                    <label>AI_TEMPERATURE</label>
+                                    <input class="admin-input" data-setting-key="AI_TEMPERATURE" data-setting-type="string" value="{{ adminSettings.ai.temperature }}">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <!-- Maintenance Section -->
             <section id="maintenance" class="admin-section">
                 <div class="admin-card">
@@ -2211,7 +2339,14 @@ window.$eXeLearningCustom = {
             presentation: '{{ t.customization or "Customization" }}',
             maintenance: '{{ t.maintenance or "Maintenance" }}',
             logins: '{{ t.logins or "Logins" }}',
-            projects_created: '{{ t.projects_created or "Projects Created" }}'
+            projects_created: '{{ t.projects_created or "Projects Created" }}',
+            ai: '{{ t.ai or "AI" }}',
+            saving: '{{ t.saving or "Saving..." }}',
+            saved: '{{ t.saved or "Saved" }}',
+            error_saving: '{{ t.error_saving or "Error saving" }}',
+            ai_testing: '{{ t.ai_testing or "Testing..." }}',
+            ai_test_ok: '{{ t.ai_test_ok or "Connection successful" }}',
+            ai_test_failed: '{{ t.ai_test_failed or "Connection failed" }}'
         };
 
         // State
@@ -2256,6 +2391,7 @@ window.$eXeLearningCustom = {
                 extensions: T.extensions,
                 settings: T.settings,
                 presentation: T.customization,
+                ai: T.ai,
                 maintenance: T.maintenance
             };
             document.getElementById('sectionTitle').textContent = titles[section] || section;
@@ -2651,7 +2787,9 @@ window.$eXeLearningCustom = {
         document.getElementById('collapseAssets')?.addEventListener('show.bs.collapse', loadCustomAssets);
 
         function collectAdminSettings() {
-            const inputs = Array.from(document.querySelectorAll('[data-setting-key]'));
+            // Exclude the AI section: it has its own scoped Save (ai.js) so the
+            // global Settings Save must not also submit/validate AI inputs.
+            const inputs = Array.from(document.querySelectorAll('[data-setting-key]')).filter(i => !i.closest('#ai'));
             const grouped = new Map();
 
             inputs.forEach(input => {
@@ -4093,5 +4231,6 @@ window.$eXeLearningCustom = {
         loadSystemInfo();
     </script>
     <script type="module" src="{{ basePath }}/app/admin/dashboard.js"></script>
+    <script type="module" src="{{ basePath }}/app/admin/ai.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds an environment- and admin-configurable AI subsystem for game-question generation, so regional/institutional installations can hide public AI options and use only their configured provider.
- New AI service layer (`src/services/ai/`): typed config parsing + provider allow-list, a fail-closed manager with request timeout, and Azure OpenAI / Ollama / OpenAI-compatible providers.
- New `POST /api/ai/generate-text` (authenticated, online-only) and admin-only `POST /api/ai/test-connection` diagnostic.
- Public, secret-free AI config `{ enabled, provider, mode, configured }` added to the parameter response; the `defaultAI` user preference is shown only in external mode.
- Admin **AI** tab backed by `app_settings` (env vars as defaults). Provider API keys are **write-only**: masked on read, and a blank value on save keeps the stored key.
- Editor behaviour matrix preserved/extended in `common_edition.js`.
- Docs: `doc/development/ai-configuration.md` + `.env.dist` entries.

## Requested by
Requested by @ignaciogros.

## Behaviour matrix
| `AI_FEATURES_ENABLED` | `AI_PROVIDER` | Game editor | `defaultAI` |
|---|---|---|---|
| `false` | (any) | No AI tab / buttons | Hidden |
| `true` | `external` | Assistant selector + **Send to AI** (current behaviour) | Shown |
| `true` | `azure` / `ollama` / `openai_compat` | Server-side **Create** button; no external options | Hidden |

When a managed provider is selected but misconfigured, generation fails closed with a clear error — it never falls back to a public AI service.

## Security
- Provider credentials stay server-side. They are never returned by `/api/config`, `/api/parameter-management/parameters/data/list`, `GET /api/admin/settings` (masked → `value: ''` + `isSet`), the static bundle, or any frontend global.
- `AI_PROVIDER` is validated against an allow-list; managed endpoint URLs are validated as `http(s)` on save.
- The provider endpoint is admin-configured (trusted); the browser only ever sends the prompt text — it cannot choose the provider URL.

## Testing (run locally on this branch)
- `make fix` — clean (only a pre-existing `noExplicitAny` warning in `src/routes/export.ts`, untouched here).
- `bun test src` — 7382 pass. The only 3 failures are the pre-existing `Resources Routes` "version prefix" tests (environmental: `getAppVersion()` returns the `v0.0.0-alpha` fallback in an untagged checkout; unrelated to this PR and unchanged by it).
- `bun test test/integration` — 721 pass, 0 fail.
- Frontend `vitest run` (full) — 13437 pass, 0 fail.
- New colocated tests added for every new file (AI service + providers, route, admin masking/validation, config gating, static bundle, `apiCallManager.getGenerateQuestions`, `common_edition` matrix, `admin/ai.js`, `pages` secret-masking).
- E2E: `test/e2e/playwright/specs/ai-configuration.spec.ts` added (disabled / external / managed UI rows). Not executed in the local sandbox (the Chromium headless-shell binary could not be downloaded here); it runs in CI.

## Reviewer verification checklist
- [ ] `make fix && make test-unit && make test-integration` are green.
- [ ] `make test-e2e` green, including `ai-configuration.spec.ts`.
- [ ] **Disabled** (`AI_FEATURES_ENABLED=false`): no AI tab/buttons in a game iDevice; `defaultAI` absent from Preferences; `POST /api/ai/generate-text` returns a safe `AI_DISABLED` error.
- [ ] **External** (`AI_PROVIDER=external`): assistant selector + “Send to AI” present; `defaultAI` shown; opening a public assistant still works.
- [ ] **Managed** (`AI_PROVIDER=ollama`/`azure`/`openai_compat`): external selector hidden; “Create” generates questions via the backend; misconfigured provider shows a clear error and does **not** open a public AI.
- [ ] No secret leak: inspect `/api/parameter-management/parameters/data/list`, `/api/config`, `GET /api/admin/settings`, and `data/bundle.json` — none contain provider keys/endpoints.
- [ ] Admin **AI** tab: provider field groups toggle by provider; saving a blank API key keeps the stored key; “Test connection” reports success/failure.
