### PR TITLE
Defer tooltips execution to ensure $exeFX.init() has completed first.

### DIFF
--- a/public/app/common/exe_tooltips/exe_tooltips.js
+++ b/public/app/common/exe_tooltips/exe_tooltips.js
@@ -1,16 +1,28 @@
 $exe.tooltips = {
 	className : "exe-tooltip",
 	init : function(path){
-		this.path = path;
-		this.viewport = $(window);
-		var as = $("A."+$exe.tooltips.className);
-		if (as.length>0) {
-			this.links = as;
-			this.loadCSS();
-            this.loadJS();
-		}
-		if (window.location.protocol.indexOf("http")==0) this.isAJAXAllowed = true;
-		if (document.body.className.indexOf("exe-single-page")!=-1) this.isAJAXAllowed = false; // To review
+		var self = this;
+		// Defer execution to the next event loop tick to ensure $exeFX.init() has completed first.
+		setTimeout(function() {
+			self.path = path;
+			self.viewport = $(window);
+
+			var as = $("A." + $exe.tooltips.className);
+
+			if (as.length > 0) {
+				self.links = as;
+				self.loadCSS();
+				self.loadJS();
+			}
+
+			if (window.location.protocol.indexOf("http") === 0) {
+				self.isAJAXAllowed = true;
+			}
+
+			if (document.body.className.indexOf("exe-single-page") !== -1) {
+				self.isAJAXAllowed = false;
+			}
+		}, 0);
 	},
 	loadCSS : function() {
 		// We can't use this in Safari $exe.loadScript("jquery.qtip.min.css","$exe.tooltips.loadJS()"); because the callback function won't work with CSS files in that browser, so we just call this.loadJS(); (see line 7)

--- a/public/app/common/exe_tooltips/exe_tooltips.test.js
+++ b/public/app/common/exe_tooltips/exe_tooltips.test.js
@@ -211,9 +211,18 @@ describe('exe_tooltips (app/common)', () => {
   });
 
   describe('init', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('initializes when tooltips are present and loads assets', () => {
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="title | text"></a>';
       exeTooltips.init('/assets/');
+      vi.runAllTimers();
       expect(exeTooltips.path).toBe('/assets/');
       expect(exeTooltips.links?.length).toBe(1);
       expect(loadScriptMock).toHaveBeenCalledWith('/assets/jquery.qtip.min.css');
@@ -226,12 +235,14 @@ describe('exe_tooltips (app/common)', () => {
     it('does not load assets when no tooltips present', () => {
       document.body.innerHTML = '<a class="regular-link">Link</a>';
       exeTooltips.init('/assets/');
+      vi.runAllTimers();
       expect(loadScriptMock).not.toHaveBeenCalled();
     });
 
     it('sets viewport to window', () => {
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="text"></a>';
       exeTooltips.init('/path/');
+      vi.runAllTimers();
       expect(exeTooltips.viewport).toBeDefined();
     });
 
@@ -242,6 +253,7 @@ describe('exe_tooltips (app/common)', () => {
       });
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="text"></a>';
       exeTooltips.init('/path/');
+      vi.runAllTimers();
       expect(exeTooltips.isAJAXAllowed).toBe(true);
     });
 
@@ -252,6 +264,7 @@ describe('exe_tooltips (app/common)', () => {
       });
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="text"></a>';
       exeTooltips.init('/path/');
+      vi.runAllTimers();
       expect(exeTooltips.isAJAXAllowed).toBe(true);
     });
 
@@ -263,6 +276,7 @@ describe('exe_tooltips (app/common)', () => {
       document.body.className = 'exe-single-page';
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="text"></a>';
       exeTooltips.init('/');
+      vi.runAllTimers();
       expect(exeTooltips.isAJAXAllowed).toBe(false);
     });
 
@@ -274,6 +288,7 @@ describe('exe_tooltips (app/common)', () => {
       document.body.innerHTML = '<a class="exe-tooltip plain-tt" title="text"></a>';
       exeTooltips.isAJAXAllowed = undefined;
       exeTooltips.init('/path/');
+      vi.runAllTimers();
       // isAJAXAllowed should remain undefined for file protocol
       expect(exeTooltips.isAJAXAllowed).toBeUndefined();
     });


### PR DESCRIPTION
**How to test:**

Add a tooltip inside an accordion or other effect. It should work in all cases now.