### PR TITLE
fix: prevent legacy HTML  decoder from corrupting LaTeX sequences

### DIFF
--- a/src/shared/import/LegacyXmlParser.spec.ts
+++ b/src/shared/import/LegacyXmlParser.spec.ts
@@ -139,36 +139,30 @@ describe('LegacyXmlParser', () => {
             const result = parser.preprocessLegacyXml(input);
             expect(result).toBe('textmore text');
         });
-
         it('should remove tabs', () => {
             const input = 'text\tmore text';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toBe('textmore text');
         });
-
         it('should convert Windows line endings', () => {
             const input = 'line1\r\nline2';
             const result = parser.preprocessLegacyXml(input);
             // After preprocessing: \r becomes \n, \n\n becomes \n
             expect(result).not.toContain('\r');
         });
-
         it('should convert hex escape sequences', () => {
             const input = '\\x41\\x42\\x43';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toBe('ABC');
         });
-
         it('should convert literal \\n to entity', () => {
             const input = 'text\\nmore text';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toContain('&#10;');
         });
-
         it('should keep encoded pre content inside unicode value attribute', () => {
             const input = 'x     <unicode value="before\t&lt;pre&gt;\tkeep     spacing&lt;/pre&gt;\tafter     end"/>';
             const result = parser.preprocessLegacyXml(input);
-
             expect(result).toBe('x<unicode value="before&lt;pre&gt;\tkeep     spacing&lt;/pre&gt;afterend"/>');
         });
         it('should preserve \\nabla instead of converting \\n to a line-break entity', () => {
@@ -177,13 +171,11 @@ describe('LegacyXmlParser', () => {
             expect(result).toContain('\\nabla');
             expect(result).not.toContain('&#10;abla');
         });
-
         it('should preserve \\newcommand', () => {
             const input = '\\( \\newcommand{\\vec}[1]{\\mathbf{#1}} \\)';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toContain('\\newcommand');
         });
-
         it('should preserve \\notin, \\neq and \\ngeq', () => {
             const input = '\\( a \\notin B \\quad x \\neq y \\quad x \\ngeq y \\)';
             const result = parser.preprocessLegacyXml(input);
@@ -191,17 +183,32 @@ describe('LegacyXmlParser', () => {
             expect(result).toContain('\\neq');
             expect(result).toContain('\\ngeq');
         });
-
         it('should handle mixed content with real line breaks and LaTeX commands together', () => {
             const input = 'Line1\\nLine2 with formula \\( \\nabla f(x) \\)';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toContain('Line1&#10;Line2');
             expect(result).toContain('\\nabla');
         });
-
         it('should preserve \\nabla inside a real eXe unicode value attribute', () => {
             const input =
                 '<unicode content="true" value="\\( \\nabla \\times \\vec{F} = \\left( \\tfrac{\\partial}{\\partial x} \\right) \\)"/>';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('\\nabla');
+            expect(result).not.toMatch(/&#10;abla/);
+        });
+
+        // --- REVIEWER REGRESSION TEST (Currency vs Formula, same fix as decodeHtmlContent) ---
+
+        it('should convert a literal \\n between two currency amounts (not treat it as a LaTeX block)', () => {
+            // Without a currency guard, "$5...$10" could be greedily matched as a single
+            // $...$ LaTeX block, leaving the literal "\n" between them unconverted.
+            const input = 'Price: $5\\nNew price: $10';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toBe('Price: $5&#10;New price: $10');
+        });
+
+        it('should still protect a real $...$ formula between two currency amounts', () => {
+            const input = 'Price: $5, formula $x \\nabla y$, total: $10';
             const result = parser.preprocessLegacyXml(input);
             expect(result).toContain('\\nabla');
             expect(result).not.toMatch(/&#10;abla/);

--- a/src/shared/import/LegacyXmlParser.spec.ts
+++ b/src/shared/import/LegacyXmlParser.spec.ts
@@ -171,6 +171,41 @@ describe('LegacyXmlParser', () => {
 
             expect(result).toBe('x<unicode value="before&lt;pre&gt;\tkeep     spacing&lt;/pre&gt;afterend"/>');
         });
+        it('should preserve \\nabla instead of converting \\n to a line-break entity', () => {
+            const input = '\\( \\nabla \\times \\vec{F} \\)';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('\\nabla');
+            expect(result).not.toContain('&#10;abla');
+        });
+
+        it('should preserve \\newcommand', () => {
+            const input = '\\( \\newcommand{\\vec}[1]{\\mathbf{#1}} \\)';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('\\newcommand');
+        });
+
+        it('should preserve \\notin, \\neq and \\ngeq', () => {
+            const input = '\\( a \\notin B \\quad x \\neq y \\quad x \\ngeq y \\)';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('\\notin');
+            expect(result).toContain('\\neq');
+            expect(result).toContain('\\ngeq');
+        });
+
+        it('should handle mixed content with real line breaks and LaTeX commands together', () => {
+            const input = 'Line1\\nLine2 with formula \\( \\nabla f(x) \\)';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('Line1&#10;Line2');
+            expect(result).toContain('\\nabla');
+        });
+
+        it('should preserve \\nabla inside a real eXe unicode value attribute', () => {
+            const input =
+                '<unicode content="true" value="\\( \\nabla \\times \\vec{F} = \\left( \\tfrac{\\partial}{\\partial x} \\right) \\)"/>';
+            const result = parser.preprocessLegacyXml(input);
+            expect(result).toContain('\\nabla');
+            expect(result).not.toMatch(/&#10;abla/);
+        });
     });
 
     describe('parse', () => {

--- a/src/shared/import/LegacyXmlParser.ts
+++ b/src/shared/import/LegacyXmlParser.ts
@@ -351,17 +351,17 @@ export class LegacyXmlParser {
      * Preprocess legacy XML content before parsing
      * Fixes encoding issues from eXe 2.x exports
      */
-    preprocessLegacyXml(xmlContent) {
+    preprocessLegacyXml(xmlContent: string): string {
         let xml = xmlContent;
-        const protectedPreBlocks = [];
-        const protectPreBlock = match => {
+        const protectedPreBlocks: string[] = [];
+        const protectPreBlock = (match: string): string => {
             const token = `__LEGACY_PRE_BLOCK_${protectedPreBlocks.length}__`;
             protectedPreBlocks.push(match);
             return token;
         };
-        xml = xml.replace(/<unicode\b[^>]*>/gi, tag => {
-            return tag.replace(/\bvalue=(['"])([\s\S]*?)\1/i, (_match, quote, value) => {
-                const protectedValue = value.replace(/&lt;pre\b[\s\S]*?&lt;\/pre&gt;/gi, encodedPre => {
+        xml = xml.replace(/<unicode\b[^>]*>/gi, (tag: string) => {
+            return tag.replace(/\bvalue=(['"])([\s\S]*?)\1/i, (_match: string, quote: string, value: string) => {
+                const protectedValue = value.replace(/&lt;pre\b[\s\S]*?&lt;\/pre&gt;/gi, (encodedPre: string) => {
                     return protectPreBlock(encodedPre);
                 });
                 return `value=${quote}${protectedValue}${quote}`;
@@ -369,30 +369,31 @@ export class LegacyXmlParser {
         });
         xml = xml.replace(/ {5}/g, '');
         xml = xml.replace(/\t/g, '');
-        xml = xml.replace(/__LEGACY_PRE_BLOCK_(\d+)__/g, (_match, index) => {
+        xml = xml.replace(/__LEGACY_PRE_BLOCK_(\d+)__/g, (_match: string, index: string) => {
             return protectedPreBlocks[Number(index)] || '';
         });
         xml = xml.replace(/\r/g, '\n');
         xml = xml.replace(/\n\n/g, '\n');
         xml = xml.replace(/\n/g, '&#10;');
         xml = xml.replace(/>&#10;</g, '>\n<');
-        xml = xml.replace(/\\x([0-9A-Fa-f]{2})/g, (_match, hex) => {
+        xml = xml.replace(/\\x([0-9A-Fa-f]{2})/g, (_match: string, hex: string) => {
             return String.fromCharCode(parseInt(hex, 16));
         });
 
-        // Protect LaTeX regions (\( \), \[ \], \begin{}...\end{}, $$ $$, $ $) before
-        // converting literal "\n" to a line-break entity. A blanket \n -> &#10;
-        // replacement (or a lookahead on the next character) cannot tell a real
-        // line-break escape apart from the start of a command like \nabla or
-        // \newcommand, since both are typically followed by a letter.
-        const latexBlocks = [];
-        let token;
+        // Protect LaTeX regions before converting literal "\n" to a line-break
+        // entity. Uses the same detection logic as BaseLegacyHandler.decodeHtmlContent
+        // for consistency: block-level protection (not a per-character lookahead,
+        // which is ambiguous), plus a currency guard so a "$" followed by an
+        // amount like "$5" doesn't pair with a later real "$...$" formula and
+        // leave a literal "\n" between them unconverted.
+        const latexBlocks: string[] = [];
+        let token: string;
         do {
             token = `\u0000LTXP${Math.random().toString(36).slice(2)}\u0000`;
         } while (xml.includes(token));
         const latexPattern =
-            /\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\]|\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}|\$\$[\s\S]*?\$\$|(?<!\\)\$[\s\S]*?(?<!\\)\$/g;
-        xml = xml.replace(latexPattern, match => {
+            /\\\((?:[^\\]|\\.)*?\\\)|\\\[(?:[^\\]|\\.)*?\\\]|\\begin\{[^}]+\}(?:[^\\]|\\.)*?\\end\{[^}]+\}|\$\$(?:[^$]|\\.)*?\$\$|(?<!\\)\$(?!\d+(?:[.,]\d+)?\b)(?:[^$\\]|\\.)*?(?<!\\)\$/g;
+        xml = xml.replace(latexPattern, (match: string) => {
             latexBlocks.push(match);
             return `${token}${latexBlocks.length - 1}${token}`;
         });
@@ -400,7 +401,7 @@ export class LegacyXmlParser {
         xml = xml.replace(/\\n/g, '&#10;');
 
         const tokenPattern = new RegExp(`${token}(\\d+)${token}`, 'g');
-        xml = xml.replace(tokenPattern, (_match, i) => latexBlocks[Number(i)]);
+        xml = xml.replace(tokenPattern, (_match: string, i: string) => latexBlocks[Number(i)]);
 
         return xml;
     }

--- a/src/shared/import/LegacyXmlParser.ts
+++ b/src/shared/import/LegacyXmlParser.ts
@@ -351,12 +351,10 @@ export class LegacyXmlParser {
      * Preprocess legacy XML content before parsing
      * Fixes encoding issues from eXe 2.x exports
      */
-    preprocessLegacyXml(xmlContent: string): string {
+    preprocessLegacyXml(xmlContent) {
         let xml = xmlContent;
-
-        // 1. Remove indentations (5 spaces, tabs)
-        const protectedPreBlocks: string[] = [];
-        const protectPreBlock = (match: string): string => {
+        const protectedPreBlocks = [];
+        const protectPreBlock = match => {
             const token = `__LEGACY_PRE_BLOCK_${protectedPreBlocks.length}__`;
             protectedPreBlocks.push(match);
             return token;
@@ -374,24 +372,35 @@ export class LegacyXmlParser {
         xml = xml.replace(/__LEGACY_PRE_BLOCK_(\d+)__/g, (_match, index) => {
             return protectedPreBlocks[Number(index)] || '';
         });
-
-        // 2. Unify newlines to Unix LF
         xml = xml.replace(/\r/g, '\n');
         xml = xml.replace(/\n\n/g, '\n');
-
-        // 3. Convert newlines to &#10; entity
         xml = xml.replace(/\n/g, '&#10;');
-
-        // 4. Restore newlines between tags
         xml = xml.replace(/>&#10;</g, '>\n<');
-
-        // 5. Convert hex escape sequences (\xNN) to characters
         xml = xml.replace(/\\x([0-9A-Fa-f]{2})/g, (_match, hex) => {
             return String.fromCharCode(parseInt(hex, 16));
         });
 
-        // 6. Convert \n to &#10;
+        // Protect LaTeX regions (\( \), \[ \], \begin{}...\end{}, $$ $$, $ $) before
+        // converting literal "\n" to a line-break entity. A blanket \n -> &#10;
+        // replacement (or a lookahead on the next character) cannot tell a real
+        // line-break escape apart from the start of a command like \nabla or
+        // \newcommand, since both are typically followed by a letter.
+        const latexBlocks = [];
+        let token;
+        do {
+            token = `\u0000LTXP${Math.random().toString(36).slice(2)}\u0000`;
+        } while (xml.includes(token));
+        const latexPattern =
+            /\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\]|\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}|\$\$[\s\S]*?\$\$|(?<!\\)\$[\s\S]*?(?<!\\)\$/g;
+        xml = xml.replace(latexPattern, match => {
+            latexBlocks.push(match);
+            return `${token}${latexBlocks.length - 1}${token}`;
+        });
+
         xml = xml.replace(/\\n/g, '&#10;');
+
+        const tokenPattern = new RegExp(`${token}(\\d+)${token}`, 'g');
+        xml = xml.replace(tokenPattern, (_match, i) => latexBlocks[Number(i)]);
 
         return xml;
     }

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
@@ -409,43 +409,43 @@ describe('BaseLegacyHandler', () => {
             // \\r followed by 'i' in 'right' should NOT be converted
             expect(handler.decodeHtmlContent(latex)).toBe('\\left( x \\right)');
         });
-        
+
         it('should preserve \\times inside \\( ... \\) delimiters', () => {
             const latex = '\\( 4 \\times \\dfrac{1}{2} \\)';
             expect(handler.decodeHtmlContent(latex)).toBe('\\( 4 \\times \\dfrac{1}{2} \\)');
         });
-        
+
         it('should preserve LaTeX commands starting with \\n (e.g. \\nabla)', () => {
             const latex = '\\( \\nabla f(x) \\)';
             expect(handler.decodeHtmlContent(latex)).toBe('\\( \\nabla f(x) \\)');
         });
-        
+
         it('should preserve LaTeX inside \\[ ... \\] block delimiters', () => {
             const latex = '\\[ \\times \\dfrac{a}{b} \\]';
             expect(handler.decodeHtmlContent(latex)).toBe('\\[ \\times \\dfrac{a}{b} \\]');
         });
-        
+
         it('should preserve LaTeX inside $ ... $ inline delimiters', () => {
             const latex = 'The result is $x \\times y$ units';
             expect(handler.decodeHtmlContent(latex)).toBe('The result is $x \\times y$ units');
         });
-        
+
         it('should preserve LaTeX inside $$ ... $$ block delimiters', () => {
             const latex = '$$ a \\times b = c $$';
             expect(handler.decodeHtmlContent(latex)).toBe('$$ a \\times b = c $$');
         });
-        
+
         it('should still decode HTML entities and real \\n outside LaTeX blocks', () => {
             const input = '&lt;p&gt;Text\\nnext line with \\( a \\times b \\)&lt;/p&gt;';
             const expected = '<p>Text\nnext line with \\( a \\times b \\)</p>';
             expect(handler.decodeHtmlContent(input)).toBe(expected);
         });
-        
+
         it('should preserve multiple LaTeX blocks in the same content', () => {
             const input = 'First \\( a \\times b \\) and then \\( c \\times d \\)';
             expect(handler.decodeHtmlContent(input)).toBe(input);
         });
-        
+
         it('should handle the real eXe example with \\times and \\dfrac', () => {
             const input =
                 '<div class="exe-text"><p>\\( 4 \\times \\dfrac{1}{2} = \\dfrac{4}{1} \\times \\dfrac{1}{2} = \\dfrac{4 \\times 1}{1 \\times 2}=\\dfrac{4}{2} \\) = 2 units</p></div>';

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
@@ -375,82 +375,65 @@ describe('BaseLegacyHandler', () => {
         });
     });
 
-    describe('decodeHtmlContent', () => {
-        it('should decode HTML entities', () => {
-            expect(handler.decodeHtmlContent('&lt;div&gt;Hello&lt;/div&gt;')).toBe('<div>Hello</div>');
+    describe('decodeHtmlContent - LaTeX stress cases (regression)', () => {
+        it.each([
+            // Commands starting with 't' (previously broken by \t -> tab)
+            ['\\( 4 \\times \\dfrac{1}{2} \\)'],
+            ['\\( \\tan(x) + \\theta \\)'],
+            ['\\( \\tfrac{1}{2} + \\text{units} \\)'],
+            ['\\( \\top \\land \\bot \\)'],
+
+            // Commands starting with 'n' (previously broken by \n -> newline)
+            ['\\( \\nabla f(x, y) \\)'],
+            ['\\( \\neq \\quad \\nleq \\quad \\ngeq \\)'],
+            ['\\( a \\notin B \\)'],
+
+            // Commands starting with 'r' (already protected before, re-confirm)
+            ['\\( \\left( x \\right) \\)'],
+            ['\\( \\rho \\cdot \\rightarrow \\)'],
+
+            // Mixed dangerous commands in the same formula
+            [
+                '\\( 4 \\times \\dfrac{1}{2} = \\dfrac{4}{1} \\times \\dfrac{1}{2} = \\dfrac{4 \\times 1}{1 \\times 2} = \\dfrac{4}{2} \\)',
+            ],
+            ['\\( \\nabla \\times \\vec{F} = \\left( \\tfrac{\\partial}{\\partial x} \\right) \\)'],
+
+            // \begin{...}...\end{...} environments without $, \(, \[ delimiters
+            ['\\begin{equation} a \\times b = c \\end{equation}'],
+            ['\\begin{align} x &= \\nabla f \\\\ y &= \\tan(\\theta) \\end{align}'],
+
+            // Multiple LaTeX blocks in the same content (placeholder collision check)
+            ['First \\( a \\times b \\) then \\( \\nabla \\times c \\) and finally \\( \\tan(\\theta) \\)'],
+
+            // Text that literally contains something resembling the internal placeholder
+            [
+                'Note: __LATEX_BLOCK_0__ is an internal placeholder, it should not be touched, and here is a real formula \\( a \\times b \\)',
+            ],
+
+            // Escaped dollar sign before a real formula
+            ['Price: \\$5, formula: $x \\times y$'],
+            ['The cost is \\$10.50 and the equation is $\\nabla \\times \\vec{F}$'],
+        ])('should leave LaTeX content unchanged: %s', input => {
+            expect(handler.decodeHtmlContent(input)).toBe(input);
         });
 
-        it('should decode &amp;', () => {
-            expect(handler.decodeHtmlContent('A &amp; B')).toBe('A & B');
-        });
-
-        it('should decode &quot;', () => {
-            expect(handler.decodeHtmlContent('Say &quot;Hello&quot;')).toBe('Say "Hello"');
-        });
-
-        it('should decode &#39;', () => {
-            expect(handler.decodeHtmlContent('It&#39;s nice')).toBe("It's nice");
-        });
-
-        it('should decode \\n to newline', () => {
-            expect(handler.decodeHtmlContent('Line1\\nLine2')).toBe('Line1\nLine2');
-        });
-
-        it('should decode \\t to tab', () => {
-            expect(handler.decodeHtmlContent('Col1\\tCol2')).toBe('Col1\tCol2');
-        });
-
-        it('should return empty string for empty input', () => {
-            expect(handler.decodeHtmlContent('')).toBe('');
-        });
-
-        it('should preserve LaTeX \\right command', () => {
-            const latex = '\\left( x \\right)';
-            // \\r followed by 'i' in 'right' should NOT be converted
-            expect(handler.decodeHtmlContent(latex)).toBe('\\left( x \\right)');
-        });
-
-        it('should preserve \\times inside \\( ... \\) delimiters', () => {
-            const latex = '\\( 4 \\times \\dfrac{1}{2} \\)';
-            expect(handler.decodeHtmlContent(latex)).toBe('\\( 4 \\times \\dfrac{1}{2} \\)');
-        });
-
-        it('should preserve LaTeX commands starting with \\n (e.g. \\nabla)', () => {
-            const latex = '\\( \\nabla f(x) \\)';
-            expect(handler.decodeHtmlContent(latex)).toBe('\\( \\nabla f(x) \\)');
-        });
-
-        it('should preserve LaTeX inside \\[ ... \\] block delimiters', () => {
-            const latex = '\\[ \\times \\dfrac{a}{b} \\]';
-            expect(handler.decodeHtmlContent(latex)).toBe('\\[ \\times \\dfrac{a}{b} \\]');
-        });
-
-        it('should preserve LaTeX inside $ ... $ inline delimiters', () => {
-            const latex = 'The result is $x \\times y$ units';
-            expect(handler.decodeHtmlContent(latex)).toBe('The result is $x \\times y$ units');
-        });
-
-        it('should preserve LaTeX inside $$ ... $$ block delimiters', () => {
-            const latex = '$$ a \\times b = c $$';
-            expect(handler.decodeHtmlContent(latex)).toBe('$$ a \\times b = c $$');
-        });
-
-        it('should still decode HTML entities and real \\n outside LaTeX blocks', () => {
-            const input = '&lt;p&gt;Text\\nnext line with \\( a \\times b \\)&lt;/p&gt;';
-            const expected = '<p>Text\nnext line with \\( a \\times b \\)</p>';
+        it.each([
+            // HTML entities inside LaTeX must still be decoded
+            ['\\( x &lt; y \\)', '\\( x < y \\)'],
+            ['$a &amp;&amp; b$', '$a && b$'],
+            ['\\begin{equation} x &lt; y \\end{equation}', '\\begin{equation} x < y \\end{equation}'],
+        ])('should decode HTML entities inside LaTeX: %s -> %s', (input, expected) => {
             expect(handler.decodeHtmlContent(input)).toBe(expected);
         });
 
-        it('should preserve multiple LaTeX blocks in the same content', () => {
-            const input = 'First \\( a \\times b \\) and then \\( c \\times d \\)';
-            expect(handler.decodeHtmlContent(input)).toBe(input);
-        });
-
-        it('should handle the real eXe example with \\times and \\dfrac', () => {
-            const input =
-                '<div class="exe-text"><p>\\( 4 \\times \\dfrac{1}{2} = \\dfrac{4}{1} \\times \\dfrac{1}{2} = \\dfrac{4 \\times 1}{1 \\times 2}=\\dfrac{4}{2} \\) = 2 units</p></div>';
-            expect(handler.decodeHtmlContent(input)).toBe(input);
-        });
+        it(
+            'KNOWN LIMITATION: ordinary currency text with multiple unescaped "$" signs ' +
+                'can still be misread as a single LaTeX block',
+            () => {
+                const input = 'Price: $5 and $10 total';
+                expect(handler.decodeHtmlContent(input)).toBe(input);
+            },
+        );
     });
 
     describe('extractTextAreaFieldRawContent (quiz option plain text)', () => {

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
@@ -376,6 +376,30 @@ describe('BaseLegacyHandler', () => {
     });
 
     describe('decodeHtmlContent - LaTeX stress cases (regression)', () => {
+        // --- RESTORED REGRESSION TESTS (plain \n / \t decoding outside LaTeX) ---
+        // These were covered before the LaTeX protection block was introduced and
+        // must keep working: since LaTeX blocks are protected first, escapes
+        // outside those blocks are decoded unconditionally, without a lookahead.
+
+        it('should decode \\n to newline', () => {
+            expect(handler.decodeHtmlContent('Line1\\nLine2')).toBe('Line1\nLine2');
+        });
+
+        it('should decode \\t to tab', () => {
+            expect(handler.decodeHtmlContent('Col1\\tCol2')).toBe('Col1\tCol2');
+        });
+
+        it('should decode \\n even when immediately followed by a letter (no false LaTeX match)', () => {
+            const input = 'Text\\nnext line without any LaTeX nearby';
+            expect(handler.decodeHtmlContent(input)).toBe('Text\nnext line without any LaTeX nearby');
+        });
+
+        it('should decode &nbsp; to a non-breaking space, not a regular space', () => {
+            const result = handler.decodeHtmlContent('Hello&nbsp;World');
+            expect(result).toBe('Hello\u00A0World');
+            expect(result).not.toBe('Hello World');
+        });
+
         it.each([
             // Commands starting with 't' (previously broken by \t -> tab)
             ['\\( 4 \\times \\dfrac{1}{2} \\)'],

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
@@ -409,6 +409,48 @@ describe('BaseLegacyHandler', () => {
             // \\r followed by 'i' in 'right' should NOT be converted
             expect(handler.decodeHtmlContent(latex)).toBe('\\left( x \\right)');
         });
+        
+        it('should preserve \\times inside \\( ... \\) delimiters', () => {
+            const latex = '\\( 4 \\times \\dfrac{1}{2} \\)';
+            expect(handler.decodeHtmlContent(latex)).toBe('\\( 4 \\times \\dfrac{1}{2} \\)');
+        });
+        
+        it('should preserve LaTeX commands starting with \\n (e.g. \\nabla)', () => {
+            const latex = '\\( \\nabla f(x) \\)';
+            expect(handler.decodeHtmlContent(latex)).toBe('\\( \\nabla f(x) \\)');
+        });
+        
+        it('should preserve LaTeX inside \\[ ... \\] block delimiters', () => {
+            const latex = '\\[ \\times \\dfrac{a}{b} \\]';
+            expect(handler.decodeHtmlContent(latex)).toBe('\\[ \\times \\dfrac{a}{b} \\]');
+        });
+        
+        it('should preserve LaTeX inside $ ... $ inline delimiters', () => {
+            const latex = 'The result is $x \\times y$ units';
+            expect(handler.decodeHtmlContent(latex)).toBe('The result is $x \\times y$ units');
+        });
+        
+        it('should preserve LaTeX inside $$ ... $$ block delimiters', () => {
+            const latex = '$$ a \\times b = c $$';
+            expect(handler.decodeHtmlContent(latex)).toBe('$$ a \\times b = c $$');
+        });
+        
+        it('should still decode HTML entities and real \\n outside LaTeX blocks', () => {
+            const input = '&lt;p&gt;Text\\nnext line with \\( a \\times b \\)&lt;/p&gt;';
+            const expected = '<p>Text\nnext line with \\( a \\times b \\)</p>';
+            expect(handler.decodeHtmlContent(input)).toBe(expected);
+        });
+        
+        it('should preserve multiple LaTeX blocks in the same content', () => {
+            const input = 'First \\( a \\times b \\) and then \\( c \\times d \\)';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
+        
+        it('should handle the real eXe example with \\times and \\dfrac', () => {
+            const input =
+                '<div class="exe-text"><p>\\( 4 \\times \\dfrac{1}{2} = \\dfrac{4}{1} \\times \\dfrac{1}{2} = \\dfrac{4 \\times 1}{1 \\times 2}=\\dfrac{4}{2} \\) = 2 units</p></div>';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
     });
 
     describe('extractTextAreaFieldRawContent (quiz option plain text)', () => {

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.spec.ts
@@ -426,12 +426,44 @@ describe('BaseLegacyHandler', () => {
             expect(handler.decodeHtmlContent(input)).toBe(expected);
         });
 
+        // --- REVIEWER REGRESSION TESTS (Currency vs Formula) ---
+
+        it('should not be tricked by preceding currency text leaving LaTeX commands unprotected (Reviewer Case)', () => {
+            // If the regex is greedy, it might match from the currency "$" to the opening "$"
+            // of the formula, leaving "\times" outside the protected block where it would be
+            // corrupted into a tab character.
+            const input = 'Price: $5 and formula $x \\times y$';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
+
+        it('should handle multiple currency amounts without misclassification', () => {
+            const input = 'Price: $5 and $10 total';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
+
+        it('should protect a $...$ formula starting with a digit glued to a variable (e.g. "2x")', () => {
+            const input = 'The formula is $2x+3$';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
+
+        it('should protect a $...$ formula with a numeric coefficient and a LaTeX command', () => {
+            const input = 'Compute $5x \\times 2$ to get the result';
+            expect(handler.decodeHtmlContent(input)).toBe(input);
+        });
+
         it(
-            'KNOWN LIMITATION: ordinary currency text with multiple unescaped "$" signs ' +
-                'can still be misread as a single LaTeX block',
+            'KNOWN LIMITATION: a $...$ formula consisting of a bare number only (e.g. "$5$") ' +
+                'is still misclassified as currency',
             () => {
-                const input = 'Price: $5 and $10 total';
-                expect(handler.decodeHtmlContent(input)).toBe(input);
+                // "$5$" has nothing after the digit but the closing "$" itself,
+                // which counts as a word boundary — so it's indistinguishable
+                // from a currency amount. Rare in practice (a lone number is
+                // seldom wrapped in $ $ without any operator or variable).
+                // Note: It remains unchanged in the output because it contains no
+                // Python-style escape sequences (\n, \t, \r) to corrupt.
+                const input = 'The answer is $5$';
+                const result = handler.decodeHtmlContent(input);
+                expect(result).toBe(input);
             },
         );
     });

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
@@ -427,8 +427,15 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
     decodeHtmlContent(content: string): string {
         if (!content) return '';
 
+        // Protect LaTeX blocks before applying replacements
+        const latexBlocks: string[] = [];
+        const protectedContent = content.replace(/\\\(.*?\\\)|\\\[.*?\\\]|\$\$.*?\$\$|\$.*?\$/gs, match => {
+            latexBlocks.push(match);
+            return `__LATEX_BLOCK_${latexBlocks.length - 1}__`;
+        });
+
         // Handle Python-style unicode escapes and HTML entities
-        const decoded = content
+        let decoded = protectedContent
             // Decode common HTML entities
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
@@ -439,6 +446,9 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
             .replace(/\\n/g, '\n')
             .replace(/\\t/g, '\t')
             .replace(/\\r(?![a-zA-Z])/g, '\r'); // Negative lookahead to preserve LaTeX commands
+
+        // Restore the original LaTeX blocks
+        decoded = decoded.replace(/__LATEX_BLOCK_(\d+)__/g, (_, i) => latexBlocks[i]);
 
         return decoded;
     }

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
@@ -427,30 +427,44 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
     decodeHtmlContent(content: string): string {
         if (!content) return '';
 
-        // Protect LaTeX blocks before applying replacements
-        const latexBlocks: string[] = [];
-        const protectedContent = content.replace(/\\\(.*?\\\)|\\\[.*?\\\]|\$\$.*?\$\$|\$.*?\$/gs, match => {
-            latexBlocks.push(match);
-            return `__LATEX_BLOCK_${latexBlocks.length - 1}__`;
-        });
-
-        // Handle Python-style unicode escapes and HTML entities
-        let decoded = protectedContent
-            // Decode common HTML entities
+        // Decode HTML entities everywhere, including inside LaTeX expressions.
+        // Entity decoding is independent from the Python-style escape handling
+        // below, so it must not be skipped just because a region is LaTeX.
+        const entitiesDecoded = content
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
             .replace(/&amp;/g, '&')
             .replace(/&quot;/g, '"')
-            .replace(/&#39;/g, "'")
-            // Handle Python unicode escapes for common characters
+            .replace(/&#39;/g, "'");
+
+        // Build a placeholder token that cannot collide with real content:
+        // it's randomized and regenerated until it's guaranteed absent from
+        // the text being processed.
+        let token: string;
+        do {
+            token = `\u0000LTX${Math.random().toString(36).slice(2)}\u0000`;
+        } while (entitiesDecoded.includes(token));
+
+        // Protect LaTeX regions so the Python-escape replacements below can't
+        // corrupt commands like \times, \nabla, \right.
+        const latexBlocks: string[] = [];
+        const latexPattern =
+            /\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\]|\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}|\$\$[\s\S]*?\$\$|(?<!\\)\$[\s\S]*?(?<!\\)\$/g;
+
+        const protectedContent = entitiesDecoded.replace(latexPattern, match => {
+            latexBlocks.push(match);
+            return `${token}${latexBlocks.length - 1}${token}`;
+        });
+
+        // Handle Python-style escape sequences, now safely outside LaTeX blocks.
+        const decoded = protectedContent
             .replace(/\\n/g, '\n')
             .replace(/\\t/g, '\t')
-            .replace(/\\r(?![a-zA-Z])/g, '\r'); // Negative lookahead to preserve LaTeX commands
+            .replace(/\\r(?![a-zA-Z])/g, '\r');
 
-        // Restore the original LaTeX blocks
-        decoded = decoded.replace(/__LATEX_BLOCK_(\d+)__/g, (_, i) => latexBlocks[i]);
-
-        return decoded;
+        // Restore the original LaTeX blocks untouched.
+        const tokenPattern = new RegExp(`${token}(\\d+)${token}`, 'g');
+        return decoded.replace(tokenPattern, (_, i) => latexBlocks[Number(i)]);
     }
 
     /**

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
@@ -426,8 +426,7 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
      */
     decodeHtmlContent(content: string): string {
         if (!content) return '';
-
-        // 1. Decode basic HTML entities (including &nbsp; and &apos;)
+        // 1. Decode basic HTML entities
         const decodedContent = content
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
@@ -435,7 +434,7 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
             .replace(/&quot;/g, '"')
             .replace(/&#39;/g, "'")
             .replace(/&apos;/g, "'")
-            .replace(/&nbsp;/g, ' ');
+            .replace(/&nbsp;/g, '\u00A0'); // see point 3 below
 
         // 2. Generate a unique and safe placeholder token to avoid collisions
         let token: string;
@@ -444,29 +443,24 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
         } while (decodedContent.includes(token));
 
         // 3. Robust LaTeX pattern.
-        // - \\\(, \\\[, \\begin: Use (?:[^\\]|\\.)*? to prevent ReDoS (catastrophic backtracking).
-        // - \$\$: Double dollar blocks.
-        // - Single \$:
-        //   a) (?<!\\)      : Must not be preceded by a backslash (ignores escaped \$).
-        //   b) (?!\d+(?:[.,]\d+)?\b) : NOT a currency amount (ignores "$5 ", "$10.50,").
-        //   c) (?:[^$\\]|\\.)*?      : Safe content matching without ReDoS.
-        //   d) (?<!\\)\$             : Closing with an unescaped $.
         const latexPattern =
             /\\\((?:[^\\]|\\.)*?\\\)|\\\[(?:[^\\]|\\.)*?\\\]|\\begin\{[^}]+\}(?:[^\\]|\\.)*?\\end\{[^}]+\}|\$\$(?:[^$]|\\.)*?\$\$|(?<!\\)\$(?!\d+(?:[.,]\d+)?\b)(?:[^$\\]|\\.)*?(?<!\\)\$/g;
-
         const latexBlocks: string[] = [];
         const protectedContent = decodedContent.replace(latexPattern, match => {
             latexBlocks.push(match);
             return `${token}${latexBlocks.length - 1}${token}`;
         });
 
-        // 4. Decode Python-style escape sequences with LaTeX command protection.
-        // The lookahead (?![a-zA-Z]) is a "safety net": if a command like \nabla or \times
-        // is left outside a LaTeX block due to malformed input, it won't be corrupted
-        // into a newline or tab character.
+        // 4. Decode Python-style escape sequences.
+        // \n and \t are decoded unconditionally: LaTeX commands using these
+        // letters (\nabla, \times) are already safe thanks to the block-level
+        // protection in step 3. \r keeps its lookahead as a safety net for
+        // LaTeX commands like \right that appear WITHOUT any recognised
+        // delimiter around them (see the bare "\left( x \right)" regression
+        // test), and are therefore not covered by step 3.
         const finalDecoded = protectedContent
-            .replace(/\\n(?![a-zA-Z])/g, '\n')
-            .replace(/\\t(?![a-zA-Z])/g, '\t')
+            .replace(/\\n/g, '\n')
+            .replace(/\\t/g, '\t')
             .replace(/\\r(?![a-zA-Z])/g, '\r');
 
         // 5. Restore the original LaTeX blocks untouched

--- a/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
+++ b/src/shared/import/legacy-handlers/BaseLegacyHandler.ts
@@ -427,44 +427,51 @@ export abstract class BaseLegacyHandler implements IdeviceHandler {
     decodeHtmlContent(content: string): string {
         if (!content) return '';
 
-        // Decode HTML entities everywhere, including inside LaTeX expressions.
-        // Entity decoding is independent from the Python-style escape handling
-        // below, so it must not be skipped just because a region is LaTeX.
-        const entitiesDecoded = content
+        // 1. Decode basic HTML entities (including &nbsp; and &apos;)
+        const decodedContent = content
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
             .replace(/&amp;/g, '&')
             .replace(/&quot;/g, '"')
-            .replace(/&#39;/g, "'");
+            .replace(/&#39;/g, "'")
+            .replace(/&apos;/g, "'")
+            .replace(/&nbsp;/g, ' ');
 
-        // Build a placeholder token that cannot collide with real content:
-        // it's randomized and regenerated until it's guaranteed absent from
-        // the text being processed.
+        // 2. Generate a unique and safe placeholder token to avoid collisions
         let token: string;
         do {
             token = `\u0000LTX${Math.random().toString(36).slice(2)}\u0000`;
-        } while (entitiesDecoded.includes(token));
+        } while (decodedContent.includes(token));
 
-        // Protect LaTeX regions so the Python-escape replacements below can't
-        // corrupt commands like \times, \nabla, \right.
-        const latexBlocks: string[] = [];
+        // 3. Robust LaTeX pattern.
+        // - \\\(, \\\[, \\begin: Use (?:[^\\]|\\.)*? to prevent ReDoS (catastrophic backtracking).
+        // - \$\$: Double dollar blocks.
+        // - Single \$:
+        //   a) (?<!\\)      : Must not be preceded by a backslash (ignores escaped \$).
+        //   b) (?!\d+(?:[.,]\d+)?\b) : NOT a currency amount (ignores "$5 ", "$10.50,").
+        //   c) (?:[^$\\]|\\.)*?      : Safe content matching without ReDoS.
+        //   d) (?<!\\)\$             : Closing with an unescaped $.
         const latexPattern =
-            /\\\([\s\S]*?\\\)|\\\[[\s\S]*?\\\]|\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}|\$\$[\s\S]*?\$\$|(?<!\\)\$[\s\S]*?(?<!\\)\$/g;
+            /\\\((?:[^\\]|\\.)*?\\\)|\\\[(?:[^\\]|\\.)*?\\\]|\\begin\{[^}]+\}(?:[^\\]|\\.)*?\\end\{[^}]+\}|\$\$(?:[^$]|\\.)*?\$\$|(?<!\\)\$(?!\d+(?:[.,]\d+)?\b)(?:[^$\\]|\\.)*?(?<!\\)\$/g;
 
-        const protectedContent = entitiesDecoded.replace(latexPattern, match => {
+        const latexBlocks: string[] = [];
+        const protectedContent = decodedContent.replace(latexPattern, match => {
             latexBlocks.push(match);
             return `${token}${latexBlocks.length - 1}${token}`;
         });
 
-        // Handle Python-style escape sequences, now safely outside LaTeX blocks.
-        const decoded = protectedContent
-            .replace(/\\n/g, '\n')
-            .replace(/\\t/g, '\t')
+        // 4. Decode Python-style escape sequences with LaTeX command protection.
+        // The lookahead (?![a-zA-Z]) is a "safety net": if a command like \nabla or \times
+        // is left outside a LaTeX block due to malformed input, it won't be corrupted
+        // into a newline or tab character.
+        const finalDecoded = protectedContent
+            .replace(/\\n(?![a-zA-Z])/g, '\n')
+            .replace(/\\t(?![a-zA-Z])/g, '\t')
             .replace(/\\r(?![a-zA-Z])/g, '\r');
 
-        // Restore the original LaTeX blocks untouched.
+        // 5. Restore the original LaTeX blocks untouched
         const tokenPattern = new RegExp(`${token}(\\d+)${token}`, 'g');
-        return decoded.replace(tokenPattern, (_, i) => latexBlocks[Number(i)]);
+        return finalDecoded.replace(tokenPattern, (_, i) => latexBlocks[Number(i)]);
     }
 
     /**


### PR DESCRIPTION
## Description
This PR fixes the bug where open legacy ELP format misinterprets LaTeX control sequences, resulting in corrupted equations.
Fixes #2160

The decoding logic has been updated to safely ignore or correctly escape LaTeX syntax while processing the legacy XML/HTML content.

**Fixes #** ## Changes Made
* Updated `Decode HTML content from legacy XML format` function to handle backslashes followed by specific characters (like `\t`) correctly within LaTeX blocks.
* Added unit tests covering LaTeX expressions containing LaTeX control sequences.

## How to Test
1. Download the attached test file: [latex.zip](https://github.com/user-attachments/files/29946812/latex.zip)
2. Open this legacy ELP (or ZIP)  file.
3. Verify that the output retains `\times` intact instead of converting it to `imes`.