### PR TITLE
ci(e2e): build assets once, shard the suite, merge a single report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,12 +21,61 @@ permissions:
   contents: read
 
 jobs:
+  # Build every asset once and share it with the test shards. Previously each of
+  # the 3 browser jobs rebuilt CSS + bundles independently (3x build); now the
+  # build is paid a single time and downloaded by the shards.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install
+
+      # build:static == build:all (css:node + every bundle) + dist/static, so it
+      # produces both the public/ bundles served by the dynamic server and the
+      # self-contained dist/static used by the static project.
+      - name: Build all assets once
+        run: bun run build:static
+
+      - name: Upload dynamic bundles (chromium/firefox)
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-public
+          retention-days: 1
+          include-hidden-files: true
+          path: |
+            public/app/app.bundle.js
+            public/app/yjs/exporters.bundle.js
+            public/app/yjs/importers.bundle.js
+            public/app/common/i18n/**
+            public/bundles/**
+            public/style/workarea/main.css
+            public/files/perm/idevices/base/slide/edition/slide-editor.bundle.js
+
+      - name: Upload static distribution (static project)
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-static
+          retention-days: 1
+          path: dist/static/**
+
   e2e:
+    needs: build
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # Let every shard finish so the merged report is complete; with fail-fast
+      # a single failing shard would cancel its siblings and hide other results.
+      fail-fast: false
       matrix:
         browser: [chromium, firefox, static]
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout code
@@ -40,11 +89,23 @@ jobs:
       - name: Install Dependencies
         run: bun install
 
-      - name: Build CSS (prod)
-        run: make css
+      # Overlay the prebuilt bundles onto the checked-out tree instead of
+      # rebuilding. The dynamic server (bun src/index.ts) serves public/ via
+      # staticPlugin, so chromium/firefox need build-public; the static project
+      # serves dist/static.
+      - name: Download dynamic bundles
+        if: matrix.browser != 'static'
+        uses: actions/download-artifact@v8
+        with:
+          name: build-public
+          path: public
 
-      - name: Bundle JavaScript
-        run: make bundle
+      - name: Download static distribution
+        if: matrix.browser == 'static'
+        uses: actions/download-artifact@v8
+        with:
+          name: build-static
+          path: dist/static
 
       - name: Install Playwright Browsers
         run: |
@@ -54,12 +115,62 @@ jobs:
             npx playwright install --with-deps ${{ matrix.browser }}
           fi
 
-      - name: E2E Tests (${{ matrix.browser }})
-        run: make test-e2e-${{ matrix.browser }}
+      # Invoke Playwright directly (not the make targets) so the build-once
+      # bundles are not rebuilt: test-e2e-firefox/static carry bundle/build-static
+      # prerequisites that would negate the shared build.
+      - name: E2E Tests (${{ matrix.browser }} ${{ matrix.shard }}/4)
+        run: bun x playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/4 --reporter=blob
 
-      - name: Upload Playwright Report
+      # Give each shard's blob a unique name so cross-project shards (e.g.
+      # chromium-1 and firefox-1, both report-1.zip) don't collide when merged.
+      - name: Stage blob report
+        if: always()
+        run: |
+          mkdir -p staged-blob
+          cp blob-report/*.zip "staged-blob/report-${{ matrix.browser }}-${{ matrix.shard }}.zip"
+
+      - name: Upload blob report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-${{ matrix.browser }}
+          name: blob-${{ matrix.browser }}-${{ matrix.shard }}
+          path: staged-blob/
+          retention-days: 1
+
+  merge-report:
+    needs: e2e
+    # Run even if some shards failed so the report still reflects every shard.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Emit GitHub annotations from merged results
+        run: bun x playwright merge-reports --reporter=github ./all-blob-reports
+
+      - name: Merge into a single HTML report
+        run: bun x playwright merge-reports --reporter=html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
           path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,6 +142,9 @@ jobs:
     # Run even if some shards failed so the report still reflects every shard.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write # allow deleting the intermediate build/blob artifacts
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -174,3 +177,29 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+      # The build-public/build-static/blob-* artifacts are pure run intermediates
+      # (shards consume them, the merge consumes the blobs). Delete them now so
+      # only the merged playwright-report is retained.
+      - name: Delete intermediate artifacts
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const intermediate = /^(build-public|build-static|blob-.*)$/;
+            for (const artifact of data.artifacts) {
+              if (intermediate.test(artifact.name)) {
+                core.info(`Deleting artifact ${artifact.name} (#${artifact.id})`);
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                });
+              }
+            }


### PR DESCRIPTION
Speeds up the E2E workflow without cutting any coverage. Pairs with #2013 (the deterministic-helpers flaky fix); this PR is CI-infra only and can land independently, but is best merged after #2013 so the sharded runs exercise the now-deterministic helpers.

## Before

`.github/workflows/e2e.yml` ran a `browser: [chromium, firefox, static]` matrix — 3 parallel jobs, each independently `bun install` → `make css` → `make bundle` → `playwright install` → the **full ~80-spec suite**. No `--shard`, so wall-clock ≈ the slowest browser job (~20–22 min), and the CSS+bundle build was paid 3× (firefox/static even build twice via their make prerequisites).

## After — build once → shard → merge

- **`build` job**: runs `bun run build:static` a single time (`build:all` = `css:node` + every bundle, then `dist/static`) and shares the outputs as artifacts:
  - `build-public` — the generated `public/` bundles the dynamic server serves via `staticPlugin({ assets: 'public' })` (chromium/firefox).
  - `build-static` — the self-contained `dist/static` PWA build (static project).
- **`e2e` job**: matrix is now `browser × shard` with `shard: [1,2,3,4]` → **12 parallel shards**, `fail-fast: false`. Each shard downloads the prebuilt artifacts (overlaid onto the checkout) and invokes Playwright **directly** with `--shard=i/4 --reporter=blob` — not the `make` targets, which would rebuild and negate build-once. Each shard's blob is staged under a unique `report-<browser>-<shard>.zip` name to avoid cross-project collisions.
- **`merge-report` job** (`if: !cancelled()`): merges all shard blobs into one HTML report + GitHub annotations via `playwright merge-reports`.

## Coverage is preserved

Firefox still runs the **full** suite (now sharded — catches Gecko-only regressions; the config sets `serviceWorkers: 'allow'` for it). The `sqlite/postgres/mariadb` matrix stays **merge-only** in `e2e-db-matrix.yml` (it already isn't on PRs).

## Expected impact

~22 → ~12 min wall-clock (~45% faster); CI-minutes stay roughly flat because the 3× build is eliminated.

## Verification

Locally confirmed: `bun run build:static` produces `dist/static` (95 MB, with `index.html`) plus all seven `build-public` bundle paths; the `blob → staged → playwright merge-reports --reporter=html` round-trip yields a single `playwright-report/index.html`. The full 12-shard orchestration + artifact overlay are validated by this PR's own CI run.

## Notes

- Action versions match the repo's existing pins (`checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`, `setup-bun@v2`).
- `actions/cache` was intentionally left out (the repo uses it nowhere, so its resolved version here is unknown); bun-install + Playwright-browser caching can be a small fast-follow once a known-good version is confirmed.
- If the org's concurrency cap (~20 jobs) causes queueing, drop the shard count from 4 to 3.