### PR TITLE
test(e2e): wait for file grid to populate before reading filenames (fix unicode flaky)

### DIFF
--- a/test/e2e/playwright/specs/file-manager-special-chars.spec.ts
+++ b/test/e2e/playwright/specs/file-manager-special-chars.spec.ts
@@ -1260,6 +1260,9 @@ test.describe('File Manager - Special Characters', () => {
             await openFileManagerViaTinyMCE(page);
 
             // Verify file still exists with correct name
+            // Wait for the grid to repopulate after reload before reading filenames
+            // (Firefox can return an empty list if the read races the async render).
+            await waitForFileInGrid(page, filename);
             const files = await getAllFilenames(page);
             expect(files).toContain(filename);
         });


### PR DESCRIPTION
`file-manager-special-chars.spec.ts` "should preserve unicode filename after save and reload" flaked on Firefox because `getAllFilenames()` ran before the grid repopulated after reload (returned `[]`). Now waits on the existing `waitForFileInGrid(page, filename)` helper before reading. Test-only, 3 lines.