### PR TITLE
`exe_media` is no longer required for `rel="lightbox"`.

### DIFF
--- a/doc/elpx-format/libraries.md
+++ b/doc/elpx-format/libraries.md
@@ -99,7 +99,6 @@ const { files: allRequiredFiles, patterns } = this.getRequiredLibraryFilesForPag
 | `exe_tooltips` | Tooltips iDevice | `exe_tooltips/jquery.qtip.min.js`, `exe_tooltips/jquery.qtip.min.css` |
 | `exe_magnify` | Image magnifier iDevice | `exe_magnify/exe_magnify.js`, CSS |
 | `exe_media` | Embedded media (audio/video) iDevice | `exe_media/exe_media.js`, CSS |
-| `exe_media_link` | Linked media iDevice | `exe_media_link/exe_media_link.js` |
 | `abcjs` | ABC music notation iDevice | `abcjs/abcjs-basic.js` |
 | `exe_math` | MathJax LaTeX expressions in content **or** `meta.addMathJax === true` | Entire `exe_math/` directory (dynamic extension loading) |
 | `exe_math_datagame` | LaTeX found inside encrypted DataGame div | `exe_math/` directory |

--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -547,10 +547,11 @@ var $exe = {
                     }
                     if (src) {
                         if (media.hasClass("exe-media-box-audio")) cont.attr("class", "pp_content_container with-audio");
-                        var ext = src.split("/");
-                        ext = ext[ext.length - 1];
-                        ext = ext.split(".")[1];
-                        if (typeof ext == 'undefined' || ext == 'undefined') ext = $exe_i18n.download;
+                        // Extension = last dot-segment of the filename, without query string or fragment
+                        var fileName = src.split("/").pop().split("?")[0].split("#")[0];
+                        var dotIndex = fileName.lastIndexOf(".");
+                        var ext = dotIndex > -1 ? fileName.substring(dotIndex + 1) : undefined;
+                        if (typeof ext == 'undefined' || ext == 'undefined' || ext == '') ext = $exe_i18n.download;
                         $(".pp_details .pp_description").append(' <span class="exe-media-download"><a href="' + src + '" title="' + $exe_i18n.download + '" download>' + ext + '</a></span>');
                     } else {
                         // Hide the title at the bottom (we use h2.pp_title instead)

--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -528,16 +528,25 @@ var $exe = {
                     var media = $(".exe-media-box-element", block);
                     if ($exe.loadMediaPlayer != undefined) {
                         if ($exe.loadMediaPlayer.isReady) {
-                            if (media.length == 1) media.mediaelementplayer();
+                            // No mediaelementplayer in prettyPhoto
+                            // if (media.length == 1) media.mediaelementplayer();
                             $exe.loadMediaPlayer.isCalledInBox = true;
                         }
                     }
                     // Add a download link and a CSS class to pp_content_container (see exe_lightbox.css)
                     var cont = $(".pp_content_container");
                     cont.attr("class", "pp_content_container");
-                    if (media.length == 1 && media[0].hasAttribute('src')) {
+                    var src = null;
+                    if (media.length == 1) {
+                        if (media[0].hasAttribute('src')) {
+                            src = media.attr('src');
+                        } else {
+                            var sourceEl = media.find('source[src]').first();
+                            if (sourceEl.length) src = sourceEl.attr('src');
+                        }
+                    }
+                    if (src) {
                         if (media.hasClass("exe-media-box-audio")) cont.attr("class", "pp_content_container with-audio");
-                        var src = media.attr('src');
                         var ext = src.split("/");
                         ext = ext[ext.length - 1];
                         ext = ext.split(".")[1];
@@ -547,6 +556,14 @@ var $exe = {
                         // Hide the title at the bottom (we use h2.pp_title instead)
                         block = $(".pp_inline", block);
                         if (block.length == 1) $(".pp_description").hide();
+                    }
+                    // Recalculate pp_content height for video elements (screen height + 50px for controls)
+                    var ppVideo = $("#pp_full_res video");
+                    if (ppVideo.length) {
+                        var videoHeight = ppVideo[0].getBoundingClientRect().height;
+                        if (videoHeight > 0) {
+                            $(".pp_content").css('height', videoHeight + 50);
+                        }
                     }
                 }
             });

--- a/public/app/common/common.test.js
+++ b/public/app/common/common.test.js
@@ -600,22 +600,18 @@ describe('common.js $exe helpers', () => {
         expect(desc.style.display).toBe('none');
       });
 
-      it('calls mediaelementplayer when loadMediaPlayer is ready', () => {
+      it('sets isCalledInBox when loadMediaPlayer is ready', () => {
         document.body.innerHTML = '<a rel="lightbox" href="audio/test.mp3">Link</a>';
         global.$exe.setMultimediaGalleries();
 
-        const mockMep = vi.fn();
-        global.$.fn.mediaelementplayer = mockMep;
         global.$exe.loadMediaPlayer.isReady = true;
         global.$exe.loadMediaPlayer.isCalledInBox = false;
 
         setupPrettyPhotoDOM('audio/test.mp3');
         prettyPhotoOptions.changepicturecallback();
 
-        expect(mockMep).toHaveBeenCalled();
         expect(global.$exe.loadMediaPlayer.isCalledInBox).toBe(true);
 
-        delete global.$.fn.mediaelementplayer;
         global.$exe.loadMediaPlayer.isReady = false;
         global.$exe.loadMediaPlayer.isCalledInBox = false;
       });

--- a/public/app/common/common.test.js
+++ b/public/app/common/common.test.js
@@ -615,6 +615,92 @@ describe('common.js $exe helpers', () => {
         global.$exe.loadMediaPlayer.isReady = false;
         global.$exe.loadMediaPlayer.isCalledInBox = false;
       });
+
+      it('extracts download src from a <source> child when the media element has no src attribute', () => {
+        document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
+        global.$exe.setMultimediaGalleries();
+
+        // Video is rendered as <video><source src="..."/></video> (no src on the element itself)
+        document.body.innerHTML = `
+          <div id="pp_full_res">
+            <video class="exe-media-box-element"><source src="video/test.mp4" /></video>
+          </div>
+          <div class="pp_content_container">
+            <div class="pp_details"><div class="pp_description"></div></div>
+          </div>
+        `;
+        prettyPhotoOptions.changepicturecallback();
+
+        const downloadLink = document.querySelector('.exe-media-download a');
+        expect(downloadLink).not.toBeNull();
+        expect(downloadLink.getAttribute('href')).toBe('video/test.mp4');
+        expect(downloadLink.textContent).toBe('mp4');
+      });
+
+      it('labels the download link with the real extension for multi-dot filenames and query strings', () => {
+        document.body.innerHTML = '<a rel="lightbox" href="video/lesson.part1.mp4">Link</a>';
+        global.$exe.setMultimediaGalleries();
+
+        document.body.innerHTML = `
+          <div id="pp_full_res">
+            <video class="exe-media-box-element"><source src="video/lesson.part1.mp4?token=abc#t=10" /></video>
+          </div>
+          <div class="pp_content_container">
+            <div class="pp_details"><div class="pp_description"></div></div>
+          </div>
+        `;
+        prettyPhotoOptions.changepicturecallback();
+
+        const downloadLink = document.querySelector('.exe-media-download a');
+        expect(downloadLink).not.toBeNull();
+        // last dot-segment, query string and fragment stripped → "mp4" (not "part1" or "mp4?token=abc#t=10")
+        expect(downloadLink.textContent).toBe('mp4');
+      });
+
+      it('recalculates pp_content height from the video bounding rect', () => {
+        document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
+        global.$exe.setMultimediaGalleries();
+
+        document.body.innerHTML = `
+          <div id="pp_full_res">
+            <video class="exe-media-box-element"><source src="video/test.mp4" /></video>
+          </div>
+          <div class="pp_content"></div>
+          <div class="pp_content_container">
+            <div class="pp_details"><div class="pp_description"></div></div>
+          </div>
+        `;
+        const video = document.querySelector('#pp_full_res video');
+        video.getBoundingClientRect = () => ({ height: 300, width: 480, top: 0, left: 0, right: 480, bottom: 300 });
+
+        prettyPhotoOptions.changepicturecallback();
+
+        // 300 (video height) + 50 (controls) = 350px
+        const content = document.querySelector('.pp_content');
+        expect(content.style.height).toBe('350px');
+      });
+
+      it('leaves pp_content height untouched when the video has zero height', () => {
+        document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
+        global.$exe.setMultimediaGalleries();
+
+        document.body.innerHTML = `
+          <div id="pp_full_res">
+            <video class="exe-media-box-element"><source src="video/test.mp4" /></video>
+          </div>
+          <div class="pp_content"></div>
+          <div class="pp_content_container">
+            <div class="pp_details"><div class="pp_description"></div></div>
+          </div>
+        `;
+        const video = document.querySelector('#pp_full_res video');
+        video.getBoundingClientRect = () => ({ height: 0, width: 0, top: 0, left: 0, right: 0, bottom: 0 });
+
+        prettyPhotoOptions.changepicturecallback();
+
+        const content = document.querySelector('.pp_content');
+        expect(content.style.height).toBe('');
+      });
     });
 
     it('applies GalleryIdevice fallback when no lightbox links but gallery exists', () => {

--- a/public/app/common/exe_lightbox/exe_lightbox.css
+++ b/public/app/common/exe_lightbox/exe_lightbox.css
@@ -91,5 +91,5 @@ div.ppt{display:none!important}
 div.with-audio .pp_gallery ul li a{border:1px solid #fff}
 div.with-audio .pp_gallery ul li a:hover,div.with-audio .pp_gallery ul li.selected a,.pp_gallery ul a:hover,div.with-audio .pp_gallery li.selected a{border-color:#aaa}
 .exe-media-audio-box{text-align:center;height:50px;padding:40px 0}
-.exe-media-video-box{text-align:center;min-width:480px;height:385px}
+.exe-media-video-box{text-align:center;min-width:480px;height:auto}
 .exe-media-download{font-weight:normal;float:right}

--- a/src/shared/export/constants.ts
+++ b/src/shared/export/constants.ts
@@ -197,23 +197,6 @@ export const LIBRARY_PATTERNS: LibraryPattern[] = [
         ],
     },
 
-    // Media player via audio/video file links with lightbox
-    {
-        name: 'exe_media_link',
-        type: 'regex',
-        pattern: /href="[^"]*\.(mp3|mp4|flv|ogg|ogv)"[^>]*rel="[^"]*lightbox/i,
-        files: [
-            'exe_media/exe_media.js',
-            'exe_media/exe_media.css',
-            'exe_media/exe_media_background.png',
-            'exe_media/exe_media_bigplay.png',
-            'exe_media/exe_media_bigplay.svg',
-            'exe_media/exe_media_controls.png',
-            'exe_media/exe_media_controls.svg',
-            'exe_media/exe_media_loading.gif',
-        ],
-    },
-
     // ABC Music notation (abcjs)
     {
         name: 'abcjs',

--- a/src/shared/export/interfaces.spec.ts
+++ b/src/shared/export/interfaces.spec.ts
@@ -288,13 +288,6 @@ describe('Export Constants', () => {
             expect(media?.files.length).toBeGreaterThan(0);
         });
 
-        it('should have regex pattern for media links', () => {
-            const mediaLink = LIBRARY_PATTERNS.find(p => p.name === 'exe_media_link');
-            expect(mediaLink).toBeDefined();
-            expect(mediaLink?.type).toBe('regex');
-            expect(mediaLink?.pattern).toBeInstanceOf(RegExp);
-        });
-
         it('should have math pattern with regex', () => {
             const math = LIBRARY_PATTERNS.find(p => p.name === 'exe_math');
             expect(math).toBeDefined();

--- a/src/shared/export/providers/FileSystemResourceProvider.ts
+++ b/src/shared/export/providers/FileSystemResourceProvider.ts
@@ -191,7 +191,6 @@ export class FileSystemResourceProvider implements ResourceProvider {
             'exe_magnify',
             'exe_highlighter',
             'exe_slidesjs',
-            'exe_media_link',
             'exe_math', // MathJax library
             'mermaid', // Mermaid diagram library
         ]);

--- a/src/shared/export/utils/LibraryDetector.spec.ts
+++ b/src/shared/export/utils/LibraryDetector.spec.ts
@@ -87,14 +87,6 @@ describe('LibraryDetector', () => {
             expect(result.files).toContain('exe_media/exe_media.js');
         });
 
-        it('should detect exe_media_link by regex pattern', () => {
-            const html = '<a href="video.mp4" rel="lightbox">Watch</a>';
-            const result = detector.detectLibraries(html);
-
-            // Both exe_lightbox and exe_media_link should be detected
-            expect(result.libraries.find(l => l.name === 'exe_media_link')).toBeDefined();
-        });
-
         it('should detect exe_math by regex pattern', () => {
             const html = '<p>The formula \\(x^2 + y^2 = z^2\\) is well known.</p>';
             const result = detector.detectLibraries(html);


### PR DESCRIPTION
How to test:

Create three links with `rel="lightbox"` or `rel="lightbox[galleryID]"`: one linking to an image, one to an MP3 file and one to an MP4 file. Verify that all three are displayed correctly, without using the old JavaScript player.