### PR TITLE
ci(e2e): make sharded workflow re-runnable + de-flake 4 slow-runner specs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,9 @@ on:
       - main
       - tikismaker
       - 'release/*'
+  # Allow maintainers to trigger extra runs by hand (e.g. to sample for flaky
+  # specs, or to exercise the re-run path) without pushing a new commit.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,6 +51,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-public
+          # Overwrite instead of 409-conflicting when a re-run reuploads over the
+          # artifact retained from the failed attempt.
+          overwrite: true
           retention-days: 1
           include-hidden-files: true
           path: |
@@ -63,6 +69,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-static
+          overwrite: true
           retention-days: 1
           path: dist/static/**
 
@@ -134,6 +141,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: blob-${{ matrix.browser }}-${{ matrix.shard }}
+          # A re-run of this shard reuploads its blob over the one retained from
+          # the failed attempt; overwrite rather than 409-conflict.
+          overwrite: true
           path: staged-blob/
           retention-days: 1
 
@@ -165,7 +175,12 @@ jobs:
           merge-multiple: true
 
       - name: Emit GitHub annotations from merged results
-        run: bun x playwright merge-reports --reporter=github ./all-blob-reports
+        # download-artifact creates no directory when zero blob-* match (e.g. a
+        # catastrophic all-shards-fail run); create it so merge-reports surfaces
+        # its own "no reports" message instead of crashing on a missing directory.
+        run: |
+          mkdir -p all-blob-reports
+          bun x playwright merge-reports --reporter=github ./all-blob-reports
 
       - name: Merge into a single HTML report
         run: bun x playwright merge-reports --reporter=html ./all-blob-reports
@@ -175,14 +190,23 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
+          overwrite: true
           path: playwright-report/
           retention-days: 14
 
       # The build-public/build-static/blob-* artifacts are pure run intermediates
-      # (shards consume them, the merge consumes the blobs). Delete them now so
-      # only the merged playwright-report is retained.
+      # (shards consume them, the merge consumes the blobs). Delete them on a
+      # fully-green run so only the merged playwright-report is retained.
+      #
+      # Only delete when the whole E2E matrix passed. On a failed run the
+      # intermediates must survive so "Re-run failed jobs" works: that feature
+      # reuses the already-successful build/shard jobs WITHOUT re-running them, so
+      # if their artifacts were deleted the re-run shard can't download
+      # build-public and the re-run merge finds no blob-* to merge. A step `if:`
+      # without a status function implicitly ANDs success(), so this also skips
+      # (retaining the artifacts) if any earlier merge-report step fails.
       - name: Delete intermediate artifacts
-        if: always()
+        if: ${{ needs.e2e.result == 'success' }}
         uses: actions/github-script@v9
         with:
           script: |

--- a/test/e2e/playwright/helpers/workarea-helpers.ts
+++ b/test/e2e/playwright/helpers/workarea-helpers.ts
@@ -1460,22 +1460,37 @@ export async function addPage(page: Page, name: string = 'New Page'): Promise<st
  * @param blockId - The block element ID (without the 'dropdownMenuButton' prefix)
  * @returns The Download object for the exported file
  */
-export async function exportBlock(page: Page, blockId: string): Promise<Download> {
-    // Click on the block's actions dropdown button (three dots)
-    const dropdownBtn = page.locator(`#dropdownMenuButton${blockId}`);
+/**
+ * Open a "three dots" actions dropdown and resolve once the target menu item is
+ * visible. The first toggle click is occasionally missed (notably on Firefox),
+ * leaving the item present-but-hidden, so re-toggle until the menu is actually
+ * open instead of racing a fixed sleep — the flaky export in
+ * component-export-import.
+ */
+async function openActionsDropdown(page: Page, dropdownSelector: string, itemSelector: string): Promise<void> {
+    const dropdownBtn = page.locator(dropdownSelector);
+    const item = page.locator(itemSelector);
     await dropdownBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await dropdownBtn.click();
-    await page.waitForTimeout(300);
+    for (let attempt = 0; attempt < 5; attempt++) {
+        if (await item.isVisible().catch(() => false)) return;
+        await dropdownBtn.click();
+        const opened = await item
+            .waitFor({ state: 'visible', timeout: 2000 })
+            .then(() => true)
+            .catch(() => false);
+        if (opened) return;
+    }
+    // Surface a clear failure if the menu never opened after retries.
+    await item.waitFor({ state: 'visible', timeout: 5000 });
+}
 
-    // Wait for download event and click export button
+export async function exportBlock(page: Page, blockId: string): Promise<Download> {
+    const exportSelector = `#dropdownBlockMore-button-export${blockId}`;
+    await openActionsDropdown(page, `#dropdownMenuButton${blockId}`, exportSelector);
+
     const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
-
-    const exportBtn = page.locator(`#dropdownBlockMore-button-export${blockId}`);
-    await exportBtn.waitFor({ state: 'visible', timeout: 5000 });
-    await exportBtn.click();
-
-    const download = await downloadPromise;
-    return download;
+    await page.locator(exportSelector).click();
+    return await downloadPromise;
 }
 
 /**
@@ -1486,21 +1501,12 @@ export async function exportBlock(page: Page, blockId: string): Promise<Download
  * @returns The Download object for the exported file
  */
 export async function exportIdevice(page: Page, ideviceId: string): Promise<Download> {
-    // Click on the iDevice's actions dropdown button (three dots horizontal)
-    const dropdownBtn = page.locator(`#dropdownMenuButtonIdevice${ideviceId}`);
-    await dropdownBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await dropdownBtn.click();
-    await page.waitForTimeout(300);
+    const exportSelector = `#exportIdevice${ideviceId}`;
+    await openActionsDropdown(page, `#dropdownMenuButtonIdevice${ideviceId}`, exportSelector);
 
-    // Wait for download event and click export button
     const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
-
-    const exportBtn = page.locator(`#exportIdevice${ideviceId}`);
-    await exportBtn.waitFor({ state: 'visible', timeout: 5000 });
-    await exportBtn.click();
-
-    const download = await downloadPromise;
-    return download;
+    await page.locator(exportSelector).click();
+    return await downloadPromise;
 }
 
 /**
@@ -1534,6 +1540,25 @@ export async function importComponent(page: Page, filePath: string): Promise<voi
 
     // Wait for the file input to be available
     await fileInput.waitFor({ state: 'attached', timeout: 10000 });
+
+    // The import inserts into the currently-selected page: modalOpenUserOdeFiles
+    // reads the selected nav node's nav-id and ComponentImporter.findPage() must
+    // resolve it in the Yjs structure. On a freshly created project the nav tree
+    // can render before the Yjs document has that page, so importing immediately
+    // failed with "Import error: Target page not found" and nothing rendered
+    // (the flaky component-export-import imports on the DB matrix). Wait for the
+    // selected page to actually exist in Yjs first — a deterministic precondition,
+    // not a fixed sleep or a longer render timeout.
+    await page.waitForFunction(
+        () => {
+            const app = (window as any).eXeLearning?.app;
+            const navId = app?.menus?.menuStructure?.menuStructureBehaviour?.nodeSelected?.getAttribute('nav-id');
+            if (!navId) return false;
+            return !!app?.project?._yjsBridge?.structureBinding?.getPage?.(navId);
+        },
+        undefined,
+        { timeout: 15000 },
+    );
 
     // Set the file - this triggers the import directly
     await fileInput.setInputFiles(filePath);

--- a/test/e2e/playwright/helpers/workarea-helpers.ts
+++ b/test/e2e/playwright/helpers/workarea-helpers.ts
@@ -1322,21 +1322,34 @@ export async function enableSearchOption(page: Page): Promise<void> {
  * Handles the rename modal that appears after cloning by pressing Escape
  */
 export async function cloneCurrentPage(page: Page): Promise<void> {
+    const navSelector = '.nav-element:not([nav-id="root"]) > .nav-element-text';
+    const countBefore = await page.locator(navSelector).count();
+
     // Dismiss any blocking alert modal before attempting to click the clone button
     await dismissBlockingAlertModal(page);
     const cloneBtn = page.locator('.button_nav_action.action_clone');
     await cloneBtn.waitFor({ state: 'visible', timeout: 5000 });
     await cloneBtn.click();
-    await page.waitForTimeout(500);
 
-    // Close rename modal by pressing Escape
+    // Cloning opens a rename modal; close it with Escape once it is actually
+    // shown instead of racing a fixed sleep.
+    await page
+        .waitForFunction(() => !!document.querySelector('.modal.show'), undefined, { timeout: 5000 })
+        .catch(() => {});
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(500);
-
-    // Wait for modal to close
     await page
         .waitForFunction(() => !document.querySelector('.modal.show'), undefined, { timeout: 5000 })
         .catch(() => {});
+
+    // Wait for the clone to be reflected in the navigation tree before returning.
+    // This previously used fixed 500ms sleeps, so on slow runners the nav was
+    // still re-rendering when the next selectPageByIndex() ran and its target
+    // node detached mid-scroll — the flaky search-preview-navigation failure.
+    await page.waitForFunction(
+        n => document.querySelectorAll('.nav-element:not([nav-id="root"]) > .nav-element-text').length > n,
+        countBefore,
+        { timeout: 15000 },
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1372,7 +1385,12 @@ export async function selectPageByIndex(page: Page, pageIndex: number = 0): Prom
             // Wait for target element to be attached
             await targetNode.waitFor({ state: 'attached', timeout: 5000 });
 
-            await targetNode.scrollIntoViewIfNeeded();
+            // A concurrent nav re-render can detach this node between the
+            // attached-wait and the scroll; the scroll is only a best-effort
+            // pre-step, so ignore a detach here — the force click below
+            // re-resolves and scrolls itself (a detach during the click falls
+            // through to the retry loop).
+            await targetNode.scrollIntoViewIfNeeded().catch(() => {});
             await targetNode.click({ force: true });
 
             // Click succeeded, exit the retry loop

--- a/test/e2e/playwright/specs/block-reorder-stability.spec.ts
+++ b/test/e2e/playwright/specs/block-reorder-stability.spec.ts
@@ -9,6 +9,7 @@ import {
     saveProject,
     openElpFile,
     addIdevice,
+    waitForTinyMCEReady,
 } from '../helpers/workarea-helpers';
 
 /**
@@ -326,36 +327,30 @@ test.describe('Block reorder stability — issue #1665', () => {
         await addIdevice(page, 'text');
         await waitForDomAndYjsBlockCount(page, sourcePageId, 2);
 
-        // Newly-added text iDevices auto-enter edition mode. While any
-        // iDevice is in edition, projectManager.checkOpenIdevice() is
-        // truthy and the block arrow click handlers return silently.
-        // Save the open iDevice (if any) so the subsequent arrow clicks
-        // are actually processed. Mirrors what a real user would do
-        // before touching block controls.
-        await page.evaluate(() => {
-            const open = document.querySelector('#node-content div.idevice_node[mode="edition"]');
-            const saveBtn = open?.querySelector('.btn-save-idevice') as HTMLElement | null;
-            saveBtn?.click();
-        });
-        // The idevice save is async: the save button is disabled synchronously
-        // (toogleIdeviceButtonsState(true)) while save() runs and the
-        // [mode="edition"] node — button included — is removed once it resolves.
-        // Wait directly for that terminal state: edition mode gone AND no save
-        // button left stuck in the disabled in-flight state. This alone is both
-        // sufficient and race-free — edition mode is still active when we click
-        // save above, so it resolves exactly when the save completes, whether the
-        // save is instantaneous or in flight. (A previous version first waited for
-        // the transient "button disabled" in-flight state, but a fast save removed
-        // the edition node before that poll ran, so the in-flight wait timed out —
-        // the flaky 10s timeout in regression #1667.)
+        // Newly-added text iDevices auto-enter edition mode with a TinyMCE
+        // editor. While any iDevice is in edition, checkOpenIdevice() is truthy
+        // and the block arrow handlers return silently, so the open iDevice must
+        // be saved (closed) first — as a real user would before touching block
+        // controls.
+        //
+        // This save is the flaky part of regression #1667: on slower runners
+        // (notably the postgres/mariadb E2E matrix) clicking save before the
+        // editor has finished initializing — or while the action buttons are
+        // still disabled by toogleIdeviceButtonsState() — does nothing, so the
+        // iDevice stays stuck in edition mode and the edition-exit wait times
+        // out. Guard both races with the project's own helpers: wait for TinyMCE
+        // to be ready, use a Playwright click (which auto-waits for the button to
+        // be enabled/actionable rather than firing on a disabled one), and give
+        // edition-exit the same 15s budget as waitForIdeviceEditionEnd().
+        await waitForTinyMCEReady(page);
+        await page
+            .locator('#node-content div.idevice_node[mode="edition"] .btn-save-idevice')
+            .first()
+            .click({ timeout: 15000 });
         await page.waitForFunction(
-            () => {
-                const stillEditing = document.querySelector('#node-content div.idevice_node[mode="edition"]');
-                const inFlightSaveBtn = document.querySelector('#node-content .btn-save-idevice[disabled]');
-                return !stillEditing && !inFlightSaveBtn;
-            },
+            () => !document.querySelector('#node-content div.idevice_node[mode="edition"]'),
             undefined,
-            { timeout: 10000 },
+            { timeout: 15000 },
         );
 
         const twoBlocksOrder = await readBlockOrderFromYjs(page, sourcePageId);

--- a/test/e2e/playwright/specs/block-reorder-stability.spec.ts
+++ b/test/e2e/playwright/specs/block-reorder-stability.spec.ts
@@ -337,22 +337,17 @@ test.describe('Block reorder stability — issue #1665', () => {
             const saveBtn = open?.querySelector('.btn-save-idevice') as HTMLElement | null;
             saveBtn?.click();
         });
-        // The idevice save button is disabled synchronously while the async
-        // save() runs, and edition mode only exits once that save fully
-        // resolves. Key off that real lifecycle instead of racing a bare
-        // edition-close timeout: first confirm the save is in flight (the save
-        // button became disabled), then wait for completion — edition mode gone
-        // AND no save button left stuck in the disabled in-flight state.
-        await page.waitForFunction(
-            () => {
-                const saveBtn = document.querySelector(
-                    '#node-content div.idevice_node[mode="edition"] .btn-save-idevice',
-                ) as HTMLButtonElement | null;
-                return !!saveBtn && saveBtn.disabled;
-            },
-            undefined,
-            { timeout: 10000 },
-        );
+        // The idevice save is async: the save button is disabled synchronously
+        // (toogleIdeviceButtonsState(true)) while save() runs and the
+        // [mode="edition"] node — button included — is removed once it resolves.
+        // Wait directly for that terminal state: edition mode gone AND no save
+        // button left stuck in the disabled in-flight state. This alone is both
+        // sufficient and race-free — edition mode is still active when we click
+        // save above, so it resolves exactly when the save completes, whether the
+        // save is instantaneous or in flight. (A previous version first waited for
+        // the transient "button disabled" in-flight state, but a fast save removed
+        // the edition node before that poll ran, so the in-flight wait timed out —
+        // the flaky 10s timeout in regression #1667.)
         await page.waitForFunction(
             () => {
                 const stillEditing = document.querySelector('#node-content div.idevice_node[mode="edition"]');

--- a/test/e2e/playwright/specs/collaborative/file-manager.spec.ts
+++ b/test/e2e/playwright/specs/collaborative/file-manager.spec.ts
@@ -266,13 +266,28 @@ test.describe('Collaborative File Manager', () => {
                 await cancelBtnA.click();
             }
 
-            // Wait for WebSocket sync (asset-renamed message)
-            await pageA.waitForTimeout(500);
+            // Wait for the rename to actually propagate into Client B's Yjs
+            // document — the renamed asset appearing in B's assets map is the real
+            // cross-client sync signal. The previous version raced the File
+            // Manager DOM render against A→server→B WebSocket propagation with a
+            // 15s DOM poll, which timed out under CI load; key off the synced
+            // state directly (per-test budget is 90s).
+            await pageB.waitForFunction(
+                (expected: string) => {
+                    const app = (window as any).eXeLearning?.app;
+                    const assets = app?.project?._yjsBridge?.assetManager?.getAllAssetsMetadata?.() || [];
+                    const base = expected.replace('.jpg', '');
+                    return assets.some((a: { filename?: string }) => (a?.filename || '').includes(base));
+                },
+                newFilename,
+                { timeout: 45000 },
+            );
 
-            // Client B opens File Manager to verify the renamed file
+            // Client B opens File Manager; the synced asset is already in B's Yjs
+            // map, so the initial load renders it without an observer-timing race.
             await openFileManager(pageB);
 
-            // Wait for file to appear in Client B's file manager
+            // Confirm the file is rendered in Client B's file manager.
             await pageB.waitForFunction(
                 () => {
                     const items = document.querySelectorAll(

--- a/test/e2e/playwright/specs/component-export-import.spec.ts
+++ b/test/e2e/playwright/specs/component-export-import.spec.ts
@@ -173,6 +173,10 @@ test.describe('Component Export/Import', () => {
 
     test('should undo imported block and imported iDevice', async ({ authenticatedPage, createProject }, testInfo) => {
         skipInStaticMode(test, testInfo, 'Requires Yjs undo manager in dynamic mode');
+        // Two full export→import→undo round-trips; the component import parses a
+        // file and inserts into Yjs before the node renders, which is slow on the
+        // cold postgres/mariadb E2E matrix — give it headroom over the default 45s.
+        test.setTimeout(90000);
         const page = authenticatedPage;
         const localTempDir = fs.mkdtempSync(path.join('/tmp', 'exelearning-e2e-undo-import-'));
 
@@ -218,7 +222,7 @@ test.describe('Component Export/Import', () => {
         await page.waitForFunction(
             () => document.querySelectorAll('#node-content article .idevice_node').length > 0,
             undefined,
-            { timeout: 15000 },
+            { timeout: 30000 },
         );
         await waitForUndoAvailable(page, 15000);
         await pressUndo(page);
@@ -233,7 +237,7 @@ test.describe('Component Export/Import', () => {
         await page.waitForFunction(
             () => document.querySelectorAll('#node-content article .idevice_node').length > 0,
             undefined,
-            { timeout: 15000 },
+            { timeout: 30000 },
         );
         await waitForUndoAvailable(page, 15000);
         await pressUndo(page);
@@ -609,6 +613,10 @@ test.describe('Component Export/Import with Images', () => {
          * Page "Inicio" contains a text iDevice with 1 image (00.jpg)
          */
         const page = authenticatedPage;
+        // Importing a block WITH an image adds an asset upload / resolution step
+        // on top of the parse+Yjs insert, which is slow on the cold
+        // postgres/mariadb E2E matrix — give it headroom over the default 45s.
+        test.setTimeout(90000);
 
         // 1. Open the fixture ELPX file
         console.log('Opening fixture ELPX file with images...');
@@ -663,7 +671,7 @@ test.describe('Component Export/Import with Images', () => {
                 return idevices.length >= 1;
             },
             undefined,
-            { timeout: 15000 },
+            { timeout: 30000 },
         );
 
         // Verify the imported block appears

--- a/test/e2e/playwright/specs/component-export-import.spec.ts
+++ b/test/e2e/playwright/specs/component-export-import.spec.ts
@@ -173,10 +173,6 @@ test.describe('Component Export/Import', () => {
 
     test('should undo imported block and imported iDevice', async ({ authenticatedPage, createProject }, testInfo) => {
         skipInStaticMode(test, testInfo, 'Requires Yjs undo manager in dynamic mode');
-        // Two full export→import→undo round-trips; the component import parses a
-        // file and inserts into Yjs before the node renders, which is slow on the
-        // cold postgres/mariadb E2E matrix — give it headroom over the default 45s.
-        test.setTimeout(90000);
         const page = authenticatedPage;
         const localTempDir = fs.mkdtempSync(path.join('/tmp', 'exelearning-e2e-undo-import-'));
 
@@ -222,7 +218,7 @@ test.describe('Component Export/Import', () => {
         await page.waitForFunction(
             () => document.querySelectorAll('#node-content article .idevice_node').length > 0,
             undefined,
-            { timeout: 30000 },
+            { timeout: 15000 },
         );
         await waitForUndoAvailable(page, 15000);
         await pressUndo(page);
@@ -237,7 +233,7 @@ test.describe('Component Export/Import', () => {
         await page.waitForFunction(
             () => document.querySelectorAll('#node-content article .idevice_node').length > 0,
             undefined,
-            { timeout: 30000 },
+            { timeout: 15000 },
         );
         await waitForUndoAvailable(page, 15000);
         await pressUndo(page);
@@ -613,10 +609,6 @@ test.describe('Component Export/Import with Images', () => {
          * Page "Inicio" contains a text iDevice with 1 image (00.jpg)
          */
         const page = authenticatedPage;
-        // Importing a block WITH an image adds an asset upload / resolution step
-        // on top of the parse+Yjs insert, which is slow on the cold
-        // postgres/mariadb E2E matrix — give it headroom over the default 45s.
-        test.setTimeout(90000);
 
         // 1. Open the fixture ELPX file
         console.log('Opening fixture ELPX file with images...');
@@ -671,7 +663,7 @@ test.describe('Component Export/Import with Images', () => {
                 return idevices.length >= 1;
             },
             undefined,
-            { timeout: 30000 },
+            { timeout: 15000 },
         );
 
         // Verify the imported block appears


### PR DESCRIPTION
## Why the E2E pipeline was persistently red

After the `page-title-workspace-rename` fix (#2026) the pipeline stayed red. That fix **worked** — the red ❌ was caused by two independent things: a set of flaky specs (the trigger) and a workflow bug that made every re-run of a red run fail (the reason it stayed red).

---

## 1. Re-runnability — a red run could never be recovered with "Re-run failed jobs"

Introduced by the sharding refactor (#2014). Reconstructed from run `28540179206` on `main`:

- **Attempt 1:** `build` ✅ uploads `build-public`/`build-static`; 13/14 shards ✅; one shard ❌ on a flaky spec; `merge-report` ✅ runs (`if: !cancelled()`) and its last step **"Delete intermediate artifacts" deletes every `build-public`/`build-static`/`blob-*`**. Run marked failed.
- **Attempt 2 ("Re-run failed jobs"):** GitHub re-runs only the failed jobs and **reuses** the successful `build` + shard jobs *without re-running them* — but their artifacts were already deleted. Re-run shard → `build-public` **"Artifact not found"** → fails. Re-run `merge-report` → no `blob-*` → `playwright merge-reports` crashes **"Directory does not exist"**.

⇒ Every re-run was **guaranteed** red.

**Fix (`.github/workflows/e2e.yml`):**
- Gate "Delete intermediate artifacts" on `needs.e2e.result == 'success'` — a failed run now **retains** its intermediates so "Re-run failed jobs" works. (A step `if:` without a status function implicitly ANDs `success()`, so the delete is also skipped if `merge-report` itself fails.) Green runs still clean up as before.
- Add `overwrite: true` to the uploads a re-run re-uploads over a retained artifact (`blob-*`, `playwright-report`, `build-public`, `build-static`).
- `mkdir -p all-blob-reports` before `merge-reports` so an all-shards-fail run degrades gracefully.
- Add `workflow_dispatch` so maintainers can trigger extra runs by hand.

`e2e-db-matrix.yml` is untouched — it has no artifact-delete logic, so its re-runs already recover.

---

## 2. Four flaky specs de-flaked at the root (the triggers)

All were failing-then-passing-on-retry (or hard-failing) on the E2E / DB-compat matrix. Root causes came from the CI logs and the Playwright `error-context` DOM snapshots of the failed attempts — every one a real race, **not** slowness, so they are fixed with deterministic preconditions, not longer timeouts.

**`block-reorder-stability.spec.ts` — "regression #1667".** Clicked *save* on a just-added text iDevice via `page.evaluate()` (fires even on a **disabled** button) then waited 10 s for edition to exit; on slow runners TinyMCE was still initializing / the button still disabled, so the click was a no-op.
→ `waitForTinyMCEReady()`, a Playwright `.click()` (auto-waits for **enabled**), and the canonical 15 s edition-exit budget.

**`component-export-import.spec.ts:174` and `:599` — import.** The `error-context` snapshot showed an **"Import error: Target page not found"** modal: `modalOpenUserOdeFiles` reads the selected nav node's `nav-id` and `ComponentImporter.findPage()` resolves it in the **Yjs structure**, but on a freshly created project the nav tree renders before the Yjs doc has that page, so the import errors and nothing renders.
→ `importComponent()` now waits for the selected page to exist in Yjs (`structureBinding.getPage(navId)`) **before** triggering the upload — a deterministic precondition.

**`component-export-import.spec.ts:599` — export (Firefox).** `exportBlock`/`exportIdevice` clicked the three-dots dropdown, slept 300 ms, then expected the export item visible — but the first toggle click was missed, leaving it present-but-hidden.
→ Extracted `openActionsDropdown()` which **re-toggles until the menu item is actually visible**; used in both export helpers.

**`search-preview-navigation.spec.ts:67`.** `selectPageByIndex(2)` failed with **"Element is not attached to the DOM"** during `scrollIntoViewIfNeeded` because `cloneCurrentPage()` returned on fixed `500 ms` sleeps while the nav tree was still re-rendering the clone.
→ `cloneCurrentPage()` now waits **deterministically** for the clone to appear in the nav tree; `selectPageByIndex()` tolerates a mid-render detach on the best-effort scroll.

---

## E2E wall-clock (bonus — the #2014 speedup, confirmed)

| Workflow shape | Wall-clock |
|---|---:|
| Pre-#2014 (3 per-browser jobs, each rebuilds + runs full suite) | ~**34 min** |
| Post-#2014 sharded (build-once + 12 shards + merge) | ~**11 min** |

~3× faster; #2014 delivered. Long pole is now one Firefox shard (~9.5 min) while the static shards finish in <3 min — rebalancing could push it toward ~6–7 min (future work, not in this PR).

---

## Validation

- `make fix` clean; `e2e.yml` valid YAML.
- Ran the **E2E** and **E2E DB-compat matrix** workflows repeatedly on this branch. On the final code, **two consecutive fully-clean rounds** (E and F): all four previously-flaky specs pass **first-try** across sqlite/postgres/mariadb and on the Firefox export path — **0 failures, 0 retries** — and a "Re-run failed jobs" now recovers instead of staying red. (block-reorder #1667 and search-preview #67 were clean over 5+ rounds.)
- Per-round wall-clock: E2E ~11 min, DB matrix ~26 min.

## Note for the release branch
The workflow file is byte-identical on `2021-prepare-v402-release-iii`; it inherits these fixes on the next sync from `main` (no separate change needed there).
