### PR TITLE
Prepare v4.0.2 release

### DIFF
--- a/.agents/skills/i18n/SKILL.md
+++ b/.agents/skills/i18n/SKILL.md
@@ -45,24 +45,23 @@ The distinction matters because the GUI language and the content language can di
 ## Commands
 
 ```bash
-make translations                        # Extract new translation keys from source
-make translations-cleanup LOCALE=es      # Remove obsolete keys for a locale
-make fix                                 # Lint
+make fix                                 # Lint (the only command this skill ever runs)
 ```
+
+> `make translations` and `make translations-cleanup` are **never run by agents**. Key extraction and all XLF changes are managed by a dedicated separate process. See the prohibition below.
 
 ## Gotchas
 
-- **Never author or edit translated values under `translations/`.** Agents add translation _keys_ only (by wrapping strings in `_()` / `c_()` / `| trans` and running `make translations`), and must leave every target/translated value blank. Do not hand-write, copy, or machine-translate target strings in a PR — the translation team owns `translations/**` and fills in the actual translations later. This mirrors AGENTS.md section 7.4.
+- **NEVER touch any file under `translations/`.** This is a hard rule. Do not run `make translations`, do not add or remove `<trans-unit>` elements, do not write or edit `<target>` values. A PR that modifies `translations/**` in any way will be rejected. Translation key extraction is handled by a separate automated process outside of code PRs.
 - **Never hardcode English strings** in UI code — even "OK" or "Cancel" must use `_()`.
 - **`_()` vs `c_()` confusion** — using the wrong function means the string is translated in the wrong context. GUI strings → `_()`, content strings → `c_()`.
 - **Forgetting `| trans` in Nunjucks** — raw English strings will appear in the UI for non-English users.
-- **Run `make translations` after adding new strings** — this extracts keys into XLF files. Without it, translators won't see the new strings.
 - **Static build config drift** — if translated strings appear in config parameters, ensure both server and static builder use the same shared function. Duplicated config leads to untranslated strings in one of the two builds. _Example: PR #1564._
 
 ## Done When
 
 - [ ] All user-facing strings use `_()` / `c_()` / `| trans`
-- [ ] `make translations` run to extract new keys
-- [ ] No translated/target values authored or edited under `translations/` (keys only; values left blank for the translation team)
+- [ ] No file under `translations/` has been modified
+- [ ] `make translations` has NOT been run
 - [ ] No hardcoded English in UI
 - [ ] `make fix` passes clean

--- a/.agents/skills/xlf-translate/SKILL.md
+++ b/.agents/skills/xlf-translate/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: xlf-translate
+description: Fill empty <target> elements in translations/messages.*.xlf files with machine-assisted translations prefixed with ~. Handles language selection, line-range filtering, encoding (inline PowerShell only), and produces a minimal diff touching only empty targets.
+---
+
+# Skill: XLF Translation
+
+> Parent: [AGENTS.md](../../../AGENTS.md) | Related: [i18n](../i18n/SKILL.md)
+
+## When to Use
+
+When asked to fill in empty translation targets (`<target></target>`) in the XLF files under `translations/`. This is the **only** legitimate reason to write to those files — and only with this skill's procedure. Never run `make translations` as part of this skill.
+
+---
+
+## Step 0 — Gather parameters
+
+Ask the user **two questions** before doing anything:
+
+**1. From which line?**
+> Do you want to translate all empty targets in the file, or only from a specific line onwards?
+
+Accept:
+- `"all"` → process every empty target regardless of position
+- A line number (e.g. `15468`) → only process empty targets at or after that line
+
+**2. Which languages?**
+> Which language files should I fill in? (English is never modified.)
+
+Available languages and their files:
+
+| Code | Language   | File                        |
+|------|------------|-----------------------------|
+| `es` | Spanish    | `messages.es.xlf`           |
+| `ca` | Catalan    | `messages.ca.xlf`           |
+| `va` | Valencian  | `messages.va.xlf`           |
+| `de` | German     | `messages.de.xlf`           |
+| `eo` | Esperanto  | `messages.eo.xlf`           |
+| `eu` | Basque     | `messages.eu.xlf`           |
+| `gl` | Galician   | `messages.gl.xlf`           |
+| `it` | Italian    | `messages.it.xlf`           |
+| `pt` | Portuguese | `messages.pt.xlf`           |
+| `ro` | Romanian   | `messages.ro.xlf`           |
+
+Accept any of:
+- `"all"` → all ten languages above
+- `"all except es"` (or any variant) → the list minus the excluded ones
+- An explicit list: `"es, ca, va"`
+
+> **`messages.en.xlf` is never touched under any circumstance.**
+
+---
+
+## Step 1 — Identify targets to translate
+
+For each language file in scope, read the file and collect every `<trans-unit>` block that:
+- Contains `<target></target>` (exactly empty — no whitespace inside)
+- Starts at or after the specified line (if a line constraint was given)
+
+Extract from each block:
+- The `<source>` text (the English original)
+- The line number of the `<target>` element
+
+Group all unique source texts — the same source may appear in multiple language files.
+
+---
+
+## Step 2 — Produce translations
+
+For every unique source text, produce a translation for each target language. Rules:
+
+- **Every translation must start with `~`** — no exceptions, including Spanish.
+  Example: source `"Save"` → Spanish `"~Guardar"`, German `"~Speichern"`.
+- Translate faithfully. Keep the same tone, punctuation, and placeholders as the source.
+- Ellipsis (`...`) stays as-is; do not convert to `…`.
+- Do not translate proper nouns: `eXeLearning`, `iDevice`, `SCORM`, `Yjs`.
+- Valencian (`va`) and Catalan (`ca`) are distinct — do not reuse one for the other.
+
+---
+
+## Step 3 — Apply translations (encoding-critical)
+
+### Why inline PowerShell only
+
+PowerShell 5.1 (Windows) reads `.ps1` script files as ANSI (Windows-1252) by default. Writing a `.ps1` file with the Write tool produces UTF-8 without BOM, which PS 5.1 misreads — corrupting every non-ASCII character silently. **Never write translations to a `.ps1` file and execute it.**
+
+The fix: run the substitution as an **inline PowerShell command** passed directly to the PowerShell tool. Inline commands are received as Unicode strings (UTF-16LE) and are unaffected by the file-encoding issue.
+
+### Substitution template
+
+For each language file, build one inline PowerShell command that:
+
+1. Reads the file as UTF-8 without BOM
+2. Detects the actual line ending (CRLF or LF)
+3. Replaces each `<source>SRC</source>LE<target></target>` with `<source>SRC</source>LE<target>~TRANSLATION</target>`
+4. Writes back as UTF-8 without BOM
+
+```powershell
+$enc = New-Object System.Text.UTF8Encoding $false
+$file = "C:\...\translations\messages.LANG.xlf"
+$content = [System.IO.File]::ReadAllText($file, $enc)
+$le = if ($content.Contains("`r`n")) { "`r`n" } else { "`n" }
+
+# One block per source text:
+$old = "        <source>SOURCE TEXT</source>$le        <target></target>"
+$new = "        <source>SOURCE TEXT</source>$le        <target>~TRANSLATION</target>"
+if ($content.Contains($old)) { $content = $content.Replace($old, $new) }
+
+# ... repeat for each source text ...
+
+[System.IO.File]::WriteAllText($file, $content, $enc)
+Write-Host "Done"
+```
+
+Key points:
+- 8 spaces before `<source>` and `<target>` — match exactly (do not guess indentation; verify from the file).
+- Use `.Contains()` + `.Replace()` — not regex — for literal source texts.
+- Use `$le` variable so the replacement works on both CRLF and LF files.
+- Process all source texts for one language in a single command (not one command per string).
+- You may batch multiple language files in a single command if they share the same base path.
+
+### Encoding verification
+
+After writing, verify at least one file per run by reading back the actual bytes of a translated target containing non-ASCII characters:
+
+```powershell
+$enc = New-Object System.Text.UTF8Encoding $false
+$content = [System.IO.File]::ReadAllText($file, $enc)
+$sample = ($content -split '\r?\n' | Where-Object { $_ -match '<target>~' } | Select-Object -Last 1).Trim()
+Write-Host $sample
+```
+
+If the output shows garbled characters (e.g., `Ã„` instead of `Ä`), the encoding is wrong — stop, revert using the revert pattern below, and diagnose before continuing.
+
+### Revert pattern (if encoding goes wrong)
+
+```powershell
+$enc = New-Object System.Text.UTF8Encoding $false
+$file = "C:\...\translations\messages.LANG.xlf"
+$content = [System.IO.File]::ReadAllText($file, $enc)
+$le = if ($content.Contains("`r`n")) { "`r`n" } else { "`n" }
+
+# For each source text, replace back to empty:
+$escaped = [regex]::Escape("SOURCE TEXT")
+$pattern = "        <source>$escaped</source>\r?\n        <target>~[^<]*</target>"
+$replacement = "        <source>SOURCE TEXT</source>" + $le + "        <target></target>"
+$content = [regex]::Replace($content, $pattern, $replacement)
+
+[System.IO.File]::WriteAllText($file, $content, $enc)
+```
+
+---
+
+## Step 4 — Verify
+
+After applying all translations:
+
+```powershell
+# Count remaining empty targets in each processed file
+$langs = @('es','ca','va','de','eo','eu','gl','it','pt','ro')
+foreach ($lang in $langs) {
+    $file = "C:\...\translations\messages.$lang.xlf"
+    $count = (Select-String -Path $file -Pattern '<target></target>' -SimpleMatch).Count
+    Write-Host "$lang: $count empty"
+}
+```
+
+Expected: `0` for every language in scope. If any remain, they were at a line before the specified start line (expected) or the pattern did not match (investigate).
+
+---
+
+## Constraints (non-negotiable)
+
+- **Only empty `<target></target>` are modified** — never touch non-empty targets, source texts, IDs, resnames, indentation, line endings, or any other attribute.
+- **`~` prefix is mandatory** on every translation, including Spanish.
+- **`messages.en.xlf` is never opened or written.**
+- **`make translations` is never run** as part of this skill.
+- **No `.ps1` files** — inline PowerShell only (see encoding section above).
+- The diff must show only `<target>~...</target>` lines changing; everything else stays byte-for-byte identical.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ make up                         # Docker dev environment
 | **Test** | `make test-coverage` | Tests with coverage report |
 | **Lint** | `make fix` | Autofix lint + check — **always run after changes** |
 | **Lint** | `make lint` | Lint without fixing |
-| **i18n** | `make translations` | Extract new translation keys |
+| **i18n** | `make translations` | Extract new translation keys — **never run by agents; managed by a separate process** |
 | **CLI** | `make create-user` | Create a user account |
 | **CLI** | `make export-*` | Export via CLI (html5, scorm12, scorm2004, epub3, ims) |
 
@@ -202,7 +202,7 @@ Key rules:
 ### 7.4 Frontend Patterns
 
 - **i18n:** `_()` for GUI strings, `c_()` for content strings, `| trans` in Nunjucks templates. Avoid hardcoded English. See [i18n skill](.agents/skills/i18n/SKILL.md).
-  - **Never write or edit translated values under `translations/`.** Wrap user-facing strings in `_()` / `c_()` / `| trans`; running `make translations` to register the new (empty) keys is expected, but leave every target/translated value blank. The translation team owns `translations/**` and fills in the actual translations later — do not hand-write, copy, or machine-translate target strings in a PR.
+  - **Never modify any file under `translations/`.** Wrap user-facing strings in `_()` / `c_()` / `| trans` in source code and stop there. Do **not** run `make translations`, do not add keys, do not write or edit any `<target>` value. Translation key extraction and all changes to XLF files are managed by a dedicated separate process — they must never appear in a code PR. PRs that touch `translations/**` will be rejected.
 - **Styles:** Prefer SCSS classes in `assets/styles/` over inline styles. See [doc/development/styles.md](doc/development/styles.md).
 - **No framework:** Vanilla JavaScript in `public/app/`.
 
@@ -314,6 +314,7 @@ Domain-specific guidance lives in `.agents/skills/*/SKILL.md`.
 | [e2e-test](.agents/skills/e2e-test/SKILL.md) | Writing Playwright E2E tests |
 | [websocket-yjs](.agents/skills/websocket-yjs/SKILL.md) | Real-time collaboration code |
 | [i18n](.agents/skills/i18n/SKILL.md) | Adding/modifying translations |
+| [xlf-translate](.agents/skills/xlf-translate/SKILL.md) | Filling empty `<target>` elements in XLF files with `~`-prefixed translations |
 | [api-v1](.agents/skills/api-v1/SKILL.md) | External REST API v1 endpoints |
 
 ## 12. Deep-Dive Documentation

--- a/doc/development/styles.md
+++ b/doc/development/styles.md
@@ -31,7 +31,6 @@ Example structure:
   <description>Example style for eXe.
 
 iDevice icons by…</description>
-  <downloadable>1</downloadable>
 </theme>
 ```
 
@@ -43,9 +42,6 @@ iDevice icons by…</description>
 - **`compatibility`**: eXeLearning version the style is compatible with.
 - **`author`**, **`license`**, **`license-url`**: Author and licensing information.
 - **`description`**: Style description (may include line breaks).
-- **`downloadable`**:  
-  - `1` → the style can be imported/downloaded from the interface.  
-  - `0` → the style cannot be downloaded or imported from the application.
 
 ---
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,54 @@
 # CHANGELOG
 
+## v4.0.2 – 2026-07-07
+
+### Added
+
+- iDevice edit mode now expands to fill the workarea, keeping the toolbar always visible and preventing the page from scrolling behind it
+- LOMLOE iDevice: added Navarra (ES-NC) and Comunitat Valenciana (ES-VC) official curriculum datasets
+- Mermaid iDevice: configurable maximum diagram width and height
+- Exported packages now emit xAPI statements for LMS activity tracking and direct LRS reporting
+- File → New: improved unsaved-changes confirmation dialog with clearer wording and action labels
+- Desktop: new File → Close menu option
+- Authentication: OIDC endpoints are now auto-discovered from `OIDC_ISSUER` when not configured individually
+
+### Fixed
+
+- Security: 32 hardening fixes across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits
+- Security: additional fixes for cross-tenant asset deletion, unauthenticated file uploads and export filename collisions for non-Latin titles
+- Collaboration: shared Yjs changes are now correctly auto-saved in collaborative sessions
+- Collaboration: assets shared between collaborators are identified consistently, preventing image loss
+- Collaboration: resolved cross-day data loss in collaborative editing
+- Collaboration: shared and collaborative projects are no longer automatically deleted on session cleanup
+- Export: iDevice structure properties are now preserved when single-box content is exported and re-imported
+- Export: internal page links are preserved in `content.xml` across export/import round trips
+- Export: LaTeX renders correctly in interactive iDevices in preview and all export formats
+- Export: pre-rendered LaTeX equations are now aligned with the surrounding text baseline
+- Export: the license footer no longer inherits the global content font
+- Export: the accessibility toolbar is now included in IMS, SCORM and EPUB exports
+- Export: duplicate assets are no longer included in self-contained HTML bundles
+- Assets without a file extension are now served with the correct MIME type, preventing automatic PDF downloads
+- iDevices panel is now disabled when the selected page is the document root
+- Electrical Circuits iDevice: AI prompt identifier corrected; Ω and Greek/math symbols now render correctly
+- Electrical Circuits iDevice: iDevice name is now correctly translated
+- Magnifier iDevice: the exported image path is now preserved so images appear in HTML exports
+- 3DMol iDevice: molecule files are now supported in the file manager and viewer
+- 3DMol iDevice: the Add iDevice menu is no longer obscured by the 3D viewer canvas
+- 3D Viewer iDevice: the empty-state overlay is now hidden over a loaded model in exports
+- Nova style: teacher-only iDevices are now highlighted with the yellow border in the workarea
+- Tooltips inside accordions and other effects now initialise correctly
+- iDevice icon selector: improved contrast in all styles
+- Styles from .elpx projects can now be downloaded from the style manager
+- Share dialog: the people-with-access list now scrolls correctly inside the modal
+- Link validator and resource report: Download CSV now works correctly
+- Preferences: the language-change warning in static and offline mode now accurately describes what to do before reloading
+
+### Upgraded
+
+- esbuild: 0.27.7 → 0.28.1
+
+---
+
 ## v4.0.1 – 2026-06-09
 
 ### Added

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Reviewed and completed Spanish (ES) translation
 - Added automated placeholder translations for new strings in incomplete translations
 
+### Changed
+
+- LOMLOE iDevice: the Galicia (ES-GA) dataset is temporarily hidden pending formal definition of its official curriculum requirements (see #1900)
+
 ### Fixed
 
 - Security: multiple hardening improvements across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -49,6 +49,10 @@
 
 - esbuild: 0.27.7 → 0.28.1
 
+### Removed
+
+- Removed the `<downloadable>` option from style `config.xml`; styles are now always downloadable
+
 ---
 
 ## v4.0.1 – 2026-06-09

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -14,13 +14,13 @@
 
 ### Fixed
 
-- Security: hardening improvements across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits
+- Security: multiple hardening improvements across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits
 - Security: enhanced protections against cross-tenant asset deletion and unauthorised file uploads; improved export filename handling for non-Latin titles
 - Collaboration: shared Yjs changes are now saved correctly during collaborative sessions
 - Collaboration: shared assets are now identified consistently, preventing image loss
 - Collaboration: fixed data loss affecting collaborative editing across day changes
 - Collaboration: shared and collaborative projects are no longer deleted during session cleanup
-- Assets without a file extension are now served with the correct MIME type, preventing unintended downloads
+- Assets without a file extension are now served with the correct MIME type, preventing unintended PDF downloads
 - Share dialog: the people-with-access list now scrolls correctly within the modal
 - Link Validator and Resource Report: Download CSV now works correctly
 - The iDevices panel is now disabled when the selected page is the document root
@@ -29,7 +29,7 @@
 - Magnifier iDevice: fixed image paths in exports so images are displayed correctly in HTML output
 - 3DMol iDevice: molecule files are now supported in the file manager and viewer
 - 3DMol iDevice: the Add iDevice menu is no longer obscured by the 3D viewer canvas
-- 3D Viewer iDevice: models are now displayed correctly in exported content
+- 3D Viewer iDevice: fixed a display issue affecting models in exported content
 - Preferences: improved the language-change warning in static and offline mode so it accurately describes the required steps before reloading
 - Tooltips inside accordions and other effects now initialise correctly
 - iDevice icon selector: improved contrast across all styles

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,44 +4,44 @@
 
 ### Added
 
-- iDevice edit mode now expands to fill the workarea, keeping the toolbar always visible and preventing the page from scrolling behind it
-- LOMLOE iDevice: added Navarra (ES-NC) and Comunitat Valenciana (ES-VC) official curriculum datasets
-- Mermaid iDevice: configurable maximum diagram width and height
+- iDevice edit mode now expands to fill the work area, keeping the toolbar visible and preventing background page scrolling
+- LOMLOE iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
+- Mermaid iDevice: added configurable maximum diagram width and height
 - Exported packages now emit xAPI statements for LMS activity tracking and direct LRS reporting
-- File → New: improved unsaved-changes confirmation dialog with clearer wording and action labels
-- Desktop: new File → Close menu option
-- Authentication: OIDC endpoints are now auto-discovered from `OIDC_ISSUER` when not configured individually
+- File → New: improved the unsaved-changes confirmation dialog with clearer wording and action labels
+- Desktop: added a new File → Close menu option
+- Authentication: OIDC endpoints are now automatically discovered from `OIDC_ISSUER` when not configured individually
 
 ### Fixed
 
-- Security: 32 hardening fixes across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits
-- Security: additional fixes for cross-tenant asset deletion, unauthenticated file uploads and export filename collisions for non-Latin titles
-- Collaboration: shared Yjs changes are now correctly auto-saved in collaborative sessions
-- Collaboration: assets shared between collaborators are identified consistently, preventing image loss
-- Collaboration: resolved cross-day data loss in collaborative editing
-- Collaboration: shared and collaborative projects are no longer automatically deleted on session cleanup
-- Export: iDevice structure properties are now preserved when single-box content is exported and re-imported
-- Export: internal page links are preserved in `content.xml` across export/import round trips
-- Export: LaTeX renders correctly in interactive iDevices in preview and all export formats
-- Export: pre-rendered LaTeX equations are now aligned with the surrounding text baseline
-- Export: the license footer no longer inherits the global content font
-- Export: the accessibility toolbar is now included in IMS, SCORM and EPUB exports
-- Export: duplicate assets are no longer included in self-contained HTML bundles
-- Assets without a file extension are now served with the correct MIME type, preventing automatic PDF downloads
-- iDevices panel is now disabled when the selected page is the document root
-- Electrical Circuits iDevice: AI prompt identifier corrected; Ω and Greek/math symbols now render correctly
-- Electrical Circuits iDevice: iDevice name is now correctly translated
-- Magnifier iDevice: the exported image path is now preserved so images appear in HTML exports
+- Security: hardening improvements across path validation, authentication, SSRF protection, XSS sanitisation, data persistence and resource limits
+- Security: enhanced protections against cross-tenant asset deletion and unauthorised file uploads; improved export filename handling for non-Latin titles
+- Collaboration: shared Yjs changes are now saved correctly during collaborative sessions
+- Collaboration: shared assets are now identified consistently, preventing image loss
+- Collaboration: fixed data loss affecting collaborative editing across day changes
+- Collaboration: shared and collaborative projects are no longer deleted during session cleanup
+- Assets without a file extension are now served with the correct MIME type, preventing unintended downloads
+- Share dialog: the people-with-access list now scrolls correctly within the modal
+- Link Validator and Resource Report: Download CSV now works correctly
+- The iDevices panel is now disabled when the selected page is the document root
+- Electrical Circuits iDevice: corrected the AI prompt identifier and fixed rendering of Ω and other Greek and mathematical symbols
+- Electrical Circuits iDevice: fixed iDevice name translations
+- Magnifier iDevice: fixed image paths in exports so images are displayed correctly in HTML output
 - 3DMol iDevice: molecule files are now supported in the file manager and viewer
 - 3DMol iDevice: the Add iDevice menu is no longer obscured by the 3D viewer canvas
-- 3D Viewer iDevice: the empty-state overlay is now hidden over a loaded model in exports
-- Nova style: teacher-only iDevices are now highlighted with the yellow border in the workarea
+- 3D Viewer iDevice: models are now displayed correctly in exported content
+- Preferences: improved the language-change warning in static and offline mode so it accurately describes the required steps before reloading
 - Tooltips inside accordions and other effects now initialise correctly
-- iDevice icon selector: improved contrast in all styles
-- Styles from .elpx projects can now be downloaded from the style manager
-- Share dialog: the people-with-access list now scrolls correctly inside the modal
-- Link validator and resource report: Download CSV now works correctly
-- Preferences: the language-change warning in static and offline mode now accurately describes what to do before reloading
+- iDevice icon selector: improved contrast across all styles
+- Styles from `.elpx` projects can now be downloaded from the style manager
+- Nova style: teacher-only iDevices are now highlighted with a yellow border in the work area
+- Export: iDevice structure properties are now preserved when single-box content is exported and re-imported
+- Export: internal page links in `content.xml` are now preserved across exports and imports
+- Export: LaTeX now renders correctly in interactive iDevices in preview and all export formats
+- Export: pre-rendered LaTeX equations are now aligned correctly with surrounding text
+- Export: the license footer no longer inherits the global content font
+- Export: the accessibility toolbar is now included in IMS, SCORM and EPUB exports
+- Export: duplicate assets are no longer included in self-contained HTML exports
 
 ### Upgraded
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -11,6 +11,8 @@
 - File → New: improved the unsaved-changes confirmation dialog with clearer wording and action labels
 - Desktop: added a new File → Close menu option
 - Authentication: OIDC endpoints are now automatically discovered from `OIDC_ISSUER` when not configured individually
+- Reviewed and completed Spanish (ES) translation
+- Added automated placeholder translations for new strings in incomplete translations
 
 ### Fixed
 

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.js
@@ -95,7 +95,13 @@ var $exeDevice = (function () {
             framework: 'LOMLOE',
             community: 'Galicia',
             file: '../data/lomloe-ES-GA.json',
-            available: true
+            // On hold (#1900 / #1898): the Galicia concretion needs official
+            // spec decisions before it can match the regulatory curriculum —
+            // a hybrid "mandatory + optional" descriptor mode (unsupported
+            // today) and official Galician descriptor labels. Hidden until
+            // those are defined; flip back to true to re-enable. The dataset
+            // JSON stays in the repo untouched.
+            available: false
         },
         {
             id: 'ES-CN',

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.test.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.test.js
@@ -583,11 +583,12 @@ describe('Per-course ESO subject filter (issue #1832)', () => {
         expect(codes).not.toContain('FQX');
     });
 
-    it('datasets without a per-course distribution (e.g. Galicia, State) are not filtered', async () => {
-        // ES-GA is absent from ESO_COURSE_SUBJECTS, like the State (ES) floor,
-        // so the full 1º–3º block is shown unchanged. (Uses ES-GA rather than
-        // ES because the module caches datasets by id across tests.)
-        const codes = await listedCodAreas('ES-GA');
+    it('datasets without a per-course distribution (e.g. Navarra, State) are not filtered', async () => {
+        // ES-NC is absent from ESO_COURSE_SUBJECTS, like the State (ES) floor,
+        // so the full 1º–3º block is shown unchanged. (Uses ES-NC rather than
+        // ES because the module caches datasets by id across tests, and rather
+        // than ES-GA because that dataset is on hold / unavailable — see #1900.)
+        const codes = await listedCodAreas('ES-NC');
         expect(codes).toContain('BIG');
         expect(codes).toContain('FQX');
         expect(codes).toContain('DIG');
@@ -1917,10 +1918,12 @@ describe('DATASETS registry (regression guard)', () => {
         expect(lomloeSrc).toContain("file: '../data/lomloe-ES-MD.json'");
     });
 
-    it('declares ES-GA with available:true and the lomloe-ES-GA.json file', () => {
+    it('declares ES-GA on hold (available:false) with the lomloe-ES-GA.json file', () => {
+        // On hold pending official Galician spec (#1900 / #1898). The dataset
+        // file stays in the repo; only the availability flag is flipped off.
         const m = entryFor('ES-GA');
         expect(m, "ES-GA entry missing").not.toBeNull();
-        expect(m[1]).toBe('true');
+        expect(m[1]).toBe('false');
         expect(lomloeSrc).toContain("file: '../data/lomloe-ES-GA.json'");
     });
 

--- a/public/files/perm/themes/base/base/config.xml
+++ b/public/files/perm/themes/base/base/config.xml
@@ -10,5 +10,4 @@
     <description>Minimally-styled, feature rich responsive style for eXe.
 
 iDevice icons by Francisco Javier Pulido Cuadrado.</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/files/perm/themes/base/flux/config.xml
+++ b/public/files/perm/themes/base/flux/config.xml
@@ -12,5 +12,4 @@
 iDevice icons by Google (https://fonts.google.com/icons), under the 2.0 version of the Apache License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 Fredoka Font, by Milena Brandao, under the SIL Open Font License, Version 1.1. Copyright (c) 2021, Milena Brandao.</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/files/perm/themes/base/neo/config.xml
+++ b/public/files/perm/themes/base/neo/config.xml
@@ -12,5 +12,4 @@
 iDevice icons by Francisco Javier Pulido Cuadrado, and new adaptations by eXeLearning.
 
 Nunito Font, by Vernon Adams (vern@newtypography.co.uk), under the SIL Open Font License, Version 1.1. Copyright (c) 2014, Vernon Adams (vern@newtypography.co.uk), with Reserved Font Name "Nunito".</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/files/perm/themes/base/nova/config.xml
+++ b/public/files/perm/themes/base/nova/config.xml
@@ -12,5 +12,4 @@
 iDevice icons by Francisco Javier Pulido Cuadrado.
 
 Open Sans Font, by The Open Sans Project Authors, under the SIL Open Font License, Version 1.1. Copyright 2020 The Open Sans Project Authors (https://github.com/googlefonts/opensans).</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/files/perm/themes/base/universal/config.xml
+++ b/public/files/perm/themes/base/universal/config.xml
@@ -14,5 +14,4 @@ iDevice icons: "EducaAnd Escolares" style, by Consejería de Educación y Deport
 Atkinson Hyperlegible Font, licensed under the SIL Open Font License, Version 1.1 (https://openfontlicense.org/open-font-license-official-text/). Copyright: Braille Institute of America, Inc. (https://www.brailleinstitute.org/freefont).
 
 Navigation icons by Google (https://fonts.google.com/icons), under the 2.0 version of the Apache License (https://www.apache.org/licenses/LICENSE-2.0.html).</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/files/perm/themes/base/zen/config.xml
+++ b/public/files/perm/themes/base/zen/config.xml
@@ -12,5 +12,4 @@
 iDevice icons by Google (https://fonts.google.com/icons), under the 2.0 version of the Apache License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 Inter Font, by Rasmus Andersson, under the SIL Open Font License, Version 1.1. Copyright (c) 2016-2020 The Inter Project Authors (https://github.com/rsms/inter).</description>
-    <downloadable>1</downloadable>
 </theme>

--- a/public/libs/README.md
+++ b/public/libs/README.md
@@ -11,12 +11,6 @@
 *   ORM: Kysely
     *   Copyright: Sami Koskimäki
     *   License: MIT
-*   Package: @babel/core
-    *   Copyright: The Babel Team
-    *   License: MIT
-*   Package: @babel/preset-env
-    *   Copyright: The Babel Team
-    *   License: MIT
 *   Package: @biomejs/biome
     *   Copyright: Emanuele Stoppa
     *   License: MIT OR Apache-2.0

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="t86aqo9" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Tots els canvis col·laboratius estan guardats.</target>
       </trans-unit>
       <trans-unit id="sn5vre4" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Els canvis col·laboratius es comparteixen en temps real i es guardaran automàticament.</target>
       </trans-unit>
       <trans-unit id="aakxbny" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Guardant canvis col·laboratius...</target>
       </trans-unit>
       <trans-unit id="i7okyvg" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~El desat automàtic ha fallat. Fes clic a Guardar abans de sortir.</target>
       </trans-unit>
       <trans-unit id="1823w67" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Els canvis d'idioma poden requerir recarregar o tornar a obrir eXeLearning per actualitzar tota la interfície.</target>
       </trans-unit>
       <trans-unit id="8gt8mt5" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~La preferència d'idioma s'ha guardat. És possible que alguns textos de la interfície no s'actualitzin fins que recarreguis o tornis a obrir eXeLearning. Guarda o descarrega el teu projecte abans de recarregar o tancar l'aplicació per evitar perdre canvis.</target>
       </trans-unit>
       <trans-unit id="nsi4av0" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Voleu guardar els canvis abans de crear un fitxer nou?</target>
       </trans-unit>
       <trans-unit id="tnvkzx6" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~No guardar</target>
       </trans-unit>
       <trans-unit id="sswuu14" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Alguns canvis col·laboratius encara no s'han guardat. Feu clic a Guardar abans de sortir per evitar perdre'ls.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Guardeu o descarteu el iDevice obert abans de guardar el projecte.</target>
       </trans-unit>
+      <trans-unit id="t86aqo9" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sn5vre4" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="aakxbny" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="i7okyvg" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="1823w67" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8gt8mt5" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="nsi4av0" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tnvkzx6" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sswuu14" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Nou fitxer</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Crea un fitxer nou sense desar</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Desant el projecte...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>No pots afegir un iDevice a la pàgina arrel</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema en afegir l'iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>~config.xml no trobat al ZIP</target>
       </trans-unit>
-      <trans-unit id="nu62n9p" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>~Aquest estil no es pot descarregar</target>
-      </trans-unit>
       <trans-unit id="yjbmryo" resname="Style already exists">
         <source>Style already exists</source>
         <target>~L'estil ja existeix</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="yxp77kp" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>~Seran redirigits automàticament a la pàgina de nivell superior.</target>
-      </trans-unit>
-      <trans-unit id="hncpzpd" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>~Les preferències s'aplicaran després d'actualitzar la pàgina.</target>
-      </trans-unit>
-      <trans-unit id="hw8yi8h" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>~És necessari recarregar la pàgina per aplicar els canvis. Descarrega el teu projecte primer per no perdre feina. Després recarrega la pàgina.</target>
       </trans-unit>
       <trans-unit id="n1mjhxq" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Speichern oder verwerfen Sie das geöffnete iDevice, bevor Sie das Projekt speichern.</target>
       </trans-unit>
+      <trans-unit id="xenawln" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="exs85m5" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="abojzb6" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6gk5ib3" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="cko432v" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="r5526jr" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="e41qda8" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="hgrsh1s" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="d0sz324" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>~Neue Datei</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>~Neue Datei ohne Speichern erstellen</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>~Projekt wird gespeichert...</target>
@@ -4528,10 +4524,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>~Sie können kein iDevice auf der Startseite hinzufügen  </target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>~Problem beim Hinzufügen des iDevice  </target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>~config.xml im ZIP nicht gefunden</target>
       </trans-unit>
-      <trans-unit id="gqvbmgo" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>~Dieser Stil kann nicht heruntergeladen werden</target>
-      </trans-unit>
       <trans-unit id="wjfaxhm" resname="Style already exists">
         <source>Style already exists</source>
         <target>~Der Stil existiert bereits</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="k9osa29" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>~Sie werden automatisch zur übergeordneten Seite weitergeleitet.</target>
-      </trans-unit>
-      <trans-unit id="8ynthbm" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>~Die Einstellungen werden nach dem Aktualisieren der Seite übernommen.</target>
-      </trans-unit>
-      <trans-unit id="trqte6q" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>~Es ist erforderlich, die Seite neu zu laden, um die Änderungen anzuwenden. Speichere dein Projekt zuerst, um Arbeit nicht zu verlieren. Lade dann die Seite neu.</target>
       </trans-unit>
       <trans-unit id="n3d7bxy" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="xenawln" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Alle kollaborativen Änderungen wurden gespeichert.</target>
       </trans-unit>
       <trans-unit id="exs85m5" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Kollaborative Änderungen werden live geteilt und automatisch gespeichert.</target>
       </trans-unit>
       <trans-unit id="abojzb6" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Kollaborative Änderungen werden gespeichert...</target>
       </trans-unit>
       <trans-unit id="6gk5ib3" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~Automatisches Speichern fehlgeschlagen. Bitte klicken Sie auf Speichern, bevor Sie die Seite verlassen.</target>
       </trans-unit>
       <trans-unit id="cko432v" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Sprachänderungen erfordern möglicherweise ein Neuladen oder Neustarten von eXeLearning, um die gesamte Oberfläche zu aktualisieren.</target>
       </trans-unit>
       <trans-unit id="r5526jr" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~Die Spracheinstellung wurde gespeichert. Einige Oberflächentexte werden möglicherweise erst nach dem Neuladen oder Neustarten von eXeLearning aktualisiert. Speichern oder laden Sie Ihr Projekt herunter, bevor Sie die App neu laden oder schließen, um Datenverlust zu vermeiden.</target>
       </trans-unit>
       <trans-unit id="e41qda8" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Möchten Sie Änderungen speichern, bevor Sie eine neue Datei erstellen?</target>
       </trans-unit>
       <trans-unit id="hgrsh1s" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Nicht speichern</target>
       </trans-unit>
       <trans-unit id="d0sz324" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Einige kollaborative Änderungen wurden noch nicht gespeichert. Klicken Sie auf Speichern, bevor Sie die Seite verlassen, um Datenverlust zu vermeiden.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target></target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target></target>
@@ -4527,10 +4523,6 @@
       </trans-unit>
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
-        <target></target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
         <target></target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
@@ -13365,10 +13357,6 @@
         <source>config.xml not found in ZIP</source>
         <target></target>
       </trans-unit>
-      <trans-unit id="dx8uoqf" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target></target>
-      </trans-unit>
       <trans-unit id="3hwxc7e" resname="Style already exists">
         <source>Style already exists</source>
         <target></target>
@@ -13447,14 +13435,6 @@
       </trans-unit>
       <trans-unit id="t2egcmx" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
-        <target></target>
-      </trans-unit>
-      <trans-unit id="28b2snj" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target></target>
-      </trans-unit>
-      <trans-unit id="9w1d6h0" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
         <target></target>
       </trans-unit>
       <trans-unit id="4iq4b75" resname="You have unsaved changes. Are you sure you want to leave?">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="8709ssa" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="633mn8l" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tzzhqkm" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="cf2a71k" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qif62ox" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xhmyzi2" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3a545eu" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="jkoh01u" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qn5nofl" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Konservu aŭ forĵetu la malfermitan iDevice antaŭ ol konservi la projekton.</target>
       </trans-unit>
+      <trans-unit id="7e2rsr4" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="sz46fwa" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="nez1q1f" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="e37lfa7" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="v9t53on" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="4re14mj" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="n3p5eoo" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="h5sfm77" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="g2efejz" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="7e2rsr4" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Ĉiuj kunlaboraj ŝanĝoj estas konservitaj.</target>
       </trans-unit>
       <trans-unit id="sz46fwa" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Kunlaboraj ŝanĝoj estas dividataj ĝisdatale kaj konserviĝos aŭtomate.</target>
       </trans-unit>
       <trans-unit id="nez1q1f" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Konservado de kunlaboraj ŝanĝoj...</target>
       </trans-unit>
       <trans-unit id="e37lfa7" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~Aŭtomata konservado malsukcesis. Bonvolu alklaki Konservi antaŭ ol eliri.</target>
       </trans-unit>
       <trans-unit id="v9t53on" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Lingvaj ŝanĝoj eble postulos reŝargi aŭ remalfermi eXeLearning por ĝisdatigi la tutan interfacon.</target>
       </trans-unit>
       <trans-unit id="4re14mj" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~La lingva prefero estis konservita. Kelkaj interfacaj tekstoj eble ne ĝisdatiĝos ĝis vi reŝargas aŭ remalfermas eXeLearning. Konservu aŭ elŝutu vian projekton antaŭ reŝargado aŭ fermado de la programo por eviti perdi ŝanĝojn.</target>
       </trans-unit>
       <trans-unit id="n3p5eoo" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Ĉu vi volas konservi ŝanĝojn antaŭ ol krei novan dosieron?</target>
       </trans-unit>
       <trans-unit id="h5sfm77" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Ne konservi</target>
       </trans-unit>
       <trans-unit id="g2efejz" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Kelkaj kunlaboraj ŝanĝoj ankoraŭ ne estis konservitaj. Alklaku Konservi antaŭ ol eliri por eviti perdi ilin.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>~Nova dosiero</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>~Krei novan dosieron sen konservi</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>~Konservas la projekton...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>~Vi ne povas aldoni iDevice en la ĉefpaĝo</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>~Problemo aldoni iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>~config.xml ne trovita en la ZIP</target>
       </trans-unit>
-      <trans-unit id="6g70xum" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>~Ĉi tiu stilo ne povas esti elŝutita</target>
-      </trans-unit>
       <trans-unit id="pfq6z0d" resname="Style already exists">
         <source>Style already exists</source>
         <target>~La stilo jam ekzistas</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="9w78mzz" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>~Ili estos aŭtomate redirektitaj al la superrega paĝo.</target>
-      </trans-unit>
-      <trans-unit id="04ta28o" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>~La preferoj estos aplikitaj post la paĝa ĝisdatigo.</target>
-      </trans-unit>
-      <trans-unit id="2yatdge" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>~Estas necesas reŝargi la paĝon por apliki la ŝanĝojn. Unue elŝutu vian projekton por ne perdi laboron. Poste reŝarĝu la paĝon.</target>
       </trans-unit>
       <trans-unit id="6l88wq6" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="u8vwyza" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>Todos los cambios colaborativos están guardados.</target>
       </trans-unit>
       <trans-unit id="c98klat" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>Los cambios colaborativos se comparten en tiempo real y se guardarán automáticamente.</target>
       </trans-unit>
       <trans-unit id="3zsnhv4" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>Guardando cambios colaborativos...</target>
       </trans-unit>
       <trans-unit id="mhyulrg" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>El autoguardado ha fallado. Haz clic en Guardar antes de salir.</target>
       </trans-unit>
       <trans-unit id="86q528f" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>Los cambios de idioma pueden requerir recargar o volver a abrir eXeLearning para actualizar toda la interfaz.</target>
       </trans-unit>
       <trans-unit id="v97r0bg" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>La preferencia de idioma ha sido guardada. Es posible que algunos textos de la interfaz no se actualicen hasta que recargues o vuelvas a abrir eXeLearning. Guarda o descarga tu proyecto antes de recargar o cerrar la aplicación para evitar perder cambios.</target>
       </trans-unit>
       <trans-unit id="vnnvf3t" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>¿Guardar cambios antes de crear un nuevo archivo?</target>
       </trans-unit>
       <trans-unit id="9659by0" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>No guardar</target>
       </trans-unit>
       <trans-unit id="6a6veiw" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>Algunos cambios colaborativos aún no se han guardado. Haz clic en Guardar antes de salir para no perderlos.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>Guarda o descarta el iDevice abierto antes de guardar el proyecto.</target>
       </trans-unit>
+      <trans-unit id="u8vwyza" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c98klat" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3zsnhv4" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="mhyulrg" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="86q528f" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="v97r0bg" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vnnvf3t" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9659by0" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6a6veiw" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Archivo nuevo</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Crear un archivo nuevo sin guardar</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Guardando el proyecto...</target>
@@ -4528,10 +4524,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>No se puede añadir un iDevice en la página de Propiedades</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema al añadir iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>config.xml no encontrado en el ZIP</target>
       </trans-unit>
-      <trans-unit id="yhpip7m" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Este estilo no se puede descargar</target>
-      </trans-unit>
       <trans-unit id="1cmko1n" resname="Style already exists">
         <source>Style already exists</source>
         <target>El estilo ya existe</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="8ruvmgd" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Serán redirigidos automáticamente a la página de nivel superior.</target>
-      </trans-unit>
-      <trans-unit id="iurj6dx" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>Las preferencias se aplicarán después de actualizar la página.</target>
-      </trans-unit>
-      <trans-unit id="o3ca8sd" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Es necesario recargar la página para aplicar los cambios. Descarga tu proyecto primero para no perder trabajo. Luego recarga la página.</target>
       </trans-unit>
       <trans-unit id="70f9sl7" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Gorde edo baztertu irekitako iDevice-a proiektua gorde aurretik.</target>
       </trans-unit>
+      <trans-unit id="nyvlopm" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="42cs8to" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="885uw4o" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="k6ucp55" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ar9ull7" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="zmmc653" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8p115mw" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vdfds2h" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="nxgeas7" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="nyvlopm" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Aldaketa kolaboratibo guztiak gordeta daude.</target>
       </trans-unit>
       <trans-unit id="42cs8to" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Aldaketa kolaboratiboak zuzenean partekatzen dira eta automatikoki gordeko dira.</target>
       </trans-unit>
       <trans-unit id="885uw4o" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Aldaketa kolaboratiboak gordetzen...</target>
       </trans-unit>
       <trans-unit id="k6ucp55" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~Automatikoki gordetzeak huts egin du. Sakatu Gorde irteten hasi aurretik.</target>
       </trans-unit>
       <trans-unit id="ar9ull7" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Hizkuntza aldaketek eXeLearning berriro kargatu edo ireki behar izan dezakete interfaze osoa eguneratzeko.</target>
       </trans-unit>
       <trans-unit id="zmmc653" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~Hizkuntza hobespena gorde da. Baliteke interfazeko testu batzuk ez eguneratzea eXeLearning berriro kargatu edo ireki arte. Gorde edo deskargatu zure proiektua aplikazioa berriro kargatu edo itxi aurretik, aldaketak galtzea ekiditeko.</target>
       </trans-unit>
       <trans-unit id="8p115mw" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Fitxategi berri bat sortu aurretik aldaketak gorde nahi dituzu?</target>
       </trans-unit>
       <trans-unit id="vdfds2h" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Ez gorde</target>
       </trans-unit>
       <trans-unit id="nxgeas7" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Aldaketa kolaboratibo batzuk oraindik ez dira gorde. Sakatu Gorde irten aurretik, galtzea ekiditeko.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Fitxategi berria</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Gorde gabe fitxategi berria sortu</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Proiektua gordetzen...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>Ezin da iDevicea gehitu erroko orrian</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Arazoa iDevicea gehitzerakoan</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>config.xml ez da aurkitu ZIP artxiboan</target>
       </trans-unit>
-      <trans-unit id="vu1hlkx" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Estilo hau ezin da deskargatu</target>
-      </trans-unit>
       <trans-unit id="010mtjt" resname="Style already exists">
         <source>Style already exists</source>
         <target>Estilo hori jada existitzen da</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="tct21y6" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Automatikoki goragoko mailako orrialdera bideratuko dira.</target>
-      </trans-unit>
-      <trans-unit id="5c4y17c" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>Lehentasunak orria eguneratu ondoren aplikatuko dira.</target>
-      </trans-unit>
-      <trans-unit id="wque1se" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Aldaketak aplikatzeko orria berriro kargatu behar da. Mesedez, lehenik deskargatu zure proiektua lana ez galtzeko, eta gero kargatu berriro orria.</target>
       </trans-unit>
       <trans-unit id="ntl25n3" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="48f8iy9" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Todos os cambios colaborativos están gardados.</target>
       </trans-unit>
       <trans-unit id="rbxe4yu" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Os cambios colaborativos compártense en tempo real e gardaranse automaticamente.</target>
       </trans-unit>
       <trans-unit id="iohduda" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Gardando cambios colaborativos...</target>
       </trans-unit>
       <trans-unit id="9dy5xl0" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~O gardado automático fallou. Fai clic en Gardar antes de saír.</target>
       </trans-unit>
       <trans-unit id="yvag2x6" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Os cambios de idioma poden requirir recargar ou volver a abrir eXeLearning para actualizar toda a interface.</target>
       </trans-unit>
       <trans-unit id="y36kqd1" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~A preferencia de idioma foi gardada. É posible que algúns textos da interface non se actualicen ata que recargues ou volvas abrir eXeLearning. Garda ou descarga o teu proxecto antes de recargar ou pechar a aplicación para evitar perder cambios.</target>
       </trans-unit>
       <trans-unit id="wg57emn" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Queres gardar os cambios antes de crear un novo ficheiro?</target>
       </trans-unit>
       <trans-unit id="c7guz6n" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Non gardar</target>
       </trans-unit>
       <trans-unit id="ymsl04n" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Algúns cambios colaborativos aínda non foron gardados. Fai clic en Gardar antes de saír para evitar perdelos.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Novo ficheiro</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Crear ficheiro novo  sen gardar</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Gardando o proxecto...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>Non se pode engadir un iDevice na páxina de propiedades</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema ao engadir o iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>Non se atopou o ficheiro config.xml no ficheiro ZIP</target>
       </trans-unit>
-      <trans-unit id="elphcpn" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Non se pode descargar este estilo</target>
-      </trans-unit>
       <trans-unit id="sn5kc7r" resname="Style already exists">
         <source>Style already exists</source>
         <target>O estilo xa existe</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="rry6eah" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Serán redirixidos automaticamente á páxina principal.</target>
-      </trans-unit>
-      <trans-unit id="o3gx0cy" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>As preferencias aplicaranse despois de actualizar a páxina.</target>
-      </trans-unit>
-      <trans-unit id="olnlaz2" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Para que os cambios teñan efecto, é necesario recargar a páxina. Primeiro descarga o proxecto para evitar perder o traballo e, a continuación, recarga a páxina.</target>
       </trans-unit>
       <trans-unit id="cslir74" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Garda ou descarta o iDevice aberto antes de gardar o proxecto.</target>
       </trans-unit>
+      <trans-unit id="48f8iy9" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="rbxe4yu" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="iohduda" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9dy5xl0" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yvag2x6" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y36kqd1" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="wg57emn" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c7guz6n" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ymsl04n" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Nuovo file</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Crea un nuovo file senza salvare il progetto</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Salvataggio del progetto...</target>
@@ -4528,10 +4524,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>Non puoi aggiungere un iDevice nella pagina delle Proprietà</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema con l'aggiunta di iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>config.xml non trovato nello ZIP</target>
       </trans-unit>
-      <trans-unit id="i1jojwp" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Questo stile non può essere scaricato</target>
-      </trans-unit>
       <trans-unit id="783er8y" resname="Style already exists">
         <source>Style already exists</source>
         <target>Lo stile esiste già</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="09m6xzz" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Verranno reindirizzati automaticamente alla pagina superiore.</target>
-      </trans-unit>
-      <trans-unit id="43fshpx" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>Le preferenze verranno applicate dopo aver aggiornato la pagina.</target>
-      </trans-unit>
-      <trans-unit id="erpvvs8" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Le modifiche richiedono il ricaricamento della pagina per avere effetto. Scarica prima il progetto per non perdere il lavoro, poi ricarica la pagina.</target>
       </trans-unit>
       <trans-unit id="enfs0qn" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Salva o annulla l'iDevice aperto prima di salvare il progetto.</target>
       </trans-unit>
+      <trans-unit id="iy9trt8" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="yn11qkw" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="28zbrst" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="916efx6" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="7602rj1" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="h02k6zx" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3vqawvm" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="u2vcq3s" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="awsyyyk" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="iy9trt8" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Tutte le modifiche collaborative sono state salvate.</target>
       </trans-unit>
       <trans-unit id="yn11qkw" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Le modifiche collaborative vengono condivise in tempo reale e verranno salvate automaticamente.</target>
       </trans-unit>
       <trans-unit id="28zbrst" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Salvataggio delle modifiche collaborative...</target>
       </trans-unit>
       <trans-unit id="916efx6" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~Il salvataggio automatico non è riuscito. Fare clic su Salva prima di uscire.</target>
       </trans-unit>
       <trans-unit id="7602rj1" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Le modifiche alla lingua potrebbero richiedere il ricaricamento o la riapertura di eXeLearning per aggiornare l'intera interfaccia.</target>
       </trans-unit>
       <trans-unit id="h02k6zx" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~La preferenza di lingua è stata salvata. Alcuni testi dell'interfaccia potrebbero non aggiornarsi fino al ricaricamento o alla riapertura di eXeLearning. Salva o scarica il tuo progetto prima di ricaricare o chiudere l'app per evitare di perdere le modifiche.</target>
       </trans-unit>
       <trans-unit id="3vqawvm" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Vuoi salvare le modifiche prima di creare un nuovo file?</target>
       </trans-unit>
       <trans-unit id="u2vcq3s" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Non salvare</target>
       </trans-unit>
       <trans-unit id="awsyyyk" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Alcune modifiche collaborative non sono ancora state salvate. Fai clic su Salva prima di uscire per evitare di perderle.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Guarde ou descarte o iDevice aberto antes de guardar o projeto.</target>
       </trans-unit>
+      <trans-unit id="5ogqi4j" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="vqqnb5a" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="t8xmt9z" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="mzuxsqv" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="94zxz4h" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5bhymwn" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="9i4tv9g" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="iomenyo" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kgn8t47" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>~Novo arquivo</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>~Criar novo arquivo sem salvar</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>~Salvando o projeto...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>~Você não pode adicionar um iDevice na página raiz</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>~Problema ao adicionar o iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>~config.xml não encontrado no ZIP</target>
       </trans-unit>
-      <trans-unit id="8zfh28y" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>~Este estilo não pode ser baixado</target>
-      </trans-unit>
       <trans-unit id="fdelgf0" resname="Style already exists">
         <source>Style already exists</source>
         <target>~O estilo já existe</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="knzdhud" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>~Serão redirecionados automaticamente para a página de nível superior.</target>
-      </trans-unit>
-      <trans-unit id="16hnzx6" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>~As preferências serão aplicadas após atualizar a página.</target>
-      </trans-unit>
-      <trans-unit id="jcl2ose" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>~É necessário recarregar a página para aplicar as alterações. Faça o download do seu projeto primeiro para não perder o trabalho. Depois, recarregue a página.</target>
       </trans-unit>
       <trans-unit id="2f34kj6" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="5ogqi4j" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Todas as alterações colaborativas foram guardadas.</target>
       </trans-unit>
       <trans-unit id="vqqnb5a" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~As alterações colaborativas são partilhadas em tempo real e serão guardadas automaticamente.</target>
       </trans-unit>
       <trans-unit id="t8xmt9z" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~A guardar alterações colaborativas...</target>
       </trans-unit>
       <trans-unit id="mzuxsqv" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~O guardado automático falhou. Clique em Guardar antes de sair.</target>
       </trans-unit>
       <trans-unit id="94zxz4h" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~As alterações de idioma podem requerer recarregar ou reabrir o eXeLearning para atualizar toda a interface.</target>
       </trans-unit>
       <trans-unit id="5bhymwn" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~A preferência de idioma foi guardada. É possível que alguns textos da interface não sejam atualizados até que recarregue ou reabra o eXeLearning. Guarde ou transfira o seu projeto antes de recarregar ou fechar a aplicação para evitar perder alterações.</target>
       </trans-unit>
       <trans-unit id="9i4tv9g" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Pretende guardar as alterações antes de criar um novo ficheiro?</target>
       </trans-unit>
       <trans-unit id="iomenyo" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Não guardar</target>
       </trans-unit>
       <trans-unit id="kgn8t47" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Algumas alterações colaborativas ainda não foram guardadas. Clique em Guardar antes de sair para evitar perdê-las.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Salvați sau renunțați la iDevice-ul deschis înainte de a salva proiectul.</target>
       </trans-unit>
+      <trans-unit id="xmec942" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ga8h4a1" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="c33jtnl" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="xsfwqoo" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="gowl21n" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="d794hcn" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="95dflc0" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y9c5p4t" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="55qb83u" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="xmec942" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Toate modificările colaborative au fost salvate.</target>
       </trans-unit>
       <trans-unit id="ga8h4a1" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Modificările colaborative sunt partajate în timp real și vor fi salvate automat.</target>
       </trans-unit>
       <trans-unit id="c33jtnl" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Se salvează modificările colaborative...</target>
       </trans-unit>
       <trans-unit id="xsfwqoo" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~Salvarea automată a eșuat. Faceți clic pe Salvare înainte de a ieși.</target>
       </trans-unit>
       <trans-unit id="gowl21n" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Modificările de limbă pot necesita reîncărcarea sau redeschiderea eXeLearning pentru a actualiza întreaga interfață.</target>
       </trans-unit>
       <trans-unit id="d794hcn" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~Preferința de limbă a fost salvată. Este posibil ca unele texte ale interfeței să nu se actualizeze până când nu reîncărcați sau redeschideți eXeLearning. Salvați sau descărcați proiectul înainte de a reîncărca sau închide aplicația pentru a evita pierderea modificărilor.</target>
       </trans-unit>
       <trans-unit id="95dflc0" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Doriți să salvați modificările înainte de a crea un fișier nou?</target>
       </trans-unit>
       <trans-unit id="y9c5p4t" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~Nu salva</target>
       </trans-unit>
       <trans-unit id="55qb83u" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Unele modificări colaborative nu au fost încă salvate. Faceți clic pe Salvare înainte de a ieși pentru a evita pierderea lor.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Fișier nou</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Creează fișier nou fără a salva</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Se salvează proiectul...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>Nu puteți adăuga un iDevice pe pagina principală</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema la adăugarea iDevice-ului</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>config.xml nu a fost găsit în ZIP</target>
       </trans-unit>
-      <trans-unit id="cu49yos" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Acest stil nu poate fi descărcat</target>
-      </trans-unit>
       <trans-unit id="x7kouct" resname="Style already exists">
         <source>Style already exists</source>
         <target>Stilul deja există</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="ujy8vwh" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Vor fi redirecționați automat către pagina de nivel superior.</target>
-      </trans-unit>
-      <trans-unit id="vtiv805" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>Preferințele vor fi aplicate după reîmprospătarea paginii.</target>
-      </trans-unit>
-      <trans-unit id="rbvvztp" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Modificările necesită o reîncărcare a paginii pentru a intra în vigoare. Vă rugăm să descărcați mai întâi proiectul pentru a evita pierderea lucrării, apoi reîncărcați pagina.</target>
       </trans-unit>
       <trans-unit id="ho5a2tz" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -3953,10 +3953,6 @@
         <source>New file</source>
         <target>Nou fitxer</target>
       </trans-unit>
-      <trans-unit id="t6INLEU" resname="Create new file without saving">
-        <source>Create new file without saving</source>
-        <target>Crea un fitxer nou sense guardar</target>
-      </trans-unit>
       <trans-unit id="H69O3Z." resname="Saving the project...">
         <source>Saving the project...</source>
         <target>Desant el projecte...</target>
@@ -4524,10 +4520,6 @@
       <trans-unit id="Q_WMYYX" resname="You can't add an iDevice on the root page">
         <source>You can't add an iDevice on the root page</source>
         <target>No pots afegir un iDevice a la pàgina arrel</target>
-      </trans-unit>
-      <trans-unit id="2Pq3_Wp" resname="Problem adding iDevice">
-        <source>Problem adding iDevice</source>
-        <target>Problema en afegir l'iDevice</target>
       </trans-unit>
       <trans-unit id="fPQsnoO" resname="You are currently editing another iDevice. Please close it before continuing">
         <source>You are currently editing another iDevice. Please close it before continuing</source>
@@ -13377,10 +13369,6 @@
         <source>config.xml not found in ZIP</source>
         <target>No s’ha trobat config.xml en el ZIP</target>
       </trans-unit>
-      <trans-unit id="a7191ex" resname="This style cannot be downloaded">
-        <source>This style cannot be downloaded</source>
-        <target>Aquest estil no es pot descarregar</target>
-      </trans-unit>
       <trans-unit id="msn42km" resname="Style already exists">
         <source>Style already exists</source>
         <target>L’estil ja existeix</target>
@@ -13460,14 +13448,6 @@
       <trans-unit id="ikjf0j0" resname="They will be automatically redirected to the parent page.">
         <source>They will be automatically redirected to the parent page.</source>
         <target>Se’ls redirigirà automàticament a la pàgina superior.</target>
-      </trans-unit>
-      <trans-unit id="u19s2wi" resname="Preferences will be applied after refreshing the page.">
-        <source>Preferences will be applied after refreshing the page.</source>
-        <target>Les preferències s’aplicaran després de recarregar la pàgina.</target>
-      </trans-unit>
-      <trans-unit id="9f33u06" resname="Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.">
-        <source>Changes require a page reload to take effect. Please download your project first to avoid losing your work, then reload the page.</source>
-        <target>Cal recarregar la pàgina perquè els canvis tinguen efecte. Descarrega primer el projecte per a evitar perdre la feina i després recarrega la pàgina.</target>
       </trans-unit>
       <trans-unit id="7ap1tb0" resname="You have unsaved changes. Are you sure you want to leave?">
         <source>You have unsaved changes. Are you sure you want to leave?</source>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15465,6 +15465,42 @@
         <source>Save or discard the open iDevice before saving the project.</source>
         <target>~Guardeu o descarteu el iDevice obert abans de guardar el projecte.</target>
       </trans-unit>
+      <trans-unit id="j19l6ce" resname="All collaborative changes are saved.">
+        <source>All collaborative changes are saved.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ouodvm2" resname="Collaborative changes are shared live and will be saved automatically.">
+        <source>Collaborative changes are shared live and will be saved automatically.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="qkn06db" resname="Saving collaborative changes...">
+        <source>Saving collaborative changes...</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="is5ie59" resname="Autosave failed. Please click Save before leaving.">
+        <source>Autosave failed. Please click Save before leaving.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="kev0vf3" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
+        <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="pewu91q" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
+        <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="nkgykn8" resname="Do you want to save changes before creating a new file?">
+        <source>Do you want to save changes before creating a new file?</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="ewss4px" resname="Don&apos;t Save">
+        <source>Don't Save</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="y6tbnwa" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
+        <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.va.xlf
+++ b/translations/messages.va.xlf
@@ -15467,39 +15467,39 @@
       </trans-unit>
       <trans-unit id="j19l6ce" resname="All collaborative changes are saved.">
         <source>All collaborative changes are saved.</source>
-        <target></target>
+        <target>~Tots els canvis col·laboratius estan guardats.</target>
       </trans-unit>
       <trans-unit id="ouodvm2" resname="Collaborative changes are shared live and will be saved automatically.">
         <source>Collaborative changes are shared live and will be saved automatically.</source>
-        <target></target>
+        <target>~Els canvis col·laboratius es compartixen en temps real i es guardaran automàticament.</target>
       </trans-unit>
       <trans-unit id="qkn06db" resname="Saving collaborative changes...">
         <source>Saving collaborative changes...</source>
-        <target></target>
+        <target>~Guardant canvis col·laboratius...</target>
       </trans-unit>
       <trans-unit id="is5ie59" resname="Autosave failed. Please click Save before leaving.">
         <source>Autosave failed. Please click Save before leaving.</source>
-        <target></target>
+        <target>~El desat automàtic ha fallat. Fes clic en Guardar abans d'eixir.</target>
       </trans-unit>
       <trans-unit id="kev0vf3" resname="Language changes may require reloading or reopening eXeLearning to update the whole interface.">
         <source>Language changes may require reloading or reopening eXeLearning to update the whole interface.</source>
-        <target></target>
+        <target>~Els canvis d'idioma poden requerir recarregar o tornar a obrir eXeLearning per a actualitzar tota la interfície.</target>
       </trans-unit>
       <trans-unit id="pewu91q" resname="The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.">
         <source>The language preference has been saved. Some interface texts may not update until you reload or reopen eXeLearning. Save or download your project before reloading or closing the app to avoid losing changes.</source>
-        <target></target>
+        <target>~La preferència d'idioma s'ha guardat. És possible que alguns textos de la interfície no s'actualitzen fins que recarregues o tornes a obrir eXeLearning. Guarda o descarrega el teu projecte abans de recarregar o tancar l'aplicació per a evitar perdre canvis.</target>
       </trans-unit>
       <trans-unit id="nkgykn8" resname="Do you want to save changes before creating a new file?">
         <source>Do you want to save changes before creating a new file?</source>
-        <target></target>
+        <target>~Vols guardar els canvis abans de crear un nou fitxer?</target>
       </trans-unit>
       <trans-unit id="ewss4px" resname="Don&apos;t Save">
         <source>Don't Save</source>
-        <target></target>
+        <target>~No guardar</target>
       </trans-unit>
       <trans-unit id="y6tbnwa" resname="Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.">
         <source>Some collaborative changes have not been saved yet. Click Save before leaving to avoid losing them.</source>
-        <target></target>
+        <target>~Alguns canvis col·laboratius encara no s'han guardat. Fes clic en Guardar abans d'eixir per a evitar perdre'ls.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
- Updated changelog.
- Updated third-party packages list.
- Full translation maintenance cycle.
- Complete Spanish translation.
- Placeholder translations for new strings in incomplete translations.
- Update styles documentation (no `downloadable` config option is required now).
- Remove de `downloadable` config option from all the default styles.
- Add new agents rule to avoid string extraction and translation.