### PR TITLE
Hide empty footer

### DIFF
--- a/doc/development/styles.md
+++ b/doc/development/styles.md
@@ -131,6 +131,32 @@ Example:
 
 ---
 
+## Empty Site Footer
+
+Every page ends with `<footer id="siteFooter">`, which holds the license and the
+content of the **Page footer** project property. When a project has neither — no
+license to display (empty, *propietary* or *not appropriate*) and a **Page footer**
+that is empty or whitespace only — the footer is rendered with an extra class:
+
+```html
+<footer id="siteFooter" class="siteFooter-empty"><div id="siteFooterContent"></div></footer>
+```
+
+`content/css/base.css` hides those footers, so a theme that gives `#siteFooter` a
+background, border or padding does not show a stray empty bar.
+
+The element stays in the DOM on purpose: a theme that wants to keep showing the
+footer area even when it is empty (a decorative bottom band, for instance) can opt
+out with a rule of equal or higher specificity:
+
+```css
+#siteFooter.siteFooter-empty {
+    display: block;
+}
+```
+
+---
+
 ## JavaScript in Styles
 
 You can use jQuery (already included in exported content).  

--- a/public/style/workarea/base.css
+++ b/public/style/workarea/base.css
@@ -757,6 +757,14 @@ html:not(.mode-teacher) .js .teacher-only {
     font-size: 0.95em;
 }
 
+/* Footer with neither license nor "Page footer" content: themes give #siteFooter
+   a background and border, so an empty one shows as a stray bar. Hidden here so
+   every theme (including custom ones) gets it, and so a theme that wants to keep
+   showing it can opt out by overriding display. */
+#siteFooter.siteFooter-empty {
+    display: none;
+}
+
 /* Skip navigation link */
 #skipNav {
     position: fixed;

--- a/src/shared/export/constants.spec.ts
+++ b/src/shared/export/constants.spec.ts
@@ -25,6 +25,8 @@ import {
     getLicenseUrl,
     LICENSE_REGISTRY,
     shouldShowLicenseFooter,
+    hasSiteFooterContent,
+    hasUserFooterContent,
     formatShortLicenseText,
     PRERENDERED_LATEX_CSS,
 } from './constants';
@@ -924,6 +926,58 @@ describe('Constants', () => {
 
             it('should return true for unknown licenses', () => {
                 expect(shouldShowLicenseFooter('some random license')).toBe(true);
+            });
+        });
+
+        describe('hasUserFooterContent', () => {
+            it('should return false for missing or empty content', () => {
+                expect(hasUserFooterContent()).toBe(false);
+                expect(hasUserFooterContent('')).toBe(false);
+                expect(hasUserFooterContent(undefined)).toBe(false);
+            });
+
+            it('should return false for whitespace-only content', () => {
+                expect(hasUserFooterContent('   ')).toBe(false);
+                expect(hasUserFooterContent('\n\t\r\n')).toBe(false);
+            });
+
+            it('should return true for real content', () => {
+                expect(hasUserFooterContent('<p>Hello</p>')).toBe(true);
+                expect(hasUserFooterContent('  text  ')).toBe(true);
+            });
+        });
+
+        describe('hasSiteFooterContent', () => {
+            it('should return false when there is neither license nor user content', () => {
+                expect(hasSiteFooterContent('')).toBe(false);
+                expect(hasSiteFooterContent('', '')).toBe(false);
+                expect(hasSiteFooterContent('', undefined)).toBe(false);
+                expect(hasSiteFooterContent(null as unknown as string)).toBe(false);
+            });
+
+            it('should return false for hidden licenses without user content', () => {
+                expect(hasSiteFooterContent('propietary license')).toBe(false);
+                expect(hasSiteFooterContent('not appropriate')).toBe(false);
+                expect(hasSiteFooterContent('Not Appropriate', '')).toBe(false);
+            });
+
+            it('should treat whitespace-only user content as empty', () => {
+                expect(hasSiteFooterContent('', '   ')).toBe(false);
+                expect(hasSiteFooterContent('', '\n\n')).toBe(false);
+                expect(hasSiteFooterContent('', ' \t \r\n ')).toBe(false);
+                expect(hasSiteFooterContent('not appropriate', '\n  \n')).toBe(false);
+            });
+
+            it('should return true when a visible license is present', () => {
+                expect(hasSiteFooterContent('creative commons: attribution 4.0')).toBe(true);
+                expect(hasSiteFooterContent('public domain', '')).toBe(true);
+                expect(hasSiteFooterContent('some random license', '   ')).toBe(true);
+            });
+
+            it('should return true when user content is present without a license', () => {
+                expect(hasSiteFooterContent('', '<p>Hello</p>')).toBe(true);
+                expect(hasSiteFooterContent('propietary license', '<p>Hello</p>')).toBe(true);
+                expect(hasSiteFooterContent('not appropriate', '  text  ')).toBe(true);
             });
         });
     });

--- a/src/shared/export/constants.ts
+++ b/src/shared/export/constants.ts
@@ -765,6 +765,34 @@ export function shouldShowLicenseFooter(licenseName: string): boolean {
     return true;
 }
 
+/**
+ * Check whether the "Page footer" project property holds anything renderable.
+ * Whitespace-only values count as empty.
+ *
+ * @param userFooterContent - Raw HTML from the "Page footer" project property
+ * @returns true when there is user content to render
+ */
+export function hasUserFooterContent(userFooterContent?: string): boolean {
+    return (userFooterContent ?? '').trim().length > 0;
+}
+
+/**
+ * Check whether the site footer has any content to display.
+ *
+ * The footer is considered empty when there is no license to show (empty,
+ * propietary or "not appropriate") and the user-defined "Page footer" property
+ * holds nothing but whitespace. Empty footers are still rendered — themes give
+ * them a background and border — so they are tagged with the `siteFooter-empty`
+ * class and hidden via CSS.
+ *
+ * @param license - The license name from metadata
+ * @param userFooterContent - Raw HTML from the "Page footer" project property
+ * @returns true when the footer has license or user content, false when empty
+ */
+export function hasSiteFooterContent(license: string, userFooterContent?: string): boolean {
+    return shouldShowLicenseFooter(license) || hasUserFooterContent(userFooterContent);
+}
+
 // =============================================================================
 // XML Namespaces
 // =============================================================================

--- a/src/shared/export/renderers/PageRenderer.spec.ts
+++ b/src/shared/export/renderers/PageRenderer.spec.ts
@@ -788,6 +788,59 @@ describe('PageRenderer', () => {
             // But no license section
             expect(html).not.toContain('id="packageLicense"');
         });
+
+        describe('siteFooter-empty class', () => {
+            it('should tag the footer as empty when there is no license and no user content', () => {
+                const html = renderer.renderFooterSection({ license: '' });
+
+                expect(html).toBe(
+                    '<footer id="siteFooter" class="siteFooter-empty"><div id="siteFooterContent"></div></footer>',
+                );
+            });
+
+            it('should tag the footer as empty for licenses hidden from the footer', () => {
+                for (const license of ['propietary license', 'not appropriate']) {
+                    const html = renderer.renderFooterSection({ license, licenseUrl: 'https://example.com' });
+
+                    expect(html).toContain('class="siteFooter-empty"');
+                }
+            });
+
+            it('should tag the footer as empty when user content is only whitespace', () => {
+                const html = renderer.renderFooterSection({ license: '', userFooterContent: '  \n  ' });
+
+                expect(html).toContain('class="siteFooter-empty"');
+                expect(html).not.toContain('id="siteUserFooter"');
+            });
+
+            it('should not tag the footer when user content is present without a license', () => {
+                const html = renderer.renderFooterSection({
+                    license: 'not appropriate',
+                    userFooterContent: '<p>Custom footer</p>',
+                });
+
+                expect(html).not.toContain('siteFooter-empty');
+                expect(html).toContain('id="siteUserFooter"');
+            });
+
+            it('should not tag the footer when a license is displayed', () => {
+                const html = renderer.renderFooterSection({
+                    license: 'creative commons: attribution 4.0',
+                    licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+                });
+
+                expect(html).not.toContain('siteFooter-empty');
+            });
+
+            it('should tag the empty footer in a full page render', () => {
+                const page = createTestPage();
+                const options = createDefaultOptions({ allPages: [page], license: '' });
+
+                const html = renderer.render(page, options);
+
+                expect(html).toContain('<footer id="siteFooter" class="siteFooter-empty">');
+            });
+        });
     });
 
     describe('renderMadeWithEXe', () => {

--- a/src/shared/export/renderers/PageRenderer.ts
+++ b/src/shared/export/renderers/PageRenderer.ts
@@ -22,6 +22,8 @@ import {
     getLicenseClass,
     formatLicenseText,
     shouldShowLicenseFooter,
+    hasSiteFooterContent,
+    hasUserFooterContent,
     getLicenseUrl,
     formatShortLicenseText,
 } from '../constants';
@@ -1072,7 +1074,8 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         const { license, licenseUrl = '', userFooterContent, language = 'en', navLabels } = options;
 
         let userFooterHtml = '';
-        if (userFooterContent) {
+        // Whitespace-only footer content is treated as no content at all
+        if (hasUserFooterContent(userFooterContent)) {
             userFooterHtml = `<div id="siteUserFooter"> <div>${userFooterContent}</div>\n</div>`;
         }
 
@@ -1080,7 +1083,9 @@ ${licenseUrl ? `<link rel="license" type="text/html" href="${licenseUrl}">\n` : 
         // - Empty license (no license specified, legacy content with unknown license)
         // - "propietary license" and "not appropriate" (no meaningful license to display)
         if (!shouldShowLicenseFooter(license)) {
-            return `<footer id="siteFooter"><div id="siteFooterContent">${userFooterHtml}</div></footer>`;
+            // Tag footers with neither license nor user content so CSS can hide them
+            const emptyClass = hasSiteFooterContent(license, userFooterContent) ? '' : ' class="siteFooter-empty"';
+            return `<footer id="siteFooter"${emptyClass}><div id="siteFooterContent">${userFooterHtml}</div></footer>`;
         }
 
         const licenseText = formatLicenseText(license);

--- a/test/e2e/playwright/specs/empty-site-footer.spec.ts
+++ b/test/e2e/playwright/specs/empty-site-footer.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, skipInStaticMode } from '../fixtures/auth.fixture';
+import {
+    waitForAppReady,
+    gotoWorkarea,
+    changeTheme,
+    addTextIdeviceWithContent,
+    waitForPreviewContent,
+    getPreviewFrame,
+} from '../helpers/workarea-helpers';
+
+/**
+ * Empty site footer (issue #2145).
+ *
+ * A project with no "Page footer" content and no displayable license still
+ * renders <footer id="siteFooter">, and several themes give it a background,
+ * border and padding — so it showed up as a stray empty bar. PageRenderer now
+ * tags those footers with the `siteFooter-empty` class and base.css hides them.
+ *
+ * These tests run against the preview, which uses the same renderer and the same
+ * content/css/base.css as the real exports, so they verify the class survives all
+ * the way to the rendered page and that no theme rule overrides the hiding.
+ */
+test.describe('Empty site footer', () => {
+    // universal draws the most visible empty footer (background + border);
+    // flux repaints #siteFooterContent, so it covers the other theme family.
+    for (const themeId of ['universal', 'flux']) {
+        test(`hides the footer in ${themeId} when there is no license and no footer content`, async ({
+            authenticatedPage,
+            createProject,
+        }, testInfo) => {
+            skipInStaticMode(test, testInfo, 'Requires server to create projects and render preview');
+
+            const page = authenticatedPage;
+
+            const projectUuid = await createProject(page, `Empty Footer ${themeId}`);
+            expect(projectUuid).toBeDefined();
+
+            await gotoWorkarea(page, projectUuid);
+            await waitForAppReady(page);
+            await changeTheme(page, themeId);
+            await addTextIdeviceWithContent(page, '<p>Some content</p>');
+
+            // "Not appropriate" is a license that is never displayed in the footer,
+            // and the footer property is left empty: nothing to show at all.
+            await page.evaluate(() => {
+                const bridge = (window as any).eXeLearning.app.project._yjsBridge;
+                bridge.updateMetadata({ license: 'not appropriate', footer: '' });
+            });
+            await page.waitForTimeout(500);
+
+            const loaded = await waitForPreviewContent(page);
+            expect(loaded).toBe(true);
+
+            const iframe = getPreviewFrame(page);
+            const footer = iframe.locator('#siteFooter');
+            await footer.waitFor({ state: 'attached', timeout: 15000 });
+
+            // The element is still in the DOM (themes may opt out) but hidden...
+            await expect(footer).toHaveClass(/siteFooter-empty/);
+            expect(await footer.evaluate(el => getComputedStyle(el).display)).toBe('none');
+
+            // ...and it takes up no space, which is the actual bug being fixed.
+            expect(await footer.boundingBox()).toBeNull();
+        });
+    }
+
+    test('keeps the footer visible when the project has footer content', async ({
+        authenticatedPage,
+        createProject,
+    }, testInfo) => {
+        skipInStaticMode(test, testInfo, 'Requires server to create projects and render preview');
+
+        const page = authenticatedPage;
+
+        const projectUuid = await createProject(page, 'Footer With Content');
+        expect(projectUuid).toBeDefined();
+
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+        await changeTheme(page, 'universal');
+        await addTextIdeviceWithContent(page, '<p>Some content</p>');
+
+        // No displayable license, but the user typed something in "Page footer".
+        await page.evaluate(() => {
+            const bridge = (window as any).eXeLearning.app.project._yjsBridge;
+            bridge.updateMetadata({ license: 'not appropriate', footer: '<p>Contact: someone@example.org</p>' });
+        });
+        await page.waitForTimeout(500);
+
+        const loaded = await waitForPreviewContent(page);
+        expect(loaded).toBe(true);
+
+        const iframe = getPreviewFrame(page);
+        const footer = iframe.locator('#siteFooter');
+        await footer.waitFor({ state: 'attached', timeout: 15000 });
+
+        await expect(footer).not.toHaveClass(/siteFooter-empty/);
+        await expect(footer).toBeVisible();
+        await expect(iframe.locator('#siteUserFooter')).toContainText('someone@example.org');
+    });
+});


### PR DESCRIPTION
The page footer is now hidden by default when it contains no content or license information.

**How to test:** 

- Choose a style with visible footer, like Flux or Universal.
- Preview or export. The footer should be visible.
- Check that there's no content in the "Page footer" field.
- Check that there's no license (or "Not appropriate").
- Preview or export. The footer should be hidden.