### PR TITLE
fix(export): preserve iDevice structure properties in single-box export/import (#1991)

### DIFF
--- a/public/app/yjs/ComponentImporter.js
+++ b/public/app/yjs/ComponentImporter.js
@@ -279,7 +279,13 @@ class ComponentImporter {
       properties = this.convertAssetPathsInObject(properties);
     }
 
-    return {
+    // Parse component-level structure properties (visibility, teacherOnly, cssClass).
+    // These live in <odeComponentsProperties> as <odeComponentsProperty> key/value
+    // pairs (NOT in jsonProperties). Without this, a re-imported .block/.idevice
+    // lost "Visible in export", "Teacher only" and custom CSS classes (issue #1991).
+    const structureProperties = this.parseComponentStructureProperties(compNode);
+
+    const compData = {
       id: compId,
       ideviceId: compId,
       ideviceType: ideviceType,
@@ -289,6 +295,43 @@ class ComponentImporter {
       htmlView: htmlView,
       properties: properties,
     };
+
+    if (structureProperties) {
+      compData.structureProperties = structureProperties;
+    }
+
+    return compData;
+  }
+
+  /**
+   * Parse component structure properties from an <odeComponent> element.
+   *
+   * Reads the <odeComponentsProperty> key/value pairs inside
+   * <odeComponentsProperties>. Returns undefined when none are present so callers
+   * can skip creating an empty properties map.
+   *
+   * @param {Element} compNode - odeComponent element
+   * @returns {Object|undefined} Map of structure property key -> string value
+   */
+  parseComponentStructureProperties(compNode) {
+    const container = compNode.querySelector('odeComponentsProperties');
+    if (!container) {
+      return undefined;
+    }
+
+    const propNodes = container.querySelectorAll('odeComponentsProperty');
+    if (!propNodes || propNodes.length === 0) {
+      return undefined;
+    }
+
+    const structureProperties = {};
+    for (const propNode of propNodes) {
+      const key = this.getTextContent(propNode, 'key');
+      if (!key) continue;
+      structureProperties[key] = this.getTextContent(propNode, 'value') || '';
+    }
+
+    return Object.keys(structureProperties).length > 0 ? structureProperties : undefined;
   }
 
   /**
@@ -434,6 +477,20 @@ class ComponentImporter {
 
     if (compData.properties && typeof compData.properties === 'object') {
       compMap.set('jsonProperties', JSON.stringify(compData.properties));
+    }
+
+    // Store component-level structure properties (visibility, teacherOnly,
+    // cssClass) in the dedicated `properties` Y.Map, matching the full-page
+    // import path (createComponentMapFromApi) so the workarea and later exports
+    // pick them up (issue #1991).
+    if (compData.structureProperties && Object.keys(compData.structureProperties).length > 0) {
+      const propsMap = new this.Y.Map();
+      for (const [key, value] of Object.entries(compData.structureProperties)) {
+        if (value !== undefined && value !== null) {
+          propsMap.set(key, value);
+        }
+      }
+      compMap.set('properties', propsMap);
     }
 
     return compMap;

--- a/public/app/yjs/ComponentImporter.test.js
+++ b/public/app/yjs/ComponentImporter.test.js
@@ -470,6 +470,155 @@ describe('ComponentImporter', () => {
     });
   });
 
+  describe('iDevice structure properties (#1991)', () => {
+    // content.xml whose component carries odeComponentsProperties (visibility,
+    // teacherOnly, cssClass). These must be parsed and stored so a re-imported
+    // .block/.idevice keeps "Visible in export", "Teacher only" and CSS classes.
+    const COMPONENT_WITH_STRUCTURE_PROPS = `<?xml version="1.0" encoding="UTF-8"?>
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odeResources>
+  <odeResource>
+    <key>odeComponentsResources</key>
+    <value>true</value>
+  </odeResource>
+</odeResources>
+<odePagStructures>
+  <odePagStructure>
+    <odeBlockId>block-sp</odeBlockId>
+    <blockName>Block With Struct Props</blockName>
+    <iconName></iconName>
+    <odePagStructureOrder>0</odePagStructureOrder>
+    <odePagStructureProperties>{}</odePagStructureProperties>
+    <odeComponents>
+      <odeComponent>
+        <odeIdeviceId>idevice-sp</odeIdeviceId>
+        <odeIdeviceTypeName>text</odeIdeviceTypeName>
+        <htmlView>&lt;p&gt;Hidden teacher content&lt;/p&gt;</htmlView>
+        <jsonProperties>{"textTextarea":"Hidden teacher content"}</jsonProperties>
+        <odeComponentsOrder>0</odeComponentsOrder>
+        <odeComponentsProperties>
+          <odeComponentsProperty>
+            <key>visibility</key>
+            <value>false</value>
+          </odeComponentsProperty>
+          <odeComponentsProperty>
+            <key>teacherOnly</key>
+            <value>true</value>
+          </odeComponentsProperty>
+          <odeComponentsProperty>
+            <key>cssClass</key>
+            <value>my-custom-class another-class</value>
+          </odeComponentsProperty>
+        </odeComponentsProperties>
+      </odeComponent>
+    </odeComponents>
+  </odePagStructure>
+</odePagStructures>
+</ode>`;
+
+    it('parseComponentFromXml should extract structureProperties', () => {
+      const docManager = createMockDocumentManager();
+      const importer = new ComponentImporter(docManager, null);
+
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(COMPONENT_WITH_STRUCTURE_PROPS, 'text/xml');
+      const compNode = xmlDoc.querySelector('odeComponent');
+
+      const compData = importer.parseComponentFromXml(compNode);
+
+      expect(compData.structureProperties).toEqual({
+        visibility: 'false',
+        teacherOnly: 'true',
+        cssClass: 'my-custom-class another-class',
+      });
+    });
+
+    it('parseComponentFromXml should omit structureProperties when the block is empty', () => {
+      const docManager = createMockDocumentManager();
+      const importer = new ComponentImporter(docManager, null);
+
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(SAMPLE_COMPONENT_XML, 'text/xml');
+      const compNode = xmlDoc.querySelector('odeComponent');
+
+      const compData = importer.parseComponentFromXml(compNode);
+
+      expect(compData.structureProperties).toBeUndefined();
+    });
+
+    it('parseComponentFromXml should omit structureProperties when the element is absent', () => {
+      const docManager = createMockDocumentManager();
+      const importer = new ComponentImporter(docManager, null);
+
+      const NO_PROPS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ode xmlns="http://www.intef.es/xsd/ode" version="2.0">
+<odePagStructures>
+  <odePagStructure>
+    <odeComponents>
+      <odeComponent>
+        <odeIdeviceId>idevice-noprops</odeIdeviceId>
+        <odeIdeviceTypeName>text</odeIdeviceTypeName>
+        <htmlView>&lt;p&gt;No props&lt;/p&gt;</htmlView>
+        <jsonProperties>{}</jsonProperties>
+        <odeComponentsOrder>0</odeComponentsOrder>
+      </odeComponent>
+    </odeComponents>
+  </odePagStructure>
+</odePagStructures>
+</ode>`;
+
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(NO_PROPS_XML, 'text/xml');
+      const compNode = xmlDoc.querySelector('odeComponent');
+
+      const compData = importer.parseComponentFromXml(compNode);
+
+      expect(compData.structureProperties).toBeUndefined();
+    });
+
+    it('should store structure properties in the component properties Y.Map on import', async () => {
+      const docManager = createMockDocumentManager([{ id: 'page-1', name: 'Test Page' }]);
+      const assetManager = createMockAssetManager();
+      global.window.fflate = createMockFflate(COMPONENT_WITH_STRUCTURE_PROPS);
+
+      const importer = new ComponentImporter(docManager, assetManager);
+      const file = new File([new Uint8Array([1, 2, 3])], 'test.block');
+
+      const result = await importer.importComponent(file, 'page-1');
+      expect(result.success).toBe(true);
+
+      const navigation = docManager._navigation;
+      const blocks = navigation.get(0).get('blocks');
+      const blockMap = blocks.get(blocks.length - 1);
+      const compMap = blockMap.get('components').get(0);
+
+      const propsMap = compMap.get('properties');
+      expect(propsMap).toBeDefined();
+      expect(propsMap.get('visibility')).toBe('false');
+      expect(propsMap.get('teacherOnly')).toBe('true');
+      expect(propsMap.get('cssClass')).toBe('my-custom-class another-class');
+    });
+
+    it('should not create a properties map when component has no structure properties', async () => {
+      const docManager = createMockDocumentManager([{ id: 'page-1', name: 'Test Page' }]);
+      const assetManager = createMockAssetManager();
+      global.window.fflate = createMockFflate(SAMPLE_COMPONENT_XML);
+
+      const importer = new ComponentImporter(docManager, assetManager);
+      const file = new File([new Uint8Array([1, 2, 3])], 'test.block');
+
+      const result = await importer.importComponent(file, 'page-1');
+      expect(result.success).toBe(true);
+
+      const navigation = docManager._navigation;
+      const blocks = navigation.get(0).get('blocks');
+      const blockMap = blocks.get(blocks.length - 1);
+      const compMap = blockMap.get('components').get(0);
+
+      expect(compMap.get('properties')).toBeUndefined();
+    });
+  });
+
   describe('generateId', () => {
     it('should generate unique IDs with prefix', () => {
       const docManager = createMockDocumentManager();

--- a/src/shared/export/exporters/ComponentExporter.spec.ts
+++ b/src/shared/export/exporters/ComponentExporter.spec.ts
@@ -378,6 +378,134 @@ describe('ComponentExporter', () => {
         });
     });
 
+    describe('Component Structure Properties (issue #1991)', () => {
+        // Pages whose iDevices carry structure properties (visibility, teacherOnly, cssClass).
+        // These must survive a single-block / single-iDevice export the same way they do in a
+        // full-page ELPX export, otherwise re-importing the exported .block/.idevice loses them.
+        const pagesWithStructureProps: ExportPage[] = [
+            {
+                id: 'page-sp',
+                title: 'Structure Props Page',
+                parentId: null,
+                order: 0,
+                blocks: [
+                    {
+                        id: 'block-sp',
+                        name: 'Block With Props',
+                        order: 0,
+                        components: [
+                            {
+                                id: 'idevice-sp-1',
+                                type: 'FreeTextIdevice',
+                                order: 0,
+                                content: '<p>Hidden teacher-only idevice.</p>',
+                                properties: {},
+                                structureProperties: {
+                                    visibility: false,
+                                    teacherOnly: true,
+                                    cssClass: 'my-custom-class another-class',
+                                },
+                            },
+                            {
+                                id: 'idevice-sp-2',
+                                type: 'FreeTextIdevice',
+                                order: 1,
+                                content: '<p>Default idevice without structure props.</p>',
+                                properties: {},
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        beforeEach(() => {
+            document = new MockDocument({}, pagesWithStructureProps);
+            exporter = new ComponentExporter(document, resources, assets, zip);
+        });
+
+        it('should preserve iDevice structure properties when exporting a whole block', async () => {
+            await exporter.exportComponent('block-sp', null);
+
+            const contentXml = new TextDecoder().decode(zip.files.get('content.xml'));
+
+            expect(contentXml).toContain('<key>visibility</key>');
+            expect(contentXml).toContain('<value>false</value>');
+            expect(contentXml).toContain('<key>teacherOnly</key>');
+            expect(contentXml).toContain('<value>true</value>');
+            expect(contentXml).toContain('<key>cssClass</key>');
+            expect(contentXml).toContain('<value>my-custom-class another-class</value>');
+            // The empty placeholder must no longer be emitted.
+            expect(contentXml).not.toContain('<odeComponentsProperties></odeComponentsProperties>');
+        });
+
+        it('should preserve structure properties when exporting a single iDevice', async () => {
+            await exporter.exportComponent('block-sp', 'idevice-sp-1');
+
+            const contentXml = new TextDecoder().decode(zip.files.get('content.xml'));
+
+            expect(contentXml).toContain('<key>visibility</key>');
+            expect(contentXml).toContain('<value>false</value>');
+            expect(contentXml).toContain('<key>teacherOnly</key>');
+            expect(contentXml).toContain('<value>true</value>');
+            expect(contentXml).toContain('<key>cssClass</key>');
+            expect(contentXml).toContain('<value>my-custom-class another-class</value>');
+        });
+
+        it('should default to visibility=true when a component has no structure properties', async () => {
+            await exporter.exportComponent('block-sp', 'idevice-sp-2');
+
+            const contentXml = new TextDecoder().decode(zip.files.get('content.xml'));
+
+            expect(contentXml).toContain('<key>visibility</key>');
+            expect(contentXml).toContain('<value>true</value>');
+            expect(contentXml).not.toContain('<key>teacherOnly</key>');
+            expect(contentXml).not.toContain('<odeComponentsProperties></odeComponentsProperties>');
+        });
+
+        it('should escape XML special characters in structure property values', async () => {
+            const pagesWithSpecialCss: ExportPage[] = [
+                {
+                    id: 'page-css',
+                    title: 'Special CSS Page',
+                    parentId: null,
+                    order: 0,
+                    blocks: [
+                        {
+                            id: 'block-css',
+                            name: 'CSS Block',
+                            order: 0,
+                            components: [
+                                {
+                                    id: 'idevice-css',
+                                    type: 'FreeTextIdevice',
+                                    order: 0,
+                                    content: '<p>Test</p>',
+                                    properties: {},
+                                    structureProperties: {
+                                        visibility: true,
+                                        cssClass: 'a&b <c> "d"',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+
+            document = new MockDocument({}, pagesWithSpecialCss);
+            exporter = new ComponentExporter(document, resources, assets, zip);
+
+            await exporter.exportComponent('block-css', null);
+
+            const contentXml = new TextDecoder().decode(zip.files.get('content.xml'));
+
+            expect(contentXml).toContain('<value>a&amp;b &lt;c&gt; &quot;d&quot;</value>');
+            // The raw, unescaped value must never appear.
+            expect(contentXml).not.toContain('<value>a&b <c> "d"</value>');
+        });
+    });
+
     describe('Asset Handling', () => {
         it('should include referenced assets in ZIP', async () => {
             assets.setAssets([

--- a/src/shared/export/exporters/ComponentExporter.ts
+++ b/src/shared/export/exporters/ComponentExporter.ts
@@ -276,9 +276,49 @@ export class ComponentExporter extends BaseExporter {
         xml += `        <htmlView><![CDATA[${this.escapeCdata(htmlContent)}]]></htmlView>\n`;
         xml += `        <jsonProperties><![CDATA[${this.escapeCdata(propsJson)}]]></jsonProperties>\n`;
         xml += `        <odeComponentsOrder>${comp.order || 0}</odeComponentsOrder>\n`;
-        xml += `        <odeComponentsProperties></odeComponentsProperties>\n`;
+        xml += `        <odeComponentsProperties>\n`;
+        xml += this.generateComponentPropertiesXml(comp);
+        xml += `        </odeComponentsProperties>\n`;
         xml += '      </odeComponent>\n';
         return xml;
+    }
+
+    /**
+     * Generate the <odeComponentsProperty> entries for an iDevice's structure
+     * properties (visibility, teacherOnly, cssClass).
+     *
+     * Mirrors OdeXmlGenerator.generateOdeComponentXml() so a single-block or
+     * single-iDevice export keeps the same component metadata as a full-page
+     * ELPX export (issue #1991). Previously this block was emitted empty, so
+     * "Visible in export", "Teacher only" and custom CSS classes were dropped
+     * when a .block/.idevice was exported and re-imported.
+     *
+     * When a component has no structureProperties we still emit visibility=true,
+     * matching COMPONENT_PROPERTY_DEFAULTS applied on import.
+     *
+     * @param comp - Component data (structureProperties carry the values)
+     */
+    private generateComponentPropertiesXml(comp: ExportComponent): string {
+        const entry = (key: string, value: string): string =>
+            `          <odeComponentsProperty>\n` +
+            `            <key>${this.escapeXml(key)}</key>\n` +
+            `            <value>${this.escapeXml(value)}</value>\n` +
+            `          </odeComponentsProperty>\n`;
+
+        const props = comp.structureProperties;
+        if (props) {
+            let xml = '';
+            const componentPropKeys = ['visibility', 'teacherOnly', 'cssClass'] as const;
+            for (const key of componentPropKeys) {
+                if (props[key] !== undefined) {
+                    xml += entry(key, String(props[key]));
+                }
+            }
+            return xml;
+        }
+
+        // Default visibility if no structure properties (matches full-page export)
+        return entry('visibility', 'true');
     }
 
     /**

--- a/test/e2e/playwright/specs/component-export-import.spec.ts
+++ b/test/e2e/playwright/specs/component-export-import.spec.ts
@@ -1178,3 +1178,160 @@ test.describe('Block Icon Preservation during Export/Import', () => {
         console.log('Block without icon correctly handled during export/import');
     });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// iDEVICE STRUCTURE PROPERTY PRESERVATION TESTS (issue #1991)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Set an iDevice's structure properties (visibility, teacherOnly, cssClass) through
+ * the same Yjs path the "iDevice properties" modal uses. These are the values that
+ * used to be dropped when exporting a single .block / .idevice (issue #1991).
+ */
+async function setIdeviceStructureProperties(
+    page: Page,
+    ideviceId: string,
+    props: { visibility?: boolean; teacherOnly?: boolean; cssClass?: string },
+): Promise<void> {
+    await page.evaluate(
+        ({ id, properties }) => {
+            const bridge = (window as any).eXeLearning?.app?.project?._yjsBridge;
+            if (!bridge?.updateComponent) {
+                throw new Error('Yjs bridge updateComponent not available');
+            }
+            bridge.updateComponent(id, { properties });
+        },
+        { id: ideviceId, properties: props },
+    );
+}
+
+test.describe('iDevice Structure Property Preservation during Export/Import (issue #1991)', () => {
+    let tempDir: string;
+
+    test.beforeAll(() => {
+        tempDir = path.join('/tmp', `exelearning-e2e-structprops-${Date.now()}`);
+        if (!fs.existsSync(tempDir)) {
+            fs.mkdirSync(tempDir, { recursive: true });
+        }
+    });
+
+    test.afterAll(() => {
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('should include iDevice structure properties in exported .block content.xml', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+
+        const projectUuid = await createProject(page, 'Struct Props Block Export');
+        await gotoWorkarea(page, projectUuid);
+        await waitForLoadingScreen(page);
+
+        await selectPageByIndex(page, 0);
+        await page.waitForTimeout(500);
+
+        await addTextIdevice(page);
+        await editTextIdevice(page, 'Teacher-only hidden content for #1991');
+
+        const { blockId, ideviceId } = await getFirstBlockAndIdeviceIds(page);
+
+        // Mark the iDevice hidden from export, teacher-only, with custom CSS classes.
+        await setIdeviceStructureProperties(page, ideviceId, {
+            visibility: false,
+            teacherOnly: true,
+            cssClass: 'my-custom-class another-class',
+        });
+
+        const blockDownload = await exportBlock(page, blockId);
+        const blockFilePath = path.join(tempDir, blockDownload.suggestedFilename());
+        await blockDownload.saveAs(blockFilePath);
+
+        const zipContents = unzipSync(fs.readFileSync(blockFilePath));
+        expect(zipContents['content.xml']).toBeDefined();
+        const contentXml = new TextDecoder().decode(zipContents['content.xml']);
+
+        // Before the fix this block was emitted empty, so none of these appeared.
+        expect(contentXml).not.toContain('<odeComponentsProperties></odeComponentsProperties>');
+        expect(contentXml).toContain('<key>visibility</key>');
+        expect(contentXml).toContain('<value>false</value>');
+        expect(contentXml).toContain('<key>teacherOnly</key>');
+        expect(contentXml).toContain('<value>true</value>');
+        expect(contentXml).toContain('<key>cssClass</key>');
+        expect(contentXml).toContain('<value>my-custom-class another-class</value>');
+    });
+
+    test('should preserve structure properties through a full export → import round-trip', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        test.setTimeout(90000);
+        const page = authenticatedPage;
+
+        // Source project: text iDevice marked teacher-only, hidden, with custom CSS classes.
+        const sourceUuid = await createProject(page, 'Struct Props Roundtrip Source');
+        await gotoWorkarea(page, sourceUuid);
+        await waitForLoadingScreen(page);
+        await selectPageByIndex(page, 0);
+        await page.waitForTimeout(500);
+        await addTextIdevice(page);
+        await editTextIdevice(page, 'Roundtrip content for #1991');
+
+        const { blockId, ideviceId } = await getFirstBlockAndIdeviceIds(page);
+        await setIdeviceStructureProperties(page, ideviceId, {
+            visibility: false,
+            teacherOnly: true,
+            cssClass: 'roundtrip-class extra-class',
+        });
+
+        const blockDownload = await exportBlock(page, blockId);
+        const blockFilePath = path.join(tempDir, blockDownload.suggestedFilename());
+        await blockDownload.saveAs(blockFilePath);
+
+        // Target project: import the exported block.
+        const targetUuid = await createProject(page, 'Struct Props Roundtrip Target');
+        await gotoWorkarea(page, targetUuid);
+        await waitForLoadingScreen(page);
+        await selectPageByIndex(page, 0);
+        await page.waitForTimeout(500);
+
+        await importComponent(page, blockFilePath);
+
+        // Wait for the imported iDevice to appear, then read its structure properties
+        // back from the document (Yjs) — this proves the values survived the
+        // export → import round-trip independent of any DOM render timing.
+        const importedProps = await page
+            .waitForFunction(
+                () => {
+                    const bridge = (window as any).eXeLearning?.app?.project?._yjsBridge;
+                    const binding = bridge?.structureBinding;
+                    if (!binding?.getComponentProperties) return null;
+                    // A fresh project may also render a default iDevice, so scan every
+                    // rendered node for the one whose properties carry our cssClass.
+                    const nodes = Array.from(document.querySelectorAll('#node-content article .idevice_node'));
+                    for (const node of nodes) {
+                        if (!node.id) continue;
+                        const props = binding.getComponentProperties(node.id);
+                        if (props && props.cssClass === 'roundtrip-class extra-class') {
+                            return props;
+                        }
+                    }
+                    return null;
+                },
+                undefined,
+                { timeout: 20000 },
+            )
+            .then(handle => handle.jsonValue());
+
+        // visibility/teacherOnly may come back as booleans or strings depending on the
+        // import path; normalize with String() before comparing.
+        expect(String(importedProps.visibility)).toBe('false');
+        expect(String(importedProps.teacherOnly)).toBe('true');
+        expect(importedProps.cssClass).toBe('roundtrip-class extra-class');
+
+        console.log('Structure properties preserved through export → import round-trip');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1991.

Exporting a **single box** (`.block`) or a **single iDevice** (`.idevice`) and importing it back dropped the iDevice structure properties:

- **Visible in export** (`visibility`)
- **Teacher only** (`teacherOnly`)
- **CSS classes** (`cssClass`)

Exporting a *whole page* preserved them correctly, because the full-page export/import uses a different code path.

## Root cause

It was actually **two bugs**, one on each side of the round-trip:

1. **Export side** — `ComponentExporter.generateIdeviceExportXml()` emitted an empty `<odeComponentsProperties></odeComponentsProperties>` for every component, ignoring `comp.structureProperties`. The full-page exporter (`OdeXmlGenerator.generateOdeComponentXml()`) already serialized these correctly.

2. **Import side** — `ComponentImporter.parseComponentFromXml()` (the `.block`/`.idevice` import path) only parsed `jsonProperties` and never read `<odeComponentsProperties>`. So even after fixing the export, the values were dropped on import. The full-page import path (`createComponentMapFromApi`) already stored them in the component's `properties` Y.Map.

## Changes

- **`src/shared/export/exporters/ComponentExporter.ts`** — serialize `visibility`, `teacherOnly`, `cssClass` into `<odeComponentsProperties>`, mirroring `OdeXmlGenerator`. Defaults to `visibility=true` when a component has no structure properties (matching `COMPONENT_PROPERTY_DEFAULTS`). Reuses the existing `escapeXml()` helper.
- **`public/app/yjs/ComponentImporter.js`** — parse the `<odeComponentsProperty>` key/value entries and store them in the component's `properties` Y.Map, matching the full-page import path.
- Tests:
  - `ComponentExporter.spec.ts` — block export, single-iDevice export, default `visibility`, and XML escaping.
  - `ComponentImporter.test.js` — parsing + storing structure properties, and the no-properties cases.
  - `component-export-import.spec.ts` (Playwright) — exported `content.xml` contains the properties, and a full **export → import round-trip** preserves them.

No existing behavior changes: full-page export/import and component asset handling are untouched.

## How to verify

### Automated

```bash
# Backend (export side)
bun test src/shared/export/exporters/ComponentExporter.spec.ts

# Frontend (import side)
npx vitest run public/app/yjs/ComponentImporter.test.js

# E2E (round-trip through the real app) — run `make bundle` first
make bundle
bun x playwright test --project=chromium \
  test/e2e/playwright/specs/component-export-import.spec.ts -g "issue #1991"
```

### Manual (matches the issue report)

1. Open the test `.elpx` from #1991 (or create a box with a Text iDevice).
2. On an iDevice, open **iDevice properties** and set: uncheck **Visible in export**, check **Teacher only**, and add one or more **CSS classes**.
3. Use the block's **⋯ → Export** to download the `.block`.
4. (Optional) Open the `.block` (it is a ZIP) and confirm each `<odeComponent>` in `content.xml` now contains an `<odeComponentsProperties>` block with `visibility`, `teacherOnly` and `cssClass`.
5. Create/open another project and **import** the `.block`.
6. Open the imported iDevice's properties: visibility, teacher-only state and the custom CSS classes are preserved.