### PR TITLE
fix(file-manager): keep selection on collaborative Yjs refresh; deterministic save wait

### DIFF
--- a/public/app/workarea/modals/modals/pages/modalFileManager.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.js
@@ -1044,10 +1044,37 @@ export default class ModalFilemanager extends Modal {
                 });
             }
         } else if (!this.multiSelect) {
-            // Single select mode - reset selection on view change
-            this.selectedAsset = null;
-            this.selectedAssets = [];
-            this.showSidebarEmpty();
+            // Single select mode - preserve the current selection across
+            // re-renders (e.g. a remote Yjs asset change triggers loadAssets ->
+            // applyFiltersAndRender -> renderCurrentView). Only clear when the
+            // selected asset is no longer present in the rendered list.
+            const currentAsset = this.selectedAsset
+                ? this.filteredAssets.find(a => a.id === this.selectedAsset.id)
+                : null;
+            if (currentAsset) {
+                // Refresh the reference to the freshly-rebuilt asset object and
+                // re-apply the visual selection to its grid item / list row.
+                this.selectedAsset = currentAsset;
+                if (this.viewMode === 'grid' && this.grid) {
+                    this.grid.querySelectorAll('.media-library-item').forEach(el => {
+                        if (el.dataset.assetId === currentAsset.id) {
+                            el.classList.add('selected');
+                        }
+                    });
+                } else if (this.listTbody) {
+                    this.listTbody.querySelectorAll('tr').forEach(el => {
+                        if (el.dataset.assetId === currentAsset.id) {
+                            el.classList.add('selected');
+                        }
+                    });
+                }
+                this.showSidebarContent(currentAsset);
+            } else {
+                // Selection is gone - reset and empty the sidebar.
+                this.selectedAsset = null;
+                this.selectedAssets = [];
+                this.showSidebarEmpty();
+            }
         }
     }
 

--- a/public/app/workarea/modals/modals/pages/modalFileManager.test.js
+++ b/public/app/workarea/modals/modals/pages/modalFileManager.test.js
@@ -760,6 +760,98 @@ it('should filter by accept=3d for 3D models', () => {
     });
   });
 
+  describe('renderCurrentView - single-select preservation (collaborative Yjs refresh)', () => {
+    it('preserves the single-select selection when the asset survives a re-render', () => {
+      const asset = { id: 'a1', filename: 'keep.png', mime: 'image/png', blob: new Blob(['x']) };
+      modal.multiSelect = false;
+      modal.viewMode = 'grid';
+      modal.selectedAsset = asset;
+      modal.selectedAssets = [];
+      modal.selectedFolder = null;
+      modal.filteredAssets = [asset];
+
+      const showContentSpy = vi.spyOn(modal, 'showSidebarContent').mockResolvedValue();
+      const showEmptySpy = vi.spyOn(modal, 'showSidebarEmpty');
+
+      modal.renderCurrentView();
+
+      // Selection reference is kept (points at the freshly-rendered asset).
+      expect(modal.selectedAsset).toBe(asset);
+      // Sidebar shows the asset details instead of being emptied.
+      expect(showContentSpy).toHaveBeenCalledWith(asset);
+      expect(showEmptySpy).not.toHaveBeenCalled();
+      // Visual selection is re-applied to the matching grid item.
+      const item = modal.grid.querySelector('.media-library-item[data-asset-id="a1"]');
+      expect(item).not.toBeNull();
+      expect(item.classList.contains('selected')).toBe(true);
+      // Single selection keeps the rename button enabled.
+      expect(modal.renameBtn.disabled).toBe(false);
+    });
+
+    it('re-applies the selection to the matching list row in list view', () => {
+      const asset = { id: 'a1', filename: 'keep.png', mime: 'image/png', blob: new Blob(['x']) };
+      modal.multiSelect = false;
+      modal.viewMode = 'list';
+      modal.selectedAsset = asset;
+      modal.selectedAssets = [];
+      modal.selectedFolder = null;
+      modal.filteredAssets = [asset];
+
+      vi.spyOn(modal, 'showSidebarContent').mockResolvedValue();
+
+      modal.renderCurrentView();
+
+      expect(modal.selectedAsset).toBe(asset);
+      const row = modal.listTbody.querySelector('tr[data-asset-id="a1"]');
+      expect(row).not.toBeNull();
+      expect(row.classList.contains('selected')).toBe(true);
+    });
+
+    it('refreshes the selection reference to the rebuilt asset object with the same id', () => {
+      const oldAsset = { id: 'a1', filename: 'old.png', mime: 'image/png', blob: new Blob(['x']) };
+      const rebuiltAsset = { id: 'a1', filename: 'renamed.png', mime: 'image/png', blob: new Blob(['x']) };
+      modal.multiSelect = false;
+      modal.viewMode = 'grid';
+      modal.selectedAsset = oldAsset;
+      modal.selectedAssets = [];
+      modal.selectedFolder = null;
+      // The remote refresh rebuilt the list with a new object instance.
+      modal.filteredAssets = [rebuiltAsset];
+
+      const showContentSpy = vi.spyOn(modal, 'showSidebarContent').mockResolvedValue();
+
+      modal.renderCurrentView();
+
+      // The reference is updated to the freshly-rebuilt object, not the stale one.
+      expect(modal.selectedAsset).toBe(rebuiltAsset);
+      expect(showContentSpy).toHaveBeenCalledWith(rebuiltAsset);
+    });
+
+    it('clears the single-select selection when the asset is gone after a re-render', () => {
+      const removedAsset = { id: 'a1', filename: 'gone.png', mime: 'image/png', blob: new Blob(['x']) };
+      const otherAsset = { id: 'a2', filename: 'other.png', mime: 'image/png', blob: new Blob(['x']) };
+      modal.multiSelect = false;
+      modal.viewMode = 'grid';
+      modal.selectedAsset = removedAsset;
+      modal.selectedAssets = [];
+      modal.selectedFolder = null;
+      // The removed asset is no longer in the rendered list.
+      modal.filteredAssets = [otherAsset];
+
+      const showContentSpy = vi.spyOn(modal, 'showSidebarContent').mockResolvedValue();
+      const showEmptySpy = vi.spyOn(modal, 'showSidebarEmpty');
+
+      modal.renderCurrentView();
+
+      expect(modal.selectedAsset).toBeNull();
+      expect(modal.selectedAssets).toEqual([]);
+      expect(showEmptySpy).toHaveBeenCalled();
+      expect(showContentSpy).not.toHaveBeenCalledWith(removedAsset);
+      // With nothing selected the rename button is disabled again.
+      expect(modal.renameBtn.disabled).toBe(true);
+    });
+  });
+
   describe('showEmptyState/hideEmptyState', () => {
     it('should show empty state and hide grid/list', () => {
       modal.showEmptyState();

--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -531,11 +531,13 @@ describe('ElpxImporter', () => {
         it('rejects a per-entry decompression bomb without inflating it', async () => {
             const fflate = await import('fflate');
 
-            // 200 MB of zeros compresses to ~200 KB (a ~1000:1 bomb). With a 5 MB
-            // per-entry cap the importer must refuse it BEFORE inflation. fflate
-            // reads originalSize from the central directory in the filter callback,
-            // so the 200 MB is never materialised.
-            const bombPayload = new Uint8Array(200 * 1024 * 1024);
+            // A 2 MB run of zeros compresses to a few KB (a strong bomb ratio). With a
+            // 1 MB per-entry cap the importer must refuse it BEFORE inflation. fflate
+            // reads originalSize from the central directory in the filter callback, so
+            // the payload is never materialised — the absolute size is irrelevant to the
+            // guard, only originalSize > cap matters, so a small payload exercises the
+            // same code path while keeping zipSync at milliseconds.
+            const bombPayload = new Uint8Array(2 * 1024 * 1024);
             const zip = fflate.zipSync(
                 {
                     'content.xml': new TextEncoder().encode(minimalContentXml),
@@ -544,11 +546,11 @@ describe('ElpxImporter', () => {
                 { level: 6 },
             );
             // Sanity: the crafted archive really is tiny on disk (the DoS vector).
-            expect(zip.length).toBeLessThan(2 * 1024 * 1024);
+            expect(zip.length).toBeLessThan(64 * 1024);
 
             const ydoc = new Y.Doc();
             const importer = new ElpxImporter(ydoc, null, silentLogger, {
-                maxEntryBytes: 5 * 1024 * 1024,
+                maxEntryBytes: 1 * 1024 * 1024,
             });
 
             await expect(importer.importFromBuffer(zip)).rejects.toThrow(ZipLimitError);
@@ -561,19 +563,21 @@ describe('ElpxImporter', () => {
             const fflate = await import('fflate');
 
             // Several individually-acceptable entries that together blow the total cap.
-            const chunk = new Uint8Array(2 * 1024 * 1024); // 2 MB each (compresses small)
+            // Each entry's originalSize is read from the central directory, so small
+            // zeroed chunks keep zipSync at milliseconds while still tripping the guard.
+            const chunk = new Uint8Array(1 * 1024 * 1024); // 1 MB each (compresses small)
             const entries: Record<string, Uint8Array> = {
                 'content.xml': new TextEncoder().encode(minimalContentXml),
             };
-            for (let i = 0; i < 10; i++) {
+            for (let i = 0; i < 5; i++) {
                 entries[`pad-${i}.bin`] = chunk;
             }
             const zip = fflate.zipSync(entries, { level: 6 });
 
             const ydoc = new Y.Doc();
             const importer = new ElpxImporter(ydoc, null, silentLogger, {
-                maxEntryBytes: 5 * 1024 * 1024, // each entry passes
-                maxTotalBytes: 8 * 1024 * 1024, // but the sum does not
+                maxEntryBytes: 2 * 1024 * 1024, // each 1 MB entry passes
+                maxTotalBytes: 4 * 1024 * 1024, // but the 5 MB sum does not
             });
 
             await expect(importer.importFromBuffer(zip)).rejects.toThrow(ZipLimitError);
@@ -608,20 +612,22 @@ describe('ElpxImporter', () => {
             const fflate = await import('fflate');
 
             // Inner ELP carries the bomb; the outer ZIP wraps it as a single .elp entry,
-            // exercising the nested-ELP branch in importFromBuffer.
+            // exercising the nested-ELP branch in importFromBuffer. A 2 MB zeroed payload
+            // over a 1 MB cap trips the same guard as a huge one (originalSize is read
+            // from the central directory, never inflated) while staying fast.
             const innerBomb = fflate.zipSync(
                 {
                     'content.xml': new TextEncoder().encode(minimalContentXml),
-                    'bomb.bin': new Uint8Array(200 * 1024 * 1024),
+                    'bomb.bin': new Uint8Array(2 * 1024 * 1024),
                 },
                 { level: 6 },
             );
             const outerZip = fflate.zipSync({ 'project.elp': innerBomb }, { level: 6 });
-            expect(outerZip.length).toBeLessThan(2 * 1024 * 1024);
+            expect(outerZip.length).toBeLessThan(64 * 1024);
 
             const ydoc = new Y.Doc();
             const importer = new ElpxImporter(ydoc, null, silentLogger, {
-                maxEntryBytes: 5 * 1024 * 1024,
+                maxEntryBytes: 1 * 1024 * 1024,
             });
 
             await expect(importer.importFromBuffer(outerZip)).rejects.toThrow(ZipLimitError);

--- a/test/e2e/playwright/specs/block-reorder-stability.spec.ts
+++ b/test/e2e/playwright/specs/block-reorder-stability.spec.ts
@@ -337,8 +337,28 @@ test.describe('Block reorder stability — issue #1665', () => {
             const saveBtn = open?.querySelector('.btn-save-idevice') as HTMLElement | null;
             saveBtn?.click();
         });
+        // The idevice save button is disabled synchronously while the async
+        // save() runs, and edition mode only exits once that save fully
+        // resolves. Key off that real lifecycle instead of racing a bare
+        // edition-close timeout: first confirm the save is in flight (the save
+        // button became disabled), then wait for completion — edition mode gone
+        // AND no save button left stuck in the disabled in-flight state.
         await page.waitForFunction(
-            () => !document.querySelector('#node-content div.idevice_node[mode="edition"]'),
+            () => {
+                const saveBtn = document.querySelector(
+                    '#node-content div.idevice_node[mode="edition"] .btn-save-idevice',
+                ) as HTMLButtonElement | null;
+                return !!saveBtn && saveBtn.disabled;
+            },
+            undefined,
+            { timeout: 10000 },
+        );
+        await page.waitForFunction(
+            () => {
+                const stillEditing = document.querySelector('#node-content div.idevice_node[mode="edition"]');
+                const inFlightSaveBtn = document.querySelector('#node-content .btn-save-idevice[disabled]');
+                return !stillEditing && !inFlightSaveBtn;
+            },
             undefined,
             { timeout: 10000 },
         );


### PR DESCRIPTION
Fixes two flaky E2E tests by addressing the underlying app races.

1. **File Manager selection lost on collaborative refresh (real UX bug).** In single-select mode, `renderCurrentView` cleared `selectedAsset` on every re-render, so an incoming **remote Yjs asset change** wiped the current user's selection and disabled the rename button. Now the selection is preserved when the asset still exists (mirrors the multiselect branch); it is cleared only when the asset is gone. Fixes `collaborative/file-manager.spec.ts` and adds 4 Vitest cases.
2. **Async save race (#1667).** `block-reorder-stability.spec.ts` now waits on the real save lifecycle (save button disabled → edition closed + button re-enabled) instead of racing a bare 10s edition-close wait. No timeout bump.

Vitest: `modalFileManager.test.js` green (360 passed).