### PR TITLE
test(e2e): deterministic navigation/selection waits, fix page-title flaky

### DIFF
--- a/test/e2e/playwright/helpers/workarea-helpers.ts
+++ b/test/e2e/playwright/helpers/workarea-helpers.ts
@@ -357,9 +357,12 @@ export async function gotoWorkarea(page: Page, projectUuid: string): Promise<voi
         return; // CRITICAL: return here to prevent server mode code from executing
     }
 
-    // Server mode: navigate to workarea with project UUID
-    await page.goto(`/workarea?project=${projectUuid}`);
-    await page.waitForLoadState('networkidle');
+    // Server mode: navigate to workarea with project UUID.
+    // Use 'domcontentloaded' and a deterministic readiness signal instead of
+    // 'networkidle': the app holds a long-lived Yjs WebSocket, so the network
+    // never goes idle, making networkidle both slow and flaky. The _yjsEnabled
+    // wait below plus waitForLoadingScreen are the real readiness signals.
+    await page.goto(`/workarea?project=${projectUuid}`, { waitUntil: 'domcontentloaded' });
     await page.waitForFunction(() => (window as any).eXeLearning?.app?.project?._yjsEnabled, undefined, {
         timeout: 30000,
     });
@@ -429,7 +432,7 @@ export async function navigateToPageByTitle(page: Page, title: string): Promise<
     await navItem.scrollIntoViewIfNeeded();
     await navItem.click({ force: true });
 
-    // Wait for content to load
+    // Wait for content to load (deterministic — no trailing fixed sleep needed)
     await page.waitForFunction(
         () => {
             const nodeContent = document.querySelector('#node-content');
@@ -438,7 +441,6 @@ export async function navigateToPageByTitle(page: Page, title: string): Promise<
         undefined,
         { timeout: 10000 },
     );
-    await page.waitForTimeout(500);
 }
 
 /**
@@ -519,8 +521,7 @@ export async function navigateToIdevicePage(page: Page, ideviceId: string, idevi
                 );
 
                 if (found) {
-                    // Small buffer for any remaining DOM settling
-                    await page.waitForTimeout(200);
+                    // The waitForFunction above already proved the page rendered.
                     return true;
                 }
             } catch {}
@@ -595,6 +596,20 @@ export async function navigateToIdevicePage(page: Page, ideviceId: string, idevi
 }
 
 /**
+ * Wait until the navigation node with the given nav-id carries the `selected`
+ * class. `waitForFunction` re-queries the DOM on each poll, so this survives the
+ * Yjs-driven structure re-render that recreates nav elements: the app's
+ * `setNodeSelected()` re-applies `selected` by nav-id after every re-render, so a
+ * held element handle would go stale, but this selector-based check does not.
+ */
+async function waitForNavNodeSelected(page: Page, navId: string, timeout = 10000): Promise<void> {
+    await page.waitForFunction(id => !!document.querySelector(`.nav-element[nav-id="${id}"].selected`), navId, {
+        timeout,
+        polling: 100,
+    });
+}
+
+/**
  * Select a node in the navigation tree by ID
  *
  * @param page - Playwright page
@@ -605,9 +620,13 @@ export async function selectNavNode(page: Page, nodeId: string): Promise<void> {
         const navItem = page.locator(`.nav-element[nav-id="${nodeId}"] > .nav-element-text`).first();
         try {
             await navItem.waitFor({ state: 'visible', timeout: 5000 });
-            await navItem.scrollIntoViewIfNeeded();
-            await navItem.click({ force: true, timeout: 5000 });
-            await page.waitForTimeout(500);
+            // Auto-waiting click() scrolls into view and re-resolves/retries on
+            // detach; an explicit scrollIntoViewIfNeeded + force click defeat that
+            // retry and widen the detach race, so they are intentionally dropped.
+            await navItem.click({ timeout: 5000 });
+            // Deterministic post-condition instead of a fixed sleep: the node is
+            // actually selected once it carries the `selected` class.
+            await waitForNavNodeSelected(page, nodeId);
             return;
         } catch {
             await page.waitForTimeout(250);
@@ -625,13 +644,28 @@ export async function selectFirstPage(page: Page): Promise<void> {
         const selected = document.querySelector('.nav-element.selected:not([nav-id="root"])');
         return !!selected;
     });
-
-    if (!isPageSelected) {
-        const pageNode = page.locator('.nav-element:not([nav-id="root"]) > .nav-element-text').first();
-        await pageNode.scrollIntoViewIfNeeded();
-        await pageNode.click({ force: true });
-        await page.waitForTimeout(500);
+    if (isPageSelected) {
+        return;
     }
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        const firstNode = page.locator('.nav-element:not([nav-id="root"])').first();
+        try {
+            const navId = await firstNode.getAttribute('nav-id');
+            if (!navId) {
+                throw new Error('first non-root page node has no nav-id yet');
+            }
+            // Auto-waiting click() handles scroll + re-resolution on detach, so
+            // scrollIntoViewIfNeeded + force (which defeat that retry) are dropped.
+            await firstNode.locator(':scope > .nav-element-text').click();
+            // Deterministic post-condition instead of a fixed sleep.
+            await waitForNavNodeSelected(page, navId);
+            return;
+        } catch {
+            await page.waitForTimeout(250);
+        }
+    }
+    throw new Error('selectFirstPage: could not select the first non-root page');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1338,9 +1372,6 @@ export async function selectPageByIndex(page: Page, pageIndex: number = 0): Prom
             // Wait for target element to be attached
             await targetNode.waitFor({ state: 'attached', timeout: 5000 });
 
-            // Small delay to let any DOM mutations settle
-            await page.waitForTimeout(100);
-
             await targetNode.scrollIntoViewIfNeeded();
             await targetNode.click({ force: true });
 
@@ -1365,9 +1396,7 @@ export async function selectPageByIndex(page: Page, pageIndex: number = 0): Prom
         throw lastError;
     }
 
-    await page.waitForTimeout(500);
-
-    // Wait for page content area to be ready
+    // Wait for page content area to be ready (deterministic — no fixed sleep)
     await page
         .waitForFunction(
             () => {

--- a/test/e2e/playwright/specs/page-title-workspace-rename.spec.ts
+++ b/test/e2e/playwright/specs/page-title-workspace-rename.spec.ts
@@ -54,6 +54,12 @@ test.describe('Workspace page title rename', () => {
         await page.evaluate(id => {
             (window as any).eXeLearning.app.project.renamePageViaYjs(id, 'New page');
         }, firstId);
+        // renamePageViaYjs re-renders the structure nav asynchronously, recreating
+        // the page node. Wait for that re-render to settle (the renamed node shows
+        // the new text) before selectFirstPage interacts with it, otherwise the
+        // selection races the re-render. The page name renders in `.node-text-span`
+        // (the `.nav-element-text` container also holds the icon node).
+        await expect(page.locator(`.nav-element[nav-id="${firstId}"] .node-text-span`)).toHaveText('New page');
         await selectFirstPage(page);
         // Force the workspace heading to render from the (updated) model.
         await page.evaluate(id => {


### PR DESCRIPTION
## Problem

The `page-title-workspace-rename` E2E spec intermittently fails in CI with `TimeoutError: ... element is not attached to the DOM` (waiting on the nav node). The root cause is in the shared navigation/selection helpers, so the same race can surface in any of the ~20 specs that use them.

`selectFirstPage` / `selectNavNode` clicked a nav node with `{ force: true }` and then slept a fixed `waitForTimeout(500)` — they never waited for the node to actually become **selected**. `force` also defeats Playwright's built-in auto-retry on detach, so when the Yjs-driven structure tree re-renders (e.g. right after `renamePageViaYjs`), the click races the re-render and the element detaches.

## Changes (test-only)

- **`waitForNavNodeSelected()`** — new shared helper that waits on `.nav-element[nav-id].selected`. The app re-applies `selected` by nav-id on every re-render, so this selector re-query is immune to the detach race a held element handle suffers.
- **`selectFirstPage` / `selectNavNode`** — drop `scrollIntoViewIfNeeded` + `force` (auto-waiting `click()` scrolls and retries on detach) and replace the trailing fixed sleep with the deterministic `.selected` post-condition.
- **`gotoWorkarea`** — drop `waitForLoadState('networkidle')`, which never settles cleanly in this Yjs/WebSocket app; the existing `_yjsEnabled` + loading-screen waits are the real readiness signal.
- **`page-title` `prepareFirstPage`** — wait for the renamed page node (`.node-text-span`) to show the new text before selecting it, so the nav re-render settles first.
- Remove redundant fixed sleeps in `navigateToPageByTitle`, `navigateToIdevicePage` and `selectPageByIndex` (each already followed by a deterministic `waitForFunction`).

Net: 6 fixed `waitForTimeout` band-aids removed from the navigation/selection paths and replaced with web-first / `waitForFunction` conditions, per the project's AGENTS.md guidance ("prefer deterministic waits over `waitForTimeout()`").

## Verification

- `--repeat-each=3` across the hover-free `selectFirstPage`/`selectNavNode` callers (rubric, slide, markdown-rendering, project-clone-duplicate, anchor-links, internal-links-roundtrip): **81/81 passed**.
- The `page-title` `toHaveText('New page')` race is resolved (the failure no longer occurs at the rename assertion).

## Scope

Focused on the navigation/selection helpers + the page-title race. Remaining `waitForTimeout` band-aids in content/editor helpers and spec files, the `block-reorder-stability` #1667 flaky, and the collaboration specs' long timeouts are left for follow-ups.