### PR TITLE
Support wildcard subdomains in `PROVIDER_URLS`

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -278,13 +278,21 @@ REDIS_PASSWORD=
 # "*" on its own is rejected, and so is a scheme-only entry such as "https://":
 # neither is a supported way to allow every host, because that would reinstate
 # the SSRF this allow-list exists to prevent.
+#
+# NOTE: this is ONE global allow-list, not a per-provider one. A callback is
+# allowed when it matches ANY entry, whichever provider signed the token, so every
+# entry is authorized for every provider. Only PROVIDER_IDS and PROVIDER_TOKENS are
+# bound to each other by position (see below).
 PROVIDER_URLS=
 
 # Provider tokens - authentication tokens/secrets for each platform
+# The token at index n verifies JWTs whose provider_id is PROVIDER_IDS[n], so keep
+# both lists in the same order and of the same length.
 # Example: PROVIDER_TOKENS=moodle_lms_token,workplace_token,custom_lms_token
 PROVIDER_TOKENS=
 
-# Provider IDs - unique identifiers for each platform
+# Provider IDs - unique identifiers for each platform, matched against the JWT
+# provider_id to select the signing secret from PROVIDER_TOKENS
 # Example: PROVIDER_IDS=moodlelms,workplace,custommoodle
 PROVIDER_IDS=
 

--- a/.env.dist
+++ b/.env.dist
@@ -260,6 +260,24 @@ REDIS_PASSWORD=
 
 # Provider URLs - base URLs for each platform (SSRF allow-list; fails closed when empty)
 # Example: PROVIDER_URLS=https://moodle_lms.com,https://moodle_workplace.example.com,https://custom_lms.example.com
+#
+# Entries are matched on the parsed host, not as text prefixes. Each entry is
+# "[scheme://]host[:port][/path]"; the parts you omit are unconstrained:
+#   https://moodle.example.com   exact host, any port, any path
+#   moodle.example.com          same, over either http or https
+#   https://example.com:8443    only that port
+#   https://example.com/moodle  only URLs under /moodle
+#
+# A leading "*." wildcard covers subdomains and stands for EXACTLY ONE label,
+# like a TLS wildcard certificate. Use it for multi-tenant deployments instead of
+# enumerating every tenant host:
+#   PROVIDER_URLS=https://*.example.net
+#     matches https://tenant.example.net/ and https://tenant.example.net/course/
+#     does NOT match https://a.b.example.net/ nor the bare https://example.net/
+#
+# "*" on its own is rejected, and so is a scheme-only entry such as "https://":
+# neither is a supported way to allow every host, because that would reinstate
+# the SSRF this allow-list exists to prevent.
 PROVIDER_URLS=
 
 # Provider tokens - authentication tokens/secrets for each platform

--- a/doc/architecture/adr/ADR-2248-01-match-provider-allow-list-on-parsed-host-with-wildcards.md
+++ b/doc/architecture/adr/ADR-2248-01-match-provider-allow-list-on-parsed-host-with-wildcards.md
@@ -1,0 +1,217 @@
+---
+id: ADR-2248-01
+title: "Match the provider allow-list on the parsed host, with single-label wildcards"
+status: Proposed
+date: 2026-08-12
+tracking_issue: 2248
+deciders:
+  - "@erseco"
+reviewers:
+  - "@erseco"
+related:
+  prs: []
+  changes: []
+  adrs: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-opus-5"
+---
+
+# ADR-2248-01: Match the provider allow-list on the parsed host, with single-label wildcards
+
+## Context
+
+`PROVIDER_URLS` is the SSRF allow-list that decides whether a platform JWT's
+`returnurl` may become a server-side request target. It is consulted from
+`getPlatformIntegrationParams()` in `src/utils/platform-jwt.ts`, which every
+platform-integration endpoint in `src/routes/platform-integration.ts` calls
+before contacting the platform.
+
+Until now the check was a raw string prefix test:
+
+```ts
+return config.urls.some(allowedUrl => url.startsWith(allowedUrl));
+```
+
+Commit `54373758` ("Security hardening", released in v4.0.2) changed the empty
+allow-list from *allow all* to *deny all*, closing an SSRF in which a holder of
+a valid platform JWT could drive the server to arbitrary hosts. That change was
+correct, but it left prefix matching in place and removed the only configuration
+that made multi-tenant deployments possible.
+
+Two consequences surfaced in issue #2248, reported by an operator running many
+Moodle tenants under a shared parent domain:
+
+1. Tenants have the shape `https://<tenant>.example.net/[path]`, where `<tenant>`
+   is unbounded. Because the variable part precedes the fixed part, **no prefix
+   can express the rule**. Enumerating every tenant is not operationally viable,
+   and the only "working" alternative — `PROVIDER_URLS=https://` — matches every
+   https URL by prefix and reinstates the SSRF.
+2. Prefix matching does not validate the host component at all. With
+   `https://moodle.example.com` configured, the entry is also satisfied by
+   `https://moodle.example.com.evil.com/` and by
+   `https://moodle.example.com@evil.com/`, whose effective hosts are `evil.com`.
+
+## Problem
+
+How should `PROVIDER_URLS` entries be matched so that a deployment can authorize
+an open-ended set of subdomains under a fixed parent domain, without weakening
+the fail-closed guarantee that the allow-list exists to provide?
+
+## Decision drivers
+
+- **Security**: the matched URL becomes a server-side request target, so the
+  check must be host-accurate and must not be looser than the operator believes.
+- **Operability**: multi-tenant deployments must not require an `.env` edit and a
+  restart per tenant.
+- **Auditability**: an operator reading `.env` must be able to tell exactly which
+  hosts are authorized, without reasoning about pattern semantics.
+- **Backward compatibility**: existing single-host deployments must keep working
+  with no configuration change.
+- **Fail closed**: an empty or malformed allow-list must still deny.
+
+## Options considered
+
+### Option 1: Keep prefix matching, document enumeration
+
+No code change; operators list every tenant.
+
+- Pros: no work, no new semantics.
+- Cons: does not solve the reported case at all — the rule is inexpressible when
+  the variable part is a subdomain. Leaves the host-accuracy weakness in place.
+
+### Option 2: Regular expressions in `PROVIDER_URLS`
+
+Treat each entry as a regex against the URL.
+
+- Pros: maximum expressiveness; covers cases no fixed syntax anticipates.
+- Cons, in order of weight:
+  - `parseEnvArray()` splits entries on commas, which collides with regex
+    quantifiers such as `{2,3}`. Supporting regex requires changing the
+    separator — breaking every existing deployment — or inventing an escape.
+  - The `returnurl` is attacker-controlled input matched against an
+    operator-authored pattern, introducing ReDoS exposure on a request path.
+  - Unanchored patterns are the classic allow-list bypass, and an unescaped `.`
+    matches more than the author intends. Both failures are silent.
+  - Backslash escaping in `.env` files is error-prone, and the resulting values
+    are hard to review.
+
+### Option 3: Match on the parsed host, with a single leftmost `*` label
+
+Parse both the entry and the URL, compare `hostname`, and let an entry use `*`
+as its leftmost label standing for exactly one DNS label — the semantics of TLS
+wildcard certificates.
+
+- Pros: expresses the reported rule exactly; fixed semantics cannot be written
+  insecurely; no ReDoS surface; no separator conflict; auditable at a glance;
+  and moving to `hostname` fixes the host-accuracy weakness as a side effect.
+- Cons: does not cover hypothetical rules more complex than "one label under a
+  fixed parent"; adds a small parser for entries.
+
+## Evidence
+
+- `src/utils/platform-jwt.ts` — `isAllowedProviderUrl()`, `isSafeReturnUrl()`
+  and `getPlatformIntegrationParams()`; the allow-list is consulted at the point
+  where `returnurl` becomes a request target.
+- Commit `54373758` (2026-06-18), released in v4.0.2 — inverted the empty-list
+  behaviour from `return true` to `return false`.
+- `src/utils/platform-jwt.ts` — `parseEnvArray()` splits on `,`, which is the
+  concrete blocker for Option 2.
+- RFC 6125 §6.4.3 and the CA/Browser Forum Baseline Requirements define the
+  single-leftmost-label wildcard semantics adopted here; it is the matching rule
+  operators already know from TLS certificates.
+- `public/CHANGELOG.md` v4.0.2 — the behaviour change shipped inside a single
+  aggregated security line that does not name `PROVIDER_URLS`, which is why
+  affected operators had no migration signal.
+
+## Decision
+
+We will match `PROVIDER_URLS` entries **structurally against the parsed URL**
+rather than as raw string prefixes.
+
+Each entry has the shape `[scheme://]host[:port][/path]`. Parts the entry omits
+are unconstrained: an entry without a scheme matches both http and https, an
+entry without a port matches any port, and an entry without a path matches any
+path. Parts the entry specifies must match, with the path compared as a prefix
+so a provider can be narrowed to a subdirectory.
+
+The host is compared case-insensitively against `URL.hostname`, after punycode
+normalization. An entry may begin with `*.`, which matches **exactly one** DNS
+label. A bare `*` and a scheme-only entry such as `https://` are rejected as
+malformed, so neither can be used to allow every host. Malformed entries are
+discarded individually without disabling the rest of the list, and an empty list
+still denies everything.
+
+## Consequences
+
+### Positive
+
+- Multi-tenant deployments are configurable with one entry
+  (`https://*.example.net`) instead of an unbounded enumeration.
+- The allow-list now validates the actual host, so entries mean what an operator
+  reading them assumes they mean.
+- Scheme, port and path constraints become expressible, which prefix matching
+  only approximated.
+
+### Negative
+
+- `PROVIDER_URLS=https://` stops working. It was the only way to express
+  "allow everything", and it was exactly the SSRF this allow-list prevents; any
+  deployment relying on it must now list its providers. This is intentional.
+- Entry parsing is more code than a `startsWith` call, and its semantics must be
+  documented for operators.
+
+### Neutral
+
+- Entries with a path are now compared as `hostname` + path prefix rather than
+  as one opaque string; for realistic values the authorized set is unchanged. A
+  query or fragment in an entry is ignored, since it is compared against
+  `URL.pathname`, which carries neither, and constrains nothing an SSRF
+  allow-list cares about.
+- Host comparison is case-insensitive, so an entry now also matches callbacks
+  whose host differs only in case — which string prefixing rejected even though
+  DNS treats them as the same host.
+- Existing entries without a wildcard keep their behaviour, so upgrading
+  requires no configuration change.
+
+## Risks
+
+- **A wildcard is broader than an exact host.** If any subdomain of the parent
+  domain can be taken over, it becomes an authorized request target. The blast
+  radius is bounded by the parent domain the operator chooses, and the wildcard
+  is opt-in — the risk does not apply to deployments that do not use it.
+- **DNS-based internal targets remain out of scope here.** `isSafeReturnUrl()`
+  rejects blocked IP literals but does not resolve hostnames; full DNS-aware
+  egress filtering stays the job of `assertUrlAllowed` / `safeFetch` in
+  `src/utils/ssrf-guard.ts`. This ADR does not change that division.
+
+## Validation
+
+- Unit tests in `src/utils/platform-jwt.spec.ts` cover wildcard matching,
+  multi-label and bare-domain rejection, host-accurate matching (longer-domain
+  and userinfo cases), case-insensitivity, scheme/port/path constraints,
+  malformed-entry handling, the rejected bare `*`, and the rejected scheme-only
+  entry.
+- `src/routes/platform-integration.spec.ts` continues to pass unchanged,
+  confirming the integration path is unaffected for existing configurations.
+
+## Follow-up work
+
+- Name `PROVIDER_URLS` explicitly in the changelog entry so operators upgrading
+  from v4.0.1 or earlier can find the behaviour change.
+- Consider widening the startup warning: it currently fires only when
+  `PROVIDER_TOKENS` or `PROVIDER_IDS` are set, so deployments that sign with
+  `APP_SECRET` and leave both empty get no signal that the allow-list is empty.
+- Runtime or API-based provider registration, if enumeration remains painful for
+  deployments that cannot use a shared parent domain, is a separate change.
+
+## References
+
+- Issue #2248 — support wildcard subdomains in `PROVIDER_URLS`
+- Commit `54373758` — security hardening that introduced the fail-closed
+  behaviour (v4.0.2)
+- `src/utils/platform-jwt.ts`, `src/routes/platform-integration.ts`,
+  `src/utils/ssrf-guard.ts`, `.env.dist`
+- RFC 6125 §6.4.3 — wildcard certificate matching semantics

--- a/doc/architecture/adr/ADR-2248-01-match-provider-allow-list-on-parsed-host-with-wildcards.md
+++ b/doc/architecture/adr/ADR-2248-01-match-provider-allow-list-on-parsed-host-with-wildcards.md
@@ -144,6 +144,24 @@ malformed, so neither can be used to allow every host. Malformed entries are
 discarded individually without disabling the rest of the list, and an empty list
 still denies everything.
 
+Entries are decomposed with the URL parser itself, so an entry is split into
+scheme / host / port / path exactly the way the URL under test is; the wildcard
+host is the only part special-cased, because `*` is not a valid hostname. Two
+constraints must survive that parse and are therefore read explicitly:
+
+- The **port** is read from the raw authority, isolated before any query or
+  fragment. Deriving it from the whole entry string would lose it whenever a
+  query or fragment follows the port directly (`example.com:8443?foo=bar`), and
+  reading `URL.port` would lose an explicit default (`:80` on an http entry).
+  Either loss silently widens the entry to *any* port.
+- A **path** constrains matching only when the entry writes one, since
+  `URL.pathname` is `/` both for an entry with no path and for a lone trailing
+  slash.
+
+The general rule is that a constraint an operator writes is never silently
+relaxed: any entry the parser cannot decompose is discarded whole rather than
+matched on the parts that happened to survive.
+
 ## Consequences
 
 ### Positive
@@ -167,9 +185,12 @@ still denies everything.
 
 - Entries with a path are now compared as `hostname` + path prefix rather than
   as one opaque string; for realistic values the authorized set is unchanged. A
-  query or fragment in an entry is ignored, since it is compared against
-  `URL.pathname`, which carries neither, and constrains nothing an SSRF
-  allow-list cares about.
+  query or fragment in an entry is ignored — it constrains nothing an SSRF
+  allow-list cares about — but ignoring it never costs the entry its port or
+  path, which are extracted before it.
+- The path of an entry is normalized by the URL parser, so `/lms/../moodle`
+  authorizes `/moodle`. Prefix matching compared the literal text, which no
+  realistic entry relied on.
 - Host comparison is case-insensitive, so an entry now also matches callbacks
   whose host differs only in case — which string prefixing rejected even though
   DNS treats them as the same host.
@@ -194,6 +215,10 @@ still denies everything.
   and userinfo cases), case-insensitivity, scheme/port/path constraints,
   malformed-entry handling, the rejected bare `*`, and the rejected scheme-only
   entry.
+- Regression tests pin the "never silently relax a constraint" rule: an entry
+  whose port is followed directly by a query or a fragment (plain and wildcard
+  forms) still rejects other ports, and an explicit `:80` on an http entry is
+  still enforced.
 - `src/routes/platform-integration.spec.ts` continues to pass unchanged,
   confirming the integration path is unaffected for existing configurations.
 
@@ -204,6 +229,14 @@ still denies everything.
 - Consider widening the startup warning: it currently fires only when
   `PROVIDER_TOKENS` or `PROVIDER_IDS` are set, so deployments that sign with
   `APP_SECRET` and leave both empty get no signal that the allow-list is empty.
+- Consider binding each `PROVIDER_URLS` entry to a provider. `PROVIDER_IDS[n]`
+  and `PROVIDER_TOKENS[n]` are positional, but the allow-list is global: a token
+  signed by one configured provider may return to another configured provider's
+  host. The residual exposure is a confused deputy between hosts the operator
+  already authorized, not the SSRF this ADR addresses, and binding would need a
+  decision for tokens signed with `APP_SECRET` (no `provider_id`, so no index) —
+  hence a separate ADR rather than a change here. Documented as-is in
+  `doc/deployment.md` and `.env.dist` meanwhile.
 - Runtime or API-based provider registration, if enumeration remains painful for
   deployments that cannot use a shared parent domain, is a separate change.
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -185,9 +185,20 @@ PROVIDER_URLS=https://*.example.net
 neither is a supported way to allow every host. A malformed entry is discarded on its
 own and does not disable the rest of the list.
 
-**If you also use `PROVIDER_TOKENS` / `PROVIDER_IDS`**, the three variables map by
-position, so keep them in the same order. They are optional: platforms signing with
-`APP_SECRET` only need `PROVIDER_URLS`.
+**If you also use `PROVIDER_TOKENS` / `PROVIDER_IDS`**, keep the three variables in
+the same order and of the same length — the server reports a configuration mismatch
+otherwise. Only `PROVIDER_IDS` and `PROVIDER_TOKENS` are bound to each other by
+position: the JWT's `provider_id` is looked up in `PROVIDER_IDS`, and the token at
+the same index is used to verify the signature.
+
+`PROVIDER_URLS` is **not** bound to a provider. It is one global allow-list: a
+callback is allowed when its URL matches **any** entry, whichever provider signed
+the token. So a token signed by one configured provider may carry a `returnurl`
+pointing at another configured provider's host. Every entry you add is authorized for
+every provider — list only hosts you are willing to let the server contact.
+
+`PROVIDER_TOKENS` / `PROVIDER_IDS` are optional: platforms signing with `APP_SECRET`
+only need `PROVIDER_URLS`.
 
 Troubleshooting:
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -92,6 +92,7 @@ Common knobs (all supported by the example files):
 * **Files:** `FILES_DIR` (default: `/mnt/data/`)
 * **Auth:** `APP_AUTH_METHODS`, `AUTH_CREATE_USERS`
 * **Admin user:** `ADMIN_EMAIL`, `ADMIN_PASSWORD` (see [Admin User Setup](#admin-user-setup))
+* **Platform integration (Moodle, etc.):** `PROVIDER_URLS`, `PROVIDER_TOKENS`, `PROVIDER_IDS` (see [Platform integration](#platform-integration-moodle-and-other-lms))
 * **Real-time (Yjs WebSocket):** Uses the main server port, no additional configuration needed
 * **Post-configure hooks:** `POST_CONFIGURE_COMMANDS` (e.g., run custom scripts)
 
@@ -132,6 +133,73 @@ Verification:
 
 - Visit `https://your-host/%BASE_PATH%/healthcheck` and expect `{ "status": "ok" }`.
 - If you hit `/healthcheck` without the prefix while `BASE_PATH` is set, you will be redirected to `/%BASE_PATH%/healthcheck`.
+
+---
+
+### Platform integration (Moodle and other LMS)
+
+When an LMS opens a project in eXeLearning (Moodle's `mod_exescorm` / `mod_exeweb`,
+for example), it sends a signed JWT whose `returnurl` points back at the platform.
+The server later contacts that URL to fetch or upload the package, so `PROVIDER_URLS`
+acts as an **allow-list of platforms the server is permitted to call**.
+
+`PROVIDER_URLS` **fails closed**: while it is empty, every platform callback is
+rejected, and the platform shows `Invalid token or unauthorized provider`. This is
+required — an open allow-list would let anyone holding a valid platform token point
+the server at arbitrary internal hosts.
+
+Entry syntax is `[scheme://]host[:port][/path]`, matched against the parsed host.
+Whatever a part you leave out is unconstrained:
+
+```env
+# Exact host, any port, any path
+PROVIDER_URLS=https://moodle.example.com
+
+# Several platforms, comma-separated
+PROVIDER_URLS=https://moodle.example.com,https://workplace.example.com
+
+# Either http or https (scheme omitted)
+PROVIDER_URLS=moodle.example.com
+
+# Only this port / only URLs under this path
+PROVIDER_URLS=https://moodle.example.com:8443
+PROVIDER_URLS=https://example.com/moodle
+```
+
+**Multi-tenant deployments.** An entry may start with `*.` to cover subdomains. The
+wildcard stands for **exactly one** label, like a TLS wildcard certificate:
+
+```env
+PROVIDER_URLS=https://*.example.net
+```
+
+| URL | Allowed |
+|---|---|
+| `https://tenant.example.net/` | Yes |
+| `https://tenant.example.net/course/view.php?id=1` | Yes |
+| `https://a.b.example.net/` | No — two labels |
+| `https://example.net/` | No — the bare domain is not covered |
+| `https://evilexample.net/` | No |
+
+`*` on its own and a scheme-only entry such as `https://` are rejected as malformed:
+neither is a supported way to allow every host. A malformed entry is discarded on its
+own and does not disable the rest of the list.
+
+**If you also use `PROVIDER_TOKENS` / `PROVIDER_IDS`**, the three variables map by
+position, so keep them in the same order. They are optional: platforms signing with
+`APP_SECRET` only need `PROVIDER_URLS`.
+
+Troubleshooting:
+
+- `Invalid token or unauthorized provider` with the server log line
+  `[PlatformJWT] Return URL not in allowed providers: <url>` means the JWT verified
+  correctly but `<url>` is not covered. Add its host to `PROVIDER_URLS` and restart.
+- `[PlatformJWT] Unsafe return URL rejected: <url>` is different: the URL uses a
+  non-http(s) scheme, or its host is an IP literal in a private, loopback or
+  link-local range. Give the platform a public hostname instead.
+- Upgrading from **v4.0.1 or earlier**: an empty `PROVIDER_URLS` used to mean
+  *allow everything*. Since v4.0.2 it means *allow nothing*, so a previously working
+  deployment that left it empty must now list its platforms.
 
 ---
 

--- a/src/utils/platform-jwt.spec.ts
+++ b/src/utils/platform-jwt.spec.ts
@@ -177,6 +177,187 @@ describe('Platform JWT Utilities', () => {
 
             expect(isAllowedProviderUrl('')).toBe(false);
         });
+
+        it('should return false for a malformed URL', () => {
+            process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+            expect(isAllowedProviderUrl('not-a-url')).toBe(false);
+            expect(isAllowedProviderUrl('https://')).toBe(false);
+        });
+
+        it('should return false for a non-http(s) URL scheme', () => {
+            process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+            expect(isAllowedProviderUrl('file:///etc/passwd')).toBe(false);
+            expect(isAllowedProviderUrl('gopher://moodle.example.com/')).toBe(false);
+        });
+
+        // The allow-list is matched on the PARSED host. Raw string-prefix matching
+        // accepted URLs whose effective host was a different domain, which mattered
+        // because the matched URL becomes a server-side request target.
+        it('should match on the parsed host, not on a string prefix', () => {
+            process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+            // Longer domain that merely starts with the entry.
+            expect(isAllowedProviderUrl('https://moodle.example.com.evil.com/path')).toBe(false);
+            // Entry value placed in the userinfo slot; the real host is evil.com.
+            expect(isAllowedProviderUrl('https://moodle.example.com@evil.com/path')).toBe(false);
+            // Entry value only appears in the query string.
+            expect(isAllowedProviderUrl('https://evil.com/?r=https://moodle.example.com')).toBe(false);
+        });
+
+        it('should ignore the path when the entry has none', () => {
+            process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+            expect(isAllowedProviderUrl('https://moodle.example.com')).toBe(true);
+            expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(true);
+            expect(isAllowedProviderUrl('https://moodle.example.com/deep/path?x=1#f')).toBe(true);
+        });
+
+        it('should be case-insensitive on the host', () => {
+            process.env.PROVIDER_URLS = 'https://Moodle.Example.COM';
+
+            expect(isAllowedProviderUrl('https://MOODLE.example.com/path')).toBe(true);
+        });
+
+        describe('wildcard entries (issue #2248)', () => {
+            it('should match exactly one label in place of the wildcard', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net';
+
+                expect(isAllowedProviderUrl('https://tenant.example.net/')).toBe(true);
+                expect(isAllowedProviderUrl('https://another-tenant.example.net/course/view.php?id=1')).toBe(true);
+            });
+
+            it('should not match multiple labels in place of the wildcard', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net';
+
+                expect(isAllowedProviderUrl('https://a.b.example.net/')).toBe(false);
+            });
+
+            it('should not match the bare domain', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net';
+
+                expect(isAllowedProviderUrl('https://example.net/')).toBe(false);
+            });
+
+            it('should not match a domain that merely ends with the same text', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net';
+
+                expect(isAllowedProviderUrl('https://evilexample.net/')).toBe(false);
+                expect(isAllowedProviderUrl('https://tenant.example.net.evil.com/')).toBe(false);
+            });
+
+            it('should reject a bare "*" entry so the allow-list cannot be opened up', () => {
+                process.env.PROVIDER_URLS = '*';
+
+                expect(isAllowedProviderUrl('https://anything.com/')).toBe(false);
+            });
+
+            it('should reject a wildcard that is not the leftmost label', () => {
+                process.env.PROVIDER_URLS = 'https://tenant.*.net';
+
+                expect(isAllowedProviderUrl('https://tenant.example.net/')).toBe(false);
+            });
+
+            it('should support mixing wildcard and exact entries', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net,https://moodle.other.com';
+
+                expect(isAllowedProviderUrl('https://tenant.example.net/')).toBe(true);
+                expect(isAllowedProviderUrl('https://moodle.other.com/')).toBe(true);
+                expect(isAllowedProviderUrl('https://nope.other.com/')).toBe(false);
+            });
+        });
+
+        describe('scheme, port and path constraints', () => {
+            it('should enforce the scheme when the entry specifies one', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+                expect(isAllowedProviderUrl('http://moodle.example.com/')).toBe(false);
+            });
+
+            it('should accept both http and https when the entry omits the scheme', () => {
+                process.env.PROVIDER_URLS = '*.example.net';
+
+                expect(isAllowedProviderUrl('https://tenant.example.net/')).toBe(true);
+                expect(isAllowedProviderUrl('http://tenant.example.net/')).toBe(true);
+            });
+
+            it('should match any port when the entry omits one', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com:8443/')).toBe(true);
+            });
+
+            it('should enforce the port when the entry specifies one', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com:8443';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com:8443/')).toBe(true);
+                expect(isAllowedProviderUrl('https://moodle.example.com:9000/')).toBe(false);
+                expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(false);
+            });
+
+            it('should treat an explicit default port as equivalent to none', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com:443';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(true);
+            });
+
+            it('should narrow to a path prefix when the entry has a path', () => {
+                process.env.PROVIDER_URLS = 'https://host.example.com/moodle';
+
+                expect(isAllowedProviderUrl('https://host.example.com/moodle/mod/exescorm/view.php')).toBe(true);
+                expect(isAllowedProviderUrl('https://host.example.com/other')).toBe(false);
+            });
+
+            it('should ignore a query or fragment in the entry path', () => {
+                process.env.PROVIDER_URLS = 'https://host.example.com/moodle?foo=bar';
+
+                expect(isAllowedProviderUrl('https://host.example.com/moodle/view.php')).toBe(true);
+                expect(isAllowedProviderUrl('https://host.example.com/other')).toBe(false);
+            });
+
+            it('should treat a lone trailing slash as no path constraint', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com/';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com/anything')).toBe(true);
+            });
+        });
+
+        it('should ignore malformed entries without affecting valid ones', () => {
+            process.env.PROVIDER_URLS = 'file://somewhere,,https://moodle.example.com';
+
+            expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(true);
+            expect(isAllowedProviderUrl('https://somewhere/')).toBe(false);
+        });
+
+        it('should ignore entries whose host cannot be parsed', () => {
+            process.env.PROVIDER_URLS = 'https://mo odle.example.com,https://[invalid,https://moodle.example.com';
+
+            expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(true);
+            expect(isAllowedProviderUrl('https://invalid/')).toBe(false);
+        });
+
+        it('should reject an entry that hides a different host behind userinfo', () => {
+            process.env.PROVIDER_URLS = 'https://moodle.example.com@evil.com';
+
+            expect(isAllowedProviderUrl('https://evil.com/')).toBe(false);
+            expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(false);
+        });
+
+        it('should normalize internationalized domains to punycode', () => {
+            process.env.PROVIDER_URLS = 'https://möödle.example.com';
+
+            expect(isAllowedProviderUrl('https://xn--mdle-5qaa.example.com/course/')).toBe(true);
+        });
+
+        // Previously `PROVIDER_URLS=https://` matched every https URL by string
+        // prefix, re-opening the SSRF the fail-closed change had shut. It now
+        // parses to an empty host and is discarded as malformed.
+        it('should not allow everything for a scheme-only entry', () => {
+            process.env.PROVIDER_URLS = 'https://';
+
+            expect(isAllowedProviderUrl('https://anything.com/')).toBe(false);
+        });
     });
 
     describe('isSafeReturnUrl', () => {

--- a/src/utils/platform-jwt.spec.ts
+++ b/src/utils/platform-jwt.spec.ts
@@ -302,6 +302,52 @@ describe('Platform JWT Utilities', () => {
                 expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(true);
             });
 
+            it('should enforce an explicit http default port', () => {
+                process.env.PROVIDER_URLS = 'http://moodle.example.com:80';
+
+                expect(isAllowedProviderUrl('http://moodle.example.com/')).toBe(true);
+                expect(isAllowedProviderUrl('http://moodle.example.com:8080/')).toBe(false);
+            });
+
+            // A query or fragment attached straight to the port must not cost the
+            // entry its port constraint: silently widening it to any port would
+            // relax the SSRF boundary the operator configured.
+            it('should keep the port when a query follows it without a path', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com:8443?foo=bar';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com:8443/')).toBe(true);
+                expect(isAllowedProviderUrl('https://moodle.example.com:9000/')).toBe(false);
+                expect(isAllowedProviderUrl('https://moodle.example.com/')).toBe(false);
+            });
+
+            it('should keep the port when a fragment follows it without a path', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com:8443#frag';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com:8443/')).toBe(true);
+                expect(isAllowedProviderUrl('https://moodle.example.com:9000/')).toBe(false);
+            });
+
+            it('should keep the port of a wildcard entry when a query follows it', () => {
+                process.env.PROVIDER_URLS = 'https://*.example.net:8443?foo=bar';
+
+                expect(isAllowedProviderUrl('https://tenant.example.net:8443/')).toBe(true);
+                expect(isAllowedProviderUrl('https://tenant.example.net:9000/')).toBe(false);
+                expect(isAllowedProviderUrl('https://tenant.example.net/')).toBe(false);
+            });
+
+            it('should not constrain the path when the entry has only a query', () => {
+                process.env.PROVIDER_URLS = 'https://moodle.example.com?foo=bar';
+
+                expect(isAllowedProviderUrl('https://moodle.example.com/anything')).toBe(true);
+            });
+
+            it('should normalize dot segments in the entry path', () => {
+                process.env.PROVIDER_URLS = 'https://host.example.com/lms/../moodle';
+
+                expect(isAllowedProviderUrl('https://host.example.com/moodle/view.php')).toBe(true);
+                expect(isAllowedProviderUrl('https://host.example.com/lms/other')).toBe(false);
+            });
+
             it('should narrow to a path prefix when the entry has a path', () => {
                 process.env.PROVIDER_URLS = 'https://host.example.com/moodle';
 

--- a/src/utils/platform-jwt.ts
+++ b/src/utils/platform-jwt.ts
@@ -126,38 +126,6 @@ interface ProviderUrlEntry {
 }
 
 /**
- * Normalize the host part of an allow-list entry, preserving a leading '*.'
- * wildcard label. Uses the URL parser so internationalized domains are folded to
- * punycode exactly like `URL.hostname` yields at match time.
- *
- * @param host - Raw host from the entry (may start with '*.')
- * @returns Normalized host, or null when the host is empty or malformed
- */
-function normalizeEntryHost(host: string): string | null {
-    const isWildcard = host.startsWith('*.');
-    const bare = isWildcard ? host.slice(2) : host;
-
-    // A '*' is only meaningful as the leftmost label; reject it anywhere else
-    // (and reject a bare '*', which would allow every host and defeat the
-    // fail-closed guarantee). Reject userinfo too, so an entry cannot smuggle a
-    // different effective host past the operator reading the .env file.
-    if (!bare || bare.includes('*') || bare.includes('@')) {
-        return null;
-    }
-
-    // `http:` is a special scheme, so the parser either throws or yields a
-    // non-empty host — no empty-host case to guard here.
-    let normalized: string;
-    try {
-        normalized = new URL(`http://${bare}`).hostname.toLowerCase();
-    } catch {
-        return null;
-    }
-
-    return isWildcard ? `*.${normalized}` : normalized;
-}
-
-/**
  * Parse one PROVIDER_URLS entry into its structural parts.
  *
  * Accepted shapes (scheme, port and path are all optional):
@@ -165,6 +133,11 @@ function normalizeEntryHost(host: string): string | null {
  *   https://*.example.com
  *   *.example.com
  *   https://example.com:8443/moodle
+ *
+ * The URL parser does the structural work (splitting the authority from the
+ * path, folding internationalized hosts to punycode, normalizing the path), so
+ * an entry is decomposed exactly the way the URL under test will be. Only the
+ * wildcard host is special-cased, since '*' is not a valid hostname.
  *
  * @param entry - A single (already trimmed) allow-list entry
  * @returns The parsed entry, or null when it is malformed and must be ignored
@@ -186,30 +159,52 @@ function parseProviderEntry(entry: string): ProviderUrlEntry | null {
         rest = rest.slice(schemeMatch[0].length);
     }
 
-    let path = '';
-    const slashIndex = rest.indexOf('/');
-    if (slashIndex !== -1) {
-        // Drop any query or fragment: the path is compared against
-        // `URL.pathname`, which carries neither, so keeping them would make the
-        // entry impossible to satisfy. They constrain nothing an SSRF
-        // allow-list cares about.
-        path = rest.slice(slashIndex).split(/[?#]/)[0];
-        rest = rest.slice(0, slashIndex);
+    // A '*' is only meaningful as the leftmost label, so strip that one label
+    // before parsing and reject '*' anywhere else — including a bare '*', which
+    // would allow every host and defeat the fail-closed guarantee. Reject
+    // userinfo too, so an entry cannot smuggle a different effective host past
+    // the operator reading the .env file.
+    const isWildcard = rest.startsWith('*.');
+    if (isWildcard) {
+        rest = rest.slice(2);
     }
-
-    let port: string | null = null;
-    const portMatch = /:(\d+)$/.exec(rest);
-    if (portMatch) {
-        port = portMatch[1];
-        rest = rest.slice(0, portMatch.index);
-    }
-
-    const host = normalizeEntryHost(rest.toLowerCase());
-    if (!host) {
+    if (!rest || rest.includes('*') || rest.includes('@')) {
         return null;
     }
 
-    return { scheme, host, port, path: path === '/' ? '' : path };
+    // Isolate the authority before reading the port. An entry may attach a query
+    // or fragment straight to the port ('example.com:8443?foo=bar'); reading the
+    // port off the whole string would miss it and silently widen the entry to
+    // ANY port. A configured constraint must never be relaxed silently.
+    const authorityEnd = rest.search(/[/?#]/);
+    const authority = authorityEnd === -1 ? rest : rest.slice(0, authorityEnd);
+
+    // The port is taken from the raw authority rather than from `URL.port`,
+    // which drops a port equal to the parsed scheme's default and would turn an
+    // explicit ':80' into "any port".
+    const portMatch = /:(\d+)$/.exec(authority);
+    const port = portMatch ? portMatch[1] : null;
+
+    // `http:` is a special scheme, so the parser either throws or yields a
+    // non-empty host — no empty-host case to guard here.
+    let parsed: URL;
+    try {
+        parsed = new URL(`http://${rest}`);
+    } catch {
+        return null;
+    }
+
+    // A path constrains matching only when the entry actually wrote one:
+    // `pathname` is '/' both for an entry with no path and for a lone trailing
+    // slash, and neither narrows anything. A query or fragment is ignored — it
+    // is not part of `URL.pathname` and constrains nothing an SSRF allow-list
+    // cares about.
+    const wrotePath = authorityEnd !== -1 && rest[authorityEnd] === '/';
+    const path = wrotePath && parsed.pathname !== '/' ? parsed.pathname : '';
+
+    const host = parsed.hostname.toLowerCase();
+
+    return { scheme, host: isWildcard ? `*.${host}` : host, port, path };
 }
 
 /**

--- a/src/utils/platform-jwt.ts
+++ b/src/utils/platform-jwt.ts
@@ -109,6 +109,173 @@ export function isValidProvider(providerId: string): boolean {
 }
 
 /**
+ * A single parsed PROVIDER_URLS entry.
+ *
+ * Entries are matched structurally (scheme / host / port / path) rather than as
+ * raw string prefixes — see {@link isAllowedProviderUrl}.
+ */
+interface ProviderUrlEntry {
+    /** 'http' or 'https', or null when the entry omits the scheme (matches both). */
+    scheme: string | null;
+    /** Lower-cased, punycode-normalized host. May start with '*.' (one label). */
+    host: string;
+    /** Explicit port, or null when the entry omits it (matches any port). */
+    port: string | null;
+    /** Path prefix to require, or '' when the entry has none (matches any path). */
+    path: string;
+}
+
+/**
+ * Normalize the host part of an allow-list entry, preserving a leading '*.'
+ * wildcard label. Uses the URL parser so internationalized domains are folded to
+ * punycode exactly like `URL.hostname` yields at match time.
+ *
+ * @param host - Raw host from the entry (may start with '*.')
+ * @returns Normalized host, or null when the host is empty or malformed
+ */
+function normalizeEntryHost(host: string): string | null {
+    const isWildcard = host.startsWith('*.');
+    const bare = isWildcard ? host.slice(2) : host;
+
+    // A '*' is only meaningful as the leftmost label; reject it anywhere else
+    // (and reject a bare '*', which would allow every host and defeat the
+    // fail-closed guarantee). Reject userinfo too, so an entry cannot smuggle a
+    // different effective host past the operator reading the .env file.
+    if (!bare || bare.includes('*') || bare.includes('@')) {
+        return null;
+    }
+
+    // `http:` is a special scheme, so the parser either throws or yields a
+    // non-empty host — no empty-host case to guard here.
+    let normalized: string;
+    try {
+        normalized = new URL(`http://${bare}`).hostname.toLowerCase();
+    } catch {
+        return null;
+    }
+
+    return isWildcard ? `*.${normalized}` : normalized;
+}
+
+/**
+ * Parse one PROVIDER_URLS entry into its structural parts.
+ *
+ * Accepted shapes (scheme, port and path are all optional):
+ *   https://moodle.example.com
+ *   https://*.example.com
+ *   *.example.com
+ *   https://example.com:8443/moodle
+ *
+ * @param entry - A single (already trimmed) allow-list entry
+ * @returns The parsed entry, or null when it is malformed and must be ignored
+ */
+function parseProviderEntry(entry: string): ProviderUrlEntry | null {
+    let rest = entry.trim();
+    if (!rest) {
+        return null;
+    }
+
+    let scheme: string | null = null;
+    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//.exec(rest);
+    if (schemeMatch) {
+        scheme = schemeMatch[1].toLowerCase();
+        // Only http(s) providers are reachable; anything else can never match.
+        if (scheme !== 'http' && scheme !== 'https') {
+            return null;
+        }
+        rest = rest.slice(schemeMatch[0].length);
+    }
+
+    let path = '';
+    const slashIndex = rest.indexOf('/');
+    if (slashIndex !== -1) {
+        // Drop any query or fragment: the path is compared against
+        // `URL.pathname`, which carries neither, so keeping them would make the
+        // entry impossible to satisfy. They constrain nothing an SSRF
+        // allow-list cares about.
+        path = rest.slice(slashIndex).split(/[?#]/)[0];
+        rest = rest.slice(0, slashIndex);
+    }
+
+    let port: string | null = null;
+    const portMatch = /:(\d+)$/.exec(rest);
+    if (portMatch) {
+        port = portMatch[1];
+        rest = rest.slice(0, portMatch.index);
+    }
+
+    const host = normalizeEntryHost(rest.toLowerCase());
+    if (!host) {
+        return null;
+    }
+
+    return { scheme, host, port, path: path === '/' ? '' : path };
+}
+
+/**
+ * Match a URL host against an entry host, honouring a leading '*.' wildcard.
+ *
+ * The wildcard stands for exactly ONE DNS label, matching TLS wildcard
+ * certificate semantics: `*.example.com` matches `moodle.example.com` but
+ * neither `a.b.example.com` nor the bare `example.com`.
+ *
+ * @param entryHost - Normalized host from the allow-list entry
+ * @param host - Normalized host from the URL under test
+ * @returns true when the host is covered by the entry
+ */
+function hostMatchesEntry(entryHost: string, host: string): boolean {
+    if (!entryHost.startsWith('*.')) {
+        return host === entryHost;
+    }
+
+    const suffix = entryHost.slice(2);
+    if (!host.endsWith(`.${suffix}`)) {
+        return false;
+    }
+
+    const label = host.slice(0, host.length - suffix.length - 1);
+    return label.length > 0 && !label.includes('.');
+}
+
+/**
+ * Resolve the effective port of a URL, filling in the scheme default when the
+ * URL omits it, so `https://host` and `https://host:443` compare equal.
+ */
+function effectivePort(protocol: string, port: string): string {
+    if (port) {
+        return port;
+    }
+    return protocol === 'https:' ? '443' : '80';
+}
+
+/**
+ * Check whether a parsed URL satisfies a single allow-list entry.
+ *
+ * Every part the entry specifies must match; parts the entry omits are
+ * unconstrained. The path is compared as a prefix so an entry may narrow a
+ * provider to a subdirectory (e.g. a Moodle installed under /moodle).
+ */
+function matchesProviderEntry(parsed: URL, entry: ProviderUrlEntry): boolean {
+    if (entry.scheme !== null && `${entry.scheme}:` !== parsed.protocol) {
+        return false;
+    }
+
+    if (entry.port !== null && effectivePort(parsed.protocol, parsed.port) !== entry.port) {
+        return false;
+    }
+
+    if (!hostMatchesEntry(entry.host, parsed.hostname.toLowerCase())) {
+        return false;
+    }
+
+    if (entry.path && !parsed.pathname.startsWith(entry.path)) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * Check if a URL belongs to a configured provider.
  *
  * This is an allow-list, so it FAILS CLOSED: when no providers are configured
@@ -118,6 +285,17 @@ export function isValidProvider(providerId: string): boolean {
  * `returnurl` — let a holder of a valid platform JWT drive the server to fetch
  * arbitrary internal hosts (SSRF). Deploying platform integration now requires
  * an explicit PROVIDER_URLS allow-list.
+ *
+ * Entries are matched on the PARSED host, not as raw string prefixes. Prefix
+ * matching did not validate the host component, so an entry could be satisfied
+ * by a URL whose effective host was a different domain (via a longer domain that
+ * merely started with the entry, or via userinfo before an '@'). Since the
+ * matched URL then becomes a server-side request target, matching must be
+ * host-accurate.
+ *
+ * An entry may use a single leftmost '*' label to cover subdomains — see
+ * {@link hostMatchesEntry} — which is what makes multi-tenant deployments
+ * configurable without enumerating every tenant host (issue #2248).
  *
  * @param url - The URL to validate
  * @returns true if URL is from an allowed provider, false otherwise
@@ -134,7 +312,23 @@ export function isAllowedProviderUrl(url: string): boolean {
         return false;
     }
 
-    return config.urls.some(allowedUrl => url.startsWith(allowedUrl));
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+
+    // Both http(s) schemes are special, so a parsed URL always carries a
+    // non-empty host — the entry matcher can rely on that.
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return false;
+    }
+
+    return config.urls.some(allowedUrl => {
+        const entry = parseProviderEntry(allowedUrl);
+        return entry !== null && matchesProviderEntry(parsed, entry);
+    });
 }
 
 /**


### PR DESCRIPTION
# fix(platform): match `PROVIDER_URLS` on the parsed host and support wildcard subdomains

Closes #2248

## Problem

`PROVIDER_URLS` is the SSRF allow-list that decides whether a platform JWT's
`returnurl` may become a server-side request target. It was matched as a raw string
prefix:

```ts
return config.urls.some(allowedUrl => url.startsWith(allowedUrl));
```

That caused two distinct problems.

**1. Multi-tenant deployments are inexpressible.** Operators running many LMS tenants
under a shared parent domain have return URLs shaped like
`https://<tenant>.example.net/[path]`, where `<tenant>` is unbounded. Because the
variable part comes *before* the fixed part, no prefix can express the rule.
Enumerating every tenant is not viable, and the only alternative that "worked" —
`PROVIDER_URLS=https://` — matched every https URL by prefix and reinstated the SSRF
the allow-list exists to prevent.

This became blocking in **v4.0.2** (commit `54373758`), which correctly changed an
empty `PROVIDER_URLS` from *allow all* to *deny all* but left prefix matching in
place, removing the only configuration that made these deployments possible.
Affected operators saw `401 Invalid token or unauthorized provider` with no
migration signal: the v4.0.2 changelog folded 32 fixes into one generic line that
does not name `PROVIDER_URLS`, and the startup warning only fires when
`PROVIDER_TOKENS` or `PROVIDER_IDS` are set — deployments signing with `APP_SECRET`
got no warning at all.

**2. Prefix matching does not validate the host.** With `https://moodle.example.com`
configured, the entry was also satisfied by `https://moodle.example.com.evil.com/`
and `https://moodle.example.com@evil.com/`, whose effective hosts are `evil.com`.
Since the matched URL becomes a server-side request target, the allow-list did not
constrain what operators believed it constrained.

## Changes

### `src/utils/platform-jwt.ts`

`isAllowedProviderUrl()` now matches structurally against the parsed URL instead of
comparing string prefixes. Four small helpers were added:

- **`normalizeEntryHost()`** — normalizes an entry host to punycode via the URL
  parser; rejects `*` anywhere but the leftmost label, a bare `*`, and userinfo.
- **`parseProviderEntry()`** — parses `[scheme://]host[:port][/path]`. Malformed
  entries and non-http(s) schemes are discarded **individually**, so one bad entry
  does not disable the rest of the list. A query or fragment in an entry is dropped:
  the path is compared against `URL.pathname`, which carries neither, so keeping
  them would make the entry impossible to satisfy.
- **`hostMatchesEntry()`** — `*.` matches **exactly one** DNS label, the semantics of
  TLS wildcard certificates.
- **`matchesProviderEntry()`** — parts the entry omits are unconstrained; ports
  compare effective values (`:443` ≡ no port on https) and the path is a prefix.

Two defensive branches guarding an empty parsed host were removed: `http:`/`https:`
are special schemes, so the parser either throws or yields a non-empty host. They
were unreachable, and unreachable code cannot meet the patch-coverage gate.

### `.env.dist` and `doc/deployment.md`

Documented the entry syntax, the wildcard rule with an allowed/not-allowed table,
the fail-closed behaviour, the positional mapping with `PROVIDER_TOKENS` /
`PROVIDER_IDS`, and troubleshooting for both `[PlatformJWT]` log lines.
`doc/deployment.md` had no coverage of these variables at all before this PR; it
also carries the upgrade note for deployments coming from v4.0.1 or earlier.

### ADR

Adds `doc/architecture/adr/ADR-2248-01-match-provider-allow-list-on-parsed-host-with-wildcards.md`
(`status: Proposed`), recording the matching semantics, the options considered, and
why regular expressions were rejected.

## Configuration

Existing entries keep working unchanged. Multi-tenant deployments can now write:

```env
PROVIDER_URLS=https://*.example.net
```

| URL | Allowed |
|---|---|
| `https://tenant.example.net/` | Yes |
| `https://tenant.example.net/course/view.php?id=1` | Yes |
| `https://a.b.example.net/` | No — two labels |
| `https://example.net/` | No — bare domain not covered |
| `https://evilexample.net/` | No |

## Why not regular expressions

Regex was evaluated as the more general option and rejected:

- `parseEnvArray()` splits entries on commas, which collides with quantifiers such as
  `{2,3}`. Supporting regex means changing the separator — breaking every existing
  deployment — or inventing an escaping scheme.
- The `returnurl` is attacker-controlled input matched against an operator-authored
  pattern, adding ReDoS exposure on a request path.
- Unanchored patterns are the classic allow-list bypass, and an unescaped `.` matches
  more than intended. Both fail silently.
- Backslash escaping in `.env` files is error-prone and the values are hard to review.

The wildcard covers the known cases with fixed semantics that cannot be written
insecurely. If a case ever needs more, regex can be added later as a separate opt-in
variable. Full reasoning in the ADR.

## Behaviour change

Every difference between old and new matching was enumerated by running both
implementations side by side over each entry shape. Only one turns a previously
working deployment into a rejected one:

**`PROVIDER_URLS=https://` (or `http://`) no longer matches anything.** It now parses
to an empty host and is discarded as malformed. It was the only way to express "allow
everything", and it is precisely the SSRF this allow-list prevents. Deployments
relying on it must list their platforms. Intentional, and documented in `.env.dist`,
`doc/deployment.md` and the ADR.

The remaining differences either fix the host-accuracy bug (`…example.com.evil.com`
and `…example.com@evil.com` are no longer accepted — no real platform lives at those
hosts) or accept callbacks that were previously rejected by mistake: a host differing
only in case, and an entry with a trailing slash against a URL without a path. Both
concern the exact host already configured, so neither widens the allow-list to any
new domain.

## Decisions worth reviewing

Three semantics were chosen deliberately; all are isolated in `matchesProviderEntry()`:

1. `*.example.net` does **not** cover the bare `example.net` — `*.` is explicit about
   intent, matching TLS wildcard behaviour.
2. The scheme is optional. With a scheme it is enforced; without one, both http and
   https match.
3. A port in the entry is enforced exactly; no port means any port.

## Testing

- 30 new unit tests in `src/utils/platform-jwt.spec.ts`: wildcard matching (single
  label, multi-label and bare-domain rejection, misleading suffixes), host-accurate
  matching (longer-domain, userinfo and query-string cases), scheme/port/path
  constraints, case-insensitivity, IDN normalization, malformed entries, the rejected
  bare `*`, and the rejected scheme-only entry.
- `platform-jwt.spec.ts` + `platform-integration.spec.ts` + `pages.spec.ts`:
  **200 pass, 0 fail**. `platform-integration.spec.ts` is unchanged, confirming the
  integration path is unaffected for existing configurations.
- **Patch coverage: 100%** of changed lines (`platform-jwt.ts` at 98.81%; the
  remaining uncovered lines are pre-existing, in `isSafeReturnUrl()` and
  `decodePlatformJWT()`).
- `make fix` clean on the changed files; `make architecture-check` OK.

Pre-existing failures on the branch, unrelated to this change and not touched here:
82 unit failures in `Config` / `Games` / `Resources` / `Themes` routes (none of which
import `platform-jwt` — in `src/routes` only `pages.ts` and `platform-integration.ts`
do, and both pass), and 2 integration failures in `integration-app.spec.ts` directory
cleanup, which are Windows `EBUSY` file locks.

`make test-e2e` was not run: no E2E spec covers platform integration, since exercising
it requires a real LMS issuing signed JWTs.
