### PR TITLE
Fix #2227 - Could not edit rubric cells using the "Edit" button.

### DIFF
--- a/.agents/skills/idevice/SKILL.md
+++ b/.agents/skills/idevice/SKILL.md
@@ -39,6 +39,18 @@ public/files/perm/idevices/base/<name>/
     └── <name>.css          # Export styles (optional)
 ```
 
+## Edition Lifecycle
+
+The workarea drives `$exeDevice` (the object exported by `edition/<name>.js`) through three calls:
+
+| Hook | Required | When |
+|------|----------|------|
+| `init(element, previousData, path)` | yes | Edition mode starts. Build the form inside `element`. |
+| `save()` | yes | The user saves. Return the HTML/JSON to persist, or a falsy value to block the save after showing a validation message. |
+| `destroy()` | no | This edition class stops being the active one — **save, discard and delete alike**. Tear down anything mounted outside `element`. |
+
+`destroy()` exists because some editors must mount UI outside their own container: a Bootstrap dialog only stacks correctly as a direct child of `<body>`, since the edition box is itself a stacking context (`assets/styles/layout/_idevice-focus.scss`). Such nodes survive the removal of the edition form, so the iDevice has to take them down itself. See `removeEditModals` in `base/rubric/edition/rubric.js`.
+
 ## Testing — Round-Trip Is Mandatory
 
 Every iDevice **must** have a round-trip test: save data → load data → verify all fields are preserved. This is the #1 source of iDevice bugs — fields silently disappear when `loadData()` doesn't restore what `save()` stored. _Example: PR #1581._
@@ -99,6 +111,7 @@ make fix
 - **Both `edition/` and `export/` are required** — missing either causes silent failures.
 - **Icon naming** — must follow `<name>-icon.svg` pattern.
 - **Use `escape()` for metadata persistence** — some iDevices use `escape()` for special characters in saved data. Be consistent with the existing pattern.
+- **`<body>`-level UI outlives edition** — anything appended outside the edition container (dialogs, backdrops, overlays) stays in the DOM when edition ends. Remove it in `destroy()`, and keep its `z-index` below the workarea dialog layer (`.modal { z-index: 20009 !important }`) so app confirmations stay on top and clickable. _Example: PR #2231._
 
 ## Done When
 

--- a/public/app/workarea/project/idevices/content/ideviceNode.js
+++ b/public/app/workarea/project/idevices/content/ideviceNode.js
@@ -1643,9 +1643,7 @@ export default class IdeviceNode {
         // Remove head scripts/styles elements
         this.clearFilesElements();
         // Restart $exeDevice value
-        if (typeof $exeDevice !== 'undefined') {
-            $exeDevice = undefined;
-        }
+        this.releaseExeDevice();
         // Load idevice edition files
         this.loadScriptsEdition();
         await this.loadStylesEdition();
@@ -1764,10 +1762,31 @@ export default class IdeviceNode {
         if (this.isSync == true) {
             this.isSync = false;
         } else {
-            if (typeof $exeDevice !== 'undefined') {
-                $exeDevice = undefined;
+            this.releaseExeDevice();
+        }
+    }
+
+    /**
+     * Drop the current idevice edition class.
+     *
+     * Edition scripts may mount UI outside their own container -- Bootstrap
+     * dialogs, for instance, must be direct children of <body> to stack
+     * correctly. Such nodes survive the removal of the edition form, so give the
+     * script a chance to take them down before it is discarded. This is the
+     * single place where an edition class stops being the active one, whether
+     * the user saved, discarded the changes or deleted the iDevice.
+     *
+     */
+    releaseExeDevice() {
+        if (typeof $exeDevice === 'undefined') return;
+        if (typeof $exeDevice.destroy === 'function') {
+            try {
+                $exeDevice.destroy();
+            } catch (error) {
+                console.warn('iDevice edition cleanup failed', error);
             }
         }
+        $exeDevice = undefined;
     }
 
     /**
@@ -3211,9 +3230,7 @@ export default class IdeviceNode {
             // Release Yjs editing lock
             this.releaseYjsEditingLock();
 
-            if (typeof $exeDevice !== 'undefined') {
-                $exeDevice = undefined;
-            }
+            this.releaseExeDevice();
         }
         // Remove content element
         this.ideviceContent.remove();

--- a/public/app/workarea/project/idevices/content/ideviceNode.test.js
+++ b/public/app/workarea/project/idevices/content/ideviceNode.test.js
@@ -1197,6 +1197,76 @@ describe('IdeviceNode', () => {
 
             expect(global.$exeDevice).toBeUndefined();
         });
+
+        it('lets the edition script clean up before dropping it', () => {
+            idevice.isSync = false;
+            const destroy = vi.fn();
+            global.$exeDevice = { destroy };
+
+            idevice.restartExeIdeviceValue();
+
+            expect(destroy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not clean up when the idevice is being synced', () => {
+            idevice.isSync = true;
+            const destroy = vi.fn();
+            global.$exeDevice = { destroy };
+
+            idevice.restartExeIdeviceValue();
+
+            expect(destroy).not.toHaveBeenCalled();
+            expect(global.$exeDevice).toBeDefined();
+        });
+    });
+
+    describe('releaseExeDevice', () => {
+        afterEach(() => {
+            global.$exeDevice = undefined;
+        });
+
+        it('calls destroy before dropping the edition class', () => {
+            const calls = [];
+            global.$exeDevice = {
+                destroy: () => calls.push(typeof global.$exeDevice),
+            };
+
+            idevice.releaseExeDevice();
+
+            // Cleanup must run while the edition class is still the active one.
+            expect(calls).toEqual(['object']);
+            expect(global.$exeDevice).toBeUndefined();
+        });
+
+        it('drops edition classes that do not implement destroy', () => {
+            global.$exeDevice = { some: 'value' };
+
+            idevice.releaseExeDevice();
+
+            expect(global.$exeDevice).toBeUndefined();
+        });
+
+        it('drops the edition class even if its cleanup throws', () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            global.$exeDevice = {
+                destroy: () => {
+                    throw new Error('broken cleanup');
+                },
+            };
+
+            idevice.releaseExeDevice();
+
+            expect(global.$exeDevice).toBeUndefined();
+            expect(warn).toHaveBeenCalled();
+            warn.mockRestore();
+        });
+
+        it('does nothing when there is no edition class', () => {
+            global.$exeDevice = undefined;
+
+            expect(() => idevice.releaseExeDevice()).not.toThrow();
+            expect(global.$exeDevice).toBeUndefined();
+        });
     });
 
     describe('showLockedPlaceholder', () => {
@@ -1718,6 +1788,16 @@ describe('IdeviceNode', () => {
             expect(global.$exeDevice).toBeUndefined();
         });
 
+        it('lets the edition script clean up when deleting an idevice being edited', () => {
+            idevice.mode = 'edition';
+            const destroy = vi.fn();
+            global.$exeDevice = { destroy };
+
+            idevice.remove(false);
+
+            expect(destroy).toHaveBeenCalledTimes(1);
+        });
+
         it('calls apiDeleteIdevice when bbdd is true', () => {
             const spy = vi.spyOn(idevice, 'apiDeleteIdevice').mockResolvedValue({});
 
@@ -1919,6 +1999,17 @@ describe('IdeviceNode', () => {
             idevice.idevice = null;
 
             expect(() => idevice.loadScriptsEdition()).not.toThrow();
+        });
+
+        it('loadEditionIdevice cleans up the previously active edition class', async () => {
+            idevice.scriptsElements = [];
+            const destroy = vi.fn();
+            global.$exeDevice = { destroy };
+
+            await idevice.loadEditionIdevice();
+
+            expect(destroy).toHaveBeenCalledTimes(1);
+            expect(global.$exeDevice).toBeUndefined();
         });
     });
 

--- a/public/files/perm/idevices/base/rubric/edition/rubric.css
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.css
@@ -296,9 +296,29 @@
   background-position: 0 0;
 }
 
-#ri_CellEditModal {
-  z-index: 1060;
+/*
+ * The edition dialogs are mounted in <body> (see mountEditModal in rubric.js),
+ * so they share the stacking layer of the workarea dialogs. The workarea forces
+ * `.modal { z-index: 20009 !important }` (assets/styles/components/_modals.scss),
+ * which would also apply here: the rubric dialogs would end up tied with the app
+ * dialogs and, being appended later, paint above them. The unsaved-changes
+ * confirmation would then open *behind* the rubric dialog, with its buttons
+ * unreachable. An id-level !important keeps the rubric layer just below.
+ *
+ * Layering: rubric backdrop (20004) < rubric dialog (20005) < app dialogs (20009).
+ */
+#ri_CellEditModal,
+#ri_RowEditModal,
+#ri_ColumnEditModal {
+  z-index: 20005 !important;
 }
+
+#ri_CellEditModalBackdrop,
+#ri_RowEditModalBackdrop,
+#ri_ColumnEditModalBackdrop {
+  z-index: 20004;
+}
+
 #ri_CellEditModal .modal-dialog {
   width: 90%;
   max-width: 560px;
@@ -309,9 +329,6 @@
   width: 100%;
 }
 
-#ri_RowEditModal {
-  z-index: 1060;
-}
 #ri_RowEditModal .modal-dialog {
   width: 90%;
   max-width: 560px;
@@ -357,9 +374,6 @@
   font-size: 18px;
 }
 
-#ri_ColumnEditModal {
-  z-index: 1060;
-}
 #ri_ColumnEditModal .modal-dialog {
   width: 90%;
   max-width: 560px;

--- a/public/files/perm/idevices/base/rubric/edition/rubric.js
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.js
@@ -146,6 +146,9 @@ var $exeDevice = {
         this.idevicePreviousData = previousData;
         this.idevicePath = path;
         this.removeLegacyRenderedArtifacts();
+        // The edition dialogs live in <body>, so a previous edition may have left
+        // them behind: start from a clean slate bound to this iDevice.
+        this.removeEditModals();
         this.createForm();
     },
 
@@ -655,6 +658,8 @@ var $exeDevice = {
             this.editor.empty();
         }
         this.cells = null;
+        // The table cells the dialogs point at are gone now.
+        this.removeEditModals();
     },
 
     exportCSV: function () {
@@ -1723,6 +1728,10 @@ var $exeDevice = {
             ? textAfterEditor.getContent()
             : ($('#eXeIdeviceTextAfter').val() || '');
 
+        // Validation passed: the edition form is about to be replaced by the
+        // rendered rubric, so take the <body>-level dialogs down with it.
+        this.removeEditModals();
+
         return this.buildSerializedRubricHTML(data, instructions, textAfter, {
             includeWrapper: true,
             wrapperClass: 'rubric-IDevice',
@@ -1928,6 +1937,65 @@ var $exeDevice = {
         $exeDevice.setMaxScore();
     },
 
+    // Ids of the table edition dialogs. Each one owns a backdrop whose id is the
+    // modal id plus the 'Backdrop' suffix (see showEditModal/hideEditModal).
+    editModalIds: ['ri_CellEditModal', 'ri_RowEditModal', 'ri_ColumnEditModal'],
+
+    /**
+     * Mount an edition dialog. Bootstrap modals must be direct children of
+     * <body>: the rubric editor is rendered inside the iDevice edition box, and
+     * that box becomes a stacking context while an iDevice is being edited
+     * (`position: absolute; z-index: 5`, see assets/styles/layout/_idevice-focus.scss).
+     * A dialog appended there has its z-index (1060, rubric.css) clamped to that
+     * context, so the <body>-level backdrop (z-index 1050) paints on top of it
+     * and swallows every click: the dialog looks open but is unusable. Keeping
+     * dialog and backdrop in the same place is what makes 1060 > 1050 effective.
+     */
+    mountEditModal: function (html) {
+        $(document.body).append(html);
+    },
+
+    showEditModal: function (modalId) {
+        $('#' + modalId)
+            .addClass('show')
+            .attr('aria-hidden', 'false')
+            .css('display', 'block');
+        $('body').addClass('modal-open');
+        var backdropId = modalId + 'Backdrop';
+        if ($('#' + backdropId).length === 0) {
+            $(document.body).append(
+                '<div id="' + backdropId + '" class="modal-backdrop fade show"></div>'
+            );
+        }
+    },
+
+    hideEditModal: function (modalId) {
+        $('#' + modalId)
+            .removeClass('show')
+            .attr('aria-hidden', 'true')
+            .css('display', 'none');
+        $('#' + modalId + 'Backdrop').remove();
+        // Other dialogs (rubric or app level) may still be open.
+        if ($('.modal-backdrop').length === 0) $('body').removeClass('modal-open');
+    },
+
+    /**
+     * Drop the dialogs and their pending state. Needed because they live in
+     * <body> and therefore survive a rebuild of #ri_TableEditor, which would
+     * otherwise leave them pointing at detached table cells (and leave stale
+     * dialogs behind once this iDevice edition ends).
+     */
+    removeEditModals: function () {
+        this.cellEditTarget = null;
+        this.rowEditState = null;
+        this.columnEditState = null;
+        this.editModalIds.forEach(function (modalId) {
+            $('#' + modalId).remove();
+            $('#' + modalId + 'Backdrop').remove();
+        });
+        if ($('.modal-backdrop').length === 0) $('body').removeClass('modal-open');
+    },
+
     ensureCellEditModal: function () {
         var modal = $('#ri_CellEditModal');
         if (modal.length === 1) return;
@@ -1971,7 +2039,7 @@ var $exeDevice = {
             '</div>' +
             '</div>';
 
-        $('#ri_TableEditor').append(html);
+        this.mountEditModal(html);
 
         $('#ri_CellEditAccept').off('click').on('click', function () {
             $exeDevice.applyCellEditModal();
@@ -1989,6 +2057,8 @@ var $exeDevice = {
 
     openCellEditModal: function (td) {
         if (!td || td.length !== 1) return;
+
+        this.ensureCellEditModal();
 
         this.cellEditTarget = td;
         var contentInput = td.find('input[type="text"]').not('.ri_Weight').first();
@@ -2012,18 +2082,12 @@ var $exeDevice = {
             _('Performance level') + (columnTitle ? ': ' + columnTitle : '')
         );
 
-        $('#ri_CellEditModal').addClass('show').attr('aria-hidden', 'false').css('display', 'block');
-        $('body').addClass('modal-open');
-        if ($('#ri_CellEditModalBackdrop').length === 0) {
-            $('body').append('<div id="ri_CellEditModalBackdrop" class="modal-backdrop fade show"></div>');
-        }
+        this.showEditModal('ri_CellEditModal');
         $('#ri_CellEditContent').focus();
     },
 
     closeCellEditModal: function () {
-        $('#ri_CellEditModal').removeClass('show').attr('aria-hidden', 'true').css('display', 'none');
-        $('body').removeClass('modal-open');
-        $('#ri_CellEditModalBackdrop').remove();
+        this.hideEditModal('ri_CellEditModal');
         this.cellEditTarget = null;
     },
 
@@ -2109,7 +2173,7 @@ var $exeDevice = {
             '</div>' +
             '</div>';
 
-        $('#ri_TableEditor').append(html);
+        this.mountEditModal(html);
 
         $('#ri_RowEditAccept').off('click').on('click', function () {
             $exeDevice.applyRowEditModal();
@@ -2182,11 +2246,7 @@ var $exeDevice = {
         $('#ri_RowEditModalTitle').text(_('Assessment criteria') + (criterionTitle ? ': ' + criterionTitle : ''));
         this.renderRowEditModalFields();
 
-        $('#ri_RowEditModal').addClass('show').attr('aria-hidden', 'false').css('display', 'block');
-        $('body').addClass('modal-open');
-        if ($('#ri_RowEditModalBackdrop').length === 0) {
-            $('body').append('<div id="ri_RowEditModalBackdrop" class="modal-backdrop fade show"></div>');
-        }
+        this.showEditModal('ri_RowEditModal');
         $('#ri_RowEditContent').focus();
     },
 
@@ -2238,9 +2298,7 @@ var $exeDevice = {
     },
 
     closeRowEditModal: function () {
-        $('#ri_RowEditModal').removeClass('show').attr('aria-hidden', 'true').css('display', 'none');
-        $('body').removeClass('modal-open');
-        $('#ri_RowEditModalBackdrop').remove();
+        this.hideEditModal('ri_RowEditModal');
         this.rowEditState = null;
     },
 
@@ -2370,7 +2428,7 @@ var $exeDevice = {
             '</div>' +
             '</div>';
 
-        $('#ri_TableEditor').append(html);
+        this.mountEditModal(html);
 
         $('#ri_ColumnEditAccept').off('click').on('click', function () {
             $exeDevice.applyColumnEditModal();
@@ -2437,11 +2495,7 @@ var $exeDevice = {
         $('#ri_ColumnEditModalTitle').text(this.columnEditState.title || _('Edit'));
         this.renderColumnEditModalFields();
 
-        $('#ri_ColumnEditModal').addClass('show').attr('aria-hidden', 'false').css('display', 'block');
-        $('body').addClass('modal-open');
-        if ($('#ri_ColumnEditModalBackdrop').length === 0) {
-            $('body').append('<div id="ri_ColumnEditModalBackdrop" class="modal-backdrop fade show"></div>');
-        }
+        this.showEditModal('ri_ColumnEditModal');
         $('#ri_ColumnEditContent').focus();
     },
 
@@ -2492,9 +2546,7 @@ var $exeDevice = {
     },
 
     closeColumnEditModal: function () {
-        $('#ri_ColumnEditModal').removeClass('show').attr('aria-hidden', 'true').css('display', 'none');
-        $('body').removeClass('modal-open');
-        $('#ri_ColumnEditModalBackdrop').remove();
+        this.hideEditModal('ri_ColumnEditModal');
         this.columnEditState = null;
     },
 

--- a/public/files/perm/idevices/base/rubric/edition/rubric.js
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.js
@@ -152,6 +152,15 @@ var $exeDevice = {
         this.createForm();
     },
 
+    /**
+     * Called by the workarea when this edition class stops being the active one,
+     * whichever way the user left edition mode: save, discard or delete. The
+     * dialogs are mounted in <body> and would otherwise outlive the edition form.
+     */
+    destroy: function () {
+        this.removeEditModals();
+    },
+
     removeLegacyRenderedArtifacts: function () {
         if (!this.ideviceBody) return;
 
@@ -1946,10 +1955,12 @@ var $exeDevice = {
      * <body>: the rubric editor is rendered inside the iDevice edition box, and
      * that box becomes a stacking context while an iDevice is being edited
      * (`position: absolute; z-index: 5`, see assets/styles/layout/_idevice-focus.scss).
-     * A dialog appended there has its z-index (1060, rubric.css) clamped to that
-     * context, so the <body>-level backdrop (z-index 1050) paints on top of it
-     * and swallows every click: the dialog looks open but is unusable. Keeping
-     * dialog and backdrop in the same place is what makes 1060 > 1050 effective.
+     * A dialog appended there has its z-index clamped to that context, so the
+     * <body>-level backdrop paints on top of it and swallows every click: the
+     * dialog looks open but is unusable. Keeping dialog and backdrop in the same
+     * place is what lets the z-index values in rubric.css order them, and those
+     * values also keep the app dialogs (the unsaved-changes confirmation, for
+     * one) above the rubric layer.
      */
     mountEditModal: function (html) {
         $(document.body).append(html);

--- a/public/files/perm/idevices/base/rubric/edition/rubric.test.js
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.test.js
@@ -589,7 +589,7 @@ describe('rubric iDevice CSV tools (edition)', () => {
       const backdrop = document.getElementById('ri_CellEditModalBackdrop');
 
       expect(backdrop).not.toBeNull();
-      // Same parent => the dialog z-index (1060) really beats the backdrop (1050).
+      // Same parent => the z-index values in rubric.css really order the two.
       expect(backdrop.parentElement).toBe(modal.parentElement);
       expect(modal.parentElement).toBe(document.body);
       expect(document.body.classList.contains('modal-open')).toBe(true);
@@ -637,6 +637,50 @@ describe('rubric iDevice CSV tools (edition)', () => {
       expect($exeDevice.cellEditTarget).toBeNull();
       expect($exeDevice.rowEditState).toBeNull();
       expect($exeDevice.columnEditState).toBeNull();
+    });
+
+    it('destroy takes the <body>-level dialogs down when edition mode ends', () => {
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+      $exeDevice.openColumnEditModal($('#ri_Table thead th').eq(1));
+
+      // The workarea calls destroy() on save, discard and delete alike: nothing
+      // this iDevice mounted outside its own container may outlive edition.
+      $exeDevice.destroy();
+
+      $exeDevice.editModalIds.forEach((modalId) => {
+        expect(document.getElementById(modalId)).toBeNull();
+        expect(document.getElementById(`${modalId}Backdrop`)).toBeNull();
+      });
+      expect(document.body.classList.contains('modal-open')).toBe(false);
+    });
+
+    it('requestCloseRowEditModal keeps the row dialog mounted until the confirmation is accepted', () => {
+      $exeDevice.openRowEditModal($('#ri_Table tbody tr').first());
+      $('#ri_RowEditContent').val('Descriptor cambiado').trigger('input');
+
+      let confirmExec = null;
+      const originalConfirm = eXe.app.confirm;
+      eXe.app.confirm = (title, body, exec) => {
+        confirmExec = exec;
+      };
+
+      try {
+        $exeDevice.requestCloseRowEditModal();
+
+        // The confirmation is an app dialog rendered on top: the row dialog must
+        // still be there, otherwise there is nothing left to discard.
+        expect(typeof confirmExec).toBe('function');
+        expect(document.getElementById('ri_RowEditModal')).not.toBeNull();
+        expect($('#ri_RowEditModal').css('display')).toBe('block');
+
+        confirmExec();
+      } finally {
+        eXe.app.confirm = originalConfirm;
+      }
+
+      expect($('#ri_RowEditModal').css('display')).toBe('none');
+      expect(document.getElementById('ri_RowEditModalBackdrop')).toBeNull();
+      expect($exeDevice.rowEditState).toBeNull();
     });
 
     it('clearCurrentRubricEdition removes dialogs pointing at the discarded table', () => {

--- a/public/files/perm/idevices/base/rubric/edition/rubric.test.js
+++ b/public/files/perm/idevices/base/rubric/edition/rubric.test.js
@@ -539,6 +539,119 @@ describe('rubric iDevice CSV tools (edition)', () => {
   });
 
   // ==========================================================================
+  // Table edition dialogs (mounting / stacking context)
+  // ==========================================================================
+
+  describe('table edition dialogs', () => {
+    const TABLE_HTML = `
+      <div id="ri_TableEditor"></div>
+      <table id="ri_Table">
+        <thead>
+          <tr>
+            <th><input type="text" value="" /></th>
+            <th><input type="text" value="Nivel Alto" /></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><input type="text" value="Contenido" /></th>
+            <td>
+              <input type="text" value="Descriptor inicial" />
+              <input type="text" class="ri_Weight" value="2" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+
+    beforeEach(() => {
+      document.body.innerHTML = TABLE_HTML;
+      document.body.className = '';
+    });
+
+    it('mounts every dialog as a direct child of <body>, never inside the editor', () => {
+      $exeDevice.ensureCellEditModal();
+      $exeDevice.ensureRowEditModal();
+      $exeDevice.ensureColumnEditModal();
+
+      $exeDevice.editModalIds.forEach((modalId) => {
+        const modal = document.getElementById(modalId);
+        expect(modal).not.toBeNull();
+        expect(modal.parentElement).toBe(document.body);
+      });
+      expect($('#ri_TableEditor').children().length).toBe(0);
+    });
+
+    it('keeps dialog and backdrop in the same stacking context so the dialog stays clickable', () => {
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+
+      const modal = document.getElementById('ri_CellEditModal');
+      const backdrop = document.getElementById('ri_CellEditModalBackdrop');
+
+      expect(backdrop).not.toBeNull();
+      // Same parent => the dialog z-index (1060) really beats the backdrop (1050).
+      expect(backdrop.parentElement).toBe(modal.parentElement);
+      expect(modal.parentElement).toBe(document.body);
+      expect(document.body.classList.contains('modal-open')).toBe(true);
+    });
+
+    it('openCellEditModal recreates the dialog when it is missing', () => {
+      $exeDevice.removeEditModals();
+      expect(document.getElementById('ri_CellEditModal')).toBeNull();
+
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+
+      expect(document.getElementById('ri_CellEditModal')).not.toBeNull();
+      expect($('#ri_CellEditContent').val()).toBe('Descriptor inicial');
+    });
+
+    it('closing one dialog keeps modal-open while another dialog is still open', () => {
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+      $exeDevice.openRowEditModal($('#ri_Table tbody tr').first());
+
+      $exeDevice.closeRowEditModal();
+
+      expect(document.getElementById('ri_RowEditModalBackdrop')).toBeNull();
+      expect(document.getElementById('ri_CellEditModalBackdrop')).not.toBeNull();
+      expect(document.body.classList.contains('modal-open')).toBe(true);
+
+      $exeDevice.closeCellEditModal();
+
+      expect(document.getElementById('ri_CellEditModalBackdrop')).toBeNull();
+      expect(document.body.classList.contains('modal-open')).toBe(false);
+      expect($('#ri_CellEditModal').css('display')).toBe('none');
+    });
+
+    it('removeEditModals drops dialogs, backdrops and pending state', () => {
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+      $exeDevice.openRowEditModal($('#ri_Table tbody tr').first());
+      $exeDevice.ensureColumnEditModal();
+
+      $exeDevice.removeEditModals();
+
+      $exeDevice.editModalIds.forEach((modalId) => {
+        expect(document.getElementById(modalId)).toBeNull();
+        expect(document.getElementById(`${modalId}Backdrop`)).toBeNull();
+      });
+      expect(document.body.classList.contains('modal-open')).toBe(false);
+      expect($exeDevice.cellEditTarget).toBeNull();
+      expect($exeDevice.rowEditState).toBeNull();
+      expect($exeDevice.columnEditState).toBeNull();
+    });
+
+    it('clearCurrentRubricEdition removes dialogs pointing at the discarded table', () => {
+      $exeDevice.editor = $('#ri_TableEditor');
+      $exeDevice.openCellEditModal($('#ri_Table tbody tr td').first());
+
+      $exeDevice.clearCurrentRubricEdition();
+
+      expect(document.getElementById('ri_CellEditModal')).toBeNull();
+      expect(document.getElementById('ri_CellEditModalBackdrop')).toBeNull();
+      expect($exeDevice.cellEditTarget).toBeNull();
+    });
+  });
+
+  // ==========================================================================
   // SCORM integration
   // ==========================================================================
 

--- a/test/e2e/playwright/specs/idevices/rubric.spec.ts
+++ b/test/e2e/playwright/specs/idevices/rubric.spec.ts
@@ -26,6 +26,8 @@ const TEST_DATA = {
     rubricTitle: 'E2E Test Rubric',
     editedDescriptor: 'E2E edited descriptor content',
     weight: '5',
+    dialogDescriptor: 'E2E descriptor edited from the cell dialog',
+    dialogWeight: '7',
 };
 
 /**
@@ -297,6 +299,59 @@ test.describe('Rubric iDevice', () => {
             // Verify the table structure is intact
             const rubricTable = page.locator('#node-content .idevice_node.rubric .exe-table');
             await expect(rubricTable).toBeVisible({ timeout: 10000 });
+        });
+    });
+
+    test.describe('Cell edition dialog', () => {
+        test('should keep the cell dialog above its backdrop and apply the changes', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Cell Dialog Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addRubricIdeviceFromPanel(page);
+            await createNewRubric(page);
+
+            // The editor is wrapped in the focused-edit stacking context: that is
+            // exactly the situation where a dialog mounted inside the editor ends
+            // up painted below the <body>-level backdrop.
+            await expect(page.locator('body.exe-idevice-focus-editing')).toHaveCount(1);
+
+            const firstCell = page.locator('#ri_Table tbody tr').first().locator('td').first();
+            await firstCell.locator('a.ri_EditTD').click();
+
+            const dialog = page.locator('#ri_CellEditModal');
+            await expect(dialog).toBeVisible({ timeout: 10000 });
+
+            // Regression guard: with the dialog trapped in the editor stacking
+            // context the backdrop is the topmost element here, so the dialog
+            // looks open but cannot be used.
+            const dialogIsOnTop = await page.evaluate(() => {
+                const content = document.querySelector('#ri_CellEditModal .modal-content');
+                if (!content) return false;
+                const rect = content.getBoundingClientRect();
+                const topmost = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                return !!topmost && !!topmost.closest('#ri_CellEditModal');
+            });
+            expect(dialogIsOnTop).toBe(true);
+
+            await page.locator('#ri_CellEditContent').fill(TEST_DATA.dialogDescriptor);
+            await page.locator('#ri_CellEditScore').fill(TEST_DATA.dialogWeight);
+
+            // A real (hit-tested) click: it fails if the backdrop covers the dialog.
+            await page.locator('#ri_CellEditAccept').click();
+
+            await expect(dialog).toBeHidden({ timeout: 5000 });
+            await expect(page.locator('#ri_CellEditModalBackdrop')).toHaveCount(0);
+            await expect(firstCell.locator('input[type="text"]:not(.ri_Weight)')).toHaveValue(
+                TEST_DATA.dialogDescriptor,
+            );
+            await expect(firstCell.locator('input.ri_Weight')).toHaveValue(TEST_DATA.dialogWeight);
         });
     });
 

--- a/test/e2e/playwright/specs/idevices/rubric.spec.ts
+++ b/test/e2e/playwright/specs/idevices/rubric.spec.ts
@@ -8,6 +8,7 @@ import {
     getPreviewFrame,
     waitForPreviewContent,
 } from '../../helpers/workarea-helpers';
+import { enableAdvancedMode } from '../../helpers/content-helpers';
 import { WorkareaPage } from '../../pages/workarea.page';
 import type { Page } from '@playwright/test';
 
@@ -178,6 +179,50 @@ async function getRubricRootInPreview(page: Page) {
     const fallback = iframe.locator('.idevice_node.rubric').first();
     await fallback.waitFor({ state: 'visible', timeout: 10000 });
     return fallback;
+}
+
+/** Ids of the rubric edition dialogs, mirroring $exeDevice.editModalIds. */
+const EDIT_MODAL_IDS = ['ri_CellEditModal', 'ri_RowEditModal', 'ri_ColumnEditModal'];
+
+/**
+ * The dialogs are mounted in <body>, so they outlive the edition form unless the
+ * iDevice takes them down when edition mode ends.
+ */
+async function expectNoRubricDialogsLeftBehind(page: Page): Promise<void> {
+    for (const modalId of EDIT_MODAL_IDS) {
+        await expect(page.locator(`#${modalId}`)).toHaveCount(0);
+        await expect(page.locator(`#${modalId}Backdrop`)).toHaveCount(0);
+    }
+    await expect(page.locator('body.modal-open')).toHaveCount(0);
+}
+
+/**
+ * Open the row editor of the first criterion and leave an unsaved change in it.
+ */
+async function openRowDialogWithUnsavedChanges(page: Page): Promise<void> {
+    await page.locator('#ri_Table tbody tr').first().locator('a.ri_EditTR').click();
+
+    const dialog = page.locator('#ri_RowEditModal');
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    await page.locator('#ri_RowEditContent').fill(TEST_DATA.dialogDescriptor);
+}
+
+/**
+ * Add a rubric, create the default table and use the cell dialog once, closing
+ * it afterwards. Closing only hides the dialog: the element stays in <body>, so
+ * this is the state that must not survive the end of edition mode.
+ */
+async function addRubricWithMountedCellDialog(page: Page): Promise<void> {
+    await addRubricIdeviceFromPanel(page);
+    await createNewRubric(page);
+
+    await page.locator('#ri_Table tbody tr').first().locator('td').first().locator('a.ri_EditTD').click();
+    await expect(page.locator('#ri_CellEditModal')).toBeVisible({ timeout: 10000 });
+
+    await page.locator('#ri_CellEditCancel').click();
+    await expect(page.locator('#ri_CellEditModal')).toBeHidden({ timeout: 5000 });
+    await expect(page.locator('#ri_CellEditModal')).toHaveCount(1);
 }
 test.describe('Rubric iDevice', () => {
     test.describe('Basic Operations', () => {
@@ -352,6 +397,140 @@ test.describe('Rubric iDevice', () => {
                 TEST_DATA.dialogDescriptor,
             );
             await expect(firstCell.locator('input.ri_Weight')).toHaveValue(TEST_DATA.dialogWeight);
+        });
+    });
+
+    test.describe('Row edition dialog', () => {
+        test('should show the unsaved-changes confirmation above the row dialog and keep it clickable', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Row Confirm Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addRubricIdeviceFromPanel(page);
+            await createNewRubric(page);
+
+            await openRowDialogWithUnsavedChanges(page);
+
+            // Closing with pending changes hands over to the workarea confirmation.
+            await page.locator('#ri_RowEditCancel').click();
+
+            const confirmDialog = page.locator('[data-testid="modal-confirm"]');
+            await expect(confirmDialog).toBeVisible({ timeout: 10000 });
+
+            // Regression guard: both dialogs live in <body>, and the workarea
+            // forces `.modal { z-index: 20009 !important }`. If the rubric dialog
+            // is not kept below that layer it paints over the confirmation --
+            // appended later, same z-index -- and blocks the whole interface.
+            const confirmIsOnTop = await page.evaluate(() => {
+                const button = document.querySelector('[data-testid="confirm-action"]');
+                if (!button) return false;
+                const rect = button.getBoundingClientRect();
+                const topmost = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                return !!topmost && !!topmost.closest('[data-testid="modal-confirm"]');
+            });
+            expect(confirmIsOnTop).toBe(true);
+
+            // A real (hit-tested) click: it fails if the rubric dialog covers it.
+            await page.locator('[data-testid="confirm-action"]').click();
+
+            await expect(page.locator('#ri_RowEditModal')).toBeHidden({ timeout: 10000 });
+            await expect(page.locator('#ri_RowEditModalBackdrop')).toHaveCount(0);
+
+            // The change was discarded, so the criterion keeps its original text.
+            const firstDescriptor = page
+                .locator('#ri_Table tbody tr')
+                .first()
+                .locator('td')
+                .first()
+                .locator('input[type="text"]:not(.ri_Weight)');
+            await expect(firstDescriptor).not.toHaveValue(TEST_DATA.dialogDescriptor);
+        });
+    });
+
+    test.describe('Edition mode teardown', () => {
+        test('should remove the dialogs and backdrops when the rubric is saved', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Save Teardown Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addRubricWithMountedCellDialog(page);
+
+            await saveRubricIdevice(page);
+
+            await expectNoRubricDialogsLeftBehind(page);
+        });
+
+        test('should remove the dialogs and backdrops when the changes are discarded', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Discard Teardown Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addRubricWithMountedCellDialog(page);
+
+            const rubricNode = page.locator('#node-content article .idevice_node.rubric').first();
+            await rubricNode.locator('.btn-undo-idevice').first().click();
+
+            await expect(page.locator('[data-testid="modal-confirm"]')).toBeVisible({ timeout: 10000 });
+            await page.locator('[data-testid="confirm-action"]').click();
+
+            // Wait for edition mode to end before checking what survived it.
+            await page.waitForFunction(
+                () => {
+                    const node = document.querySelector('#node-content article .idevice_node.rubric');
+                    return !node || node.getAttribute('mode') !== 'edition';
+                },
+                undefined,
+                { timeout: 15000 },
+            );
+
+            await expectNoRubricDialogsLeftBehind(page);
+        });
+
+        test('should remove the dialogs and backdrops when the iDevice is deleted while editing', async ({
+            authenticatedPage,
+            createProject,
+        }) => {
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, 'Rubric Delete Teardown Test');
+            await gotoWorkarea(page, projectUuid);
+
+            await waitForAppReady(page);
+
+            await addRubricWithMountedCellDialog(page);
+
+            // While editing, the delete action is only offered in advanced mode.
+            await enableAdvancedMode(page);
+
+            const rubricNode = page.locator('#node-content article .idevice_node.rubric').first();
+            await rubricNode.locator('.btn-delete-idevice').first().click();
+
+            await expect(page.locator('[data-testid="modal-confirm"]')).toBeVisible({ timeout: 10000 });
+            await page.locator('[data-testid="confirm-action"]').click();
+
+            await expect(page.locator('#node-content article .idevice_node.rubric')).toHaveCount(0, {
+                timeout: 15000,
+            });
+
+            await expectNoRubricDialogsLeftBehind(page);
         });
     });
 


### PR DESCRIPTION
You could not edit a rubric cell using the "Edit" button because Bootstrap modals must be direct children of `<body>`, at least for now.

How to test: just add a rubric and click on the pencil to edit any cell.