### PR TITLE
fix(export): include content.xml in the download-source-file .elpx manifest

### DIFF
--- a/src/shared/export/exporters/ElpxExporter.spec.ts
+++ b/src/shared/export/exporters/ElpxExporter.spec.ts
@@ -144,6 +144,24 @@ class MockZipProvider implements ZipProvider {
     }
 }
 
+/**
+ * Parse the embedded `window.__ELPX_MANIFEST__` JSON from the generated
+ * `libs/elpx-manifest.js`. The download-source-file iDevice rebuilds the
+ * package client-side from this manifest, so its `files` list must faithfully
+ * reflect the ZIP contents.
+ */
+function parseElpxManifest(zip: MockZipProvider): { version: number; files: string[]; projectTitle: string } {
+    const manifestJs = zip.files.get('libs/elpx-manifest.js') as string;
+    if (!manifestJs) {
+        throw new Error('libs/elpx-manifest.js not found in ZIP');
+    }
+    const match = manifestJs.match(/window\.__ELPX_MANIFEST__=(\{[\s\S]*?\});/);
+    if (!match) {
+        throw new Error('Could not parse __ELPX_MANIFEST__ from manifest file');
+    }
+    return JSON.parse(match[1]);
+}
+
 // Sample pages for testing
 const samplePages: ExportPage[] = [
     {
@@ -1157,6 +1175,54 @@ describe('ElpxExporter', () => {
 
             const manifest = JSON.parse(manifestMatch![1]);
             expect(manifest.files).toContain('libs/elpx-manifest.js');
+        });
+
+        // Regression: the download-source-file iDevice rebuilds the .elpx from the
+        // manifest. The ODE re-import files (content.xml, content.dtd, screenshot.png)
+        // are added AFTER the HTML5 section, so they were silently omitted from the
+        // manifest — producing a re-download without content.xml that cannot be reopened.
+        it('should list content.xml and content.dtd in the manifest so the re-download is re-importable', async () => {
+            document = new MockDocument({}, pagesWithDownloadSourceFile);
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            // content.xml + content.dtd are always written to the .elpx for re-import.
+            expect(zip.files.has('content.xml')).toBe(true);
+            expect(zip.files.has('content.dtd')).toBe(true);
+
+            const manifest = parseElpxManifest(zip);
+            expect(manifest.files).toContain('content.xml');
+            expect(manifest.files).toContain('content.dtd');
+        });
+
+        it('should list screenshot.png in the manifest when the project has a screenshot', async () => {
+            // Minimal valid 1x1 red PNG data URL.
+            const pngDataUrl =
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+            document = new MockDocument({ screenshot: pngDataUrl }, pagesWithDownloadSourceFile);
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            expect(zip.files.has('screenshot.png')).toBe(true);
+
+            const manifest = parseElpxManifest(zip);
+            expect(manifest.files).toContain('screenshot.png');
+        });
+
+        it('should list every file in the ZIP in the manifest so the re-download is a faithful copy', async () => {
+            const pngDataUrl =
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+            document = new MockDocument({ screenshot: pngDataUrl }, pagesWithDownloadSourceFile);
+            exporter = new ElpxExporter(document, resources, assets, zip);
+
+            await exporter.export();
+
+            const manifest = parseElpxManifest(zip);
+            const listed = new Set(manifest.files);
+            const missing = Array.from(zip.files.keys()).filter(path => !listed.has(path));
+            expect(missing).toEqual([]);
         });
 
         it('should use correct base path for manifest script on index page', async () => {

--- a/src/shared/export/exporters/ElpxExporter.ts
+++ b/src/shared/export/exporters/ElpxExporter.ts
@@ -148,7 +148,7 @@ export class ElpxExporter extends Html5Exporter {
                 language: meta.language || 'en',
             });
 
-            // 1.1 Generate HTML pages with optional Mermaid pre-rendering, store for later — manifest script tag injection happens after manifest is created)
+            // 1.1 Generate HTML pages with optional LaTeX/Mermaid pre-rendering and store them for ZIP insertion.
             const pageHtmlMap = new Map<string, string>();
             let mermaidWasRendered = false;
             let latexWasRendered = false;

--- a/src/shared/export/exporters/ElpxExporter.ts
+++ b/src/shared/export/exporters/ElpxExporter.ts
@@ -330,20 +330,10 @@ export class ElpxExporter extends Html5Exporter {
             // 1.9 Add project assets
             await this.addAssetsToZipWithResourcePath(fileList);
 
-            // 1.10 Generate ELPX manifest and add HTML pages to ZIP
-            if (needsElpxDownload && fileList) {
-                for (const [htmlFile] of pageHtmlMap) {
-                    if (!fileList.includes(htmlFile)) {
-                        fileList.push(htmlFile);
-                    }
-                }
-                // Include the manifest file itself in the file list (self-reference)
-                fileList.push('libs/elpx-manifest.js');
-                const manifestJs = this.generateElpxManifestFile(fileList);
-                this.zip.addFile('libs/elpx-manifest.js', manifestJs);
-            }
-
-            // 1.11 Add HTML pages to ZIP (with manifest script on pages that have download-source-file)
+            // 1.10 Add HTML pages to ZIP (with manifest script on pages that have download-source-file).
+            // The ELPX download manifest itself is generated LAST (Section 2.4) — after the content.xml /
+            // content.dtd / screenshot.png source files are added in Section 2 — so it faithfully lists
+            // every file in the package and the re-downloaded .elpx stays re-importable.
             for (let i = 0; i < pages.length; i++) {
                 const page = pages[i];
                 const pageFilename = pageFilenameMap.get(page.id) || 'page.html';
@@ -406,10 +396,28 @@ export class ElpxExporter extends Html5Exporter {
             }
 
             // =========================================================================
+            // SECTION 2.4: ELPX download manifest — generated LAST, from real ZIP contents
+            // =========================================================================
+            //
+            // The download-source-file iDevice rebuilds the .elpx client-side from this
+            // manifest (public/libs/exe_elpx_download/exe_elpx_download.js). Building it from
+            // this.zip.getFilePaths() — AFTER content.xml, content.dtd and screenshot.png have
+            // been added in Section 2 — keeps the manifest a faithful reflection of the package,
+            // so the re-downloaded .elpx stays re-importable. Generating it earlier silently
+            // dropped those ODE source files from the download.
+            if (needsElpxDownload) {
+                const manifestPath = 'libs/elpx-manifest.js';
+                const manifestFiles = this.zip.getFilePaths().filter(path => path !== manifestPath);
+                manifestFiles.push(manifestPath); // self-reference so the round-trip stays reproducible
+                const manifestJs = this.generateElpxManifestFile(manifestFiles);
+                this.zip.addFile(manifestPath, manifestJs);
+            }
+
+            // =========================================================================
             // SECTION 3: Generate final ZIP
             // =========================================================================
             this.logElpxExportDebugPhase('exporter:zip-generate:start', {
-                zipFiles: fileList?.length || this.zip.getFilePaths?.().length || null,
+                zipFiles: this.zip.getFilePaths?.().length ?? fileList?.length ?? null,
             });
             const buffer = await this.zip.generateAsync();
             const zipStats =

--- a/src/shared/export/exporters/Html5Exporter.spec.ts
+++ b/src/shared/export/exporters/Html5Exporter.spec.ts
@@ -28,6 +28,21 @@ function decodePreviewFile(content: ArrayBuffer | Uint8Array | string | undefine
     return new TextDecoder().decode(bytes);
 }
 
+// Parse the JSON payload embedded in libs/elpx-manifest.js. Accepts both the raw
+// string stored in the ZIP mock and the ArrayBuffer returned by generateForPreview.
+function parseElpxManifest(content: ArrayBuffer | Uint8Array | string | undefined): {
+    version: number;
+    files: string[];
+    projectTitle: string;
+} {
+    const manifestJs = decodePreviewFile(content);
+    const manifestMatch = manifestJs.match(/window\.__ELPX_MANIFEST__=(\{[\s\S]*?\});/);
+    if (!manifestMatch) {
+        throw new Error('ELPX manifest payload not found');
+    }
+    return JSON.parse(manifestMatch[1]);
+}
+
 // Mock document adapter
 class MockDocument implements ExportDocument {
     private metadata: ExportMetadata;
@@ -2032,10 +2047,33 @@ describe('Html5Exporter', () => {
             expect(htmlFiles.length).toBe(1);
         });
 
-        it('should NOT include content.xml (not needed for preview)', async () => {
+        it('should include content.xml when exportSource is true', async () => {
+            document = new MockDocument({ exportSource: true }, samplePages);
+            exporter = new Html5Exporter(document, resources, assets, zip);
+
             const files = await exporter.generateForPreview();
 
-            // Preview should not include content.xml to save space
+            // Editable source is requested, so the re-importable ODE file must ship.
+            expect(files.has('content.xml')).toBe(true);
+            const contentXml = decodePreviewFile(files.get('content.xml'));
+            expect(contentXml).toContain('<?xml');
+            expect(contentXml).toContain('<ode');
+        });
+
+        it('should include content.xml when exportSource is undefined (editable by default)', async () => {
+            // Default metadata leaves exportSource undefined; editable content is on by default.
+            const files = await exporter.generateForPreview();
+
+            expect(files.has('content.xml')).toBe(true);
+        });
+
+        it('should NOT include content.xml when exportSource is false', async () => {
+            document = new MockDocument({ exportSource: false }, samplePages);
+            exporter = new Html5Exporter(document, resources, assets, zip);
+
+            const files = await exporter.generateForPreview();
+
+            // Author opted out of shipping the source, so preview omits it too.
             expect(files.has('content.xml')).toBe(false);
         });
 
@@ -2384,6 +2422,83 @@ describe('Html5Exporter', () => {
 
             const manifest = JSON.parse(manifestMatch![1]);
             expect(manifest.files).toContain('libs/elpx-manifest.js');
+        });
+
+        it('should list content.xml in the preview ELPX manifest when editable source is enabled', async () => {
+            const pagesWithDownload: ExportPage[] = [
+                {
+                    id: 'page1',
+                    title: 'Page 1',
+                    parentId: null,
+                    order: 0,
+                    blocks: [
+                        {
+                            id: 'block1',
+                            name: 'Block 1',
+                            order: 0,
+                            components: [
+                                {
+                                    id: 'comp1',
+                                    type: 'download-source-file',
+                                    order: 0,
+                                    content: '<p>Download</p>',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+
+            document = new MockDocument({ exportSource: true }, pagesWithDownload);
+            exporter = new Html5Exporter(document, resources, assets, zip);
+
+            const files = await exporter.generateForPreview();
+
+            // Editable source is on, so the preview file map ships content.xml...
+            expect(files.has('content.xml')).toBe(true);
+
+            // ...and the manifest that drives the download-source-file iDevice lists it.
+            expect(files.has('libs/elpx-manifest.js')).toBe(true);
+            const manifest = parseElpxManifest(files.get('libs/elpx-manifest.js'));
+            expect(manifest.files).toContain('content.xml');
+            expect(manifest.files).toContain('index.html');
+        });
+
+        it('should NOT list content.xml in the preview ELPX manifest when exportSource is false', async () => {
+            const pagesWithDownload: ExportPage[] = [
+                {
+                    id: 'page1',
+                    title: 'Page 1',
+                    parentId: null,
+                    order: 0,
+                    blocks: [
+                        {
+                            id: 'block1',
+                            name: 'Block 1',
+                            order: 0,
+                            components: [
+                                {
+                                    id: 'comp1',
+                                    type: 'download-source-file',
+                                    order: 0,
+                                    content: '<p>Download</p>',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+
+            document = new MockDocument({ exportSource: false }, pagesWithDownload);
+            exporter = new Html5Exporter(document, resources, assets, zip);
+
+            const files = await exporter.generateForPreview();
+
+            // Source shipping is disabled: no content.xml file and none in the manifest.
+            expect(files.has('content.xml')).toBe(false);
+            expect(files.has('libs/elpx-manifest.js')).toBe(true);
+            const manifest = parseElpxManifest(files.get('libs/elpx-manifest.js'));
+            expect(manifest.files).not.toContain('content.xml');
         });
 
         it('should create ELPX manifest when exe-package:elp class is in content', async () => {

--- a/src/shared/export/exporters/Html5Exporter.ts
+++ b/src/shared/export/exporters/Html5Exporter.ts
@@ -232,11 +232,8 @@ export class Html5Exporter extends BaseExporter {
                 addFile('search_index.js', searchIndexContent);
             }
 
-            // 3. Add content.xml (ODE format for re-import) - only if exportSource is enabled
-            if (meta.exportSource !== false) {
-                const contentXml = this.generateContentXml(pages);
-                addFile('content.xml', contentXml);
-            }
+            // 3. Add content.xml (ODE format for re-import) - only when editable source is enabled
+            this.addEditableContentXml(pages, meta, addFile);
 
             // 4. Add base CSS (fetch from content/css) and pre-rendered LaTeX/Mermaid CSS
             const contentCssFiles = await this.resources.fetchContentCss();
@@ -547,6 +544,28 @@ export class Html5Exporter extends BaseExporter {
     }
 
     /**
+     * Add the re-editable ODE `content.xml` to the package, unless the author
+     * opted out of shipping the source (`exportSource === false`).
+     *
+     * Single source of truth shared by the HTML5 ZIP export and the Service
+     * Worker preview so both decide identically whether the output stays
+     * re-importable. During preview the file is registered through `addFile`,
+     * so it is automatically listed in `libs/elpx-manifest.js` when a
+     * download-source-file iDevice is present.
+     */
+    protected addEditableContentXml(
+        pages: ExportPage[],
+        meta: ExportMetadata,
+        addFile: (path: string, content: string) => void,
+    ): void {
+        if (meta.exportSource === false) {
+            return;
+        }
+
+        addFile('content.xml', this.generateContentXml(pages));
+    }
+
+    /**
      * Generate preview files map (for Service Worker-based preview)
      * Returns a map of file paths to transferable ArrayBuffers
      * Same structure as ZIP export but without creating the archive
@@ -654,8 +673,9 @@ export class Html5Exporter extends BaseExporter {
                 addFile('search_index.js', searchIndexContent);
             }
 
-            // 3. Skip content.xml for preview (not needed for viewing)
-            // This saves space and prevents unnecessary file generation
+            // 3. Add content.xml (ODE format for re-import) when editable source is enabled.
+            // Registered via addFile, so it is automatically listed in the ELPX manifest below.
+            this.addEditableContentXml(pages, meta, addFile);
 
             // 4. Add base CSS (fetch from content/css) and pre-rendered LaTeX/Mermaid CSS
             const contentCssFiles = await this.resources.fetchContentCss();


### PR DESCRIPTION
## What

Fixes #2195: the **Download source file** iDevice produced an `.elpx` **missing `content.xml`** (plus `content.dtd` and root `screenshot.png`), so the downloaded package could not be reopened/edited.

This PR now fixes the same defect on **both** download paths:

1. **Direct ELPX export** (`ElpxExporter`) — the re-download manifest dropped the ODE source files.
2. **In-app Service Worker preview** (`Html5Exporter.generateForPreview()`) — the preview omitted `content.xml` entirely, so a download triggered from the preview was never editable.

## Why

The iDevice rebuilds the `.elpx` client-side from `libs/elpx-manifest.js` (consumed by `public/libs/exe_elpx_download/exe_elpx_download.js`), fetching exactly the files the manifest lists.

- In `ElpxExporter`, the manifest was generated in Section 1, **before** Section 2 added the ODE re-import files with `this.zip.addFile(...)`. Those files were in the saved `.elpx` but absent from the manifest, so the re-download silently dropped them.
- In `Html5Exporter.generateForPreview()`, `content.xml` was skipped unconditionally ("not needed for viewing"). But the preview is also a real download source for the iDevice, so a preview-originated `.elpx` was non-re-importable even when editable source was enabled.

Related to but **not** the same as #2028: here `exportSource` is enabled and `content.xml` **is** in the saved `.elpx` — it was only missing from the re-download manifest / preview.

## Fix

**`ElpxExporter`** — generate the manifest **last**, from the actual ZIP contents (`this.zip.getFilePaths()`), after every file (including `content.xml`, `content.dtd`, `screenshot.png`) has been added. The manifest can no longer drift from the package. `ElpxExporter` always ships `content.xml`, so a direct ELPX export stays fully editable.

**`Html5Exporter`** — extract a single shared helper `addEditableContentXml(pages, meta, addFile)` that decides whether `content.xml` is generated (skipped only when `exportSource === false`) and use it in **both** `export()` and `generateForPreview()`. Because the preview `addFile()` already tracks files in the manifest `fileList`, `content.xml` is now automatically listed in `libs/elpx-manifest.js` when editable source is on — no manual manifest append, and no duplicated `exportSource` conditional between export and preview.

Also fixed a stale comment in `ElpxExporter.ts`.

### Resulting behaviour

| Context | `exportSource` | `content.xml` |
| --- | ---: | ---: |
| HTML5 ZIP export | `true` or undefined | Included |
| HTML5 ZIP export | `false` | Omitted |
| Service Worker preview | `true` or undefined | Included |
| Service Worker preview | `false` | Omitted |
| ELPX direct export | any value | Included |

## Tests (TDD)

`ElpxExporter.spec.ts`:

- lists `content.xml` and `content.dtd` in the manifest so the re-download is re-importable;
- lists `screenshot.png` in the manifest when the project has a screenshot;
- **completeness invariant**: every file present in the ZIP is listed in the manifest (a faithful copy) — this guards against the whole class of "file added but not tracked".

`Html5Exporter.spec.ts` (added a `parseElpxManifest()` test helper and preview regression tests):

- preview includes `content.xml` when `exportSource` is `true`;
- preview includes `content.xml` when `exportSource` is undefined (editable by default);
- preview omits `content.xml` when `exportSource` is `false`;
- with a Download source file iDevice, the preview `libs/elpx-manifest.js` lists `content.xml` when enabled and does **not** list it when `exportSource` is `false`.

## How to verify

- `bun test src/shared/export/exporters/ElpxExporter.spec.ts src/shared/export/exporters/Html5Exporter.spec.ts` — all pass.
- `make test-unit` / `make test-integration` — green.
- Manual: add a Download source file iDevice → open the in-app **preview** → click **"Download the .elpx file"** → the downloaded `.elpx` now contains `content.xml` and re-imports cleanly. Setting **Export source: off** (`exportSource === false`) omits it, as before.

## Files changed

- `src/shared/export/exporters/ElpxExporter.ts`
- `src/shared/export/exporters/Html5Exporter.ts`
- `src/shared/export/exporters/Html5Exporter.spec.ts`
- `src/shared/export/exporters/ElpxExporter.spec.ts`
