### PR TITLE
Prepare v4.0.2 release (II)

### DIFF
--- a/.agents/skills/mkdocs-nav/SKILL.md
+++ b/.agents/skills/mkdocs-nav/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: mkdocs-nav
+description: Sync the mkdocs.yml nav with the actual contents of doc/. Finds every .md file under doc/, identifies which are missing from the nav, proposes a complete ordered nav, and writes it to mkdocs.yml.
+---
+
+# Skill: Sync mkdocs.yml nav
+
+> Parent: [AGENTS.md](../../../AGENTS.md)
+
+Keep the `nav:` section in `mkdocs.yml` in sync with the files that actually exist under `doc/`. Run this whenever a new doc is added and needs to appear on https://exelearning.github.io/exelearning/.
+
+---
+
+## 0. Before you start
+
+Read these two sources in full:
+
+1. `mkdocs.yml` — current nav and site config.
+2. All `.md` files under `doc/` — use Glob with `doc/**/*.md`.
+
+Do not skip any file. The goal is a nav that references **every** `.md` file exactly once.
+
+---
+
+## 1. Identify gaps
+
+List every `.md` path returned by the glob. Normalize paths to forward slashes and strip the `doc/` prefix (MkDocs paths are relative to `docs_dir: doc`).
+
+Compare with every path already referenced under `nav:` in `mkdocs.yml`.
+
+Report which files are **missing** from the nav and which nav entries point to **files that no longer exist** (stale entries). Both must be fixed.
+
+---
+
+## 2. Assign each doc to a section
+
+Use the table below to decide where each file belongs. When in doubt, read the first two lines of the file for its title and description.
+
+| Path prefix / filename | Nav section |
+|------------------------|-------------|
+| `index.md` | Top level — always first |
+| `overview.md` | Top level |
+| `install.md` | Top level |
+| `profile-avatars.md` | Top level (end users) |
+| `deployment.md` | Top level |
+| `high-availability.md` | Top level |
+| `deploy/README.md` | Top level — label **"Deploy: Sample Configs"** |
+| `architecture.md` | Top level — label **"Architecture"** |
+| `conventions.md` | Top level — label **"Conventions"** |
+| `development/*.md` | **Development** section |
+| `contentv3-format.md` | **File Formats** section — label **"Legacy ELP Format"** |
+| `elpx-format.md` | **File Formats** section — label **"ELPX Format"** (subsection root) |
+| `elpx-format/*.md` | **File Formats › ELPX Format** subsection |
+| `elpx-format/idevices/*.md` | **File Formats › ELPX Format › iDevices** sub-subsection |
+| `elpx-format/examples/*.md` | **File Formats › ELPX Format › Examples** sub-subsection |
+
+### Ordering within each section
+
+**Top level** (in this order):
+1. Home (`index.md`)
+2. Overview (`overview.md`)
+3. Install (`install.md`)
+4. Profile Avatars (`profile-avatars.md`)
+5. Deployment (`deployment.md`)
+6. High Availability (`high-availability.md`)
+7. Deploy: Sample Configs (`deploy/README.md`)
+8. Architecture (`architecture.md`)
+9. Conventions (`conventions.md`)
+
+**Development** (alphabetical by label, except Environment first):
+Environment → Version Control → Contributing → Testing → Internationalization → Real Time → Embedding → Profiling → Customization → Styles → Installers → REST API → Authentication
+
+**File Formats** (Legacy ELP first, then ELPX):
+1. Legacy ELP Format (`contentv3-format.md`)
+2. ELPX Format (`elpx-format.md`) — then subsections in this order:
+   - Container & XML group: Container → content.xml → IDs → Metadata → Pages & Blocks
+   - iDevices subsection: Catalog → Patterns → config.xml → Snippets
+   - Resources group: Themes → Libraries → Assets → Screenshot
+   - Pipelines group: Tracking → Export Pipeline → Import Pipeline → Validation
+   - AI Generation
+   - Examples subsection: Minimal → Multi-page → Full Package Tree
+
+If a new file appears that doesn't match any entry above, add it to the most logical section and note your choice as a comment in your response.
+
+---
+
+## 3. Write the updated `mkdocs.yml`
+
+Preserve **everything outside the `nav:` block** exactly as-is (theme, plugins, markdown_extensions, extra, validation, etc.). Only replace the `nav:` block.
+
+Use 2-space indentation inside `nav:` (MkDocs convention). Labels must be human-readable title case.
+
+Target structure (expand as needed to include every file):
+
+```yaml
+nav:
+  - Home: index.md
+  - Overview: overview.md
+  - Install: install.md
+  - Profile Avatars: profile-avatars.md
+  - Deployment: deployment.md
+  - High Availability: high-availability.md
+  - Deploy\: Sample Configs: deploy/README.md
+  - Architecture: architecture.md
+  - Conventions: conventions.md
+  - Development:
+      - Environment: development/environment.md
+      - Version Control: development/version-control.md
+      - Contributing: development/contributing.md
+      - Testing: development/testing.md
+      - Internationalization: development/internationalization.md
+      - Real Time: development/real-time.md
+      - Embedding: development/embedding.md
+      - Profiling: development/profiling.md
+      - Customization: development/customization.md
+      - Styles: development/styles.md
+      - Installers: development/installers.md
+      - REST API: development/rest-api.md
+      - Authentication: development/authentication.md
+  - File Formats:
+      - Legacy ELP Format: contentv3-format.md
+      - ELPX Format:
+          - Overview: elpx-format.md
+          - Container: elpx-format/container.md
+          - content.xml: elpx-format/content-xml.md
+          - IDs: elpx-format/ids.md
+          - Metadata: elpx-format/metadata.md
+          - Pages & Blocks: elpx-format/pages-blocks.md
+          - iDevices:
+              - Catalog: elpx-format/idevices/catalog.md
+              - Patterns: elpx-format/idevices/patterns.md
+              - config.xml: elpx-format/idevices/config-xml.md
+              - Snippets: elpx-format/idevices/snippets.md
+          - Themes: elpx-format/themes.md
+          - Libraries: elpx-format/libraries.md
+          - Assets: elpx-format/assets.md
+          - Screenshot: elpx-format/screenshot.md
+          - Tracking: elpx-format/tracking-emission.md
+          - Export Pipeline: elpx-format/export-pipeline.md
+          - Import Pipeline: elpx-format/import-pipeline.md
+          - Validation: elpx-format/validation.md
+          - AI Generation: elpx-format/ai-generation.md
+          - Examples:
+              - Minimal content.xml: elpx-format/examples/minimal-content-xml.md
+              - Multi-page content.xml: elpx-format/examples/multi-page-content-xml.md
+              - Full Package Tree: elpx-format/examples/full-package-tree.md
+```
+
+> **Important:** The colon in `Deploy: Sample Configs` must be escaped as `\:` inside a YAML mapping key. Alternatively, quote the key: `"Deploy: Sample Configs"`. Either is correct YAML; prefer the quoted form for readability.
+
+After writing the file, re-read it and confirm the YAML is valid (no duplicate keys, consistent indentation).
+
+---
+
+## 4. Report back
+
+Tell the user:
+
+1. Which files were **added** to the nav (list them).
+2. Which entries were **removed** as stale (list them, if any).
+3. Which files, if any, you placed in a section not listed in the table above, and why.
+4. Any file you skipped and the reason (e.g., it is a `doc/style.css` or non-Markdown asset — those should never appear in the nav).
+
+Do **not** modify any file other than `mkdocs.yml`.

--- a/.claude/commands/mkdocs-nav.md
+++ b/.claude/commands/mkdocs-nav.md
@@ -1,0 +1,1 @@
+Read the file `.agents/skills/mkdocs-nav/SKILL.md` and follow its instructions exactly to sync the `mkdocs.yml` nav with the current contents of `doc/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,7 @@ Domain-specific guidance lives in `.agents/skills/*/SKILL.md`.
 | [websocket-yjs](.agents/skills/websocket-yjs/SKILL.md) | Real-time collaboration code |
 | [i18n](.agents/skills/i18n/SKILL.md) | Adding/modifying translations |
 | [xlf-translate](.agents/skills/xlf-translate/SKILL.md) | Filling empty `<target>` elements in XLF files with `~`-prefixed translations |
+| [mkdocs-nav](.agents/skills/mkdocs-nav/SKILL.md) | Sync `mkdocs.yml` nav with the actual contents of `doc/` |
 | [api-v1](.agents/skills/api-v1/SKILL.md) | External REST API v1 endpoints |
 
 ## 12. Deep-Dive Documentation

--- a/assets/styles/components/_buttons.scss
+++ b/assets/styles/components/_buttons.scss
@@ -6,36 +6,21 @@
     padding: 0;
 }
 
-// Edit-title button: hidden accessibly by default, revealed on hover/focus-within
+// Edit-title button: invisible by default, revealed on hover/focus-within.
+// Kept in the flex flow so the container's hit-area always includes the button
+// space — hovering where the pencil will appear also triggers the reveal.
 .content-editable-title {
     .btn-edit-title {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
         opacity: 0;
+        pointer-events: none;
         transition: opacity 0.2s ease;
     }
 
     &:hover,
     &:focus-within {
         .btn-edit-title {
-            position: static;
-            width: auto;
-            height: auto;
-            padding: 0;
-            margin: 0 0 0 .5em !important;
-            margin-inline-start: 0.25rem;
-            overflow: visible;
-            clip: auto;
-            white-space: normal;
-            border: 0;
             opacity: 1;
+            pointer-events: auto;
         }
     }
 }

--- a/assets/styles/layout/_nodecontainer.scss
+++ b/assets/styles/layout/_nodecontainer.scss
@@ -69,6 +69,9 @@
         margin-right: -5px;
         z-index: 997;
     }
+    #page-title-node-content + .btn-edit-title {
+        margin-left: .5em;
+    }
     #node-content {
         height: auto;
         // Page title with inline rename affordance (single click on the title
@@ -84,10 +87,6 @@
                     width: 16px;
                     height: 16px;
                 }
-            }
-            // Hide the pencil when the page title itself is hidden/empty.
-            .page-title.hidden ~ .btn-edit-title {
-                display: none;
             }
         }
         .page-title {

--- a/assets/styles/layout/_nodecontainer.scss
+++ b/assets/styles/layout/_nodecontainer.scss
@@ -88,6 +88,10 @@
                     height: 16px;
                 }
             }
+            // Hide the pencil when the page title itself is hidden/empty.
+            .page-title.hidden ~ .btn-edit-title {
+                display: none;
+            }
         }
         .page-title {
             margin-top: 15px;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,12 @@ nav:
   - Home: index.md
   - Overview: overview.md
   - Install: install.md
+  - Profile Avatars: profile-avatars.md
   - Deployment: deployment.md
+  - High Availability: high-availability.md
+  - "Deploy: Sample Configs": deploy/README.md
+  - Architecture: architecture.md
+  - Conventions: conventions.md
   - Development:
       - Environment: development/environment.md
       - Version Control: development/version-control.md
@@ -32,12 +37,41 @@ nav:
       - Testing: development/testing.md
       - Internationalization: development/internationalization.md
       - Real Time: development/real-time.md
+      - Embedding: development/embedding.md
+      - Profiling: development/profiling.md
       - Customization: development/customization.md
       - Styles: development/styles.md
       - Installers: development/installers.md
       - REST API: development/rest-api.md
       - Authentication: development/authentication.md
-      
+  - File Formats:
+      - Legacy ELP Format: contentv3-format.md
+      - ELPX Format:
+          - Overview: elpx-format.md
+          - Container: elpx-format/container.md
+          - content.xml: elpx-format/content-xml.md
+          - IDs: elpx-format/ids.md
+          - Metadata: elpx-format/metadata.md
+          - Pages & Blocks: elpx-format/pages-blocks.md
+          - iDevices:
+              - Catalog: elpx-format/idevices/catalog.md
+              - Patterns: elpx-format/idevices/patterns.md
+              - config.xml: elpx-format/idevices/config-xml.md
+              - Snippets: elpx-format/idevices/snippets.md
+          - Themes: elpx-format/themes.md
+          - Libraries: elpx-format/libraries.md
+          - Assets: elpx-format/assets.md
+          - Screenshot: elpx-format/screenshot.md
+          - Tracking: elpx-format/tracking-emission.md
+          - Export Pipeline: elpx-format/export-pipeline.md
+          - Import Pipeline: elpx-format/import-pipeline.md
+          - Validation: elpx-format/validation.md
+          - AI Generation: elpx-format/ai-generation.md
+          - Examples:
+              - Minimal content.xml: elpx-format/examples/minimal-content-xml.md
+              - Multi-page content.xml: elpx-format/examples/multi-page-content-xml.md
+              - Full Package Tree: elpx-format/examples/full-package-tree.md
+
 
 
 plugins:

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - iDevice edit mode now expands to fill the work area, keeping the toolbar visible and preventing background page scrolling
+- Page titles can now be renamed directly from the workspace
 - LOMLOE iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
 - Mermaid iDevice: added configurable maximum diagram width and height
 - Exported packages now emit xAPI statements for LMS activity tracking and direct LRS reporting
@@ -37,7 +38,7 @@
 - 3DMol iDevice: the Add iDevice menu is no longer obscured by the 3D viewer canvas
 - 3D Viewer iDevice: fixed a display issue affecting models in exported content
 - Preferences: improved the language-change warning in static and offline mode so it accurately describes the required steps before reloading
-- Tooltips inside accordions and other effects now initialise correctly
+- Tooltips and lightbox links inside accordions and other effects now initialise correctly
 - iDevice icon selector: improved contrast across all styles
 - Styles from `.elpx` projects can now be downloaded from the style manager
 - Nova style: teacher-only iDevices are now highlighted with a yellow border in the work area
@@ -56,6 +57,7 @@
 ### Removed
 
 - Removed the `<downloadable>` option from style `config.xml`; styles are now always downloadable
+- `lightbox` links no longer use the JavaScript media player for video and audio playback
 
 ---
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Share dialog: the people-with-access list now scrolls correctly within the modal
 - Link Validator and Resource Report: Download CSV now works correctly
 - The iDevices panel is now disabled when the selected page is the document root
+- DigCompEdu iDevice: improved table header hover contrast for better readability
 - Electrical Circuits iDevice: corrected the AI prompt identifier and fixed rendering of Ω and other Greek and mathematical symbols
 - Electrical Circuits iDevice: fixed iDevice name translations
 - Magnifier iDevice: fixed image paths in exports so images are displayed correctly in HTML output

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - iDevice edit mode now expands to fill the work area, keeping the toolbar visible and preventing background page scrolling
 - Page titles can now be renamed directly from the workspace
-- LOMLOE iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
+- DigCompEdu iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
 - Mermaid iDevice: added configurable maximum diagram width and height
 - Exported packages now emit xAPI statements for LMS activity tracking and direct LRS reporting
 - File → New: improved the unsaved-changes confirmation dialog with clearer wording and action labels
@@ -17,7 +17,7 @@
 
 ### Changed
 
-- LOMLOE iDevice: the Galicia (ES-GA) dataset is temporarily hidden pending formal definition of its official curriculum requirements (see #1900)
+- DigCompEdu iDevice: the Galicia (ES-GA) and Extremadura (ES-EX) curriculum datasets are temporarily disabled pending confirmation for reactivation
 
 ### Fixed
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - iDevice edit mode now expands to fill the work area, keeping the toolbar visible and preventing background page scrolling
 - Page titles can now be renamed directly from the workspace
-- DigCompEdu iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
+- LOMLOE iDevice: added official curriculum datasets for Navarra (ES-NC) and Comunitat Valenciana (ES-VC)
 - Mermaid iDevice: added configurable maximum diagram width and height
 - Exported packages now emit xAPI statements for LMS activity tracking and direct LRS reporting
 - File → New: improved the unsaved-changes confirmation dialog with clearer wording and action labels
@@ -17,7 +17,7 @@
 
 ### Changed
 
-- DigCompEdu iDevice: the Galicia (ES-GA) and Extremadura (ES-EX) curriculum datasets are temporarily disabled pending confirmation for reactivation
+- LOMLOE iDevice: the Galicia (ES-GA) and Extremadura (ES-EX) curriculum datasets are temporarily disabled pending confirmation for reactivation
 
 ### Fixed
 
@@ -31,7 +31,7 @@
 - Share dialog: the people-with-access list now scrolls correctly within the modal
 - Link Validator and Resource Report: Download CSV now works correctly
 - The iDevices panel is now disabled when the selected page is the document root
-- DigCompEdu iDevice: improved table header hover contrast for better readability
+- LOMLOE iDevice: improved table header hover contrast for better readability
 - Electrical Circuits iDevice: corrected the AI prompt identifier and fixed rendering of Ω and other Greek and mathematical symbols
 - Electrical Circuits iDevice: fixed iDevice name translations
 - Magnifier iDevice: fixed image paths in exports so images are displayed correctly in HTML output

--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -519,55 +519,59 @@ var $exe = {
                     $exe.hasMultimediaGalleries = true;
                 }
             });
-            lightboxLinks.prettyPhoto({
-                social_tools: "",
-                deeplinking: false,
-                opacity: 0.85,
-                changepicturecallback: function () {
-                    var block = $("#pp_full_res")
-                    var media = $(".exe-media-box-element", block);
-                    if ($exe.loadMediaPlayer != undefined) {
-                        if ($exe.loadMediaPlayer.isReady) {
-                            // No mediaelementplayer in prettyPhoto
-                            // if (media.length == 1) media.mediaelementplayer();
-                            $exe.loadMediaPlayer.isCalledInBox = true;
+            // Re-query after $exeFX.init() has finished rebuilding exe-fx DOM (e.g. accordion rft()).
+            // Using the pre-captured lightboxLinks set would miss elements replaced by rft().
+            setTimeout(function() {
+                $("a[rel^='lightbox']").prettyPhoto({
+                    social_tools: "",
+                    deeplinking: false,
+                    opacity: 0.85,
+                    changepicturecallback: function () {
+                        var block = $("#pp_full_res")
+                        var media = $(".exe-media-box-element", block);
+                        if ($exe.loadMediaPlayer != undefined) {
+                            if ($exe.loadMediaPlayer.isReady) {
+                                // No mediaelementplayer in prettyPhoto
+                                // if (media.length == 1) media.mediaelementplayer();
+                                $exe.loadMediaPlayer.isCalledInBox = true;
+                            }
                         }
-                    }
-                    // Add a download link and a CSS class to pp_content_container (see exe_lightbox.css)
-                    var cont = $(".pp_content_container");
-                    cont.attr("class", "pp_content_container");
-                    var src = null;
-                    if (media.length == 1) {
-                        if (media[0].hasAttribute('src')) {
-                            src = media.attr('src');
+                        // Add a download link and a CSS class to pp_content_container (see exe_lightbox.css)
+                        var cont = $(".pp_content_container");
+                        cont.attr("class", "pp_content_container");
+                        var src = null;
+                        if (media.length == 1) {
+                            if (media[0].hasAttribute('src')) {
+                                src = media.attr('src');
+                            } else {
+                                var sourceEl = media.find('source[src]').first();
+                                if (sourceEl.length) src = sourceEl.attr('src');
+                            }
+                        }
+                        if (src) {
+                            if (media.hasClass("exe-media-box-audio")) cont.attr("class", "pp_content_container with-audio");
+                            // Extension = last dot-segment of the filename, without query string or fragment
+                            var fileName = src.split("/").pop().split("?")[0].split("#")[0];
+                            var dotIndex = fileName.lastIndexOf(".");
+                            var ext = dotIndex > -1 ? fileName.substring(dotIndex + 1) : undefined;
+                            if (typeof ext == 'undefined' || ext == 'undefined' || ext == '') ext = $exe_i18n.download;
+                            $(".pp_details .pp_description").append(' <span class="exe-media-download"><a href="' + src + '" title="' + $exe_i18n.download + '" download>' + ext + '</a></span>');
                         } else {
-                            var sourceEl = media.find('source[src]').first();
-                            if (sourceEl.length) src = sourceEl.attr('src');
+                            // Hide the title at the bottom (we use h2.pp_title instead)
+                            block = $(".pp_inline", block);
+                            if (block.length == 1) $(".pp_description").hide();
+                        }
+                        // Recalculate pp_content height for video elements (screen height + 50px for controls)
+                        var ppVideo = $("#pp_full_res video");
+                        if (ppVideo.length) {
+                            var videoHeight = ppVideo[0].getBoundingClientRect().height;
+                            if (videoHeight > 0) {
+                                $(".pp_content").css('height', videoHeight + 50);
+                            }
                         }
                     }
-                    if (src) {
-                        if (media.hasClass("exe-media-box-audio")) cont.attr("class", "pp_content_container with-audio");
-                        // Extension = last dot-segment of the filename, without query string or fragment
-                        var fileName = src.split("/").pop().split("?")[0].split("#")[0];
-                        var dotIndex = fileName.lastIndexOf(".");
-                        var ext = dotIndex > -1 ? fileName.substring(dotIndex + 1) : undefined;
-                        if (typeof ext == 'undefined' || ext == 'undefined' || ext == '') ext = $exe_i18n.download;
-                        $(".pp_details .pp_description").append(' <span class="exe-media-download"><a href="' + src + '" title="' + $exe_i18n.download + '" download>' + ext + '</a></span>');
-                    } else {
-                        // Hide the title at the bottom (we use h2.pp_title instead)
-                        block = $(".pp_inline", block);
-                        if (block.length == 1) $(".pp_description").hide();
-                    }
-                    // Recalculate pp_content height for video elements (screen height + 50px for controls)
-                    var ppVideo = $("#pp_full_res video");
-                    if (ppVideo.length) {
-                        var videoHeight = ppVideo[0].getBoundingClientRect().height;
-                        if (videoHeight > 0) {
-                            $(".pp_content").css('height', videoHeight + 50);
-                        }
-                    }
-                }
-            });
+                });
+            }, 0);
             // If there are galleries, but lightboxLinks.length==0, there's an error
             // No links with the rel attribute were selected
             // This might happen in some ePub readers

--- a/public/app/common/common.js
+++ b/public/app/common/common.js
@@ -520,9 +520,10 @@ var $exe = {
                 }
             });
             // Re-query after $exeFX.init() has finished rebuilding exe-fx DOM (e.g. accordion rft()).
-            // Using the pre-captured lightboxLinks set would miss elements replaced by rft().
+            // Both prettyPhoto and the gallery-error fallback use the same post-FX-init set.
             setTimeout(function() {
-                $("a[rel^='lightbox']").prettyPhoto({
+                var currentLightboxLinks = $("a[rel^='lightbox']");
+                currentLightboxLinks.prettyPhoto({
                     social_tools: "",
                     deeplinking: false,
                     opacity: 0.85,
@@ -571,30 +572,28 @@ var $exe = {
                         }
                     }
                 });
-            }, 0);
-            // If there are galleries, but lightboxLinks.length==0, there's an error
-            // No links with the rel attribute were selected
-            // This might happen in some ePub readers
-            // See issue #258
-            var eXeGalleries = $('.GalleryIdevice');
-            if (lightboxLinks.length == 0 && eXeGalleries.length > 0 && typeof (exe_editor_mode) == "undefined") {
-                // We execute this code only outside eXe or the Image Gallery edition will fail (see issue #317)
-                $('.exeImageGallery a').each(function () {
-                    this.title += " ~ [" + this.href + "]";
-                    this.href = "#";
-                    this.onclick = function () {
-                        var ul = $(this).parent().parent();
-                        if (ul.length == 1 && ul.attr('id') != "") {
-                            if ($("#" + ul.attr('id') + "-warning").length == 0) {
-                                // Due to G. Chrome's Content Security Policy
-                                var txt = $exe_i18n.dataError;
-                                if ($('body').hasClass('exe-epub3')) txt += '<br /><br />' + $exe_i18n.epubJSerror;
-                                ul.prepend('<div id="' + ul.attr('id') + '-warning">' + txt + '</div>');
+                // If there are galleries but no lightbox links, there's an error (e.g. some ePub readers).
+                // See issue #258
+                var eXeGalleries = $('.GalleryIdevice');
+                if (currentLightboxLinks.length == 0 && eXeGalleries.length > 0 && typeof (exe_editor_mode) == "undefined") {
+                    // We execute this code only outside eXe or the Image Gallery edition will fail (see issue #317)
+                    $('.exeImageGallery a').each(function () {
+                        this.title += " ~ [" + this.href + "]";
+                        this.href = "#";
+                        this.onclick = function () {
+                            var ul = $(this).parent().parent();
+                            if (ul.length == 1 && ul.attr('id') != "") {
+                                if ($("#" + ul.attr('id') + "-warning").length == 0) {
+                                    // Due to G. Chrome's Content Security Policy
+                                    var txt = $exe_i18n.dataError;
+                                    if ($('body').hasClass('exe-epub3')) txt += '<br /><br />' + $exe_i18n.epubJSerror;
+                                    ul.prepend('<div id="' + ul.attr('id') + '-warning">' + txt + '</div>');
+                                }
                             }
                         }
-                    }
-                });
-            }
+                    });
+                }
+            }, 0);
         }
     },
 

--- a/public/app/common/common.test.js
+++ b/public/app/common/common.test.js
@@ -396,6 +396,7 @@ describe('common.js $exe helpers', () => {
     let prettyPhotoOptions;
 
     beforeEach(() => {
+      vi.useFakeTimers();
       prettyPhotoOptions = null;
       // The guard in setMultimediaGalleries checks $.prettyPhoto (static), not $.fn.prettyPhoto
       global.$.prettyPhoto = vi.fn();
@@ -407,6 +408,7 @@ describe('common.js $exe helpers', () => {
     });
 
     afterEach(() => {
+      vi.useRealTimers();
       delete global.$.prettyPhoto;
       delete global.$.fn.prettyPhoto;
       delete global.eXeLearningAssetResolver;
@@ -421,6 +423,7 @@ describe('common.js $exe helpers', () => {
     it('calls prettyPhoto when it is defined', () => {
       document.body.innerHTML = '';
       global.$exe.setMultimediaGalleries();
+      vi.runAllTimers();
       expect(global.$.fn.prettyPhoto).toHaveBeenCalled();
     });
 
@@ -548,7 +551,7 @@ describe('common.js $exe helpers', () => {
       it('adds download link with extension from src filename', () => {
         document.body.innerHTML = '<a rel="lightbox" href="audio/test.mp3">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         setupPrettyPhotoDOM('audio/test.mp3');
         prettyPhotoOptions.changepicturecallback();
 
@@ -560,7 +563,7 @@ describe('common.js $exe helpers', () => {
       it('falls back to i18n.download when ext is undefined (blob URL without extension)', () => {
         document.body.innerHTML = '<a rel="lightbox" href="audio/test.mp3">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         // src with no dot → split(".")[1] is undefined
         setupPrettyPhotoDOM('blob:http://localhost:8080/some-uuid');
         prettyPhotoOptions.changepicturecallback();
@@ -573,7 +576,7 @@ describe('common.js $exe helpers', () => {
       it('adds with-audio class to container for audio elements', () => {
         document.body.innerHTML = '<a rel="lightbox" href="audio/test.mp3">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         setupPrettyPhotoDOM('audio/test.mp3', 'exe-media-box-audio');
         prettyPhotoOptions.changepicturecallback();
 
@@ -584,7 +587,7 @@ describe('common.js $exe helpers', () => {
       it('hides description for inline (non-media) content', () => {
         document.body.innerHTML = '<a rel="lightbox" href="image/photo.jpg">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         document.body.innerHTML = `
           <div id="pp_full_res">
             <div class="pp_inline"><p>Inline content</p></div>
@@ -603,7 +606,7 @@ describe('common.js $exe helpers', () => {
       it('sets isCalledInBox when loadMediaPlayer is ready', () => {
         document.body.innerHTML = '<a rel="lightbox" href="audio/test.mp3">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         global.$exe.loadMediaPlayer.isReady = true;
         global.$exe.loadMediaPlayer.isCalledInBox = false;
 
@@ -619,7 +622,7 @@ describe('common.js $exe helpers', () => {
       it('extracts download src from a <source> child when the media element has no src attribute', () => {
         document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         // Video is rendered as <video><source src="..."/></video> (no src on the element itself)
         document.body.innerHTML = `
           <div id="pp_full_res">
@@ -640,7 +643,7 @@ describe('common.js $exe helpers', () => {
       it('labels the download link with the real extension for multi-dot filenames and query strings', () => {
         document.body.innerHTML = '<a rel="lightbox" href="video/lesson.part1.mp4">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         document.body.innerHTML = `
           <div id="pp_full_res">
             <video class="exe-media-box-element"><source src="video/lesson.part1.mp4?token=abc#t=10" /></video>
@@ -660,7 +663,7 @@ describe('common.js $exe helpers', () => {
       it('recalculates pp_content height from the video bounding rect', () => {
         document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         document.body.innerHTML = `
           <div id="pp_full_res">
             <video class="exe-media-box-element"><source src="video/test.mp4" /></video>
@@ -683,7 +686,7 @@ describe('common.js $exe helpers', () => {
       it('leaves pp_content height untouched when the video has zero height', () => {
         document.body.innerHTML = '<a rel="lightbox" href="video/test.mp4">Link</a>';
         global.$exe.setMultimediaGalleries();
-
+        vi.runAllTimers();
         document.body.innerHTML = `
           <div id="pp_full_res">
             <video class="exe-media-box-element"><source src="video/test.mp4" /></video>

--- a/public/app/common/common.test.js
+++ b/public/app/common/common.test.js
@@ -718,6 +718,7 @@ describe('common.js $exe helpers', () => {
         </div>
       `;
       global.$exe.setMultimediaGalleries();
+      vi.runAllTimers();
 
       const link = document.querySelector('.exeImageGallery a');
       // element.href property returns absolute URL in happy-dom; use getAttribute for raw value

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.js
@@ -75,6 +75,9 @@ var $exeDevice = (function () {
             framework: 'LOMLOE',
             community: 'Extremadura',
             file: '../data/lomloe-ES-EX.json',
+            // Temporarily disabled, awaiting confirmation for reactivation. The
+            // dataset JSON stays in the repo untouched; flip back to true to
+            // re-enable.
             available: false
         },
         {

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.js
@@ -75,7 +75,7 @@ var $exeDevice = (function () {
             framework: 'LOMLOE',
             community: 'Extremadura',
             file: '../data/lomloe-ES-EX.json',
-            available: true
+            available: false
         },
         {
             id: 'ES-MD',

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.js
@@ -161,7 +161,7 @@ var $exeDevice = (function () {
      * only the subjects actually taught in the selected course. See issue #1832.
      *
      * Only datasets whose norm fixes a per-course distribution appear here:
-     *   - ES-EX:  Decreto 110/2022 (DOE), Anexo V.
+     *   - ES-EX:  Decreto 110/2022 (DOE), Anexo V. (unreachable while ES-EX available:false)
      *   - ES-MD:  Decreto 65/2022 (BOCM), Anexo I.
      *   - ES-EFP: Orden EFP/754/2022 (BOE), per-course markers of Anexo II.
      * Datasets absent from this map (ES state floor, ES-CN, ES-GA already
@@ -171,6 +171,8 @@ var $exeDevice = (function () {
      */
     var ESO_COURSE_SUBJECTS = {
         // ES-EX uses the official Extremadura subject codes (see README).
+        // Unreachable while available:false above — getCourseSubjectFilter('ES-EX') is never
+        // called for disabled datasets. Restore together with the available flag above.
         'ES-EX': {
             '1º ESO': ['BG', 'EF', 'EPVA', 'GH', 'LCL', 'LE', 'MAT', 'MUS'],
             '2º ESO': ['EF', 'EVCE', 'FQ', 'GH', 'LCL', 'LE', 'MAT', 'MUS', 'TECD'],

--- a/public/files/perm/idevices/base/lomloe/edition/lomloe.test.js
+++ b/public/files/perm/idevices/base/lomloe/edition/lomloe.test.js
@@ -454,7 +454,9 @@ describe('toggleCriterio descriptor modes via browse panel (issue #1832)', () =>
     }
 
     it('checkbox-mode dataset starts empty with descriptorOptions and hides browse tags', async () => {
-        const sel = await selectCriterio('ES-EX');
+        // ES-MD stands in for any available checkbox-mode (non-Canarias) dataset.
+        // (ES-EX is on hold — available:false — so its loader path is unreachable.)
+        const sel = await selectCriterio('ES-MD');
         expect(sel.competenciasClave).toEqual([]);
         expect(sel.descriptorOptions).toEqual(['CCL1', 'STEM4', 'CD2']);
         // Browse panel must not present descriptors as fixed per-criterio tags.
@@ -550,31 +552,15 @@ describe('Per-course ESO subject filter (issue #1832)', () => {
             .map(li => li.getAttribute('data-codarea'));
     }
 
-    // Extremadura uses official subject codes (BG, FQ…); see README.
-    const EX_SAMPLE = {
-        ESO: {
-            '1º ESO': {
-                BG: area('Biología y Geología'),
-                FQ: area('Física y Química'),
-                GH: area('Geografía e Historia'),
-                EF: area('Educación Física'),
-                DIG: area('Digitalización')
-            }
-        }
-    };
-
-    it('Extremadura 1º ESO hides Física y Química (not taught in 1º)', async () => {
-        const codes = await listedCodAreas('ES-EX', EX_SAMPLE);
-        expect(codes).toContain('BG');
-        expect(codes).not.toContain('FQ');
-        // 4º-only optatives duplicated into the cycle are also filtered out.
-        expect(codes).not.toContain('DIG');
-    });
-
+    // The per-course filter is exercised on Madrid because Extremadura (ES-EX) is
+    // on hold (available:false) and its loader path is unreachable; the filtering
+    // mechanism is dataset-agnostic, so ES-MD covers it equally. See issue #1832.
     it('Madrid 1º ESO hides Física y Química too', async () => {
         const codes = await listedCodAreas('ES-MD');
         expect(codes).toContain('BIG');
         expect(codes).not.toContain('FQX');
+        // 4º-only optatives duplicated into the cycle are also filtered out.
+        expect(codes).not.toContain('DIG');
     });
 
     it('EFP (Ceuta/Melilla) 1º ESO hides Física y Química too', async () => {
@@ -1904,10 +1890,12 @@ describe('DATASETS registry (regression guard)', () => {
         expect(lomloeSrc).toContain("file: '../data/lomloe-ES-EFP.json'");
     });
 
-    it('declares ES-EX with available:true and the lomloe-ES-EX.json file', () => {
+    it('declares ES-EX on hold (available:false) with the lomloe-ES-EX.json file', () => {
+        // Temporarily disabled pending confirmation for reactivation. The dataset
+        // file stays in the repo; only the availability flag is flipped off.
         const m = entryFor('ES-EX');
         expect(m, "ES-EX entry missing").not.toBeNull();
-        expect(m[1]).toBe('true');
+        expect(m[1]).toBe('false');
         expect(lomloeSrc).toContain("file: '../data/lomloe-ES-EX.json'");
     });
 

--- a/public/files/perm/idevices/base/lomloe/export/lomloe.css
+++ b/public/files/perm/idevices/base/lomloe/export/lomloe.css
@@ -78,8 +78,8 @@
     background-color: var(--lomloe-stripe, rgba(0, 0, 0, 0.025));
 }
 
-.lomloe-export-table tr:hover td,
-.lomloe-export-table tr:hover th {
+.lomloe-export-table tbody tr:hover td,
+.lomloe-export-table tbody tr:hover th {
     background-color: var(--lomloe-hover, rgba(0, 0, 0, 0.055));
 }
 


### PR DESCRIPTION
- New agent skill to keep the `nav:` section in `mkdocs.yml` in sync with the files that actually exist under `doc/`.
- Updated `mkdocs.yml` (some sections were missing).
- The LOMLOE — Extremadura curriculum is temporarily disabled. Awaiting confirmation for reactivation.
- LOMLOE iDevice minor presentation fix: improved readability of light text on light background when hovering over the table header.
- Edit iDevice title: show the “Edit” pencil when hovering over its wrapper (`.content-editable-title`).
- `[rel^='lightbox']` links inside accordions and other effects now initialise correctly.
- Updated CHANGELOG.

Closes #2009 