### PR TITLE
fix(import): resolve legacy dropdown/cloze iDevice images to asset:// URLs

### DIFF
--- a/src/shared/import/ElpxImporter.spec.ts
+++ b/src/shared/import/ElpxImporter.spec.ts
@@ -1816,6 +1816,104 @@ describe('ElpxImporter - findAssetUrlForPath coverage', () => {
             ydoc.destroy();
         });
 
+        it('should convert images embedded in a legacy dropdown (ListaIdevice) form to asset:// URLs', async () => {
+            // Regression for legacy "Actividad desplegable" (ListaIdevice → form):
+            // the image lives inside the question HTML stored in an iDevice
+            // PROPERTY (questionsData[].baseText), not in htmlView. It must still
+            // be rewritten to an asset:// URL, otherwise the picture renders
+            // broken and only its alt text is shown.
+            const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
+<instance class="exe.engine.package.Package" reference="1">
+  <dictionary>
+    <string role="key" value="_title"/>
+    <unicode value="Test"/>
+    <string role="key" value="_lang"/>
+    <unicode value="en"/>
+    <string role="key" value="_root"/>
+    <instance class="exe.engine.node.Node" reference="2">
+      <dictionary>
+        <string role="key" value="_title"/>
+        <unicode value="Page"/>
+        <string role="key" value="parent"/>
+        <none/>
+        <string role="key" value="idevices"/>
+        <list>
+          <instance class="exe.engine.listaidevice.ListaIdevice" reference="3">
+            <dictionary>
+              <string role="key" value="_title"/>
+              <unicode value="Dropdown"/>
+              <string role="key" value="_content"/>
+              <instance class="exe.engine.listaidevice.ListaField" reference="4">
+                <dictionary>
+                  <string role="key" value="_encodedContent"/>
+                  <unicode value="&lt;p&gt;&lt;img src=&quot;dropimg.png&quot;/&gt;&lt;/p&gt;&lt;p&gt;Pick the &lt;u&gt;right&lt;/u&gt; one&lt;/p&gt;"/>
+                  <string role="key" value="content_w_resourcePaths"/>
+                  <unicode value="&lt;p&gt;&lt;img src=&quot;resources/dropimg.png&quot;/&gt;&lt;/p&gt;&lt;p&gt;Pick the &lt;u&gt;right&lt;/u&gt; one&lt;/p&gt;"/>
+                  <string role="key" value="otras"/>
+                  <unicode value="wrong1|wrong2"/>
+                </dictionary>
+              </instance>
+            </dictionary>
+          </instance>
+        </list>
+      </dictionary>
+    </instance>
+  </dictionary>
+</instance>`;
+
+            // Image stored at root level (legacy format)
+            const imageData = new Uint8Array([137, 80, 78, 71]); // PNG header
+            const zipContents: Record<string, Uint8Array> = {
+                'contentv3.xml': new TextEncoder().encode(legacyXml),
+                'dropimg.png': imageData,
+            };
+
+            const ydoc = new Y.Doc();
+            const assetHandler = new FileSystemAssetHandler(testDir);
+            const importer = new ElpxImporter(ydoc, assetHandler, silentLogger);
+
+            const result = await importer.importFromZipContents(zipContents);
+            expect(result.assets).toBeGreaterThanOrEqual(1);
+
+            // Collect every string stored under the imported navigation tree
+            // (iDevice properties are serialised into the jsonProperties string).
+            const collectStrings = (obj: unknown): string[] => {
+                if (typeof obj === 'string') return [obj];
+                if (obj instanceof Y.Text) return [obj.toString()];
+                if (obj instanceof Y.Map) {
+                    const out: string[] = [];
+                    obj.forEach(v => out.push(...collectStrings(v)));
+                    return out;
+                }
+                if (obj instanceof Y.Array) {
+                    const out: string[] = [];
+                    obj.forEach(v => out.push(...collectStrings(v)));
+                    return out;
+                }
+                if (obj && typeof obj === 'object') {
+                    return Object.values(obj).flatMap(collectStrings);
+                }
+                return [];
+            };
+
+            const navigation = ydoc.getArray('navigation');
+            const questionProps = collectStrings(navigation).filter(s => s.includes('questionsData'));
+
+            // The dropdown must have been imported as a form with questionsData
+            expect(questionProps.length).toBeGreaterThan(0);
+            const parsed = JSON.parse(questionProps[0]) as { questionsData: { baseText: string }[] };
+            const baseText = parsed.questionsData[0].baseText;
+
+            // Gap markers must survive, and the embedded image must be rewritten
+            // to an asset:// URL rather than left as a bare or resources/ path.
+            expect(baseText).toContain('<u>right</u>');
+            expect(baseText).toContain('asset://');
+            expect(baseText).not.toContain('src="dropimg.png"');
+            expect(baseText).not.toContain('src="resources/dropimg.png"');
+
+            ydoc.destroy();
+        });
+
         it('should handle files without extension in resources directory', async () => {
             const legacyXml = `<?xml version="1.0" encoding="utf-8"?>
 <instance class="exe.engine.package.Package" reference="1">

--- a/src/shared/import/ElpxImporter.ts
+++ b/src/shared/import/ElpxImporter.ts
@@ -2291,18 +2291,23 @@ export class ElpxImporter {
         }
 
         if (typeof obj === 'string') {
-            // Handle {{context_path}}/... references (in HTML content)
-            if (obj.includes('{{context_path}}') && this.assetHandler) {
-                return this.assetHandler.convertContextPathToAssetRefs(obj, this.assetMap);
-            }
-
-            // Handle resources/filename.jpg paths (legacy gallery/iDevice properties)
-            // These are just path strings, not HTML, so we look them up directly
+            // Standalone legacy resource path (e.g. gallery image property
+            // "resources/foo.jpg"): these are plain path strings, not HTML, so we
+            // look them up directly.
             if (obj.startsWith('resources/') && this.assetMap.size > 0) {
                 const assetUrl = this.findAssetUrlForPath(obj);
                 if (assetUrl) {
                     return assetUrl;
                 }
+            }
+
+            // HTML fragments stored inside iDevice properties (e.g. form
+            // questionsData[].baseText, instructions, feedback) can embed
+            // {{context_path}}/... or legacy src="resources/..." references. Route
+            // them through the same rewriter used for htmlView so their images
+            // resolve to asset:// URLs instead of rendering broken.
+            if (this.assetHandler && (obj.includes('{{context_path}}') || obj.includes('resources/'))) {
+                return this.assetHandler.convertContextPathToAssetRefs(obj, this.assetMap);
             }
 
             return obj;

--- a/src/shared/import/legacy-handlers/DropdownHandler.ts
+++ b/src/shared/import/legacy-handlers/DropdownHandler.ts
@@ -215,11 +215,16 @@ export class DropdownHandler extends BaseLegacyHandler {
         const qDict = this.getDirectChildByTagName(listaFieldInst, 'dictionary');
         if (!qDict) return null;
 
-        // Extract question text from _encodedContent or content_w_resourcePaths
-        // Keep <u> tags intact - form.js will convert them to <select> elements
+        // Extract question text, keeping <u> tags intact (form.js converts them
+        // to <select> elements). Prefer content_w_resourcePaths: it stores image
+        // src attributes with the resources/ prefix, which the asset-path
+        // rewriter needs to turn them into asset:// URLs. _encodedContent holds
+        // the same markup but with BARE image paths (src="foo.jpg"), which can no
+        // longer be resolved once imported, leaving the picture broken. This also
+        // matches how every other field is read (see extractTextAreaFieldContent).
         let baseText =
-            this.findDictStringValue(qDict, '_encodedContent') ||
             this.findDictStringValue(qDict, 'content_w_resourcePaths') ||
+            this.findDictStringValue(qDict, '_encodedContent') ||
             '';
 
         // Fallback: check for questionTextArea field (some legacy formats)

--- a/src/shared/import/legacy-handlers/FillHandler.ts
+++ b/src/shared/import/legacy-handlers/FillHandler.ts
@@ -155,7 +155,11 @@ export class FillHandler extends BaseLegacyHandler {
             const clozeDict = this.getDirectChildByTagName(contentInst, 'dictionary');
             if (clozeDict) {
                 // Symfony extracts from _encodedContent
-                const encodedContent = this.findDictStringValue(clozeDict, '_encodedContent');
+                // Prefer content_w_resourcePaths (resources/-prefixed image src,
+                // resolvable to asset://) over _encodedContent (bare image src).
+                const encodedContent =
+                    this.findDictStringValue(clozeDict, 'content_w_resourcePaths') ||
+                    this.findDictStringValue(clozeDict, '_encodedContent');
                 if (encodedContent) {
                     const parsedText = this.parseClozeText(encodedContent);
                     if (parsedText.baseText) {
@@ -176,6 +180,7 @@ export class FillHandler extends BaseLegacyHandler {
             const clozeDict = this.getDirectChildByTagName(clozeInst, 'dictionary');
             if (clozeDict) {
                 const clozeText =
+                    this.findDictStringValue(clozeDict, 'content_w_resourcePaths') ||
                     this.findDictStringValue(clozeDict, '_encodedContent') ||
                     this.findDictStringValue(clozeDict, '_clozeText') ||
                     this.findDictStringValue(clozeDict, 'clozeText');
@@ -201,7 +206,11 @@ export class FillHandler extends BaseLegacyHandler {
         if (clozeFieldByClass) {
             const clozeDict = this.getDirectChildByTagName(clozeFieldByClass, 'dictionary');
             if (clozeDict) {
-                const encodedContent = this.findDictStringValue(clozeDict, '_encodedContent');
+                // Prefer content_w_resourcePaths (resources/-prefixed image src,
+                // resolvable to asset://) over _encodedContent (bare image src).
+                const encodedContent =
+                    this.findDictStringValue(clozeDict, 'content_w_resourcePaths') ||
+                    this.findDictStringValue(clozeDict, '_encodedContent');
                 if (encodedContent) {
                     const parsedText = this.parseClozeText(encodedContent);
                     if (parsedText.baseText) {

--- a/src/shared/import/legacy-handlers/handlers.spec.ts
+++ b/src/shared/import/legacy-handlers/handlers.spec.ts
@@ -1462,6 +1462,34 @@ describe('FillHandler', () => {
             expect(questions[0].answers).toContain('mat');
         });
 
+        it('prefers content_w_resourcePaths over _encodedContent so cloze image paths keep the resources/ prefix', () => {
+            // Same defect as DropdownHandler: a ClozeField stores its gap text
+            // twice. _encodedContent holds BARE image paths (src="tree.png"),
+            // content_w_resourcePaths holds resources/-prefixed paths that can be
+            // resolved to asset:// URLs on import. Prefer the resolvable copy.
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="_content"/>
+                    <instance class="ClozeField">
+                        <dictionary>
+                            <string role="key" value="_encodedContent"/>
+                            <string value="&lt;p&gt;&lt;img src=&quot;tree.png&quot;/&gt;A &lt;u&gt;cone&lt;/u&gt;&lt;/p&gt;"/>
+                            <string role="key" value="content_w_resourcePaths"/>
+                            <string value="&lt;p&gt;&lt;img src=&quot;resources/tree.png&quot;/&gt;A &lt;u&gt;cone&lt;/u&gt;&lt;/p&gt;"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const props = handler.extractProperties(dict);
+            const questions = props.questionsData as { baseText: string; answers: string[] }[];
+            expect(questions.length).toBe(1);
+            // Cloze gap answers must still be parsed from the <u> markers
+            expect(questions[0].answers).toContain('cone');
+            // The image must keep the resources/ prefix so it resolves to asset://
+            expect(questions[0].baseText).toContain('resources/tree.png');
+            expect(questions[0].baseText).not.toContain('src="tree.png"');
+        });
+
         it('should extract from _cloze key', () => {
             const dict = createDomElement(`
                 <dictionary>
@@ -1713,6 +1741,38 @@ describe('DropdownHandler', () => {
             const questions = props.questionsData as { baseText: string }[];
             expect(questions.length).toBe(1);
             expect(questions[0].baseText).toContain('<u>blank</u>');
+        });
+
+        it('prefers content_w_resourcePaths over _encodedContent so image paths keep the resources/ prefix', () => {
+            // Real legacy ListaIdevice stores the question twice: _encodedContent
+            // holds the editor/display copy with BARE image paths (src="pic.png"),
+            // while content_w_resourcePaths holds the canonical copy with
+            // resources/-prefixed paths (src="resources/pic.png"). Only the
+            // resources/-prefixed form can later be resolved to an asset:// URL,
+            // so the handler must prefer it (as every other field extraction does).
+            const dict = createDomElement(`
+                <dictionary>
+                    <string role="key" value="_content"/>
+                    <instance class="ListaField">
+                        <dictionary>
+                            <string role="key" value="_encodedContent"/>
+                            <string value="&lt;p&gt;&lt;img src=&quot;pic.png&quot;/&gt;&lt;/p&gt;&lt;p&gt;Pick the &lt;u&gt;right&lt;/u&gt; one&lt;/p&gt;"/>
+                            <string role="key" value="content_w_resourcePaths"/>
+                            <string value="&lt;p&gt;&lt;img src=&quot;resources/pic.png&quot;/&gt;&lt;/p&gt;&lt;p&gt;Pick the &lt;u&gt;right&lt;/u&gt; one&lt;/p&gt;"/>
+                            <string role="key" value="otras"/>
+                            <string value="wrong1|wrong2"/>
+                        </dictionary>
+                    </instance>
+                </dictionary>
+            `);
+            const props = handler.extractProperties(dict);
+            const questions = props.questionsData as { baseText: string }[];
+            expect(questions.length).toBe(1);
+            // Dropdown gap markers must survive regardless of which copy is used
+            expect(questions[0].baseText).toContain('<u>right</u>');
+            // The image must keep the resources/ prefix so it resolves to asset://
+            expect(questions[0].baseText).toContain('resources/pic.png');
+            expect(questions[0].baseText).not.toContain('src="pic.png"');
         });
 
         it('should include eXeFormInstructions', () => {


### PR DESCRIPTION
## What

Fixes broken images when importing legacy `.elp` files (the `contentv3.xml` format): images embedded in **dropdown** (`ListaIdevice` / "Actividad desplegable") and **cloze** (`ClozeIdevice` / "Rellenar huecos") iDevices were imported with a plain relative path instead of an `asset://` URL, so they rendered broken and only the `alt`/caption text was shown (e.g. form "Las Torres Hejduk del Gaiás" on page "3.7. De Museo a Museo").

Closes #2155.

## Root cause

1. **Wrong field read.** Legacy `ListaField`/`ClozeField` store the question markup twice: `_encodedContent` (bare `src="foo.jpg"`) and `content_w_resourcePaths` (`src="resources/foo.jpg"`). `DropdownHandler` and `FillHandler` read `_encodedContent` first, so the bare path — which can no longer be resolved after import — was used.
2. **Property HTML not rewritten.** These activities keep their HTML in an iDevice property (`questionsData[].baseText`), not in `htmlView`. `ElpxImporter.convertAssetPathsInObject` only converted strings containing `{{context_path}}` or *starting with* `resources/`, so an HTML fragment merely containing `src="resources/…"` was left untouched. (Normal text works via `htmlView`; gallery/attachment images via standalone `resources/…` path properties.)

## Fix

- `DropdownHandler` and `FillHandler` now prefer `content_w_resourcePaths` (fallback to `_encodedContent`), matching every other field extractor.
- `convertAssetPathsInObject` routes property HTML fragments (those containing `{{context_path}}` or `resources/`) through the same `convertContextPathToAssetRefs` rewriter already used for `htmlView`.

## Tests

- `DropdownHandler` unit test: prefers `content_w_resourcePaths`; image keeps the `resources/` prefix, `<u>` gap markers preserved.
- `FillHandler` unit test: same for cloze, with gap answers still parsed.
- `ElpxImporter` integration test: a full legacy dropdown import produces `questionsData[].baseText` with an `asset://` image (no bare/`resources/` path).
- All 678 tests in `src/shared/import/` pass; `make fix` clean.
- Verified against the reported resource: **0** `<img>` sources remain unconverted across the whole document after import.

No ADR/SDD change — this restores intended import behavior and does not alter a durable architecture decision.
