### PR TITLE
Prevent fork pull requests from running CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   build_and_test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
   # the 3 browser jobs rebuilt CSS + bundles independently (3x build); now the
   # build is paid a single time and downloaded by the shards.
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -74,6 +75,7 @@ jobs:
           path: dist/static/**
 
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -150,7 +152,7 @@ jobs:
   merge-report:
     needs: e2e
     # Run even if some shards failed so the report still reflects every shard.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- skip the main build and test workflow for pull requests originating from forks
- skip the E2E build, twelve-browser-shard matrix, and report merge jobs for fork pull requests
- preserve pushes, tags, manual E2E runs, and same-repository pull requests

## Security rationale

These workflows install dependencies, build Docker images, run unit, integration, frontend, and Playwright tests, upload artifacts, and include write-capable permissions for packages, security events, and Actions artifact cleanup. Restricting fork-originated jobs prevents untrusted contributors from consuming substantial runner resources or executing code in write-capable jobs.

## Scope

This PR is separate from #2211, which removes the unused external preview workflow.