### PR TITLE
fix(workarea): hide non-edited block siblings during focused iDevice editing

### DIFF
--- a/assets/styles/layout/_idevice-focus.scss
+++ b/assets/styles/layout/_idevice-focus.scss
@@ -69,6 +69,17 @@ body.exe-idevice-focus-editing {
             flex-direction: column;
             overflow: hidden;
         }
+
+        /* A block can contain several iDevices. Only the edited one is the
+         * focused editor; its non-edited siblings must leave the focused
+         * surface. We keep them in the DOM (queryable by tooling / assistive
+         * tech, consistent with the sibling-block note above) but remove them
+         * from layout — otherwise a tall sibling whose view content is opaque
+         * and captures pointer events (e.g. an interactive-video `<video>`)
+         * overlaps the editor and swallows every click. */
+        .idevice_node:not(.idevice-node--focused-editing) {
+            display: none;
+        }
     }
 
     .idevice-node--focused-editing {

--- a/test/e2e/playwright/specs/idevices/focused-edit-mode.spec.ts
+++ b/test/e2e/playwright/specs/idevices/focused-edit-mode.spec.ts
@@ -304,4 +304,46 @@ test.describe('Focused iDevice edit mode (experiment)', () => {
         });
         expect(overflowY).toBe('hidden');
     });
+
+    test('hides non-edited sibling iDevices in the same block while focused', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Focused Edit - block siblings');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        await addTextIdevice(page);
+        const ideviceId = await getTextIdeviceId(page);
+        await ensureEditing(page, ideviceId);
+        await waitForFocusActive(page);
+
+        // A block can hold several iDevices, but only the edited one is the focused
+        // editor. Its non-edited siblings must leave the focused surface — otherwise
+        // a tall sibling whose view content is opaque and captures pointer events
+        // (e.g. an interactive-video <video>) overlaps the editor and swallows every
+        // click. Add a real sibling iDevice node to the focused block and assert the
+        // fix removes it from layout while the edited iDevice stays visible.
+        const result = await page.evaluate(focusedId => {
+            const focused = document.getElementById(focusedId);
+            const block = focused.closest('.box');
+            const content = block.querySelector(':scope > .box-content') || block;
+            const sibling = document.createElement('div');
+            sibling.className = 'idevice_node idevice-element-in-content draggable text';
+            sibling.id = 'focus-sibling-probe';
+            sibling.style.height = '600px';
+            content.appendChild(sibling);
+            void document.body.offsetHeight; // force layout
+            const out = {
+                sibling: getComputedStyle(sibling).display,
+                focused: getComputedStyle(focused).display,
+            };
+            sibling.remove();
+            return out;
+        }, ideviceId);
+
+        expect(result.sibling).toBe('none'); // the non-edited sibling is hidden by the fix
+        expect(result.focused).not.toBe('none'); // the edited iDevice stays visible
+    });
 });


### PR DESCRIPTION
## What this does

Fixes #2151.

In *focused edit mode* (Refs #1811 / #1411), editing an iDevice lifts the whole block that contains it over the workarea. When a block holds **more than one iDevice**, the non-edited siblings stayed in the layout of the focused surface. A tall sibling whose view content is opaque and captures pointer events — most visibly an **Interactive Video `<video>`** — painted over the editor and swallowed every click, so the iDevice could not be edited.

## Fix

One rule in `assets/styles/layout/_idevice-focus.scss`: inside the focused block, hide the non-edited sibling iDevices — kept in the DOM (queryable by tooling / assistive tech, consistent with the existing sibling-block note) but removed from layout.

## How this was verified

- Reproduced live in Chrome on a block containing a Text + an Interactive Video iDevice: at the editor's centre the top element was `video.exe-iv-video`; hiding the Interactive Video container exposed the text editor (`idevice_body` -> the TinyMCE iframe). With the rule, editing the text iDevice works normally.
- Adds a Playwright E2E in `focused-edit-mode.spec.ts` asserting a non-edited sibling iDevice in the focused block computes `display: none` while the edited iDevice stays visible.

## Tests

- `bun x playwright test --project=chromium -g "hides non-edited sibling" test/e2e/playwright/specs/idevices/focused-edit-mode.spec.ts` -> **1 passed**
- `biome check` clean on the changed spec.

## Notes

Affects any multi-iDevice block; the Interactive Video `<video>` (opaque, pointer-capturing, tall) just makes it most visible. The compiled `main.css` is gitignored, so the only source change is `_idevice-focus.scss` (+ the E2E). Run `make css` to rebuild.
