### PR TITLE
fix(assets): stop leaking blob URLs into detached anchor href reads (#2186)

### DIFF
--- a/public/app/common/asset_url_resolver.js
+++ b/public/app/common/asset_url_resolver.js
@@ -655,9 +655,18 @@
 
         // For anchor elements reading 'href'
         if (name === 'href' && this.tagName === 'A') {
-            // If href is still asset://, try to return the resolved blob:// from cache
-            // This helps SimpleLightbox and similar libraries get the real URL
-            if (value && value.startsWith('asset://') && resolvedCache.has(value)) {
+            // If href is still asset://, return the resolved blob:// from cache, but
+            // only for anchors that live in the document. SimpleLightbox and similar
+            // libraries operate on the rendered page and need a loadable URL before
+            // the MutationObserver has rewritten the href.
+            //
+            // Detached anchors are never rendered: they belong to the throwaway
+            // wrappers iDevices build to parse their own stored HTML back into form
+            // data (e.g. classify's `$('<div></div>').html(previousData)`). Handing
+            // them an ephemeral blob: URL makes them persist a reference that dies
+            // with the page, wiping the media on reload (issue #2186). Those reads
+            // must see the persistent asset:// URL that is literally in the DOM.
+            if (this.isConnected && value && value.startsWith('asset://') && resolvedCache.has(value)) {
                 return resolvedCache.get(value);
             }
             // For persistence: return the original asset:// URL if we have one stored

--- a/public/app/common/asset_url_resolver.test.js
+++ b/public/app/common/asset_url_resolver.test.js
@@ -8,12 +8,21 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+// The resolver patches Element.prototype.getAttribute on import. Every re-import
+// (vi.resetModules() + await import) installs another layer on top of the previous
+// one, and each layer owns a separate resolvedCache. Stacked layers feed each
+// other's return value back through the asset://<->blob:// mapping, which produces
+// results no single layer would ever return. Capture the pristine method once and
+// restore it between tests so each test exercises exactly one layer.
+const nativeGetAttribute = Element.prototype.getAttribute;
+
 describe('AssetUrlResolver', () => {
   let mockAssetManager;
   let mockAssetWebSocketHandler;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    Element.prototype.getAttribute = nativeGetAttribute;
 
     // Mock console methods
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -33,6 +42,7 @@ describe('AssetUrlResolver', () => {
     delete window.eXeLearningAssetResolver;
     delete window.jQuery;
     delete window.eXeLearning;
+    Element.prototype.getAttribute = nativeGetAttribute;
     vi.restoreAllMocks();
   });
 
@@ -253,8 +263,11 @@ describe('AssetUrlResolver', () => {
       });
 
       it('populates cache so getAttribute can return blob URL for asset:// href (SimpleLightbox support)', async () => {
-        // This test verifies the behavior for SimpleLightbox and similar libraries
-        // When they read the href of an anchor, they should get the resolved blob:// URL
+        // This test verifies the behavior for SimpleLightbox and similar libraries.
+        // When they read the href of an anchor *in the live document*, they should
+        // get the resolved blob:// URL. The anchor must be connected: detached
+        // anchors are parsing wrappers reading back stored HTML and must keep the
+        // persistent asset:// URL instead (see issue #2186).
         const assetUrl = 'asset://cached-uuid-test/lightbox-image.jpg';
         const blobUrl = 'blob:http://localhost/cached-blob-test';
         mockAssetManager.resolveAssetURL.mockResolvedValue(blobUrl);
@@ -263,13 +276,99 @@ describe('AssetUrlResolver', () => {
         const resolved = await resolver.resolve(assetUrl);
         expect(resolved).toBe(blobUrl);
 
-        // Now create an anchor with the asset:// href
+        // Now create an anchor with the asset:// href, live in the document
         const a = document.createElement('a');
         a.setAttribute('href', assetUrl);
+        document.body.appendChild(a);
 
-        // When reading the href, should get the cached blob URL
-        const result = a.getAttribute('href');
-        expect(result).toBe(blobUrl);
+        try {
+          // When reading the href, should get the cached blob URL
+          const result = a.getAttribute('href');
+          expect(result).toBe(blobUrl);
+        } finally {
+          a.remove();
+        }
+      });
+    });
+
+    describe('anchor href reads on detached wrappers (issue #2186)', () => {
+      const assetUrl = 'asset://2d982eb3-cow/COW2.jpg';
+      const blobUrl = 'blob:app://localhost/ephemeral-blob-uuid';
+
+      beforeEach(async () => {
+        // Populate resolvedCache the way page-view rendering does before editing
+        mockAssetManager.resolveAssetURL.mockResolvedValue(blobUrl);
+        await resolver.resolve(assetUrl);
+      });
+
+      it('returns the persistent asset:// URL for a detached anchor even when cached', () => {
+        // Reproduces how game iDevices read their media refs back: the stored
+        // HTML is parsed into a *detached* wrapper and hrefs are read from it.
+        // See public/files/perm/idevices/base/classify/edition/classify.js:681.
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = `<a href="${assetUrl}" class="js-hidden clasifica-LinkImages">0</a>`;
+        const anchor = wrapper.querySelector('a');
+
+        expect(anchor.isConnected).toBe(false);
+        expect(anchor.getAttribute('href')).toBe(assetUrl);
+      });
+
+      it('returns the cached blob URL for a connected anchor (lightbox keeps working)', () => {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', assetUrl);
+        document.body.appendChild(anchor);
+
+        try {
+          expect(anchor.isConnected).toBe(true);
+          expect(anchor.getAttribute('href')).toBe(blobUrl);
+        } finally {
+          anchor.remove();
+        }
+      });
+
+      it('returns asset:// for a detached anchor whose asset is not cached', () => {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = '<a href="asset://uncached-uuid/photo.jpg">1</a>';
+
+        expect(wrapper.querySelector('a').getAttribute('href')).toBe(
+          'asset://uncached-uuid/photo.jpg'
+        );
+      });
+
+      it('still maps blob href back to asset:// via data-asset-url when detached', () => {
+        // Branch 2 (persistence) stays ungated: a detached anchor carrying a
+        // resolved blob href must still report the persistent asset:// URL.
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = `<a href="${blobUrl}" data-asset-url="${assetUrl}">0</a>`;
+
+        expect(wrapper.querySelector('a').getAttribute('href')).toBe(assetUrl);
+      });
+
+      it('still maps blob href back to asset:// via data-asset-url when connected', () => {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('data-asset-url', assetUrl);
+        anchor.setAttribute('href', blobUrl);
+        document.body.appendChild(anchor);
+
+        try {
+          expect(anchor.getAttribute('href')).toBe(assetUrl);
+        } finally {
+          anchor.remove();
+        }
+      });
+
+      it('reads back every link anchor of a stored game iDevice as asset://', () => {
+        // Full classify-style read-back: the value written on save must be the
+        // same persistent reference that was stored, never a blob: URL.
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML =
+          `<a href="${assetUrl}" class="js-hidden clasifica-LinkImages">0</a>` +
+          `<a href="${assetUrl}" class="js-hidden clasifica-LinkAudios">1</a>`;
+
+        const hrefs = [...wrapper.querySelectorAll('a')].map((a) => a.getAttribute('href'));
+
+        expect(hrefs).toEqual([assetUrl, assetUrl]);
+        expect(hrefs.some((href) => href.startsWith('blob:'))).toBe(false);
       });
     });
 
@@ -633,6 +732,21 @@ describe('AssetUrlResolver', () => {
   });
 
   describe('getAttribute interception', () => {
+    beforeEach(async () => {
+      vi.resetModules();
+
+      window.jQuery = function() {
+        return { each: vi.fn(), length: 0 };
+      };
+      window.jQuery.fn = { attr: vi.fn(), prop: vi.fn() };
+      window.eXeLearning = {
+        app: { project: { _yjsBridge: { assetManager: mockAssetManager } } },
+      };
+
+      delete window.eXeLearningAssetResolver;
+      await import('./asset_url_resolver.js');
+    });
+
     it('returns asset URL when data-asset-url exists and src is blob URL', () => {
       const img = document.createElement('img');
       img.setAttribute('data-asset-url', 'asset://uuid-123/image.png');


### PR DESCRIPTION
## Problem

`asset_url_resolver.js` patches `Element.prototype.getAttribute` so that code reading `src`/`href` **for saving** gets the persistent `asset://` URL instead of the ephemeral `blob://` one — that is the stated intent in the comment above the patch.

The anchor branch did the exact opposite:

```js
if (name === 'href' && this.tagName === 'A') {
    if (value && value.startsWith('asset://') && resolvedCache.has(value)) {
        return resolvedCache.get(value);   // <- hands out the ephemeral blob URL
    }
```

Game iDevices store their media references as hidden anchors:

```html
<a href="asset://<uuid>" class="js-hidden clasifica-LinkImages">0</a>
```

and read them back by parsing their **stored** HTML (`htmlView`, straight from Yjs) into a **detached** wrapper — `classify.js:681` builds `$('<div></div>').html(originalHTML)` and `classify.js:693` does `$(this).attr('href')`. jQuery `.attr()` calls `getAttribute`, the patch sees the asset is in `resolvedCache` (populated when the iDevice was rendered in page view before editing), and returns `blob:app://...`.

The editor therefore reads a blob URL although the DOM literally holds `asset://<uuid>`, and re-persists it on save (`classify.js:811` re-emits `<a href="${word.url}">`). The blob dies with the page, leaving a dead reference after reload. The read-back pattern is shared by ~19 iDevices (identify, discover, sort, az-quiz-game, crossword, dragdrop, map, guess, relate, hidden-image, puzzle, flipcards, select-media-files, quick-questions, word-search, beforeafter, trivial).

## Fix

Gate the cache lookup on `Element.isConnected`.

The discriminator matches why the branch exists in the first place: SimpleLightbox and friends operate on anchors **in the rendered page** and need a loadable URL in the window before the MutationObserver has rewritten the href. Detached anchors are never rendered — they are throwaway wrappers used to parse stored HTML back into form data, and must see the persistent value.

This does not regress persistence for live anchors. Verified against the MutationObserver (`asset_url_resolver.js:578-604`): for anchors in the document it calls `trackElementAsset()` (storing `data-asset-url` = `asset://...`) **and** rewrites the href to the blob. So a live anchor read for saving hits branch 2 (`data-asset-url` + `blob:` href) and already returns `asset://`. Branch 2 stays ungated, so both detached and connected anchors keep mapping blob back to `asset://`.

No per-iDevice special casing, and no class-name matching — the fix is at the single point where the wrong value is produced.

## How to reproduce

1. Download the eXeLearning 2.9 manual: https://descargas.intef.es/cedec/exe_learning/Manuales/manual_exe29/referencias_y_fuentes.html
2. Import the `.elp` into eXeLearning.
3. Navigate to the **"Classify"** section (`Clasifica`) and click **Edit** on the activity.
4. Inspect the image URLs loaded into the form fields.

**Before:** the URLs read `blob:app://.../<uuid>` in the desktop/Electron build (`blob:http://localhost:8080/...` in the web build) — an ephemeral reference. Saving writes that blob back into the stored HTML, so after a reload the images are gone.

**After:** the URLs read `asset://<uuid>/<filename>` — the persistent reference actually stored in the document. Saving round-trips the same value and the images survive a reload.

Also confirm the lightbox is unaffected: open any iDevice with a linked image in preview and click it — it still opens, because live-DOM anchors keep receiving the resolved blob URL.

## Tests

`public/app/common/asset_url_resolver.test.js`, colocated (Vitest). Added a `describe` block covering the regression, all of which fail on `main`:

- a **detached** `<a href="asset://uuid">` whose asset is in `resolvedCache` returns `asset://uuid`
- a **connected** anchor still returns the cached blob URL (lightbox behaviour preserved)
- a detached anchor whose asset is not cached returns `asset://`
- blob href + `data-asset-url` still maps back to `asset://`, detached **and** connected
- a full classify-style read-back of `clasifica-LinkImages` / `clasifica-LinkAudios` anchors yields no `blob:` URL

The existing test named *"populates cache so getAttribute can return blob URL for asset:// href (SimpleLightbox support)"* asserted the buggy behaviour: it used a **detached** anchor, which is not how SimpleLightbox works. It now appends the anchor to the document, matching the real scenario the branch is there to serve.

While adding these I found the test file never restored `Element.prototype.getAttribute`. Each `vi.resetModules()` + re-import stacked another patch layer with its own `resolvedCache`, and the layers fed each other's return value back through the `asset://` <-> `blob://` mapping, producing values no single layer would return. The `getAttribute interception` block had no import at all and silently relied on a patch **leaked** from earlier blocks. The native method is now restored between tests and that block imports the module itself.

```
npx vitest run public/app/common/asset_url_resolver.test.js
 Test Files  1 passed (1)
      Tests  130 passed (130)

make test-frontend
 Test Files  247 passed (247)
      Tests  13724 passed (13724)
```

`make fix` is clean. Coverage on `asset_url_resolver.js`: 97.58% lines / 84.95% branches; both outcomes of the changed condition are exercised directly.

## Out of scope

The two secondary items in the issue are left for separate PRs, as they are independent defects with their own blast radius:

- the `blob:https?://` regexes that never match `blob:app://` (`AssetManager.js:3277`, `blobPasteGuard.js:63`)
- `validateData` ignoring `mquestion.audio` (the *"You must indicate an image, a text or/and an audio"* error), tracked in #2166

Closes #2186
