### PR TITLE
docs(architecture): define ADR and SDD workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,19 @@ The UI **tries browser-side first**, falling back to server-side.
 
 Static editor embeds in LMS plugins (WordPress, Moodle, Drupal, Omeka-S) via iframe + postMessage. Key files: `RuntimeConfig.js`, `Capabilities.js`, `EmbeddingBridge.js`, `app.js`, `previewPanel.js`, `main.scss`. See `doc/development/embedding.md`.
 
+### 7.11 Architecture Decision Records (ADR) & Software Design Documents (SDD)
+
+Significant technical work is documented before or alongside the code. Full policy: [ADR guide](doc/architecture/adr/README.md), [SDD guide](doc/architecture/sdd/README.md).
+
+- **Create or update an ADR** when a change introduces or modifies a **durable architecture decision**. ADRs are required for decisions affecting: architecture, storage model, file formats (ELP/ELPX), import/export behavior, the collaboration model, security/sandboxing, accessibility strategy, public APIs (REST v1, embedding bridge), or AI-generation workflows.
+- **Create an SDD** for significant features, major refactors, design gates, cross-cutting changes, or proposals with multiple implementation phases. SDDs may describe the feature plan, but **durable decisions inside an SDD must link to an ADR** (existing or newly proposed) — don't bury the decision.
+- Locations: ADRs live under `doc/architecture/adr/`, SDDs under `doc/architecture/sdd/`.
+- Templates: `doc/architecture/adr/ADR-0000-template.md`, `doc/architecture/sdd/SDD-0000-template.md`. IDs are monotonic and never reused.
+- **Do not rewrite accepted ADRs** — supersede them with a new ADR (`supersedes` / `superseded_by`). **Do not rewrite implemented SDDs** except for typo/link fixes; supersede them if the design changes substantially.
+- While a decision or design is still under discussion, use `status: Proposed` (ADR) or `status: Draft` / `In Review` (SDD).
+- Document AI assistance in the ADR/SDD frontmatter (`ai_assistance.tool` / `ai_assistance.model`; `none` if not used).
+- Mention any ADRs or SDDs a PR creates or updates in the PR description.
+
 ## 8. Environment Configuration
 
 Configure via `.env` file (use `.env.dist` as template).
@@ -334,3 +347,5 @@ Domain-specific guidance lives in `.agents/skills/*/SKILL.md`.
 | Styles/Themes | [doc/development/styles.md](doc/development/styles.md) |
 | Conventions | [doc/conventions.md](doc/conventions.md) |
 | Architecture | [doc/architecture.md](doc/architecture.md) |
+| Architecture Decision Records | [doc/architecture/adr/README.md](doc/architecture/adr/README.md) |
+| Software Design Documents | [doc/architecture/sdd/README.md](doc/architecture/sdd/README.md) |

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -781,8 +781,25 @@ This design follows the same pattern as other user-specific data (like favorite 
 
 ---
 
+## Architecture Decision Records and Software Design Documents
+
+Durable architecture decisions are tracked as **ADRs** under `doc/architecture/adr/`.
+
+Significant technical designs and design-gated proposals are tracked as **SDDs** under `doc/architecture/sdd/`.
+
+ADRs and SDDs complement each other: an SDD describes the design and implementation plan for a change, while an ADR records a specific decision and its rationale. When an SDD contains a durable decision, that decision should link to an existing ADR or propose a new one.
+
+See:
+
+- [Architecture Decision Records](architecture/adr/README.md)
+- [Software Design Documents](architecture/sdd/README.md)
+
+---
+
 ## Further Reading
 
+- [Architecture Decision Records](architecture/adr/README.md) - Durable decisions and their rationale
+- [Software Design Documents](architecture/sdd/README.md) - Design gates for significant changes
 - [Real-Time Collaboration](development/real-time.md) - WebSocket and Yjs details
 - [REST API](development/rest-api.md) - API endpoints
 - [Testing](development/testing.md) - Test patterns and coverage

--- a/doc/architecture/adr/ADR-0000-template.md
+++ b/doc/architecture/adr/ADR-0000-template.md
@@ -1,0 +1,113 @@
+---
+id: ADR-0000
+title: "Short decision title"
+status: Proposed
+date: YYYY-MM-DD
+deciders:
+  - "@github-user"
+reviewers:
+  - "@github-user"
+related:
+  issues: []
+  prs: []
+  sdds: []
+  adrs: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: ""
+  model: ""
+---
+
+<!--
+How to use this template:
+1. Copy this file to `ADR-NNNN-short-kebab-case-title.md` with the next free ID.
+2. Update the frontmatter above (id, title, date, deciders, reviewers, related).
+3. Fill every section below. Delete guidance comments before submitting.
+4. Keep the file at `status: Proposed` until reviewers accept it.
+5. Cite a verifiable source for each technical claim (repo path + commit,
+   documentation, benchmark, experiment, issue, PR, SDD, or prior ADR).
+6. Record AI assistance in `ai_assistance` (values, or `none` if not used).
+See ../README.md for the full policy.
+-->
+
+# ADR-0000: Short decision title
+
+## Status
+
+Proposed
+
+<!-- One of: Proposed | Accepted | Rejected | Superseded. Keep it in sync with
+the frontmatter `status`. If superseded, link the replacement ADR. -->
+
+## Context
+
+<!-- The situation that forces a decision. What is happening, what constraints
+apply, and why now. State facts, not opinions. -->
+
+## Problem
+
+<!-- The specific question this ADR answers, phrased so a "yes/no" or a chosen
+option resolves it. -->
+
+## Decision drivers
+
+<!-- The forces that matter: performance, security, accessibility, maintainability,
+backward compatibility, effort, team familiarity, etc. -->
+
+- Driver 1
+- Driver 2
+
+## Options considered
+
+### Option 1: ...
+
+<!-- Describe the option, then its pros and cons. -->
+
+### Option 2: ...
+
+### Option 3: ...
+
+## Evidence
+
+<!-- The verifiable basis for the decision. Prefer:
+- repository path + commit (e.g. `src/shared/export/BaseExporter.ts` @ `abc1234`)
+- official documentation or a specification (link)
+- a benchmark or reproducible experiment (numbers + how to reproduce)
+- a linked issue, PR, SDD, or prior ADR
+No technical claim without a source. -->
+
+## Decision
+
+<!-- The option that was chosen, stated plainly. "We will ...". -->
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Neutral
+
+- ...
+
+## Risks
+
+<!-- What could go wrong, and how likely / severe. -->
+
+## Validation
+
+<!-- How we will know the decision was correct: tests, metrics, a follow-up
+review date, an experiment to run. -->
+
+## Follow-up work
+
+<!-- Concrete next steps this decision creates. Link issues/PRs when they exist. -->
+
+## References
+
+<!-- All sources cited above, plus related issues, PRs, SDDs and ADRs. -->

--- a/doc/architecture/adr/README.md
+++ b/doc/architecture/adr/README.md
@@ -1,0 +1,192 @@
+# Architecture Decision Records
+
+## Purpose
+
+An **Architecture Decision Record (ADR)** captures a single durable architectural
+decision together with the reasoning behind it: the context, the problem, the
+options that were considered, the evidence that informed the choice, the decision
+itself, and the consequences that follow.
+
+ADRs exist so that eXeLearning contributors — human and AI — can answer *"why is
+it built this way?"* years later, without archaeology through pull request
+threads or chat logs. A decision that is only recorded inside a PR description is
+easy to lose; an ADR is a first-class, long-lived document.
+
+Guiding principles, borrowed from the traceability workflow used in
+[`exelearning/mod_exelearning`](https://github.com/exelearning/mod_exelearning):
+
+- **Evidence before preference.** Prefer a verifiable source over an assertion.
+- **No technical claim without a source.** Cite a repository path + commit,
+  official documentation, a benchmark, a reproducible experiment, an issue, a
+  PR, an SDD, or a previous ADR.
+- **Separate facts, interpretation and decision.** Say what is observed, what it
+  means, and what was decided — in that order.
+- **Stable, monotonic IDs.** IDs are never reused.
+- **Append-only.** Accepted decisions are not rewritten; they are superseded.
+
+## ADRs vs SDDs
+
+ADRs and [Software Design Documents (SDDs)](../sdd/README.md) are complementary,
+not competing.
+
+| Artifact | Answers | Lifetime |
+|----------|---------|----------|
+| **SDD** | *What* will be built and *how* a significant change will be implemented | May become historical once implemented |
+| **ADR** | *Which* durable decision was made and *why* | Long-lived, append-only |
+| **PR** | The concrete code/doc changes under review | Historical review record |
+| **Issue** | The problem, proposal or discussion being coordinated | Historical coordination record |
+
+A large change usually starts with an SDD that describes the design and the
+implementation plan. Inside that SDD, the decisions that will outlive the change
+itself — a storage model, a file-format guarantee, a security boundary — should
+be extracted into ADRs or linked to existing ones. The SDD records the design;
+the ADR records the decision and its rationale. Do **not** copy the whole SDD
+into an ADR.
+
+## ADRs vs OpenSpec / spec-driven workflows
+
+Spec-driven development (SDD, in the "spec" sense) and tools such as
+[OpenSpec](https://github.com/Fission-AI/OpenSpec) focus on aligning humans and
+AI assistants on *what to build* **before** any code is written. OpenSpec, for
+example, organizes each change as a proposal → review → implement → archive cycle
+where a change folder carries its proposal, specs, design and tasks
+(see the OpenSpec [concepts documentation](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md)).
+
+That is the same problem our **SDD** documents address: intent and plan before
+implementation. ADRs address a different, longer-lived problem: *why* a durable
+architectural decision was made, and what was rejected.
+
+The main eXeLearning repository does **not** depend on OpenSpec or any external
+spec tool. OpenSpec is referenced here only as prior art for the spec-driven
+half of the workflow. Adopting it (or GitHub's Spec Kit, or any other tool)
+formally would itself be an architecture decision, and would require its own ADR
+and reviewer approval.
+
+## When an ADR is required
+
+Create or update an ADR when a change **introduces or modifies a durable
+architectural decision** — one that future contributors should not have to
+re-litigate. In eXeLearning this includes decisions affecting:
+
+- overall architecture (e.g. client-as-source-of-truth, browser-first export);
+- storage model (IndexedDB, Cache API, server persistence, Yjs snapshots);
+- file formats (ELP / ELPX / `content.xml`) and backward-compatibility guarantees;
+- import/export behavior and the export pipeline;
+- the real-time collaboration model (Yjs, WebSocket relay);
+- security, sandboxing, or content-sanitization boundaries;
+- accessibility strategy;
+- public API contracts (REST API v1, embedding/`postMessage` bridge);
+- AI-assisted generation workflows and policies.
+
+If in doubt, prefer writing a short ADR over losing the reasoning.
+
+## When an ADR is not required
+
+Do **not** write an ADR for:
+
+- bug fixes that restore intended behavior;
+- routine refactors with no externally observable decision;
+- dependency bumps, lint/format changes, copy edits;
+- purely local implementation details with no cross-cutting impact.
+
+If a change is significant enough to need a design but does not yet lock a
+durable decision, start with an [SDD](../sdd/README.md) instead.
+
+## Location and naming
+
+- ADRs live in `doc/architecture/adr/`.
+- Filenames follow: `ADR-NNNN-short-kebab-case-title.md` — for example
+  `ADR-0001-store-assets-by-content-hash.md`.
+- IDs are zero-padded, monotonic and never reused. The next ID is
+  `max(existing) + 1`.
+- [`ADR-0000-template.md`](ADR-0000-template.md) is the canonical template.
+  Copy it to a new file and assign the next ID.
+- [`records.md`](records.md) lists every ADR. For now the index is maintained by
+  hand; generation tooling can be added later if the process grows.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| `Proposed` | Under discussion; not yet agreed. |
+| `Accepted` | Agreed and in force. |
+| `Rejected` | Considered and declined. Kept for the record. |
+| `Superseded` | Replaced by a later ADR (see `superseded_by`). |
+
+A decision that is still being debated stays `Proposed`. It becomes `Accepted`
+only after reviewer approval.
+
+## Evidence and traceability
+
+Every technical claim in an ADR should cite a verifiable source. Acceptable
+evidence includes:
+
+- a repository path plus commit (e.g. `src/shared/export/BaseExporter.ts` @ `abc1234`);
+- official documentation or a specification;
+- a benchmark or a reproducible experiment;
+- a linked issue, PR, SDD, or prior ADR.
+
+Keep the evidence **inside** the ADR for now. The main repository intentionally
+does not (yet) maintain a separate `sources/`, `experiments/`, or `schemas/`
+tree; introducing one would be a process change for reviewers to approve.
+
+## AI-assisted ADRs
+
+If an AI tool helped draft or research an ADR, disclose it in the frontmatter:
+
+```yaml
+ai_assistance:
+  tool: "Claude Code"        # tool / interface used
+  model: "claude-opus-4-8"   # model, when relevant
+```
+
+If no AI tool was involved, set both fields to `none`. Disclosure is about
+traceability, not judgement: it records how the document was produced so the
+evidence can be weighed accordingly.
+
+## Superseding an ADR
+
+Accepted ADRs are **append-only**. Do not rewrite them except to fix typos or
+broken links.
+
+To change an accepted decision:
+
+1. Create a new ADR with the next ID.
+2. Set `supersedes: [ADR-XXXX]` in the new ADR's frontmatter.
+3. Set `status: Superseded` and `superseded_by: [ADR-YYYY]` in the old ADR.
+4. Update [`records.md`](records.md).
+
+This keeps the decision history intact and readable in order.
+
+## Referencing ADRs
+
+Refer to ADRs by their ID so links stay stable:
+
+- **From code / comments:** `// See ADR-0007 for why assets are addressed by hash.`
+- **From docs:** `[ADR-0007](adr/ADR-0007-....md)` (adjust the relative path).
+- **From an SDD:** list the ADR in the SDD's *ADRs required or referenced* table.
+- **From a PR or issue:** mention `ADR-0007` in the description and link the file.
+
+## Workflow
+
+1. Identify a durable decision (see *When an ADR is required*).
+2. Copy [`ADR-0000-template.md`](ADR-0000-template.md) to
+   `ADR-NNNN-short-title.md` with the next ID.
+3. Fill in context, problem, options, evidence, decision and consequences.
+   Start at `status: Proposed`.
+4. Add the ADR to [`records.md`](records.md).
+5. Open (or reference) a PR. Reviewers discuss and, if agreed, the status moves
+   to `Accepted`.
+6. If a later change reverses the decision, supersede it — never edit the
+   accepted record.
+
+## Review checklist
+
+- [ ] The ADR has a unique, monotonic ID and a kebab-case title.
+- [ ] Context, problem, options, decision and consequences are all present.
+- [ ] Every technical claim cites a verifiable source.
+- [ ] Positive, negative and neutral consequences are stated honestly.
+- [ ] `status` reflects reality (`Proposed` while under discussion).
+- [ ] `ai_assistance` is filled in (values or `none`).
+- [ ] Superseding ADRs set `supersedes` / the old ADR sets `superseded_by`.
+- [ ] [`records.md`](records.md) is updated.

--- a/doc/architecture/adr/records.md
+++ b/doc/architecture/adr/records.md
@@ -1,0 +1,24 @@
+# ADR Index
+
+This page lists Architecture Decision Records for the main eXeLearning
+repository. See [Architecture Decision Records](README.md) for the policy and the
+[`ADR-0000-template.md`](ADR-0000-template.md) for the starting point.
+
+The index is maintained by hand for now. When an ADR is added, superseded, or
+changes status, update the table and the per-status lists below.
+
+| ID | Title | Status | Date |
+|---|---|---|---|
+| ADR-0000 | Template | Template | — |
+
+## Proposed ADRs
+
+_No proposed ADRs yet._
+
+## Accepted ADRs
+
+_No accepted ADRs yet._
+
+## Superseded ADRs
+
+_No superseded ADRs yet._

--- a/doc/architecture/sdd/README.md
+++ b/doc/architecture/sdd/README.md
@@ -1,0 +1,164 @@
+# Software Design Documents
+
+## Purpose
+
+A **Software Design Document (SDD)** describes *what* a significant change will
+build and *how* it will be implemented. It is the design gate for large work:
+the place to agree on goals, non-goals, user experience, technical design, data
+model, migration, security, accessibility, testing and rollout **before**
+implementation starts.
+
+An SDD makes a big change reviewable as a whole, instead of arriving as a large
+pull request that reviewers must reverse-engineer. The Software Design Document
+introduced by PR
+[`#2147`](https://github.com/exelearning/exelearning/pull/2147) — the
+interactive-video iDevice refactor — is an example of this kind of
+design-gated proposal document.
+
+## SDDs vs ADRs
+
+| Artifact | Answers | Lifetime |
+|----------|---------|----------|
+| **SDD** | *What* will be built and *how* it will be implemented | May become historical once implemented |
+| **ADR** | *Which* durable decision was made and *why* | Long-lived, append-only |
+
+An SDD is a **design**; an [ADR](../adr/README.md) is a **decision**. A single
+SDD often contains several durable decisions (a storage choice, a compatibility
+guarantee, a security boundary). Those belong in ADRs so they outlive the
+feature work — the SDD then links to them instead of burying them in prose.
+
+> Every significant proposal may start with an SDD. Every durable architectural
+> decision inside that SDD should either link to an existing ADR or propose a new
+> ADR.
+
+## SDDs vs OpenSpec / spec-driven workflows
+
+"Spec-driven development" and tools such as
+[OpenSpec](https://github.com/Fission-AI/OpenSpec) exist to align humans and AI
+assistants on *what to build* before code is written — the same goal as an SDD.
+OpenSpec organizes each change as a proposal → review → implement → archive cycle
+with its own proposal, specs, design and tasks
+(see the OpenSpec [concepts documentation](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md)).
+
+Our SDD is a lightweight, English, Markdown-first version of that idea that lives
+directly in `doc/` and needs no extra tooling. The main eXeLearning repository
+does **not** adopt OpenSpec or any external spec tool as a dependency. It is
+mentioned here as prior art; formally adopting such a tool would be its own
+architecture decision (and its own ADR).
+
+## When an SDD is required
+
+Write an SDD for work that needs a design gate before implementation:
+
+- significant new features;
+- major refactors or rewrites of a subsystem;
+- cross-cutting changes (export pipeline, collaboration, storage, embedding);
+- proposals with multiple implementation phases;
+- changes that touch several of: architecture, storage, file formats,
+  import/export, security, accessibility, or public APIs.
+
+## When an SDD is not required
+
+Skip the SDD for:
+
+- bug fixes and small enhancements;
+- localized changes with an obvious implementation;
+- work already fully covered by an existing, current SDD.
+
+A durable decision that needs no full design can go straight to an
+[ADR](../adr/README.md).
+
+## Location and naming
+
+- SDDs live in `doc/architecture/sdd/`.
+- Filenames follow: `SDD-NNNN-short-kebab-case-title.md` — for example
+  `SDD-0001-interactive-video-refactor.md`.
+- IDs are zero-padded, monotonic and never reused. The next ID is
+  `max(existing) + 1`.
+- [`SDD-0000-template.md`](SDD-0000-template.md) is the canonical template.
+- [`records.md`](records.md) lists every SDD. The index is maintained by hand for
+  now; generation tooling can be added later if the process grows.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| `Draft` | Being written; not yet ready for review. |
+| `In Review` | Under review; open for feedback. |
+| `Accepted` | Design agreed; implementation may start. |
+| `Implemented` | The design has shipped. Kept as a historical record. |
+| `Superseded` | Replaced by a newer SDD (see `superseded_by`). |
+| `Abandoned` | Dropped before implementation. Kept for the record. |
+
+An SDD can be edited freely while it is `Draft` or `In Review`. Once
+`Implemented`, avoid rewriting it except for typo/link fixes. If the design
+changes substantially, create a new SDD or mark the previous one `Superseded`.
+
+## Evidence and traceability
+
+As with ADRs, technical claims should cite a verifiable source: a repository path
+plus commit, official documentation, a benchmark, a reproducible experiment, or a
+linked issue, PR or ADR. Keep the evidence inside the SDD for now; the main
+repository does not maintain a separate `sources/` or `experiments/` tree.
+
+## AI-assisted SDDs
+
+If an AI tool helped draft or research an SDD, disclose it in the frontmatter:
+
+```yaml
+ai_assistance:
+  tool: "Claude Code"        # tool / interface used
+  model: "claude-opus-4-8"   # model, when relevant
+```
+
+If no AI tool was involved, set both fields to `none`.
+
+## Linking SDDs and ADRs
+
+Every SDD template includes an **ADRs required or referenced** table. Use it to:
+
+- link durable decisions to existing ADRs; or
+- flag decisions that still need an ADR (`ADR needed`).
+
+Do not duplicate a full SDD inside an ADR. The ADR records the decision and its
+rationale; the SDD records the implementation design. An ADR may, in turn,
+reference one or more SDDs.
+
+## Superseding or abandoning an SDD
+
+- **Substantial design change:** create a new SDD (or set the old one to
+  `Superseded` with `superseded_by`).
+- **Design dropped before implementation:** set `status: Abandoned` and note why.
+- **Shipped:** set `status: Implemented`. Keep it as a historical design record;
+  do not delete it.
+
+## Referencing SDDs
+
+Refer to SDDs by their ID so links stay stable:
+
+- **From a PR or issue:** mention `SDD-0001` and link the file.
+- **From an ADR:** list the SDD under `related.sdds` and in the References.
+- **From docs / code:** `[SDD-0001](sdd/SDD-0001-....md)` (adjust the relative path).
+
+## Workflow
+
+1. Copy [`SDD-0000-template.md`](SDD-0000-template.md) to
+   `SDD-NNNN-short-title.md` with the next ID. Start at `status: Draft`.
+2. Fill in the design: problem, goals, non-goals, technical design, migration,
+   security, accessibility, testing, rollout, risks and acceptance criteria.
+3. List durable decisions in the *ADRs required or referenced* table; create or
+   link ADRs for them.
+4. Add the SDD to [`records.md`](records.md) and open (or reference) a PR. Move to
+   `In Review`.
+5. On approval, set `Accepted` and implement. When it ships, set `Implemented`.
+
+## Review checklist
+
+- [ ] The SDD has a unique, monotonic ID and a kebab-case title.
+- [ ] Goals and non-goals are explicit.
+- [ ] Migration/compatibility, security, accessibility and testing are addressed.
+- [ ] Durable decisions are captured in the *ADRs required or referenced* table.
+- [ ] Every technical claim cites a verifiable source.
+- [ ] `status` reflects reality (`Draft`/`In Review` while under discussion).
+- [ ] `ai_assistance` is filled in (values or `none`).
+- [ ] [`records.md`](records.md) is updated.

--- a/doc/architecture/sdd/SDD-0000-template.md
+++ b/doc/architecture/sdd/SDD-0000-template.md
@@ -1,0 +1,146 @@
+---
+id: SDD-0000
+title: "Short design title"
+status: Draft
+date: YYYY-MM-DD
+authors:
+  - "@github-user"
+reviewers:
+  - "@github-user"
+related:
+  issues: []
+  prs: []
+  adrs: []
+  sdds: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: ""
+  model: ""
+---
+
+<!--
+How to use this template:
+1. Copy this file to `SDD-NNNN-short-kebab-case-title.md` with the next free ID.
+2. Update the frontmatter above (id, title, date, authors, reviewers, related).
+3. Fill the relevant sections. Delete sections that truly do not apply, and
+   delete these guidance comments before submitting.
+4. Use an SDD for significant proposals, not small fixes.
+5. Cite a verifiable source for each technical claim (repo path + commit,
+   documentation, benchmark, experiment, issue, PR, or ADR).
+6. Capture durable decisions in "ADRs required or referenced" — link an existing
+   ADR or mark it "ADR needed".
+7. Record AI assistance in `ai_assistance` (values, or `none` if not used).
+Editing is free while Draft / In Review. Once Implemented, only fix typos/links.
+See ../README.md for the full policy.
+-->
+
+# SDD-0000: Short design title
+
+## Status
+
+Draft
+
+<!-- One of: Draft | In Review | Accepted | Implemented | Superseded | Abandoned.
+Keep it in sync with the frontmatter `status`. -->
+
+## Summary
+
+<!-- One or two paragraphs: what this changes and why it matters. -->
+
+## Problem statement
+
+<!-- The problem being solved, and who has it. -->
+
+## Goals
+
+<!-- What success looks like. Make these testable where possible. -->
+
+## Non-goals
+
+<!-- What this design explicitly does not attempt. -->
+
+## Current state
+
+<!-- How things work today. Cite repository paths + commits. -->
+
+## Proposed design
+
+<!-- The design at a high level. Diagrams welcome. -->
+
+## User experience
+
+<!-- What users see and do. Flows, states, edge cases. -->
+
+## Technical design
+
+<!-- Components, modules, interfaces, data flow. Cite the files that will change. -->
+
+## Data model
+
+<!-- New/changed structures, schemas, Yjs shapes, DB tables, ELP/ELPX shapes. -->
+
+## Migration and compatibility
+
+<!-- Backward compatibility, data migration, feature flags, rollback. -->
+
+## Security and privacy
+
+<!-- Sanitization, sandboxing, path safety, auth, secrets, PII. -->
+
+## Accessibility
+
+<!-- Keyboard, screen readers, contrast, focus management, WCAG considerations. -->
+
+## Internationalization
+
+<!-- New user-facing strings, `_()` / `c_()` / `| trans` usage, RTL, locale data. -->
+
+## Performance
+
+<!-- Expected cost, budgets, large-document behavior, profiling hooks. -->
+
+## Testing strategy
+
+<!-- Unit, integration, E2E. Patch-coverage plan. Which flows get a Playwright spec. -->
+
+## Rollout plan
+
+<!-- Phases, order of merges, feature flags, staged enablement. -->
+
+## Risks and mitigations
+
+<!-- What could go wrong, likelihood/severity, and how it is mitigated. -->
+
+## Open questions
+
+<!-- Unresolved points that reviewers should weigh in on. -->
+
+## ADRs required or referenced
+
+<!-- List durable decisions. Link an existing ADR, or mark it "ADR needed". -->
+
+| Decision | ADR | Status |
+|---|---|---|
+| Example durable decision | ADR-XXXX | Proposed |
+
+## Evidence
+
+<!-- The verifiable basis for the design: repo paths + commits, docs, benchmarks,
+reproducible experiments, issues, PRs, ADRs. No technical claim without a source. -->
+
+## Acceptance criteria
+
+<!-- Concrete, checkable conditions for "done". -->
+
+- [ ] ...
+
+## Implementation checklist
+
+<!-- The steps to build it, roughly in order. -->
+
+- [ ] ...
+
+## References
+
+<!-- All sources cited above, plus related issues, PRs, ADRs and SDDs. -->

--- a/doc/architecture/sdd/records.md
+++ b/doc/architecture/sdd/records.md
@@ -1,0 +1,32 @@
+# SDD Index
+
+This page lists Software Design Documents for the main eXeLearning repository.
+See [Software Design Documents](README.md) for the policy and the
+[`SDD-0000-template.md`](SDD-0000-template.md) for the starting point.
+
+The index is maintained by hand for now. When an SDD is added or changes status,
+update the table and the per-status lists below.
+
+| ID | Title | Status | Date |
+|---|---|---|---|
+| SDD-0000 | Template | Template | — |
+
+## Draft SDDs
+
+_No draft SDDs yet._
+
+## In Review SDDs
+
+_No SDDs in review yet._
+
+## Accepted SDDs
+
+_No accepted SDDs yet._
+
+## Implemented SDDs
+
+_No implemented SDDs yet._
+
+## Superseded SDDs
+
+_No superseded SDDs yet._

--- a/doc/development/contributing.md
+++ b/doc/development/contributing.md
@@ -35,6 +35,27 @@ Access http://localhost:8080 and log in with the default credentials shown in `.
 
 Details: [development/version-control.md](version-control.md)
 
+## Architecture Decisions & Design Documents
+
+Significant technical work is documented before or alongside the code:
+
+- Write a **Software Design Document (SDD)** for large feature proposals, major
+  refactors, design gates and multi-step implementations. SDDs live under
+  [`doc/architecture/sdd/`](../architecture/sdd/README.md).
+- Write an **Architecture Decision Record (ADR)** for durable decisions likely to
+  affect future work. ADRs live under
+  [`doc/architecture/adr/`](../architecture/adr/README.md).
+- An ADR is expected for changes affecting architecture, storage model, file
+  formats, database migrations, import/export behavior, the collaboration model,
+  security/sandboxing, accessibility strategy, public API contracts, or
+  AI-assisted generation policy.
+- When an SDD contains a durable decision, link it to an existing ADR or propose
+  a new one — don't bury the decision in the design.
+- Mention any ADRs or SDDs your PR creates or updates in the PR description.
+
+See the [ADR](../architecture/adr/README.md) and
+[SDD](../architecture/sdd/README.md) guides for templates, IDs and statuses.
+
 ## Coding Standards
 
 - Run linters and fix style before pushing:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,14 @@ nav:
   - Deployment: deployment.md
   - High Availability: high-availability.md
   - "Deploy: Sample Configs": deploy/README.md
-  - Architecture: architecture.md
+  - Architecture:
+      - Overview: architecture.md
+      - Architecture Decision Records: architecture/adr/README.md
+      - ADR Index: architecture/adr/records.md
+      - ADR Template: architecture/adr/ADR-0000-template.md
+      - Software Design Documents: architecture/sdd/README.md
+      - SDD Index: architecture/sdd/records.md
+      - SDD Template: architecture/sdd/SDD-0000-template.md
   - Conventions: conventions.md
   - Development:
       - Environment: development/environment.md


### PR DESCRIPTION
## What this does

Defines a lightweight Architecture Decision Record (ADR) and Software Design Document (SDD) workflow for the main eXeLearning repository.

This is inspired by the broader traceability workflow used in [exelearning/mod_exelearning](https://github.com/exelearning/mod_exelearning), but intentionally starts smaller:

- ADRs live under `doc/architecture/adr/`.
- SDDs live under `doc/architecture/sdd/`.
- ADRs use English `ADR-0001` IDs.
- SDDs use English `SDD-0001` IDs.
- Reusable ADR and SDD templates are added.
- ADR and SDD index pages are added.
- `AGENTS.md` tells AI agents when ADRs and SDDs are required or recommended.
- The architecture and contributing docs link to the workflow.
- MkDocs exposes ADRs and SDDs as normal documentation pages.

## Why

Recent proposal work, especially `#2147`, uses SDD-style documentation to define large changes before implementation.

That is useful, but SDDs and ADRs serve different purposes:

- SDDs describe the feature, design gate, plan and acceptance criteria.
- ADRs record durable decisions and their rationale.

This PR defines how both should coexist.

## Scope

Documentation/process only.

No production code changes.

## Proposed policy

- Store ADRs in `doc/architecture/adr/`.
- Store SDDs in `doc/architecture/sdd/`.
- Use `ADR-0001` style IDs for ADRs.
- Use `SDD-0001` style IDs for SDDs.
- Use ADR statuses: `Proposed`, `Accepted`, `Rejected`, `Superseded`.
- Use SDD statuses: `Draft`, `In Review`, `Accepted`, `Implemented`, `Superseded`, `Abandoned`.
- Keep accepted ADRs append-only.
- Supersede decisions with a new ADR instead of rewriting history.
- Keep implemented SDDs as historical design records.
- Supersede SDDs when the design changes substantially.
- Keep evidence inside each ADR/SDD for now.
- Do not introduce a full `doc/research/` tree yet.
- Do not add validation tooling yet.
- Record AI assistance in ADR/SDD frontmatter when applicable.
- Link ADRs from SDDs when a feature proposal includes durable architecture decisions.

## Relationship with OpenSpec / spec-driven workflows

ADRs and SDDs are complementary, not competing:

- An **SDD** describes *what* will be built and *how* — the same intent-before-code goal as spec-driven development. Tools like [OpenSpec](https://github.com/Fission-AI/OpenSpec) organize each change as a proposal → review → implement → archive cycle carrying its own proposal, specs, design and tasks (see the OpenSpec [concepts docs](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md)). Our SDD is a lightweight, English, Markdown-first version of that idea living directly in `doc/`.
- An **ADR** records a *durable decision and its rationale* — a longer-lived concern than a single change's spec.

This PR does **not** add OpenSpec or any external spec tool as a dependency. OpenSpec is referenced only as prior art; formally adopting a spec tool would itself be an ADR, subject to reviewer approval.

## Note on file naming (`records.md` instead of `index.md`)

The proposal recommended an `index.md` list page per folder. MkDocs treats `README.md` and `index.md` in the same directory as the **same page** and excludes one of them (it drops the `README.md` guide). To keep the guide as the folder landing page — matching the repo's existing `doc/deploy/README.md` convention — the list page is named `records.md`. It appears in the docs nav as "ADR Index" / "SDD Index". Reviewers can rename it later if preferred.

## Review questions

Please review especially:

1. Is `doc/architecture/adr/` the right ADR location?
2. Is `doc/architecture/sdd/` the right SDD location?
3. Should we keep this ADR + SDD only for now, or introduce a broader `research/`-style evidence system?
4. Should IDs be `ADR-0001` / `SDD-0001`, or should ADRs follow the `DEC-NNNN` convention used in `mod_exelearning`?
5. Should SDDs be required to link to ADRs when they contain durable architecture decisions?
6. Should OpenSpec/spec-driven workflows be mentioned as optional, or should they be formally adopted later?

## Testing

Documentation-only change.

Commands run:

```text
mkdocs build     # nav + link validation: builds clean, no warnings on the new ADR/SDD pages
make fix         # Biome lint/format: checked 149 files, no fixes applied (Markdown/YAML untouched)
python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml'))"   # mkdocs.yml is valid YAML
```

## Related issue

Closes #2148
