### PR TITLE
fix(idevice/classify): accept audio-only cards on save (#2187)

### DIFF
--- a/public/files/perm/idevices/base/classify/edition/classify.js
+++ b/public/files/perm/idevices/base/classify/edition/classify.js
@@ -36,6 +36,9 @@ var $exeDevice = {
     playerAudio: '',
     isVideoType: false,
     numberCards: 3,
+    // Shortest string accepted as a media URL. Empty media is stored as '', so
+    // this only guards against blank or truncated values.
+    minMediaUrlLength: 4,
     version: 0.8,
     id: false,
     checkAltImage: true,
@@ -849,15 +852,14 @@ var $exeDevice = {
         p.msgHit = $('#clasificaEMessageOK').val();
         p.msgError = $('#clasificaEMessageKO').val();
 
-        if (p.type === 0 && p.url.length < 5) {
-            message = msgs.msgCompleteImage;
-        } else if (p.type === 1 && p.eText.trim().length === 0) {
-            message = msgs.msgCompleteText;
-        } else if (
-            p.type === 2 &&
-            (p.eText.trim().length === 0 || p.url.length < 5)
-        ) {
-            message = msgs.msgCompleteBoth;
+        if (!$exeDevice.isQuestionComplete(p)) {
+            if (p.type === 1) {
+                message = msgs.msgCompleteText;
+            } else if (p.type === 2) {
+                message = msgs.msgCompleteBoth;
+            } else {
+                message = msgs.msgCompleteImage;
+            }
         }
 
         p = $exeDevice.normalizeQuestionByType(p);
@@ -938,13 +940,10 @@ var $exeDevice = {
                 $exeDevice.wordsGame[i]
             );
             $exeDevice.wordsGame[i] = mquestion;
-            if (
-                (mquestion.type === 0 && mquestion.url.length < 4) ||
-                (mquestion.type === 1 && mquestion.eText.trim().length === 0) ||
-                (mquestion.type === 2 &&
-                    (mquestion.url.length < 4 ||
-                        mquestion.eText.trim().length === 0))
-            ) {
+            if (!$exeDevice.isQuestionComplete(mquestion)) {
+                // Bring the offending card up so the message points at something.
+                $exeDevice.active = i;
+                $exeDevice.showQuestion(i);
                 $exeDevice.showMessage($exeDevice.msgs.msgCompleteData);
                 return false;
             }
@@ -998,6 +997,36 @@ var $exeDevice = {
             }
         );
         return false;
+    },
+
+    /**
+     * Whether a card carries enough content to be playable.
+     *
+     * The player builds a card out of any of image / text / audio, and renders
+     * a card that has only an audio as a big audio button (CQP-LinkAudioBig in
+     * the export code), so an audio on its own is enough for Image and Text
+     * cards. "Both" cards are the exception: they promise an image *and* a text.
+     * This is the rule msgCompleteImage / msgCompleteText / msgCompleteData have
+     * always stated.
+     *
+     * Shared by the per-card and the whole-form validation so a card can never
+     * pass one and fail the other.
+     *
+     * @param {object} question
+     * @returns {boolean}
+     */
+    isQuestionComplete: function (question) {
+        if (!question) return false;
+        const text = (value) => (typeof value === 'string' ? value.trim() : '');
+        const hasImage =
+            text(question.url).length >= $exeDevice.minMediaUrlLength;
+        const hasAudio =
+            text(question.audio).length >= $exeDevice.minMediaUrlLength;
+        const hasText = text(question.eText).length > 0;
+
+        if (question.type === 2) return hasImage && hasText;
+        if (question.type === 1) return hasText || hasAudio;
+        return hasImage || hasAudio;
     },
 
     normalizeQuestionByType: function (question) {

--- a/public/files/perm/idevices/base/classify/edition/classify.test.js
+++ b/public/files/perm/idevices/base/classify/edition/classify.test.js
@@ -365,4 +365,83 @@ describe('classify iDevice', () => {
       expect(normalized.audio).toBe('files/sound.mp3');
     });
   });
+
+  describe('isQuestionComplete', () => {
+    describe('type 0 (Image)', () => {
+      it('accepts a card with an image', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: 'files/img.png', eText: '', audio: '' })).toBe(true);
+      });
+
+      // Regression for #2187: the player renders an audio-only card as a big
+      // audio button (CQP-LinkAudioBig), so the editor must accept it. The 2.9
+      // manual ships exactly this card (type 0, no image, only COW2.mp3).
+      it('accepts a card that only has an audio', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: '', eText: '', audio: 'resources/COW2.mp3' })).toBe(true);
+      });
+
+      it('rejects a card with neither image nor audio', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: '', eText: '', audio: '' })).toBe(false);
+      });
+
+      it('rejects a card whose text alone would not render', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: '', eText: 'ignored', audio: '' })).toBe(false);
+      });
+    });
+
+    describe('type 1 (Text)', () => {
+      it('accepts a card with text', () => {
+        expect($exeDevice.isQuestionComplete({ type: 1, url: '', eText: 'Cat', audio: '' })).toBe(true);
+      });
+
+      it('accepts a card that only has an audio', () => {
+        expect($exeDevice.isQuestionComplete({ type: 1, url: '', eText: '', audio: 'resources/cat.mp3' })).toBe(true);
+      });
+
+      it('rejects a card with neither text nor audio', () => {
+        expect($exeDevice.isQuestionComplete({ type: 1, url: '', eText: '', audio: '' })).toBe(false);
+      });
+
+      it('rejects whitespace-only text', () => {
+        expect($exeDevice.isQuestionComplete({ type: 1, url: '', eText: '   ', audio: '' })).toBe(false);
+      });
+    });
+
+    describe('type 2 (Both)', () => {
+      it('accepts a card with image and text', () => {
+        expect($exeDevice.isQuestionComplete({ type: 2, url: 'files/img.png', eText: 'Pig', audio: '' })).toBe(true);
+      });
+
+      it('rejects a card missing the text', () => {
+        expect($exeDevice.isQuestionComplete({ type: 2, url: 'files/img.png', eText: '', audio: '' })).toBe(false);
+      });
+
+      it('rejects a card missing the image', () => {
+        expect($exeDevice.isQuestionComplete({ type: 2, url: '', eText: 'Pig', audio: '' })).toBe(false);
+      });
+
+      // "Both" promises an image *and* a text, so an audio must not rescue it.
+      it('does not let an audio stand in for the missing half', () => {
+        expect($exeDevice.isQuestionComplete({ type: 2, url: 'files/img.png', eText: '', audio: 'a.mp3' })).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('rejects a missing question', () => {
+        expect($exeDevice.isQuestionComplete(null)).toBe(false);
+        expect($exeDevice.isQuestionComplete(undefined)).toBe(false);
+      });
+
+      it('treats non-string media fields as empty', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: undefined, eText: '', audio: null })).toBe(false);
+      });
+
+      it('treats a url shorter than the minimum as empty', () => {
+        expect($exeDevice.isQuestionComplete({ type: 0, url: 'a.p', eText: '', audio: '' })).toBe(false);
+      });
+
+      it('treats an audio shorter than the minimum as empty', () => {
+        expect($exeDevice.isQuestionComplete({ type: 1, url: '', eText: '', audio: 'a.p' })).toBe(false);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #2187. Found by @ignaciogros while testing #2166 — thanks. Unrelated to that PR; this reproduces on `main`.

## The bug

The Classify activity of the [eXeLearning 2.9 manual](https://descargas.intef.es/cedec/exe_learning/Manuales/manual_exe29/referencias_y_fuentes.html) cannot be saved **at all**, even without touching anything:

> You must indicate an image, a text or/and an audio for each card

The card it rejects **has** an audio. Neither validator ever read the `audio` field, although three of the messages they print say an audio counts:

| message | text | rule it states |
|---|---|---|
| `msgCompleteImage` (type 0) | "You must link an image **or sound** to this card" | image **or** audio |
| `msgCompleteText` (type 1) | "You must indicate a text **or sound** for this card" | text **or** audio |
| `msgCompleteBoth` (type 2) | "You must select an image **and** text for this card" | image **and** text |

And the player is **built for** audio-only cards — `export/classify.js:1491-1496` gives a card with no image and no text a big audio button (`CQP-LinkAudioBig`), which has its own styling (`export/classify.css:520`) and event wiring. The editor was refusing content the player renders by design.

There is no "audio" card type (only Image / Text / Both), which is exactly why the type must not gate the audio.

## The fix

One shared predicate, `isQuestionComplete`, used by **both** the per-card and the whole-form validation — removing duplicated logic that had drifted to two different thresholds (`< 5` vs `< 4`):

- type 0 (Image): `url` **or** `audio`
- type 1 (Text): `eText` **or** `audio`
- type 2 (Both): `url` **and** `eText`

The whole-form validation now also brings the offending card up before showing the message, so it points at something instead of failing the form anonymously. This needs no new translatable string.

## How to reproduce

1. Import the 2.9 manual `.elp`.
2. Go to the **"Classify"** section and edit the activity.
3. Press save **without changing anything**.

**Before:** rejected with the message above.
**After:** saves cleanly, and the cow card (audio only) is preserved.

To see the offending card: it is **card 7 of 8**. The activity has 8 cards but only 6 `clasifica-LinkImages` anchors; decrypting the `clasifica-DataGame` payload (`unescape` + XOR 146) shows card 7 is `type: 0` (image) with an empty `url` and only `resources/COW2.mp3`. Card 6 is the same idea done as `type: 1` with the text "Cat", which is why it always passed.

This is data from the original 2.9 file — eXe 2.9 accepted that card, 4.x did not. The legacy import is faithful and not at fault.

## Tests

`public/files/perm/idevices/base/classify/edition/classify.test.js` — 16 new cases covering the three types plus edge cases (missing question, non-string fields, sub-threshold values, whitespace-only text), including a regression test for the manual's cow card and one asserting an audio does **not** rescue a "Both" card missing its half.

Verified the tests actually catch the bug: reverting the predicate to the pre-fix semantics fails exactly the two audio-only cases.

```
npx vitest run public/files/perm/idevices/base/classify/edition/classify.test.js
 Test Files  1 passed (1)
      Tests  55 passed (55)

npx vitest run           # full frontend suite
 Test Files  247 passed (247)
      Tests  13734 passed (13734)
```

I also replayed the real payload from the manual through the patched predicate: all 8 cards now pass, card 7 included.

Note: `focusedEditMode.test.js` failed once in a full parallel run and passed in isolation and on re-run. It is unrelated to this change (which only touches `classify`) and looks like pre-existing flakiness — flagging it rather than hiding it.

## Out of scope

- #2186 — the `blob:app://` URLs seen in the same test (fixed in #2188).
- The `useParseIntRadix` lint infos in this file are pre-existing and untouched. Note `make fix` runs `biome lint` over `public/app/` only, so `public/files/perm/idevices/**` is deliberately not formatted; I kept the file's existing style rather than reformatting it.
