### PR TITLE
refactor(storage): shard project assets and make storage paths portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ CLIENT (Browser)                        SERVER (Bun/Elysia)
 YjsDocumentManager (Y.Doc)              SessionManager: lightweight metadata
 ├── navigation (Y.Array)                WebSocket: stateless relay
 ├── metadata (Y.Map)                    Database: projects + yjs snapshots
-├── assets (Y.Map)                      Filesystem: FILES_DIR/assets/{uuid}/
+├── assets (Y.Map)                      Filesystem: FILES_DIR/assets/{shard}/{uuid}/
 └── themeFiles (Y.Map)
 ```
 
@@ -185,7 +185,7 @@ Client-side storage:
 
 ```
 FILES_DIR/
-├── assets/{projectUuid}/           # Permanent project assets
+├── assets/{shard}/{projectUuid}/   # Permanent project assets (shard = first 2 hex chars of UUID, ADR-2250-01)
 ├── tmp/{year}/{month}/{day}/{id}/  # Temporary files
 ├── dist/{year}/{month}/{day}/{id}/ # Ready-to-download exports
 ├── chunks/                         # Upload chunks
@@ -196,6 +196,8 @@ FILES_DIR/
 Key rules:
 - Directories created **lazily** (on-demand), never eagerly
 - Assets use project **UUID**, not numeric ID
+- `assets.storage_path` is stored **relative to FILES_DIR** (`assets/<shard>/<uuid>/...`, POSIX separators) —
+  never absolute; always build/resolve through `src/utils/asset-paths.ts` via `src/services/file-helper.ts`
 - Always use `isPathSafe()` for user-supplied paths
 - Use `path.join()` for cross-platform paths
 

--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -9,7 +9,7 @@ deciders:
 reviewers:
   - "@ignaciogros"
 related:
-  prs: []
+  prs: [2266]
   changes:
     - "2250-asset-storage-sharding"
   adrs: []

--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -274,8 +274,10 @@ We will:
 - One extra directory level in every asset path.
 - A transitional legacy-read fallback exists in the resolver until installations
   converge; it must eventually be removed (see "Follow-up work").
-- Startup performs one cheap check per boot (one indexed-free `NOT LIKE 'assets/%'`
-  query + one readdir of the assets root) even on converged installations.
+- Startup performs a cheap, bounded check per boot even on converged installations: one
+  indexed-free `NOT LIKE 'assets/%'` query, one readdir of the assets root, and a
+  content check (`readdir`) of each existing two-decimal shard bucket (`00`-`99`) to
+  distinguish it from a legacy numeric project-id directory.
 
 ### Neutral
 
@@ -333,8 +335,12 @@ We will:
 ## Follow-up work
 
 - Remove the legacy absolute-path read fallback from the resolver once field
-  installations have converged (tracked for a future major release; the migration's
-  per-boot summary tells operators when their installation is clean).
+  installations have converged (tracked in
+  <https://github.com/exelearning/exelearning/issues/2288> for a future major release;
+  the migration's per-boot summary tells operators when their installation is clean).
+- Provide a CLI subcommand that lists parked migration conflicts and resolves them
+  with an explicit keep-old / keep-new choice
+  (<https://github.com/exelearning/exelearning/issues/2287>).
 - Consider validating client-supplied project identifiers at creation time so the
   FNV-1a fallback becomes purely defensive.
 

--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -1,0 +1,356 @@
+---
+id: ADR-2250-01
+title: "Shard project asset storage using a single 8-bit bucket level"
+status: Accepted
+date: 2026-08-15
+tracking_issue: 2250
+deciders:
+  - "@erseco"
+reviewers:
+  - "@ignaciogros"
+related:
+  prs: []
+  changes:
+    - "2250-asset-storage-sharding"
+  adrs: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-fable-5"
+---
+
+# ADR-2250-01: Shard project asset storage using a single 8-bit bucket level
+
+## Context
+
+Server-side project assets are stored under one directory per project:
+
+```
+FILES_DIR/assets/<projectUuid>/<clientId>.<ext>          (flat uploads)
+FILES_DIR/assets/<projectUuid>/<clientId>/<filename>     (ZIP extraction / duplication)
+```
+
+This layout was introduced deliberately by PR #788, which replaced session/numeric-id
+directories with UUID-based directories and lazy creation. It is an intentional design,
+not an accident. Application code never enumerates the root of `assets/` at runtime —
+all `readdir` calls are scoped to a single project directory (verified in issue #2250,
+and consistent with issue #1842, where the only root-level reads are per-project
+`FileSystemAssetProvider` scans of `FILES_DIR/assets/<uuid>`).
+
+Two separate concerns were raised in issue #2250:
+
+1. **Portability (a concrete defect):** `assets.storage_path` persisted **absolute host
+   filesystem paths** such as `/mnt/data/assets/<uuid>/<clientId>.png`
+   (`src/routes/assets.ts` @ `3c7c9e821`, write sites at lines 427/443/690/704/1159/1173/1314).
+   This couples every database row to one specific `FILES_DIR` mount point. Moving,
+   remounting or restoring the data directory to a different path silently invalidates
+   every asset row. Notably, the `themes` and `templates` tables already store
+   FILES_DIR-relative paths (`src/routes/admin-themes.ts:603`,
+   `src/routes/admin-templates.ts:223`) — assets were the outlier.
+
+2. **Scalability (a preventive concern):** the flat `assets/` root grows without bound —
+   one subdirectory per project, forever. There is **no measured runtime failure at
+   current scale** (see "Evidence"), but an ever-growing single directory is unnecessary,
+   and changing the layout is far cheaper now than after years of data accumulation —
+   especially because fixing concern 1 first decouples the database from the physical
+   layout.
+
+## Problem
+
+Should project asset storage (a) keep absolute `storage_path` values, and (b) keep the
+flat one-directory-per-project layout — and if not, how many shard levels should the new
+layout use, and how do existing installations migrate safely?
+
+## Decision drivers
+
+- Database rows must survive a change of `FILES_DIR` (backup/restore, remount, Docker
+  volume relocation, desktop-app data moves).
+- Bounded directory sizes at plausible scales (tens of thousands to millions of
+  projects) without adding depth or complexity that no evidence justifies.
+- Lazy directory creation (established by PR #788) must be preserved.
+- The migration must be idempotent, resumable, crash-safe, safe under multi-instance
+  startup, and must never silently overwrite user data.
+- One canonical layout long-term; no permanent dual-write or dual-layout support.
+- Cross-platform correctness: the same backend runs on Linux servers and inside the
+  Electron desktop app on Windows/macOS (`AGENTS.md` §1: EBUSY file locks, `path.join`).
+
+## Options considered
+
+### Sharding depth
+
+Assuming two hexadecimal characters per level, average **bucket-namespace** occupancy
+(directories are created lazily, so unused buckets never physically exist):
+
+| Projects | 0 levels (1 dir) | 1 level (256 buckets) | 2 levels (65,536) | 3 levels (16,777,216) |
+|---:|---:|---:|---:|---:|
+| 20,000 | 20,000 | ≈ 78 | ≈ 0.31 | ≈ 0.0012 |
+| 200,000 | 200,000 | ≈ 781 | ≈ 3.05 | ≈ 0.0119 |
+| 1,000,000 | 1,000,000 | ≈ 3,906 | ≈ 15.26 | ≈ 0.0596 |
+| 10,000,000 | 10,000,000 | ≈ 39,063 | ≈ 152.59 | ≈ 0.5960 |
+
+**Option A — 0 levels (status quo):** no migration cost; but the root keeps growing
+unbounded, and retrofitting later means migrating much more data.
+
+**Option B — 1 level (`assets/aa/<uuid>/`), chosen:** caps per-bucket project counts
+very effectively at plausible scales (≈ 781 per bucket at 200k projects; even at 10M
+projects a bucket averages ≈ 39k entries — a size ext4's htree handles for lookups, and
+far from any structural limit). Minimal path depth, minimal intermediate directories,
+one readable hop (`assets/ab/ab12…`). Precedent: Git loose objects use exactly one
+two-hex-character level (see "Evidence").
+
+**Option C — 2 levels (`assets/aa/bb/<uuid>/`, the issue's original proposal):**
+65,536 possible buckets is disproportionate: at 1M projects the average bucket would
+hold ≈ 15 directories, i.e. the intermediate level does almost nothing except add
+depth and intermediate directories. No measurement indicates it is needed. (The issue
+described two levels as "the scheme used by Git"; Git actually uses **one** level —
+see "Evidence".)
+
+**Option D — 3 levels:** ≈ 0.06 projects per leaf bucket at 1M projects; pure overhead
+at any plausible eXeLearning scale.
+
+We do **not** claim one level is universally optimal — it is the proportional choice for
+the expected scale and current evidence, and the path portability work (below) makes a
+future re-shard cheap if measurements ever justify it.
+
+### Stored-path representation
+
+**Chosen:** `storage_path` is a normalized POSIX-style path **relative to `FILES_DIR`,
+including the `assets/` component**: `assets/ab/<uuid>/<clientId>.png` (nested form:
+`assets/ab/<uuid>/<clientId>/<filename>`). This matches the existing themes/templates
+convention, is unambiguous (no implicit `assets/` root to remember), and is portable
+across hosts and path-separator conventions.
+
+Rejected: keeping absolute paths (the defect being fixed), and prefix-free relative
+paths (`ab/<uuid>/…`) which hide the storage root and invite `path.join(filesDir, …)`
+mistakes.
+
+### Shard algorithm
+
+**Chosen:** for canonical UUIDs (8-4-4-4-12 hex), the shard is the **lowercased first
+two hex characters**. Project UUIDs are generated with `uuid.v4()`
+(`src/db/queries/projects.ts:302`) or `crypto.randomUUID()`
+(`src/services/session-manager.ts:48`), whose first byte is uniformly random, so the
+256 buckets are uniformly filled and an operator can find a project's directory by
+reading its UUID.
+
+However, `projects.uuid` is **not format-validated at every creation site** — e.g.
+`createProjectWithUuid` accepts a client-supplied identifier verbatim
+(`src/routes/project.ts:1251`). For any non-canonical identifier the shard falls back to
+a deterministic, stable 8-bit **FNV-1a** hash rendered as two lowercase hex characters,
+so the mapping is total and stable for arbitrary strings. Both branches are golden-tested
+in `src/utils/asset-paths.spec.ts`.
+
+Caveat recorded for the future: if project ID generation ever switches to a time-ordered
+scheme (e.g. UUIDv7, whose leading bits are a timestamp), the first-two-hex prefix would
+stop being uniform and this ADR must be revisited (worst case degrades toward today's
+flat layout, not below it).
+
+### Migration / compatibility strategy
+
+Evaluated:
+
+- **(a) Permanent support for both layouts** — rejected: two storage architectures
+  forever, every reader forked.
+- **(b) Temporary legacy-read compatibility + convergent migration** — **chosen**: the
+  shared resolver re-roots legacy absolute values via their `assets/…` suffix under the
+  *current* `FILES_DIR`, so not-yet-migrated (or conflict-parked) rows keep working —
+  and, as a side effect, legacy rows become FILES_DIR-portable even before migration.
+  All **new writes emit only the new format**; there is **no dual-write**.
+- **(c) Immediate hard cut-over** — rejected: a failed or interrupted move would break
+  reads with no fallback; unacceptable for user data.
+
+The migration is **deliberately not a Kysely schema migration**: a filesystem move and a
+database update cannot share one transaction, Kysely migrations run exactly once, and a
+partially applied filesystem state must be re-checked on every startup. Instead a
+dedicated idempotent service (`src/services/asset-storage-migration.ts`) runs in
+`bootstrap()` after schema migrations and before `app.listen()`. Per row it moves the
+file first, then rewrites the row under an optimistic
+`WHERE id = ? AND storage_path = <old>` guard (crash-safe; safe when several app
+instances start concurrently — one instance wins each row, the others reconcile). It
+handles: source-only (move), destination-only (crash recovery: rewrite), both-identical
+(drop legacy copy), both-different (**never overwrite** — keep both, report, park the row
+on its legacy location in portable relative form), neither (log, rewrite so the table
+converges, reads keep returning 404 as before), uninterpretable values (leave untouched,
+report). A second phase sweeps orphan files (on disk, no row) from legacy directories
+into the sharded layout and removes emptied directories; unrecognized entries are
+reported and left in place. Cross-device moves fall back to copy-to-temp + rename +
+size-verify + remove, so a destination never holds a partial file (`EXDEV`, bind mounts).
+
+## Evidence
+
+- Current flat layout and lazy creation are intentional: PR #788
+  (<https://github.com/exelearning/exelearning/pull/788>); no runtime enumeration of the
+  assets root: issue #2250 review of all `readdir`/`listFiles` call sites; per-project
+  scoping also visible in issue #1842
+  (<https://github.com/exelearning/exelearning/issues/1842>).
+- Absolute write sites / read sites: `src/routes/assets.ts`, `src/routes/api/v1/assets.ts`,
+  `src/routes/upload-session.ts`, `src/services/folder-manager.ts`,
+  `src/routes/project.ts` @ `3c7c9e821`.
+- **ext4 known-name lookup is indexed, not linear:** with `EXT4_INDEX_FL` set, "this
+  directory uses a hashed btree (htree) to organize and find directory entries"; htree
+  depth "cannot be larger than 3 if the INCOMPAT_LARGEDIR feature is set; cannot be
+  larger than 2 otherwise" — Linux kernel ext4 directory documentation
+  (<https://docs.kernel.org/filesystems/ext4/directory.html>; inode flags:
+  <https://docs.kernel.org/filesystems/ext4/inodes.html>).
+- ext4 feature semantics: `dir_index` ("Use hashed b-trees to speed up name lookups in
+  large directories"), `dir_nlink` (lifts the ~65k-subdirectory link-count limit),
+  `large_dir` (raises maximum directory size and htree height) — ext4(5) man page
+  (<https://man7.org/linux/man-pages/man5/ext4.5.html>).
+- **Git precedent (one level, not two):** loose objects are stored "with the first two
+  hex characters of the object ID being the directory and the remaining characters being
+  the file name … to shard the data and avoid too many files being in one directory,
+  since some file systems perform poorly with many items in a directory"
+  (<https://git-scm.com/docs/gitformat-loose>); "objects are splayed over 256
+  subdirectories using the first two characters of the sha1 object name"
+  (<https://git-scm.com/docs/gitrepository-layout>).
+- Docker storage semantics (see "Consequences" for the operational guidance):
+  volumes "write directly to the host filesystem", bypassing the storage-driver
+  union-filesystem overhead of the container writable layer, and the local volume
+  driver supports NFS mounts (<https://docs.docker.com/engine/storage/>,
+  <https://docs.docker.com/engine/storage/volumes/>,
+  <https://docs.docker.com/engine/storage/bind-mounts/>).
+- Reproducible benchmark harness: `scripts/benchmark-asset-storage.ts` (correctness
+  tests in `scripts/benchmark-asset-storage.spec.ts`); see "Validation".
+
+Facts this decision explicitly does **not** rest on:
+
+- **The flat layout is not a demonstrated runtime bug at current scale.** Known-path
+  lookup on modern ext4 with `dir_index` is htree-indexed; nothing in the application
+  enumerates the assets root at runtime. Sharding here is **low-cost preventive
+  hardening**, adopted while it is cheap, not a fix for a measured failure.
+- **Sharding does not make full-tree operations free.** A complete recursive traversal
+  (full backup, `du`, `find`, `tar`, `rsync` file-list generation) still visits every
+  filesystem object; sharding *redistributes* entries into smaller directories and adds
+  intermediate directories. Its benefits are bounded directory sizes, avoidance of
+  pathological single-directory extremes, predictable organization, and easier future
+  partitioning — any claim that specific tools get materially faster must come from
+  measurements on the actual storage backend.
+- Historical large-directory folklore (early-2000s ext2/ext3 on spinning disks) is not
+  evidence about modern Linux + SSD/NVMe behavior.
+- NTFS behavior is **not** part of this server-side justification: the production
+  server target is Linux. (The same storage code does run inside the Electron desktop
+  app on Windows, which constrains the *migration* — EBUSY tolerance, `path.join` — but
+  not the sharding decision.)
+
+## Decision
+
+We will:
+
+1. Store project assets under **one 8-bit shard level**:
+   `FILES_DIR/assets/<shard>/<projectUuid>/…`, where `<shard>` is the lowercased first
+   two hex characters of the canonical project UUID (FNV-1a 8-bit fallback for
+   non-canonical identifiers). 256 possible buckets, created **lazily**.
+2. Persist `assets.storage_path` as a **POSIX-style path relative to `FILES_DIR`**,
+   always starting with `assets/`. Absolute paths are no longer written.
+3. Centralize the path grammar in `src/utils/asset-paths.ts`
+   (`getAssetShard`, `buildAssetStoragePath`, `resolveAssetStoragePath`,
+   `tryResolveAssetStoragePath`, `getProjectAssetsDirCandidates`) with FILES_DIR-bound
+   wrappers in `src/services/file-helper.ts`; **every** conversion between a stored
+   value and a physical path goes through this resolver (absolute-input rejection for
+   new-format paths, `..`/separator/control-character rejection, containment check
+   under `FILES_DIR/assets`).
+4. Migrate existing installations at startup via the idempotent, resumable
+   reconciliation described above, with a **temporary** legacy-read fallback in the
+   resolver (accepting old absolute values via their `assets/…` suffix) that exists only
+   to make deployment safe while rows converge.
+
+## Consequences
+
+### Positive
+
+- Database asset rows survive any change of `FILES_DIR`; restoring a backup to a
+  different mount no longer requires rewriting rows (regression-tested).
+- Directory sizes are bounded (≈ N/256 project directories per bucket); the assets root
+  itself holds at most 256 entries.
+- One shared, hardened resolver replaces scattered `path.join` logic; storage layout can
+  change again in the future by touching one module plus a migration.
+- Assets now follow the same relative-path convention as themes and templates.
+- Deletion paths (cleanup scheduler, admin user deletion, CLI cleanup) remove both the
+  sharded and the legacy directory, so pre-migration leftovers cannot linger.
+
+### Negative
+
+- One extra directory level in every asset path.
+- A transitional legacy-read fallback exists in the resolver until installations
+  converge; it must eventually be removed (see "Follow-up work").
+- Startup performs one cheap check per boot (one indexed-free `NOT LIKE 'assets/%'`
+  query + one readdir of the assets root) even on converged installations.
+
+### Neutral
+
+- Full-tree operations (backup, `du`, `find`) still scale with total object count.
+- Operators may use Docker named volumes, bind mounts, NFS-backed volumes, SAN/CSI
+  storage, etc.; the requirement is only that persistent `FILES_DIR` data live outside
+  the container writable layer. Docker named volumes are not inherently a performance
+  problem. NFS/SAN/network storage behaves differently from local ext4 and should be
+  benchmarked on the actual deployment; local results must not be extrapolated to
+  network filesystems.
+- Very large deployments should choose their storage backend (ext4, XFS, Btrfs,
+  OpenZFS, NFS-backed, SAN/block, or object storage if the architecture evolves) from
+  operational requirements and measured workloads — ext4 is **not** declared unsuitable
+  for large installations, and no alternative filesystem is recommended solely for
+  being perceived as "large-scale". Btrfs, for example, offers snapshots, checksums and
+  send/receive (<https://docs.kernel.org/filesystems/btrfs.html>), which are operational
+  features, not automatic performance wins for this workload.
+
+## Risks
+
+- **Interrupted migration** (crash, power loss, EBUSY on Windows desktops): mitigated by
+  the move-then-rewrite protocol, per-row optimistic guards, per-row error isolation
+  (one failure never aborts the run) and re-execution on every startup; unmigrated rows
+  keep resolving through the legacy fallback in the meantime.
+- **Conflicting files** (both legacy and sharded location populated with different
+  content, e.g. after a crashed replace-upload): never overwritten; both copies are
+  kept, the row is parked on its legacy location in portable relative form, and the
+  situation is re-reported on every boot until an operator resolves it.
+- **Concurrent multi-instance startup** (Redis HA): both instances run the migration;
+  the optimistic row guard and existence checks make the race benign (worst case: a
+  redundant identical copy attempt).
+- **Rollback:** rolling back the application binary alone is safe *before* migration has
+  run. After migration, old binaries cannot read relative paths — so the operational
+  rollback path is restoring the pre-upgrade backup of `FILES_DIR` + database (the
+  change document's deployment guide requires taking one). No `down()` script is
+  provided on purpose: reverse-moving user files would recreate the risk the forward
+  migration is designed to manage, for no product benefit.
+
+## Validation
+
+- Unit specs: `src/utils/asset-paths.spec.ts` (grammar, shard, traversal rejection,
+  FILES_DIR portability), `src/services/asset-storage-migration.spec.ts` (all seven
+  migration states, idempotency, EXDEV fallback, orphan sweep, conflict handling),
+  plus updated route/service/provider specs asserting relative sharded writes and
+  legacy-read fallback.
+- `scripts/benchmark-asset-storage.ts` provides a reproducible comparison of 0/1/2/3
+  levels (creation, known-path stat, root/bucket readdir, full traversal) at
+  configurable scale (20k/200k/1M project targets). It is **not** run in CI (its spec
+  only checks harness correctness; timing thresholds do not belong in CI). Operators
+  should run it on local ext4 SSD/NVMe, on the actual production backend, and on
+  NFS/SAN if used, recording kernel version, filesystem type, mount options and
+  container context. Benchmark results at larger scales may justify revisiting the
+  shard depth; the resolver abstraction keeps that change cheap.
+
+## Follow-up work
+
+- Remove the legacy absolute-path read fallback from the resolver once field
+  installations have converged (tracked for a future major release; the migration's
+  per-boot summary tells operators when their installation is clean).
+- Consider validating client-supplied project identifiers at creation time so the
+  FNV-1a fallback becomes purely defensive.
+
+## References
+
+- Issue <https://github.com/exelearning/exelearning/issues/2250> (tracking);
+  PR #788 <https://github.com/exelearning/exelearning/pull/788>;
+  issue #1842 <https://github.com/exelearning/exelearning/issues/1842>.
+- Linux kernel ext4 documentation: directories
+  <https://docs.kernel.org/filesystems/ext4/directory.html>, inodes
+  <https://docs.kernel.org/filesystems/ext4/inodes.html>; ext4(5)
+  <https://man7.org/linux/man-pages/man5/ext4.5.html>.
+- Git: <https://git-scm.com/docs/gitformat-loose>,
+  <https://git-scm.com/docs/gitrepository-layout>.
+- Docker: <https://docs.docker.com/engine/storage/>,
+  <https://docs.docker.com/engine/storage/volumes/>,
+  <https://docs.docker.com/engine/storage/bind-mounts/>.
+- Btrfs: <https://docs.kernel.org/filesystems/btrfs.html>.
+- Change document: `doc/architecture/changes/2250-asset-storage-sharding/design.md`.

--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -42,7 +42,7 @@ Two separate concerns were raised in issue #2250:
 
 1. **Portability (a concrete defect):** `assets.storage_path` persisted **absolute host
    filesystem paths** such as `/mnt/data/assets/<uuid>/<clientId>.png`
-   (`src/routes/assets.ts` @ `3c7c9e821`, write sites at lines 427/443/690/704/1159/1173/1314).
+   (`src/routes/assets.ts` @ `3c7c7e821`, write sites at lines 427/443/690/704/1159/1173/1314).
    This couples every database row to one specific `FILES_DIR` mount point. Moving,
    remounting or restoring the data directory to a different path silently invalidates
    every asset row. Notably, the `themes` and `templates` tables already store
@@ -186,7 +186,7 @@ size-verify + remove, so a destination never holds a partial file (`EXDEV`, bind
   (<https://github.com/exelearning/exelearning/issues/1842>).
 - Absolute write sites / read sites: `src/routes/assets.ts`, `src/routes/api/v1/assets.ts`,
   `src/routes/upload-session.ts`, `src/services/folder-manager.ts`,
-  `src/routes/project.ts` @ `3c7c9e821`.
+  `src/routes/project.ts` @ `3c7c7e821`.
 - **ext4 known-name lookup is indexed, not linear:** with `EXT4_INDEX_FL` set, "this
   directory uses a hashed btree (htree) to organize and find directory entries"; htree
   depth "cannot be larger than 3 if the INCOMPAT_LARGEDIR feature is set; cannot be

--- a/doc/architecture/changes/2250-asset-storage-sharding/design.md
+++ b/doc/architecture/changes/2250-asset-storage-sharding/design.md
@@ -77,8 +77,12 @@ readable through the resolver's legacy fallback until migrated.
 
 The migration runs automatically inside `bootstrap()` (`src/index.ts`) on **every
 startup**, after database schema migrations and **before** the server starts listening.
-It is idempotent and resumable; on a converged installation it costs one cheap query
-plus one `readdir` and logs `[AssetStorage] Asset storage layout is up to date.`
+It is idempotent and resumable; on a converged installation it performs one legacy-row
+query and one `readdir` of the assets root, plus bounded content checks for existing
+two-decimal shard buckets (`00`-`99`) to tell them apart from legacy numeric project-id
+directories, then logs `[AssetStorage] Asset storage layout is up to date.` Re-checking
+the filesystem on every startup is deliberate: it is what lets restored legacy data
+converge automatically.
 
 Phase 1 walks all rows whose `storage_path` is not yet relative (cursor-paged batches,
 default 500). Per row it derives the target `assets/<shard>/<uuid>/…` path, then:
@@ -96,7 +100,9 @@ Row rewrites use an optimistic `WHERE storage_path = <old>` guard, so concurrent
 startups of several instances (Redis HA) are safe.
 
 Phase 2 lists the assets root: entries that are not two-hex shard buckets are legacy
-leftovers. Directories identified as projects (by UUID, or by numeric id for the legacy
+leftovers (two-decimal bucket names, `00`-`99`, are ambiguous with legacy numeric
+project-id directories, so each existing one gets a bounded content check every boot).
+Directories identified as projects (by UUID, or by numeric id for the legacy
 numeric-directory quirk) have their remaining files — orphans with no database row —
 moved into the sharded layout with the same never-overwrite rules; emptied directories
 are removed. Files still referenced by conflict rows are left in place (and re-reported
@@ -115,16 +121,20 @@ each boot). Unrecognized entries are reported and left alone.
 - **Downtime**: the migration runs before the server accepts connections; startup is
   delayed once by roughly the time needed to rename the existing asset files (renames on
   one filesystem are metadata operations; expect seconds up to a few minutes for very
-  large stores, longer on network storage). Subsequent startups are unaffected.
+  large stores, longer on network storage). Subsequent startups repeat only the cheap,
+  bounded convergence checks described above.
 - **Failure reporting**: every anomaly is logged with the `[AssetStorage]` prefix, and a
   one-line summary (files moved, rows rewritten, missing, conflicts, errors) is printed
-  at the end of the run.
+  at the end of the run. During a large migration a progress line is printed every 1,000
+  processed rows, e.g.
+  `[AssetStorage] Migration progress: 1,000/3,250 legacy row(s) processed, 2,250 pending.`
 - **Retries**: yes — the migration re-runs on every startup and finishes whatever a
   previous interrupted run left over. Individual file errors never abort the run.
 - **Verifying success**: after the upgrade boot, the log shows the summary; on the next
   boot it shows `Asset storage layout is up to date.` and
   `SELECT COUNT(*) FROM assets WHERE storage_path NOT LIKE 'assets/%'` returns 0.
-  Remaining warnings identify conflict files to resolve manually.
+  Remaining warnings identify conflict files to resolve manually (a reconciliation
+  CLI is tracked in issue #2287).
 - **Rollback**: restore the pre-upgrade backup (database + `FILES_DIR`) and redeploy the
   previous release. Rolling back only the binary after migration is not supported —
   old releases cannot read relative paths.
@@ -135,7 +145,8 @@ each boot). Unrecognized entries are reported and left alone.
 
 - All new writes emit only the new format; there is no dual-write.
 - The resolver's legacy-absolute fallback exists only so unmigrated/conflict rows keep
-  working; its removal is tracked as follow-up in ADR-2250-01.
+  working; its removal is tracked as follow-up in ADR-2250-01 (issue #2288, a future
+  major release).
 - Deletion paths (cleanup scheduler, admin user deletion, `projects-cleanup` CLI) remove
   both the sharded and the legacy directory during the transition.
 
@@ -158,8 +169,9 @@ Not applicable; filenames with non-ASCII characters are covered by tests.
 ## Performance
 
 Runtime request paths gain one string operation per asset access (path build/parse) —
-negligible against the accompanying file I/O. Startup adds one cheap no-op check per
-boot after convergence. Benchmarking of layout depths is provided by
+negligible against the accompanying file I/O. Startup adds a cheap, bounded no-op check
+per boot after convergence (see "Migration and compatibility"). Benchmarking of layout
+depths is provided by
 `scripts/benchmark-asset-storage.ts`; see ADR-2250-01 ("Validation") for how and where
 to run it. On the author's machine (macOS/APFS, Apple M5, Bun 1.3.14 — *not* the
 production ext4 target) with 20,000 projects × 2 assets, one level was fastest overall

--- a/doc/architecture/changes/2250-asset-storage-sharding/design.md
+++ b/doc/architecture/changes/2250-asset-storage-sharding/design.md
@@ -1,0 +1,204 @@
+---
+tracking_issue: 2250
+title: "Sharded, portable project asset storage"
+status: accepted
+date: 2026-08-15
+authors:
+  - "@erseco"
+reviewers:
+  - "@ignaciogros"
+implementation_prs: []
+related_adrs:
+  - "ADR-2250-01"
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-fable-5"
+---
+
+# Sharded, portable project asset storage — design
+
+## Current state
+
+- Physical layout (introduced by PR #788, lazy creation):
+  `FILES_DIR/assets/<projectUuid>/<clientId>.<ext>` for uploads and
+  `FILES_DIR/assets/<projectUuid>/<clientId>/<filename>` for ZIP extraction and
+  file-manager duplication (`src/services/file-helper.ts:142`,
+  `src/services/folder-manager.ts`).
+- `assets.storage_path` holds **absolute host paths** written at upload time
+  (`src/routes/assets.ts`, `src/routes/api/v1/assets.ts`, `src/routes/upload-session.ts`,
+  `src/routes/project.ts` duplicate flow) and read verbatim by download/delete routes and
+  `src/shared/export/providers/DatabaseAssetProvider.ts`.
+- A legacy quirk: asset routes accepted numeric project ids in the URL and used the raw
+  parameter as the directory name, so `assets/<numericId>/` directories can exist.
+- `themes.storage_path` / `templates.storage_path` already store FILES_DIR-relative
+  values — assets were the outlier.
+
+## Technical design
+
+Decisions and their rationale live in [ADR-2250-01](../../adr/ADR-2250-01-shard-project-asset-storage.md).
+Summary of the implementation:
+
+- **Pure path module** `src/utils/asset-paths.ts` — single source of truth:
+  - `getAssetShard(id)` — first two hex chars of a canonical UUID, lowercased;
+    deterministic 8-bit FNV-1a fallback for non-canonical identifiers.
+  - `buildAssetStoragePath(uuid, ...segments)` — canonical stored value
+    `assets/<shard>/<uuid>/<segments...>` (POSIX separators, validated segments).
+  - `resolveAssetStoragePath(filesDir, stored)` / `tryResolveAssetStoragePath` — the
+    only stored-value → physical-path conversion. Accepts canonical relative values
+    and (transitionally) legacy absolute values via their `assets/…` suffix; rejects
+    traversal, backslashes in relative values, control characters, and anything that
+    would escape `FILES_DIR/assets`.
+  - `getProjectAssetsDirCandidates(filesDir, uuid)` — sharded + legacy directory, for
+    deletion/cleanup paths.
+- **`src/services/file-helper.ts`** binds these to `getFilesDir()` and exposes them via
+  the existing `FileHelper` interface (DI-friendly). `getProjectAssetsDir()` now returns
+  the sharded directory.
+- **Write sites** (upload, chunked finalize, `/sync`, `/stream`, upload-session batch,
+  API v1 upload, ZIP extraction, asset duplication, project duplication) build the
+  stored value with `buildAssetStoragePath` and derive the physical path from it via the
+  resolver — the two can never diverge. Project identity is resolved to the canonical
+  `projects.uuid` first, so numeric-id URLs no longer mint numeric directories.
+- **Read/delete sites** resolve `storage_path` through `tryResolveAssetStoragePath`;
+  an unresolvable value behaves exactly like a missing file.
+- **Startup migration** `src/services/asset-storage-migration.ts` (see below).
+- **Benchmark** `scripts/benchmark-asset-storage.ts` compares 0/1/2/3 shard levels.
+
+## Data model
+
+No schema change. `assets.storage_path` (TEXT) changes representation from absolute
+host paths to FILES_DIR-relative POSIX paths starting with `assets/`. Old values remain
+readable through the resolver's legacy fallback until migrated.
+
+## Migration and compatibility
+
+### What happens, and when
+
+The migration runs automatically inside `bootstrap()` (`src/index.ts`) on **every
+startup**, after database schema migrations and **before** the server starts listening.
+It is idempotent and resumable; on a converged installation it costs one cheap query
+plus one `readdir` and logs `[AssetStorage] Asset storage layout is up to date.`
+
+Phase 1 walks all rows whose `storage_path` is not yet relative (cursor-paged batches,
+default 500). Per row it derives the target `assets/<shard>/<uuid>/…` path, then:
+
+| State found | Action |
+|---|---|
+| file at legacy path, target free | move (rename; EXDEV → copy-tmp+rename+verify+remove), rewrite row |
+| file already at target, legacy gone | rewrite row (crash recovery) |
+| both exist, identical content (size + SHA-256) | remove legacy copy, rewrite row |
+| both exist, different content | **keep both**, log conflict, park row on its legacy location in portable relative form |
+| neither exists | log missing file, rewrite row to target (reads keep 404ing as before) |
+| value uninterpretable (no `assets/…` suffix, traversal) | leave row untouched, log |
+
+Row rewrites use an optimistic `WHERE storage_path = <old>` guard, so concurrent
+startups of several instances (Redis HA) are safe.
+
+Phase 2 lists the assets root: entries that are not two-hex shard buckets are legacy
+leftovers. Directories identified as projects (by UUID, or by numeric id for the legacy
+numeric-directory quirk) have their remaining files — orphans with no database row —
+moved into the sharded layout with the same never-overwrite rules; emptied directories
+are removed. Files still referenced by conflict rows are left in place (and re-reported
+each boot). Unrecognized entries are reported and left alone.
+
+### Administrator guide (upgrading an existing installation)
+
+- **Back up first**: take a normal backup of the database **and** `FILES_DIR` before
+  upgrading, as for any release that touches stored data.
+- **Where files move**: `FILES_DIR/assets/<uuid>/…` → `FILES_DIR/assets/<xy>/<uuid>/…`
+  where `<xy>` is the first two hex characters of the project UUID. Same filesystem →
+  the moves are renames (no extra disk space, fast). `assets/` and its buckets are the
+  only locations touched; `tmp/`, `dist/`, `themes/` are unaffected.
+- **What is written to the database**: `assets.storage_path` becomes
+  `assets/<xy>/<uuid>/<file…>` (relative to `FILES_DIR`, `/` separators).
+- **Downtime**: the migration runs before the server accepts connections; startup is
+  delayed once by roughly the time needed to rename the existing asset files (renames on
+  one filesystem are metadata operations; expect seconds up to a few minutes for very
+  large stores, longer on network storage). Subsequent startups are unaffected.
+- **Failure reporting**: every anomaly is logged with the `[AssetStorage]` prefix, and a
+  one-line summary (files moved, rows rewritten, missing, conflicts, errors) is printed
+  at the end of the run.
+- **Retries**: yes — the migration re-runs on every startup and finishes whatever a
+  previous interrupted run left over. Individual file errors never abort the run.
+- **Verifying success**: after the upgrade boot, the log shows the summary; on the next
+  boot it shows `Asset storage layout is up to date.` and
+  `SELECT COUNT(*) FROM assets WHERE storage_path NOT LIKE 'assets/%'` returns 0.
+  Remaining warnings identify conflict files to resolve manually.
+- **Rollback**: restore the pre-upgrade backup (database + `FILES_DIR`) and redeploy the
+  previous release. Rolling back only the binary after migration is not supported —
+  old releases cannot read relative paths.
+- **Moving `FILES_DIR`** (after this change): move the directory, update the
+  environment variable, restart — database rows no longer need rewriting.
+
+### Compatibility rules
+
+- All new writes emit only the new format; there is no dual-write.
+- The resolver's legacy-absolute fallback exists only so unmigrated/conflict rows keep
+  working; its removal is tracked as follow-up in ADR-2250-01.
+- Deletion paths (cleanup scheduler, admin user deletion, `projects-cleanup` CLI) remove
+  both the sharded and the legacy directory during the transition.
+
+## Security and privacy
+
+All stored-value resolution funnels through one hardened resolver: rejection of `..`
+segments, separators inside segments, control characters/NUL, and a separator-aware
+containment check under `FILES_DIR/assets` (reusing `isWithinBase`). The migration never
+follows arbitrary absolute paths from the database — values without a safe `assets/…`
+suffix are left untouched and reported. No user data is ever overwritten.
+
+## Accessibility
+
+Not applicable (server-side storage layout).
+
+## Internationalization
+
+Not applicable; filenames with non-ASCII characters are covered by tests.
+
+## Performance
+
+Runtime request paths gain one string operation per asset access (path build/parse) —
+negligible against the accompanying file I/O. Startup adds one cheap no-op check per
+boot after convergence. Benchmarking of layout depths is provided by
+`scripts/benchmark-asset-storage.ts`; see ADR-2250-01 ("Validation") for how and where
+to run it. On the author's machine (macOS/APFS, Apple M5, Bun 1.3.14 — *not* the
+production ext4 target) with 20,000 projects × 2 assets, one level was fastest overall
+and full traversal got *slower* with each additional level (flat 1.21 s, 1 level 1.04 s,
+2 levels 1.64 s, 3 levels 2.25 s), consistent with deeper trees adding directory visits.
+
+## Testing strategy
+
+- `src/utils/asset-paths.spec.ts` — shard/grammar/resolution/portability/traversal.
+- `src/services/file-helper.spec.ts` — sharded dirs, resolver wrappers, FILES_DIR
+  portability regression (same stored path valid under two FILES_DIR values).
+- `src/services/asset-storage-migration.spec.ts` — all migration states, idempotency,
+  batching, EXDEV fallback, orphan sweep, conflicts, traversal safety, unusual
+  filenames, numeric legacy directories.
+- Route/service/provider specs updated to assert relative sharded writes and
+  legacy-read fallback: `src/routes/assets.spec.ts`, `src/routes/api/v1/assets.spec.ts`,
+  `src/routes/upload-session.spec.ts`, `src/routes/project.spec.ts`,
+  `src/routes/filemanager.spec.ts`, `src/services/folder-manager.spec.ts`,
+  `src/services/cleanup-scheduler.spec.ts`, `src/routes/admin.spec.ts`,
+  `src/cli/commands/projects-cleanup.spec.ts`,
+  `src/shared/export/providers/DatabaseAssetProvider.spec.ts`.
+- `scripts/benchmark-asset-storage.spec.ts` — benchmark harness correctness only (no
+  timing assertions in CI).
+- Existing Playwright E2E suites exercise upload/file-manager/import/export/duplicate
+  flows end-to-end against the new layout.
+
+## Rollout plan
+
+Ships in one PR; the migration is automatic at first startup. No feature flag: the
+resolver's legacy fallback is the safety net, and the migration converges the data.
+
+## Risks and mitigations
+
+See ADR-2250-01 ("Risks"): interrupted migration (re-run + fallback), conflicts (never
+overwrite, keep both, re-report), concurrent instances (optimistic guards), rollback
+(backup-based).
+
+## ADRs required or referenced
+
+| Decision | ADR |
+|---|---|
+| One 8-bit shard level; relative `storage_path`; migration strategy | [ADR-2250-01](../../adr/ADR-2250-01-shard-project-asset-storage.md) |

--- a/doc/architecture/changes/2250-asset-storage-sharding/design.md
+++ b/doc/architecture/changes/2250-asset-storage-sharding/design.md
@@ -7,7 +7,7 @@ authors:
   - "@erseco"
 reviewers:
   - "@ignaciogros"
-implementation_prs: []
+implementation_prs: [2266]
 related_adrs:
   - "ADR-2250-01"
 supersedes: []

--- a/scripts/benchmark-asset-storage.spec.ts
+++ b/scripts/benchmark-asset-storage.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Correctness tests for the asset storage benchmark (issue #2250).
+ *
+ * These tests only validate that the benchmark harness is correct (layouts,
+ * counts, result structure) using tiny datasets. They intentionally assert no
+ * timing thresholds — timings are environment-dependent and belong in the
+ * benchmark's own report, not in CI.
+ */
+import { describe, it, expect } from 'bun:test';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    layoutSegments,
+    generateProjectUuids,
+    runBenchmark,
+    parseCliOptions,
+    formatResultsTable,
+    runCli,
+} from './benchmark-asset-storage';
+
+describe('benchmark-asset-storage', () => {
+    describe('layoutSegments', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+
+        it('produces the flat layout for 0 levels', () => {
+            expect(layoutSegments(0, uuid)).toEqual([uuid]);
+        });
+
+        it('produces one two-hex level for 1 level', () => {
+            expect(layoutSegments(1, uuid)).toEqual(['ab', uuid]);
+        });
+
+        it('produces two levels for 2 levels', () => {
+            expect(layoutSegments(2, uuid)).toEqual(['ab', '12', uuid]);
+        });
+
+        it('produces three levels for 3 levels', () => {
+            expect(layoutSegments(3, uuid)).toEqual(['ab', '12', 'cd', uuid]);
+        });
+
+        it('rejects unsupported depths', () => {
+            expect(() => layoutSegments(4, uuid)).toThrow();
+            expect(() => layoutSegments(-1, uuid)).toThrow();
+        });
+    });
+
+    describe('generateProjectUuids', () => {
+        it('generates the requested number of unique, deterministic UUIDs', () => {
+            const uuids = generateProjectUuids(50, 42);
+            expect(uuids.length).toBe(50);
+            expect(new Set(uuids).size).toBe(50);
+            for (const uuid of uuids) {
+                expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            }
+            // Same seed -> same sequence (reproducibility).
+            expect(generateProjectUuids(50, 42)).toEqual(uuids);
+            // Different seed -> different sequence.
+            expect(generateProjectUuids(50, 43)).not.toEqual(uuids);
+        });
+    });
+
+    describe('runBenchmark', () => {
+        it('creates the expected tree per level and reports consistent counts', async () => {
+            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-bench-test-'));
+            try {
+                const results = await runBenchmark({
+                    root,
+                    projects: 20,
+                    assetsPerProject: 2,
+                    levels: [0, 1, 2, 3],
+                    statSamples: 5,
+                    seed: 7,
+                });
+
+                expect(results.length).toBe(4);
+                for (const result of results) {
+                    expect(result.projects).toBe(20);
+                    expect(result.filesCreated).toBe(40);
+                    // Full traversal must visit every asset file exactly once.
+                    expect(result.traversal.files).toBe(40);
+                    expect(result.traversal.bytes).toBeGreaterThan(0);
+                    // Timings exist and are non-negative; no thresholds.
+                    expect(result.createMs).toBeGreaterThanOrEqual(0);
+                    expect(result.statMs).toBeGreaterThanOrEqual(0);
+                    expect(result.traversalMs).toBeGreaterThanOrEqual(0);
+                }
+
+                const byLevel = new Map(results.map(r => [r.levels, r]));
+                // 0 levels: root readdir sees one entry per project.
+                expect(byLevel.get(0)!.rootEntries).toBe(20);
+                // 1 level: root readdir sees at most 256 buckets and at most
+                // one bucket per project (lazy creation, no empty buckets).
+                expect(byLevel.get(1)!.rootEntries).toBeLessThanOrEqual(20);
+                expect(byLevel.get(1)!.rootEntries).toBeGreaterThan(0);
+            } finally {
+                await fs.remove(root);
+            }
+        });
+
+        it('cleans up its working directories between levels', async () => {
+            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-bench-test-'));
+            try {
+                await runBenchmark({ root, projects: 3, assetsPerProject: 1, levels: [0, 1], statSamples: 2, seed: 1 });
+                const entries = await fs.readdir(root);
+                expect(entries.length).toBe(0);
+            } finally {
+                await fs.remove(root);
+            }
+        });
+    });
+
+    describe('parseCliOptions', () => {
+        it('applies defaults when no flags are given', () => {
+            const options = parseCliOptions(['bun', 'script.ts']);
+            expect(options.projects).toBe(10000);
+            expect(options.assetsPerProject).toBe(2);
+            expect(options.levels).toEqual([0, 1, 2, 3]);
+            expect(options.statSamples).toBe(2000);
+            expect(options.seed).toBe(1);
+            expect(options.root).toBeUndefined();
+            expect(options.jsonOut).toBeUndefined();
+        });
+
+        it('parses explicit flags', () => {
+            const options = parseCliOptions([
+                'bun',
+                'script.ts',
+                '--projects',
+                '500',
+                '--assets',
+                '3',
+                '--levels',
+                '0,1',
+                '--stat-samples',
+                '10',
+                '--seed',
+                '9',
+                '--root',
+                '/tmp/x',
+                '--json',
+                'out.json',
+            ]);
+            expect(options.projects).toBe(500);
+            expect(options.assetsPerProject).toBe(3);
+            expect(options.levels).toEqual([0, 1]);
+            expect(options.statSamples).toBe(10);
+            expect(options.seed).toBe(9);
+            expect(options.root).toBe('/tmp/x');
+            expect(options.jsonOut).toBe('out.json');
+        });
+    });
+
+    describe('formatResultsTable', () => {
+        it('renders one line per level plus a header', async () => {
+            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-bench-test-'));
+            try {
+                const results = await runBenchmark({
+                    root,
+                    projects: 2,
+                    assetsPerProject: 1,
+                    levels: [0, 1],
+                    statSamples: 1,
+                    seed: 3,
+                });
+                const lines = formatResultsTable(results);
+                expect(lines.length).toBe(3);
+                expect(lines[0]).toContain('levels');
+                expect(lines[1]).toStartWith('0');
+                expect(lines[2]).toStartWith('1');
+            } finally {
+                await fs.remove(root);
+            }
+        });
+    });
+
+    describe('runCli', () => {
+        it('runs end to end with injected IO, writes JSON, and cleans up its temp root', async () => {
+            const jsonOut = path.join(os.tmpdir(), `asset-bench-cli-${Date.now()}.json`);
+            const logged: string[] = [];
+            try {
+                await runCli({
+                    argv: [
+                        'bun',
+                        'script.ts',
+                        '--projects',
+                        '3',
+                        '--assets',
+                        '1',
+                        '--levels',
+                        '0,1',
+                        '--stat-samples',
+                        '2',
+                        '--json',
+                        jsonOut,
+                    ],
+                    log: (message: string) => logged.push(message),
+                });
+
+                expect(logged.join('\n')).toContain('levels');
+                const report = JSON.parse(await fs.readFile(jsonOut, 'utf-8'));
+                expect(report.results.length).toBe(2);
+                expect(report.environment.platform).toBe(os.platform());
+                expect(report.options.projects).toBe(3);
+            } finally {
+                await fs.remove(jsonOut).catch(() => {});
+            }
+        });
+    });
+});

--- a/scripts/benchmark-asset-storage.ts
+++ b/scripts/benchmark-asset-storage.ts
@@ -1,0 +1,331 @@
+/**
+ * Asset storage layout benchmark (issue #2250 / ADR-2250-01).
+ *
+ * Compares directory sharding depths for the project asset store:
+ *
+ *     0 levels: assets/<uuid>/
+ *     1 level:  assets/aa/<uuid>/                (the layout adopted by ADR-2250-01)
+ *     2 levels: assets/aa/bb/<uuid>/
+ *     3 levels: assets/aa/bb/cc/<uuid>/
+ *
+ * For each depth it creates N projects with M small asset files, then measures:
+ *   - creation time (directories + files),
+ *   - known-path stat() lookups (random sample),
+ *   - readdir of the assets root and of one bucket,
+ *   - a complete recursive traversal (files visited + bytes, du-style).
+ *
+ * The sharding decision is preventive, not driven by a measured failure —
+ * run this on the storage backend you actually deploy on (local ext4/NVMe,
+ * NFS, SAN, ...) before drawing conclusions, and do not extrapolate local
+ * results to network filesystems. Timings are wall-clock and environment
+ * dependent; this script is NOT part of CI (its spec only checks correctness).
+ *
+ * Usage:
+ *     bun run scripts/benchmark-asset-storage.ts --projects 20000 --assets 3
+ *     bun run scripts/benchmark-asset-storage.ts --projects 200000 --levels 0,1 --json out.json
+ *
+ * Options:
+ *     --projects N       number of projects per layout (default 10000)
+ *     --assets M         asset files per project (default 2)
+ *     --levels a,b,...   sharding depths to test (default 0,1,2,3)
+ *     --root DIR         working directory (default: a temp dir; DELETED afterwards)
+ *     --stat-samples N   number of random known-path lookups (default 2000)
+ *     --seed N           RNG seed for reproducible UUID sets (default 1)
+ *     --json FILE        also write results as JSON
+ */
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+
+// ============================================================================
+// Pure helpers (unit tested)
+// ============================================================================
+
+/**
+ * Directory segments for a project under a given sharding depth, using
+ * consecutive two-hex-character prefixes of the UUID per level.
+ */
+export function layoutSegments(levels: number, uuid: string): string[] {
+    if (!Number.isInteger(levels) || levels < 0 || levels > 3) {
+        throw new Error(`Unsupported sharding depth: ${levels}`);
+    }
+    const segments: string[] = [];
+    for (let i = 0; i < levels; i++) {
+        segments.push(uuid.slice(i * 2, i * 2 + 2));
+    }
+    segments.push(uuid);
+    return segments;
+}
+
+/**
+ * Deterministic pseudo-random UUIDv4-shaped identifiers (mulberry32 PRNG),
+ * so runs with the same seed operate on identical directory sets.
+ */
+export function generateProjectUuids(count: number, seed: number): string[] {
+    let state = seed >>> 0;
+    const next = (): number => {
+        state = (state + 0x6d2b79f5) >>> 0;
+        let t = state;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+    const hex = (n: number): string => Math.floor(next() * 16 ** n).toString(16).padStart(n, '0');
+    const uuids: string[] = [];
+    const seen = new Set<string>();
+    while (uuids.length < count) {
+        const uuid = `${hex(8)}-${hex(4)}-4${hex(3)}-${((Math.floor(next() * 4) + 8).toString(16) + hex(3)).slice(0, 4)}-${hex(8)}${hex(4)}`;
+        if (!seen.has(uuid)) {
+            seen.add(uuid);
+            uuids.push(uuid);
+        }
+    }
+    return uuids;
+}
+
+// ============================================================================
+// Benchmark
+// ============================================================================
+
+export interface BenchmarkOptions {
+    root: string;
+    projects: number;
+    assetsPerProject: number;
+    levels: number[];
+    statSamples: number;
+    seed: number;
+}
+
+export interface LevelResult {
+    levels: number;
+    projects: number;
+    filesCreated: number;
+    createMs: number;
+    statMs: number;
+    statSamples: number;
+    rootReaddirMs: number;
+    rootEntries: number;
+    bucketReaddirMs: number;
+    bucketEntries: number;
+    traversalMs: number;
+    traversal: { files: number; directories: number; bytes: number };
+}
+
+async function traverse(dir: string): Promise<{ files: number; directories: number; bytes: number }> {
+    const totals = { files: 0, directories: 0, bytes: 0 };
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const entryPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            totals.directories++;
+            const sub = await traverse(entryPath);
+            totals.files += sub.files;
+            totals.directories += sub.directories;
+            totals.bytes += sub.bytes;
+        } else {
+            totals.files++;
+            const stat = await fs.stat(entryPath);
+            totals.bytes += stat.size;
+        }
+    }
+    return totals;
+}
+
+/**
+ * Run the benchmark for every requested sharding depth. Each depth gets a
+ * fresh tree under `<root>/level-<n>/assets`, removed before the next depth
+ * so disk usage stays bounded.
+ */
+export async function runBenchmark(options: BenchmarkOptions): Promise<LevelResult[]> {
+    const { root, projects, assetsPerProject, levels, statSamples, seed } = options;
+    const uuids = generateProjectUuids(projects, seed);
+    const payload = Buffer.from('exelearning-benchmark-asset-payload\n');
+    const results: LevelResult[] = [];
+
+    for (const depth of levels) {
+        const assetsRoot = path.join(root, `level-${depth}`, 'assets');
+        await fs.ensureDir(assetsRoot);
+
+        // ---- creation --------------------------------------------------------
+        const createStart = performance.now();
+        let filesCreated = 0;
+        for (const uuid of uuids) {
+            const projectDir = path.join(assetsRoot, ...layoutSegments(depth, uuid));
+            await fs.ensureDir(projectDir);
+            for (let i = 0; i < assetsPerProject; i++) {
+                await fs.writeFile(path.join(projectDir, `asset-${i}.bin`), payload);
+                filesCreated++;
+            }
+        }
+        const createMs = performance.now() - createStart;
+
+        // ---- known-path lookups ---------------------------------------------
+        let state = seed >>> 0;
+        const nextIndex = (): number => {
+            state = (state * 1664525 + 1013904223) >>> 0;
+            return state % uuids.length;
+        };
+        const samples = Math.min(statSamples, uuids.length * assetsPerProject);
+        const statStart = performance.now();
+        for (let i = 0; i < samples; i++) {
+            const uuid = uuids[nextIndex()];
+            const file = path.join(assetsRoot, ...layoutSegments(depth, uuid), `asset-${i % assetsPerProject}.bin`);
+            await fs.stat(file);
+        }
+        const statMs = performance.now() - statStart;
+
+        // ---- readdir of the root and of one bucket --------------------------
+        const rootStart = performance.now();
+        const rootEntryNames = await fs.readdir(assetsRoot);
+        const rootReaddirMs = performance.now() - rootStart;
+
+        const bucketDir = depth === 0 ? assetsRoot : path.join(assetsRoot, rootEntryNames[0]);
+        const bucketStart = performance.now();
+        const bucketEntryNames = await fs.readdir(bucketDir);
+        const bucketReaddirMs = performance.now() - bucketStart;
+
+        // ---- complete recursive traversal (du-style) -------------------------
+        const traversalStart = performance.now();
+        const traversal = await traverse(assetsRoot);
+        const traversalMs = performance.now() - traversalStart;
+
+        results.push({
+            levels: depth,
+            projects,
+            filesCreated,
+            createMs,
+            statMs,
+            statSamples: samples,
+            rootReaddirMs,
+            rootEntries: rootEntryNames.length,
+            bucketReaddirMs,
+            bucketEntries: bucketEntryNames.length,
+            traversalMs,
+            traversal,
+        });
+
+        await fs.remove(path.join(root, `level-${depth}`));
+    }
+
+    return results;
+}
+
+// ============================================================================
+// CLI
+// ============================================================================
+
+export interface CliOptions {
+    projects: number;
+    assetsPerProject: number;
+    levels: number[];
+    statSamples: number;
+    seed: number;
+    root?: string;
+    jsonOut?: string;
+}
+
+/** Parse CLI flags (see the header comment for the option list). */
+export function parseCliOptions(argv: string[]): CliOptions {
+    const getArg = (name: string): string | undefined => {
+        const index = argv.indexOf(`--${name}`);
+        return index !== -1 ? argv[index + 1] : undefined;
+    };
+    return {
+        projects: parseInt(getArg('projects') ?? '10000', 10),
+        assetsPerProject: parseInt(getArg('assets') ?? '2', 10),
+        levels: (getArg('levels') ?? '0,1,2,3').split(',').map(v => parseInt(v, 10)),
+        statSamples: parseInt(getArg('stat-samples') ?? '2000', 10),
+        seed: parseInt(getArg('seed') ?? '1', 10),
+        root: getArg('root'),
+        jsonOut: getArg('json'),
+    };
+}
+
+/** Render the human-readable results table (header + one line per level). */
+export function formatResultsTable(results: LevelResult[]): string[] {
+    const lines = [
+        `levels | create(ms) | stat x${results[0]?.statSamples ?? 0}(ms) | root readdir(ms/entries) | traversal(ms/files)`,
+    ];
+    for (const result of results) {
+        lines.push(
+            `${result.levels}      | ${result.createMs.toFixed(0).padStart(10)} | ${result.statMs
+                .toFixed(0)
+                .padStart(12)} | ${result.rootReaddirMs.toFixed(1)}ms / ${result.rootEntries} | ${result.traversalMs.toFixed(
+                0,
+            )}ms / ${result.traversal.files}`,
+        );
+    }
+    return lines;
+}
+
+export interface CliDeps {
+    argv: string[];
+    log: (message: string) => void;
+}
+
+/** CLI entrypoint with injected IO so the whole flow is testable. */
+export async function runCli(deps: CliDeps): Promise<void> {
+    const options = parseCliOptions(deps.argv);
+    const root = options.root ?? (await fs.mkdtemp(path.join(os.tmpdir(), 'exe-asset-bench-')));
+
+    const environment = {
+        platform: os.platform(),
+        release: os.release(),
+        arch: os.arch(),
+        cpus: os.cpus()[0]?.model ?? 'unknown',
+        bun: typeof Bun !== 'undefined' ? Bun.version : 'n/a',
+        root,
+        note: 'Record the filesystem type and mount options of the root path (e.g. `df -T`, `mount`) alongside these numbers.',
+    };
+
+    deps.log(`[bench] environment: ${JSON.stringify(environment, null, 2)}`);
+    deps.log(
+        `[bench] projects=${options.projects} assetsPerProject=${options.assetsPerProject} levels=${options.levels.join(',')}`,
+    );
+
+    const results = await runBenchmark({
+        root,
+        projects: options.projects,
+        assetsPerProject: options.assetsPerProject,
+        levels: options.levels,
+        statSamples: options.statSamples,
+        seed: options.seed,
+    });
+
+    for (const line of formatResultsTable(results)) {
+        deps.log(line);
+    }
+
+    if (options.jsonOut) {
+        await fs.writeFile(
+            options.jsonOut,
+            JSON.stringify(
+                {
+                    environment,
+                    options: {
+                        projects: options.projects,
+                        assetsPerProject: options.assetsPerProject,
+                        levels: options.levels,
+                        statSamples: options.statSamples,
+                        seed: options.seed,
+                    },
+                    results,
+                },
+                null,
+                2,
+            ),
+        );
+        deps.log(`[bench] JSON written to ${options.jsonOut}`);
+    }
+
+    if (!options.root) {
+        await fs.remove(root);
+    }
+}
+
+if (import.meta.main) {
+    runCli({ argv: process.argv, log: console.log }).catch(err => {
+        console.error(err);
+        process.exit(1);
+    });
+}

--- a/src/cli/commands/projects-cleanup.spec.ts
+++ b/src/cli/commands/projects-cleanup.spec.ts
@@ -239,6 +239,49 @@ describe('Projects Cleanup Command', () => {
             expect(result.stats.diskCleaned).toBe(1);
         });
 
+        it('should report a legacy-directory failure even when the sharded directory was removed', async () => {
+            const shard = getAssetShard('uuid-1');
+            const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
+            const existingPaths = new Set([`/data/assets/${shard}/uuid-1`, '/data/assets/uuid-1']);
+            const removeErrors = new Map([['/data/assets/uuid-1', new Error('EBUSY: locked')]]);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths, removeErrors });
+
+            const deps: ProjectsCleanupDependencies = {
+                db: {} as Kysely<Database>,
+                queries: createMockQueries({ unsavedProjects }),
+                fileHelper,
+            };
+
+            const result = await execute([], { yes: true }, deps);
+
+            expect(result.stats.diskCleaned).toBe(1);
+            expect(result.stats.diskFailures.length).toBe(1);
+            expect(result.stats.diskFailures[0]).toContain('EBUSY');
+            expect(result.success).toBe(false);
+        });
+
+        it('should not abort the run when a project uuid cannot form a safe directory path', async () => {
+            const shard2 = getAssetShard('uuid-2');
+            const unsavedProjects = [
+                createMockProject({ id: 1, uuid: '../evil' }),
+                createMockProject({ id: 2, uuid: 'uuid-2' }),
+            ];
+            const existingPaths = new Set([`/data/assets/${shard2}/uuid-2`]);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths });
+
+            const deps: ProjectsCleanupDependencies = {
+                db: {} as Kysely<Database>,
+                queries: createMockQueries({ unsavedProjects }),
+                fileHelper,
+            };
+
+            const result = await execute([], { yes: true }, deps);
+
+            // The second project is still processed and cleaned.
+            expect(result.stats.diskCleaned).toBe(1);
+            expect(result.stats.diskFailures.length).toBe(1);
+        });
+
         it('should count missing asset directories correctly', async () => {
             const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
             const fileHelper = createMockFileHelper({

--- a/src/cli/commands/projects-cleanup.spec.ts
+++ b/src/cli/commands/projects-cleanup.spec.ts
@@ -11,6 +11,7 @@ import {
 } from './projects-cleanup';
 import type { Kysely } from 'kysely';
 import type { Database, Project } from '../../db/types';
+import { getAssetShard } from '../../utils/asset-paths';
 
 describe('Projects Cleanup Command', () => {
     // Mock file helper
@@ -214,6 +215,26 @@ describe('Projects Cleanup Command', () => {
             const result = await execute([], { yes: true }, deps);
 
             expect(result.success).toBe(true);
+            expect(fileHelper._removedPaths).toContain('/data/assets/uuid-1');
+            expect(result.stats.diskCleaned).toBe(1);
+        });
+
+        it('should remove sharded and legacy asset directories when both exist', async () => {
+            const shard = getAssetShard('uuid-1');
+            const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
+            const existingPaths = new Set([`/data/assets/${shard}/uuid-1`, '/data/assets/uuid-1']);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths });
+
+            const deps: ProjectsCleanupDependencies = {
+                db: {} as Kysely<Database>,
+                queries: createMockQueries({ unsavedProjects }),
+                fileHelper,
+            };
+
+            const result = await execute([], { yes: true }, deps);
+
+            expect(result.success).toBe(true);
+            expect(fileHelper._removedPaths).toContain(`/data/assets/${shard}/uuid-1`);
             expect(fileHelper._removedPaths).toContain('/data/assets/uuid-1');
             expect(result.stats.diskCleaned).toBe(1);
         });

--- a/src/cli/commands/projects-cleanup.ts
+++ b/src/cli/commands/projects-cleanup.ts
@@ -20,7 +20,7 @@ import {
     deleteProjectWithRelatedData as deleteProjectWithRelatedDataDefault,
 } from '../../db/queries/projects';
 import { getFilesDir, remove, fileExists } from '../../services/file-helper';
-import * as path from 'path';
+import { getProjectAssetsDirCandidates } from '../../utils/asset-paths';
 
 export interface ProjectsCleanupResult {
     success: boolean;
@@ -71,25 +71,33 @@ const defaultDependencies: ProjectsCleanupDependencies = {
 };
 
 /**
- * Remove project assets from disk
+ * Remove project assets from disk. Removes both the sharded directory and the
+ * legacy unsharded directory, so projects created before the sharding
+ * migration are fully cleaned up.
  */
 async function cleanupProjectAssets(
     projectUuid: string,
     fileHelper: ProjectsCleanupDependencies['fileHelper'],
 ): Promise<{ removed: boolean; error?: string }> {
-    const assetsDir = path.join(fileHelper.getFilesDir(), 'assets', projectUuid);
+    const candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    let removed = false;
+    const errors: string[] = [];
 
-    try {
-        const exists = await fileHelper.fileExists(assetsDir);
-        if (!exists) {
-            return { removed: false };
+    for (const assetsDir of candidates) {
+        try {
+            const exists = await fileHelper.fileExists(assetsDir);
+            if (!exists) {
+                continue;
+            }
+            await fileHelper.remove(assetsDir);
+            removed = true;
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            errors.push(`${assetsDir}: ${message}`);
         }
-        await fileHelper.remove(assetsDir);
-        return { removed: true };
-    } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { removed: false, error: `${assetsDir}: ${message}` };
     }
+
+    return { removed, error: errors.length > 0 ? errors.join('; ') : undefined };
 }
 
 export async function execute(

--- a/src/cli/commands/projects-cleanup.ts
+++ b/src/cli/commands/projects-cleanup.ts
@@ -79,7 +79,15 @@ async function cleanupProjectAssets(
     projectUuid: string,
     fileHelper: ProjectsCleanupDependencies['fileHelper'],
 ): Promise<{ removed: boolean; error?: string }> {
-    const candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    // Candidate computation can reject an unsafe project uuid; report that as
+    // a cleanup failure instead of letting it abort the whole run.
+    let candidates: string[];
+    try {
+        candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { removed: false, error: `${projectUuid}: ${message}` };
+    }
     let removed = false;
     const errors: string[] = [];
 
@@ -163,9 +171,12 @@ export async function execute(
         const assetResult = await cleanupProjectAssets(project.uuid, fileHelper);
         if (assetResult.removed) {
             diskStats.cleaned++;
-        } else if (assetResult.error) {
+        }
+        // A partial failure (e.g. sharded dir removed, legacy dir locked)
+        // reports both removed=true AND an error.
+        if (assetResult.error) {
             diskStats.failures.push(assetResult.error);
-        } else {
+        } else if (!assetResult.removed) {
             diskStats.missing++;
         }
     }
@@ -176,9 +187,12 @@ export async function execute(
         const assetResult = await cleanupProjectAssets(project.uuid, fileHelper);
         if (assetResult.removed) {
             diskStats.cleaned++;
-        } else if (assetResult.error) {
+        }
+        // A partial failure (e.g. sharded dir removed, legacy dir locked)
+        // reports both removed=true AND an error.
+        if (assetResult.error) {
             diskStats.failures.push(assetResult.error);
-        } else {
+        } else if (!assetResult.removed) {
             diskStats.missing++;
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { getAppVersion } from './utils/version';
 import { getFilesDir } from './services/file-helper';
 import { db, closeDb } from './db/client';
 import { migrateToLatest } from './db/migrations';
+import { migrateAssetStorage } from './services/asset-storage-migration';
 import { findUserByEmail, createUser, updateUser } from './db/queries/users';
 import { upsertBaseTheme, removeOrphanedBaseThemes } from './db/queries/themes';
 import { renderTemplate, setRenderLocale } from './services/template';
@@ -730,6 +731,17 @@ async function bootstrap() {
     if (!migrationResult.success) {
         console.error('[DB] Migration failed:', migrationResult.error);
         process.exit(1);
+    }
+
+    // 1b. Converge the asset storage layout (sharded directories + relative
+    // storage_path, issue #2250 / ADR-2250-01). Idempotent and resumable; a
+    // fast no-op once converged. Failures are logged and retried on the next
+    // startup — unmigrated rows keep working through the transitional
+    // legacy-path read fallback in the storage resolver.
+    try {
+        await migrateAssetStorage();
+    } catch (err) {
+        console.error('[AssetStorage] Migration failed (will retry on next startup):', err);
     }
 
     // 2. Initialize Redis for high availability (if configured)

--- a/src/routes/admin.spec.ts
+++ b/src/routes/admin.spec.ts
@@ -16,6 +16,12 @@ import {
 import type { Kysely } from 'kysely';
 import type { Database, User, Project } from '../db/types';
 import type { FileHelper } from '../services/file-helper';
+import {
+    getAssetShard,
+    getProjectAssetsDirCandidates as getProjectAssetsDirCandidatesPure,
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 
 // ============================================================================
 // TEST HELPERS
@@ -71,7 +77,10 @@ const createMockFileHelper = (overrides: Partial<FileHelper> = {}): FileHelper =
     getPreviewExportPath: () => '/mock/preview',
     getOdeSessionDistDir: () => '/mock/dist',
     getOdeSessionTempDir: () => '/mock/tmp',
-    getProjectAssetsDir: (uuid: string) => `/mock/data/assets/${uuid}`,
+    getProjectAssetsDir: (uuid: string) => `/mock/data/assets/${getAssetShard(uuid)}/${uuid}`,
+    getProjectAssetsDirCandidates: (uuid: string) => getProjectAssetsDirCandidatesPure('/mock/data', uuid),
+    resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure('/mock/data', storagePath),
+    tryResolveAssetStoragePath: (storagePath: string) => tryResolveAssetStoragePathPure('/mock/data', storagePath),
     getPublicDirectory: () => '/mock/public',
     getLibsDir: () => '/mock/public/libs',
     getThemesDir: () => '/mock/public/style/themes',
@@ -1183,9 +1192,12 @@ describe('Admin Routes', () => {
                 }),
             );
 
-            // Verify both project asset directories were cleaned up
-            expect(removedPaths.length).toBe(2);
+            // Verify both projects' asset directories were cleaned up, in the
+            // sharded location and the legacy unsharded location.
+            expect(removedPaths.length).toBe(4);
+            expect(removedPaths).toContain(`/mock/data/assets/${getAssetShard('project-uuid-1')}/project-uuid-1`);
             expect(removedPaths).toContain('/mock/data/assets/project-uuid-1');
+            expect(removedPaths).toContain(`/mock/data/assets/${getAssetShard('project-uuid-2')}/project-uuid-2`);
             expect(removedPaths).toContain('/mock/data/assets/project-uuid-2');
         });
 

--- a/src/routes/admin.spec.ts
+++ b/src/routes/admin.spec.ts
@@ -1239,6 +1239,44 @@ describe('Admin Routes', () => {
             expect(deleteUserCalled).toBe(true);
         });
 
+        it('should still attempt the legacy directory when removing the sharded directory fails', async () => {
+            const userProjects = [mockProject({ id: 1, uuid: 'project-uuid-1' })];
+            const shardedDir = `/mock/data/assets/${getAssetShard('project-uuid-1')}/project-uuid-1`;
+            const legacyDir = '/mock/data/assets/project-uuid-1';
+            const removedPaths: string[] = [];
+
+            const app = new Elysia().use(
+                createAdminRoutes(
+                    createMockDeps(
+                        {
+                            findProjectsByOwnerId: async () => userProjects,
+                        },
+                        {
+                            fileExists: async () => true,
+                            remove: async (target: string) => {
+                                if (target === shardedDir) {
+                                    throw new Error('EBUSY: locked');
+                                }
+                                removedPaths.push(target);
+                            },
+                        },
+                    ),
+                ),
+            );
+            const adminToken = await generateAdminToken();
+
+            const response = await app.handle(
+                new Request('http://localhost/api/admin/users/2', {
+                    method: 'DELETE',
+                    headers: { Authorization: `Bearer ${adminToken}` },
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            // The failure on the sharded candidate must not skip the legacy one.
+            expect(removedPaths).toContain(legacyDir);
+        });
+
         it('should skip asset cleanup for non-existent directories', async () => {
             const userProjects = [mockProject({ id: 1, uuid: 'project-uuid-1' })];
             let removeCalled = false;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1321,15 +1321,18 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
 
                 const yjsDoc = await reconstructDocument(project.id);
                 const publicDir = pathModule.resolve(__dirname, '../../public');
-                const assetsDir = fileHelper!.getProjectAssetsDir(project.uuid);
+                // Sharded directory first, legacy unsharded directory second, so
+                // filename-addressed files without database rows still export
+                // while an installation converges after the storage migration.
+                const assetDirs = fileHelper!.getProjectAssetsDirCandidates(project.uuid);
 
                 const wrapper = new ServerYjsDocumentWrapper(yjsDoc, project.uuid);
                 const document = new YjsDocumentAdapter(wrapper);
                 const resources = new FileSystemResourceProvider(publicDir);
                 const zip = new FflateZipProvider();
-                const fsAssets = new FileSystemAssetProvider(assetsDir);
-                const dbAssets = new DatabaseAssetProvider(db, project.id, assetsDir);
-                const assets = new CombinedAssetProvider([dbAssets, fsAssets]);
+                const fsAssets = assetDirs.map(dir => new FileSystemAssetProvider(dir));
+                const dbAssets = new DatabaseAssetProvider(db, project.id, assetDirs[0]);
+                const assets = new CombinedAssetProvider([dbAssets, ...fsAssets]);
 
                 const exporter = new ElpxExporter(document, resources, assets, zip);
                 const result = await exporter.export();
@@ -1393,19 +1396,26 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
 
                 // Clean up asset directories for each project (both the sharded
                 // and the legacy unsharded location, so pre-sharding projects
-                // are fully cleaned up).
-                // Continue even if some cleanups fail - the DB cascade will still remove records
+                // are fully cleaned up). Errors are isolated per candidate so a
+                // failure on one directory never skips the other, and per
+                // project so a failure never skips the remaining projects — the
+                // DB cascade will still remove the records either way.
                 for (const project of userProjects) {
+                    let candidates: string[] = [];
                     try {
-                        for (const assetsDir of fileHelper.getProjectAssetsDirCandidates(project.uuid)) {
+                        candidates = fileHelper.getProjectAssetsDirCandidates(project.uuid);
+                    } catch (err) {
+                        console.error(`Failed to compute asset directories for project ${project.uuid}:`, err);
+                    }
+                    for (const assetsDir of candidates) {
+                        try {
                             const exists = await fileHelper.fileExists(assetsDir);
                             if (exists) {
                                 await fileHelper.remove(assetsDir);
                             }
+                        } catch (err) {
+                            console.error(`Failed to clean up assets for project ${project.uuid}:`, err);
                         }
-                    } catch (err) {
-                        console.error(`Failed to clean up assets for project ${project.uuid}:`, err);
-                        // Continue with deletion - DB cascade will handle records
                     }
                 }
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1391,14 +1391,17 @@ export function createAdminRoutes(deps: AdminDependencies = defaultDependencies)
                 const userProjects = await queries.findProjectsByOwnerId(db, userId);
                 const deletedProjectsCount = userProjects.length;
 
-                // Clean up asset directories for each project
+                // Clean up asset directories for each project (both the sharded
+                // and the legacy unsharded location, so pre-sharding projects
+                // are fully cleaned up).
                 // Continue even if some cleanups fail - the DB cascade will still remove records
                 for (const project of userProjects) {
                     try {
-                        const assetsDir = fileHelper.getProjectAssetsDir(project.uuid);
-                        const exists = await fileHelper.fileExists(assetsDir);
-                        if (exists) {
-                            await fileHelper.remove(assetsDir);
+                        for (const assetsDir of fileHelper.getProjectAssetsDirCandidates(project.uuid)) {
+                            const exists = await fileHelper.fileExists(assetsDir);
+                            if (exists) {
+                                await fileHelper.remove(assetsDir);
+                            }
                         }
                     } catch (err) {
                         console.error(`Failed to clean up assets for project ${project.uuid}:`, err);

--- a/src/routes/api/v1/assets.spec.ts
+++ b/src/routes/api/v1/assets.spec.ts
@@ -15,6 +15,7 @@ import { now } from '../../../db/types';
 import { assetsRoutes } from './assets';
 import { createAuthRoutes } from '../../auth';
 import { findUserByEmail, findUserById, createUser, createAsset } from '../../../db/queries';
+import { getAssetShard } from '../../../utils/asset-paths';
 import { configureDocManager, resetDocManager, configureBroadcaster, resetBroadcaster } from '../../../yjs';
 import * as Y from 'yjs';
 
@@ -405,11 +406,17 @@ describe('Assets API v1', () => {
             expect(body.success).toBe(false);
             expect(body.error.code).toBe('BAD_REQUEST');
 
-            // Nothing was written outside (or inside) the project assets directory.
+            // Nothing was written outside (or inside) the project assets directory
+            // (checked in both the sharded and the legacy unsharded location).
             expect(await fs.pathExists(escapeTarget)).toBe(false);
-            const assetsDir = path.join(TEST_FILES_DIR, 'assets', 'user-project-traversal');
-            const entries = (await fs.pathExists(assetsDir)) ? await fs.readdir(assetsDir) : [];
-            expect(entries.length).toBe(0);
+            const shard = getAssetShard('user-project-traversal');
+            for (const assetsDir of [
+                path.join(TEST_FILES_DIR, 'assets', shard, 'user-project-traversal'),
+                path.join(TEST_FILES_DIR, 'assets', 'user-project-traversal'),
+            ]) {
+                const entries = (await fs.pathExists(assetsDir)) ? await fs.readdir(assetsDir) : [];
+                expect(entries.length).toBe(0);
+            }
 
             // And no asset record was created.
             const rows = await db.selectFrom('assets').selectAll().execute();
@@ -446,9 +453,25 @@ describe('Assets API v1', () => {
             expect(body.data.clientId).toBe(clientId);
             expect(body.data.filename).toBe('safe.png');
 
-            // File is stored as {clientId}.{ext} inside the project assets directory.
-            const expectedPath = path.join(TEST_FILES_DIR, 'assets', 'user-project-uuid-clientid', `${clientId}.png`);
+            // File is stored as {clientId}.{ext} inside the sharded project
+            // assets directory, and the DB row holds the FILES_DIR-relative path.
+            const shard = getAssetShard('user-project-uuid-clientid');
+            const expectedPath = path.join(
+                TEST_FILES_DIR,
+                'assets',
+                shard,
+                'user-project-uuid-clientid',
+                `${clientId}.png`,
+            );
             expect(await fs.pathExists(expectedPath)).toBe(true);
+
+            const row = await db
+                .selectFrom('assets')
+                .selectAll()
+                .where('client_id', '=', clientId)
+                .executeTakeFirstOrThrow();
+            expect(row.storage_path).toBe(`assets/${shard}/user-project-uuid-clientid/${clientId}.png`);
+            expect(path.isAbsolute(row.storage_path)).toBe(false);
         });
     });
 

--- a/src/routes/api/v1/assets.ts
+++ b/src/routes/api/v1/assets.ts
@@ -9,6 +9,7 @@
 import { Elysia, t } from 'elysia';
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 
 import { db } from '../../../db/client';
 import { buildContentDisposition } from '../../../shared/http/headers';
@@ -23,8 +24,15 @@ import {
     updateAsset,
 } from '../../../db/queries';
 import type { Asset } from '../../../db/types';
-import { getProjectAssetsDir, fileExists, readFile, remove } from '../../../services/file-helper';
-import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../../../utils/safe-path';
+import {
+    resolveAssetStoragePath,
+    tryResolveAssetStoragePath,
+    fileExists,
+    readFile,
+    remove,
+} from '../../../services/file-helper';
+import { buildAssetStoragePath } from '../../../utils/asset-paths';
+import { isSafePathSegment, sanitizeFileExtension } from '../../../utils/safe-path';
 import { withDocument, setAssetMetadata, deleteAssetMetadata, type AssetMetadata } from '../../../yjs';
 import {
     authenticateRequest,
@@ -207,13 +215,13 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
                 return errorResponse('BAD_REQUEST', 'Invalid file format');
             }
 
-            // Store file: assets/{projectUuid}/{clientId}.{ext}
-            const baseStoragePath = getProjectAssetsDir(params.uuid);
-            await fs.ensureDir(baseStoragePath);
-
+            // Sharded storage: assets/<shard>/<projectUuid>/<clientId>.<ext>
+            // The database stores the FILES_DIR-relative path.
             const ext = sanitizeFileExtension(filename);
             const flatFilename = `${clientId}${ext}`;
-            const filePath = safeJoin(baseStoragePath, flatFilename);
+            const storagePath = buildAssetStoragePath(project!.uuid, flatFilename);
+            const filePath = resolveAssetStoragePath(storagePath);
+            await fs.ensureDir(path.dirname(filePath));
 
             // Write file
             if (typeof Bun !== 'undefined' && Bun.write) {
@@ -230,7 +238,7 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
                 // Update existing in DB
                 const updatedAsset = await updateAsset(db, existingAsset.id, {
                     filename: filename,
-                    storage_path: filePath,
+                    storage_path: storagePath,
                     mime_type: mimetype,
                     file_size: String(fileBuffer.length),
                     folder_path: folderPath,
@@ -241,7 +249,7 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
                 asset = await createAsset(db, {
                     project_id: project!.id,
                     filename: filename,
-                    storage_path: filePath,
+                    storage_path: storagePath,
                     mime_type: mimetype,
                     file_size: String(fileBuffer.length),
                     component_id: null,
@@ -308,13 +316,14 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
             }
 
             // Check if file exists
-            if (!(await fileExists(asset.storage_path))) {
+            const absPath = asset.storage_path ? tryResolveAssetStoragePath(asset.storage_path) : null;
+            if (!absPath || !(await fileExists(absPath))) {
                 set.status = 404;
                 return errorResponse('NOT_FOUND', 'Asset file not found on disk');
             }
 
             // Return file
-            const fileBuffer = await readFile(asset.storage_path);
+            const fileBuffer = await readFile(absPath);
             set.headers['content-type'] = asset.mime_type || 'application/octet-stream';
             set.headers['content-disposition'] = buildContentDisposition(asset.filename);
             return fileBuffer;
@@ -403,7 +412,10 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
             }
 
             // Delete file from disk
-            await remove(asset.storage_path).catch(() => {});
+            const absPath = asset.storage_path ? tryResolveAssetStoragePath(asset.storage_path) : null;
+            if (absPath) {
+                await remove(absPath).catch(() => {});
+            }
 
             // Delete database record
             await dbDeleteAsset(db, assetId);
@@ -455,7 +467,10 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
 
             // Delete files and database records
             for (const asset of assets) {
-                await remove(asset.storage_path).catch(() => {});
+                const absPath = asset.storage_path ? tryResolveAssetStoragePath(asset.storage_path) : null;
+                if (absPath) {
+                    await remove(absPath).catch(() => {});
+                }
                 await dbDeleteAsset(db, asset.id);
             }
 

--- a/src/routes/api/v1/assets.ts
+++ b/src/routes/api/v1/assets.ts
@@ -235,6 +235,15 @@ export const assetsRoutes = new Elysia({ prefix: '/projects' })
 
             let asset: Asset;
             if (existingAsset) {
+                // A relocating update (row still pointing at a legacy or
+                // conflict-parked location) must not leave the superseded file
+                // behind as an untracked orphan.
+                if (existingAsset.storage_path && existingAsset.storage_path !== storagePath) {
+                    const oldPath = tryResolveAssetStoragePath(existingAsset.storage_path);
+                    if (oldPath && oldPath !== filePath) {
+                        await remove(oldPath).catch(() => {});
+                    }
+                }
                 // Update existing in DB
                 const updatedAsset = await updateAsset(db, existingAsset.id, {
                     filename: filename,

--- a/src/routes/api/v1/export.ts
+++ b/src/routes/api/v1/export.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { db } from '../../../db/client';
 import { findProjectByUuid } from '../../../db/queries';
-import { getFilesDir } from '../../../services/file-helper';
+import { getProjectAssetsDir } from '../../../services/file-helper';
 import { buildContentDisposition } from '../../../shared/http/headers';
 import {
     Html5Exporter,
@@ -181,9 +181,8 @@ export const exportRoutes = new Elysia({ prefix: '/export' })
                     const wrapper = new ServerYjsDocumentWrapper(ydoc, params.uuid);
                     const documentAdapter = new YjsDocumentAdapter(wrapper);
 
-                    // Create asset providers
-                    const filesDir = getFilesDir();
-                    const assetsPath = path.join(filesDir, 'assets', params.uuid);
+                    // Create asset providers (sharded project assets directory)
+                    const assetsPath = getProjectAssetsDir(project!.uuid);
 
                     const fsAssetProvider = new FileSystemAssetProvider(assetsPath);
                     const dbAssetProvider = new DatabaseAssetProvider(db, project!.id);

--- a/src/routes/api/v1/export.ts
+++ b/src/routes/api/v1/export.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { db } from '../../../db/client';
 import { findProjectByUuid } from '../../../db/queries';
-import { getProjectAssetsDir } from '../../../services/file-helper';
+import { getProjectAssetsDirCandidates } from '../../../services/file-helper';
 import { buildContentDisposition } from '../../../shared/http/headers';
 import {
     Html5Exporter,
@@ -181,12 +181,15 @@ export const exportRoutes = new Elysia({ prefix: '/export' })
                     const wrapper = new ServerYjsDocumentWrapper(ydoc, params.uuid);
                     const documentAdapter = new YjsDocumentAdapter(wrapper);
 
-                    // Create asset providers (sharded project assets directory)
-                    const assetsPath = getProjectAssetsDir(project!.uuid);
-
-                    const fsAssetProvider = new FileSystemAssetProvider(assetsPath);
+                    // Create asset providers. Filesystem providers cover both
+                    // the sharded directory and the legacy unsharded directory,
+                    // so filename-addressed files without database rows are
+                    // still exported while an installation converges (the
+                    // startup migration can be interrupted and retried).
+                    const assetDirs = getProjectAssetsDirCandidates(project!.uuid);
+                    const fsAssetProviders = assetDirs.map(dir => new FileSystemAssetProvider(dir));
                     const dbAssetProvider = new DatabaseAssetProvider(db, project!.id);
-                    const assetProvider = new CombinedAssetProvider([fsAssetProvider, dbAssetProvider]);
+                    const assetProvider = new CombinedAssetProvider([...fsAssetProviders, dbAssetProvider]);
 
                     // Create resource provider (themes, idevices, base CSS)
                     // Note: ResourceProvider expects the public/ directory as root

--- a/src/routes/assets.spec.ts
+++ b/src/routes/assets.spec.ts
@@ -21,9 +21,18 @@ import {
     type AssetsSessionManagerDeps,
     type AssetsPriorityQueueDeps,
 } from './assets';
+import {
+    buildAssetStoragePath,
+    getAssetShard,
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 
 const testDir = path.join(process.cwd(), 'test', 'temp', 'assets-test');
 const testProjectId = 'test-project-123';
+// Legacy (pre-sharding) on-disk project directory. Several fixtures seed files
+// here with absolute storage_path values to exercise the legacy read fallback.
+const legacyProjectDir = path.join(testDir, 'assets', testProjectId);
 const OWNER_USER_ID = 42;
 // Match the fallback in getJwtSecret() so we don't have to mutate process.env.
 const TEST_JWT_SECRET = 'dev_secret_change_me';
@@ -44,7 +53,8 @@ let mockSessions: Map<string, any>;
 function createMockFileHelper(): AssetsFileHelperDeps {
     return {
         getOdeSessionTempDir: (sessionId: string) => path.join(testDir, 'tmp', sessionId),
-        getProjectAssetsDir: (projectUuid: string) => path.join(testDir, 'assets', projectUuid),
+        resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure(testDir, storagePath),
+        tryResolveAssetStoragePath: (storagePath: string) => tryResolveAssetStoragePathPure(testDir, storagePath),
         fileExists: async (filePath: string) => fs.pathExists(filePath),
         readFile: async (filePath: string) => fs.readFile(filePath),
         writeFile: async (filePath: string, data: Buffer) => fs.writeFile(filePath, data),
@@ -543,10 +553,92 @@ describe('Assets Routes', () => {
         });
     });
 
+    describe('Sharded relative storage (issue #2250)', () => {
+        const expectedShard = getAssetShard(testProjectId);
+
+        it('should store a FILES_DIR-relative sharded storage_path on upload', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['sharded content'], { type: 'text/plain' }), 'photo.png');
+            formData.append('clientId', 'client-shard-1');
+
+            // Addressed by numeric id on purpose: storage must still use the
+            // canonical project UUID, never the raw URL parameter.
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }),
+            );
+            expect(res.status).toBe(200);
+
+            const stored = Array.from(mockAssets.values()).find(a => a.client_id === 'client-shard-1');
+            expect(stored).toBeDefined();
+            expect(stored.storage_path).toBe(buildAssetStoragePath(testProjectId, 'client-shard-1.png'));
+            expect(stored.storage_path).toBe(`assets/${expectedShard}/${testProjectId}/client-shard-1.png`);
+            expect(path.isAbsolute(stored.storage_path)).toBe(false);
+
+            const physical = path.join(testDir, 'assets', expectedShard, testProjectId, 'client-shard-1.png');
+            expect(await fs.pathExists(physical)).toBe(true);
+            expect(await fs.readFile(physical, 'utf-8')).toBe('sharded content');
+        });
+
+        it('should serve a download from the sharded location after upload', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['roundtrip content'], { type: 'text/plain' }), 'note.txt');
+            formData.append('clientId', 'client-shard-2');
+
+            const uploadRes = await handle(
+                new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }),
+            );
+            expect(uploadRes.status).toBe(200);
+
+            const res = await handle(new Request(`http://localhost/api/projects/1/assets/by-client-id/client-shard-2`));
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('roundtrip content');
+        });
+
+        it('should remove the sharded file on delete', async () => {
+            const formData = new FormData();
+            formData.append('file', new Blob(['delete me'], { type: 'text/plain' }), 'gone.txt');
+            formData.append('clientId', 'client-shard-3');
+
+            await handle(new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }));
+            const physical = path.join(testDir, 'assets', expectedShard, testProjectId, 'client-shard-3.txt');
+            expect(await fs.pathExists(physical)).toBe(true);
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/by-client-id/client-shard-3`, {
+                    method: 'DELETE',
+                }),
+            );
+            expect(res.status).toBe(200);
+            expect(await fs.pathExists(physical)).toBe(false);
+        });
+
+        it('should still serve an asset whose row holds a legacy absolute storage_path', async () => {
+            // Simulates a not-yet-migrated row: absolute path from an old
+            // FILES_DIR mount that no longer exists. The resolver re-roots the
+            // assets/... suffix under the current FILES_DIR.
+            const legacyFile = path.join(legacyProjectDir, 'legacy-row.png');
+            await fs.writeFile(legacyFile, 'legacy bytes');
+            mockAssets.set(50, {
+                id: 50,
+                project_id: 1,
+                filename: 'legacy-row.png',
+                storage_path: `/old-deployment/data/assets/${testProjectId}/legacy-row.png`,
+                mime_type: 'image/png',
+                client_id: 'legacy-client-50',
+            });
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets/by-client-id/legacy-client-50`),
+            );
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('legacy bytes');
+        });
+    });
+
     describe('GET /api/projects/:projectId/assets/:assetId - Download Asset', () => {
         it('should download asset file', async () => {
             // Create test file
-            const filePath = path.join(testDir, 'test-asset.txt');
+            const filePath = path.join(legacyProjectDir, 'test-asset.txt');
             await fs.writeFile(filePath, 'Asset content');
 
             mockAssets.set(1, {
@@ -581,7 +673,7 @@ describe('Assets Routes', () => {
         });
 
         it('should return 404 when numeric asset belongs to another project', async () => {
-            const filePath = path.join(testDir, 'other-project-asset.txt');
+            const filePath = path.join(legacyProjectDir, 'other-project-asset.txt');
             await fs.writeFile(filePath, 'Other project content');
 
             mockAssets.set(1, {
@@ -599,7 +691,7 @@ describe('Assets Routes', () => {
         });
 
         it('should resolve UUID-like client_id in :assetId param', async () => {
-            const filePath = path.join(testDir, 'uuid-client-asset.txt');
+            const filePath = path.join(legacyProjectDir, 'uuid-client-asset.txt');
             await fs.writeFile(filePath, 'UUID client asset content');
 
             const clientId = '960cbe4b-0c2c-4466-95d4-6a3c4d7fd275';
@@ -645,7 +737,7 @@ describe('Assets Routes', () => {
         // accented characters (e.g. "San Marcial de Rubicón.png") used to surface
         // as a 500 with "Header has invalid value" instead of streaming the file.
         it('should download asset whose filename contains non-ASCII characters', async () => {
-            const filePath = path.join(testDir, 'rubicon-asset.png');
+            const filePath = path.join(legacyProjectDir, 'rubicon-asset.png');
             await fs.writeFile(filePath, 'Rubicón content');
 
             mockAssets.set(1, {
@@ -667,7 +759,7 @@ describe('Assets Routes', () => {
         });
 
         it('should expose the asset filename in by-client-id X-Filename header without throwing on accents', async () => {
-            const filePath = path.join(testDir, 'valeron-asset.png');
+            const filePath = path.join(legacyProjectDir, 'valeron-asset.png');
             await fs.writeFile(filePath, 'Valerón content');
 
             const clientId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
@@ -694,7 +786,7 @@ describe('Assets Routes', () => {
 
     describe('GET /api/projects/:projectId/assets/by-client-id/:clientId', () => {
         it('should download asset by client ID', async () => {
-            const filePath = path.join(testDir, 'client-asset.txt');
+            const filePath = path.join(legacyProjectDir, 'client-asset.txt');
             await fs.writeFile(filePath, 'Client asset content');
 
             mockAssets.set(1, {
@@ -770,7 +862,7 @@ describe('Assets Routes', () => {
 
     describe('DELETE /api/projects/:projectId/assets/:assetId', () => {
         it('should delete asset', async () => {
-            const filePath = path.join(testDir, 'to-delete.txt');
+            const filePath = path.join(legacyProjectDir, 'to-delete.txt');
             await fs.writeFile(filePath, 'Delete me');
 
             mockAssets.set(1, {
@@ -803,7 +895,7 @@ describe('Assets Routes', () => {
         });
 
         it('should not delete an asset owned by another project (cross-tenant IDOR)', async () => {
-            const filePath = path.join(testDir, 'other-tenant.txt');
+            const filePath = path.join(legacyProjectDir, 'other-tenant.txt');
             await fs.writeFile(filePath, 'Belongs to project 2');
 
             // Asset belongs to project 2; attacker owns project 1 and targets it
@@ -830,7 +922,7 @@ describe('Assets Routes', () => {
 
     describe('DELETE /api/projects/:projectId/assets/by-client-id/:clientId', () => {
         it('should delete asset by client ID', async () => {
-            const filePath = path.join(testDir, 'client-delete.txt');
+            const filePath = path.join(legacyProjectDir, 'client-delete.txt');
             await fs.writeFile(filePath, 'Delete me');
 
             mockAssets.set(1, {
@@ -882,8 +974,8 @@ describe('Assets Routes', () => {
 
     describe('DELETE /api/projects/:projectId/assets/bulk', () => {
         it('should delete multiple assets by client IDs', async () => {
-            const filePath1 = path.join(testDir, 'bulk-delete-1.txt');
-            const filePath2 = path.join(testDir, 'bulk-delete-2.txt');
+            const filePath1 = path.join(legacyProjectDir, 'bulk-delete-1.txt');
+            const filePath2 = path.join(legacyProjectDir, 'bulk-delete-2.txt');
             await fs.writeFile(filePath1, 'Delete me 1');
             await fs.writeFile(filePath2, 'Delete me 2');
 
@@ -961,7 +1053,7 @@ describe('Assets Routes', () => {
         });
 
         it('should only delete assets that exist (partial match)', async () => {
-            const filePath = path.join(testDir, 'partial-delete.txt');
+            const filePath = path.join(legacyProjectDir, 'partial-delete.txt');
             await fs.writeFile(filePath, 'Delete me');
 
             mockAssets.set(1, {

--- a/src/routes/assets.spec.ts
+++ b/src/routes/assets.spec.ts
@@ -612,6 +612,37 @@ describe('Assets Routes', () => {
             expect(await fs.pathExists(physical)).toBe(false);
         });
 
+        it('should remove the file at the previous location when a re-upload relocates the asset', async () => {
+            // A conflict-parked row points at the legacy unsharded location.
+            const legacyFile = path.join(legacyProjectDir, 'parked-client.png');
+            await fs.writeFile(legacyFile, 'old parked bytes');
+            mockAssets.set(60, {
+                id: 60,
+                project_id: 1,
+                filename: 'parked.png',
+                storage_path: `assets/${testProjectId}/parked-client.png`,
+                mime_type: 'image/png',
+                client_id: 'parked-client',
+            });
+
+            const formData = new FormData();
+            formData.append('file', new Blob(['new bytes'], { type: 'image/png' }), 'parked.png');
+            formData.append('clientId', 'parked-client');
+
+            const res = await handle(
+                new Request(`http://localhost/api/projects/1/assets`, { method: 'POST', body: formData }),
+            );
+            expect(res.status).toBe(200);
+
+            // Row repointed to the sharded location; the superseded legacy
+            // file is removed so it cannot linger as an untracked orphan.
+            const row = mockAssets.get(60);
+            expect(row.storage_path).toBe(`assets/${expectedShard}/${testProjectId}/parked-client.png`);
+            expect(await fs.pathExists(legacyFile)).toBe(false);
+            const physical = path.join(testDir, 'assets', expectedShard, testProjectId, 'parked-client.png');
+            expect(await fs.readFile(physical, 'utf-8')).toBe('new bytes');
+        });
+
         it('should still serve an asset whose row holds a legacy absolute storage_path', async () => {
             // Simulates a not-yet-migrated row: absolute path from an old
             // FILES_DIR mount that no longer exists. The resolver re-roots the

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -335,6 +335,26 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
         return asset.storage_path ? tryResolveAssetStoragePath(asset.storage_path) : null;
     }
 
+    /**
+     * When an update relocates an asset's storage path (e.g. a re-upload of a
+     * row still pointing at a legacy or conflict-parked location), remove the
+     * file at the previous location so superseded copies never linger as
+     * untracked orphans. No-op when the location is unchanged.
+     */
+    async function removeSupersededAssetFile(
+        existing: Pick<Asset, 'storage_path'>,
+        newStoragePath: string,
+    ): Promise<void> {
+        if (!existing.storage_path || existing.storage_path === newStoragePath) {
+            return;
+        }
+        const oldPath = tryResolveAssetStoragePath(existing.storage_path);
+        const newPath = tryResolveAssetStoragePath(newStoragePath);
+        if (oldPath && oldPath !== newPath) {
+            await remove(oldPath).catch(() => {});
+        }
+    }
+
     return (
         new Elysia({ prefix: '/api/projects/:projectId/assets' })
             // Auth: every asset endpoint requires an authenticated user with
@@ -433,6 +453,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
 
                     if (existingAsset) {
                         // Asset already exists - update it (idempotent)
+                        await removeSupersededAssetFile(existingAsset, storagePath);
                         const updatedAsset = await queries.updateAsset(database, existingAsset.id, {
                             filename: filename,
                             storage_path: storagePath,
@@ -694,6 +715,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     let asset: Asset | undefined;
                     if (existingAsset) {
                         // Update existing asset
+                        await removeSupersededAssetFile(existingAsset, storagePath);
                         asset = await queries.updateAsset(database, existingAsset.id, {
                             filename: upload.filename,
                             storage_path: storagePath,
@@ -1182,6 +1204,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
 
                         const existing = existingMap.get(data.clientId);
                         if (existing) {
+                            await removeSupersededAssetFile(existing, data.storagePath);
                             toUpdate.push({
                                 id: existing.id,
                                 data: {

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -10,7 +10,7 @@ import * as mimeTypes from 'mime-types';
 
 import { db } from '../db/client';
 import { buildContentDisposition, encodeHeaderValue } from '../shared/http/headers';
-import type { Asset, Database } from '../db/types';
+import type { Asset, Database, Project } from '../db/types';
 import {
     createAsset,
     createAssets,
@@ -30,7 +30,8 @@ import { withJwtAuth, enforceProjectAccess } from '../utils/route-auth';
 
 import {
     getOdeSessionTempDir as getOdeSessionTempDirDefault,
-    getProjectAssetsDir as getProjectAssetsDirDefault,
+    resolveAssetStoragePath as resolveAssetStoragePathDefault,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathDefault,
     fileExists as fileExistsDefault,
     readFile as readFileDefault,
     writeFile as writeFileDefault,
@@ -44,6 +45,7 @@ import { getSession as getSessionDefault } from '../services/session-manager';
 import { serverPriorityQueue as serverPriorityQueueDefault } from '../services/asset-priority-queue';
 import type { AssetUploadRequest } from './types/request-payloads';
 import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../utils/safe-path';
+import { buildAssetStoragePath } from '../utils/asset-paths';
 
 /**
  * File with optional name property (for Blob/File uploads)
@@ -75,7 +77,8 @@ export interface AssetsQueries {
  */
 export interface AssetsFileHelperDeps {
     getOdeSessionTempDir: typeof getOdeSessionTempDirDefault;
-    getProjectAssetsDir: typeof getProjectAssetsDirDefault;
+    resolveAssetStoragePath: typeof resolveAssetStoragePathDefault;
+    tryResolveAssetStoragePath: typeof tryResolveAssetStoragePathDefault;
     fileExists: typeof fileExistsDefault;
     readFile: typeof readFileDefault;
     writeFile: typeof writeFileDefault;
@@ -116,7 +119,8 @@ export interface AssetsDependencies {
  */
 const defaultFileHelper: AssetsFileHelperDeps = {
     getOdeSessionTempDir: getOdeSessionTempDirDefault,
-    getProjectAssetsDir: getProjectAssetsDirDefault,
+    resolveAssetStoragePath: resolveAssetStoragePathDefault,
+    tryResolveAssetStoragePath: tryResolveAssetStoragePathDefault,
     fileExists: fileExistsDefault,
     readFile: readFileDefault,
     writeFile: writeFileDefault,
@@ -291,7 +295,8 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
     // Variable shadowing for file-helper functions
     const {
         getOdeSessionTempDir: _getOdeSessionTempDir, // Kept for DI interface, unused for asset storage
-        getProjectAssetsDir,
+        resolveAssetStoragePath,
+        tryResolveAssetStoragePath,
         fileExists,
         readFile,
         writeFile,
@@ -308,20 +313,26 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
     const serverPriorityQueue = deps.priorityQueue ?? defaultPriorityQueue;
 
     /**
-     * Helper to get numeric project ID from UUID or numeric string
-     * @param projectIdOrUuid - Project UUID or numeric ID string
-     * @returns Numeric project ID or null if not found
+     * Resolve the project row from a URL parameter that may be either the
+     * project UUID or a numeric database id. Asset storage paths are always
+     * derived from the canonical `projects.uuid`, never from the raw URL
+     * value, so every project has exactly one on-disk directory.
      */
-    async function getNumericProjectId(projectIdOrUuid: string): Promise<number | null> {
-        // Check if it's already a numeric ID (must be digits only to avoid UUID prefix collisions)
+    async function resolveProject(projectIdOrUuid: string): Promise<Project | undefined> {
+        // Digits-only check avoids misparsing UUIDs that start with a digit.
         if (/^\d+$/.test(projectIdOrUuid)) {
-            const numericId = parseInt(projectIdOrUuid, 10);
-            return numericId;
+            return queries.findProjectById(database, parseInt(projectIdOrUuid, 10));
         }
+        return queries.findProjectByUuid(database, projectIdOrUuid);
+    }
 
-        // It's a UUID - look up the project
-        const project = await queries.findProjectByUuid(database, projectIdOrUuid);
-        return project?.id ?? null;
+    /**
+     * Resolve a stored `assets.storage_path` value to an absolute path,
+     * returning null when the value is unresolvable or the row has no path.
+     * Callers treat null exactly like a missing file.
+     */
+    function resolveAssetFile(asset: Pick<Asset, 'storage_path'>): string | null {
+        return asset.storage_path ? tryResolveAssetStoragePath(asset.storage_path) : null;
     }
 
     return (
@@ -357,12 +368,13 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const { projectId } = params;
                     const data = body as AssetUploadRequest;
 
-                    // Get numeric project ID (handles both UUID and numeric strings)
-                    const projectIdNum = await getNumericProjectId(projectId);
-                    if (projectIdNum === null) {
+                    // Resolve the project row (handles both UUID and numeric strings)
+                    const project = await resolveProject(projectId);
+                    if (!project) {
                         set.status = 404;
                         return { success: false, error: 'Project not found' };
                     }
+                    const projectIdNum = project.id;
 
                     if (!data.file) {
                         set.status = 400;
@@ -399,15 +411,14 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         mimetype = data.mimetype || 'application/octet-stream';
                     }
 
-                    // Flat UUID-based storage: assets/{projectUuid}/{clientId}.{ext}
-                    // No folder hierarchy on disk - folderPath is only stored in database for UI/export
-                    const baseStoragePath = getProjectAssetsDir(projectId);
-                    await fs.ensureDir(baseStoragePath);
-
-                    // Use clientId as filename with original extension
+                    // Sharded storage: assets/<shard>/<projectUuid>/<clientId>.<ext>
+                    // The database stores the FILES_DIR-relative path; the physical
+                    // path is derived from it through the shared resolver. No folder
+                    // hierarchy on disk - folderPath is only stored for UI/export.
                     const ext = sanitizeFileExtension(filename);
-                    const flatFilename = `${clientId}${ext}`;
-                    const filePath = safeJoin(baseStoragePath, flatFilename);
+                    const storagePath = buildAssetStoragePath(project.uuid, `${clientId}${ext}`);
+                    const filePath = resolveAssetStoragePath(storagePath);
+                    await fs.ensureDir(path.dirname(filePath));
 
                     // Write file using Bun.write for optimal performance
                     if (typeof Bun !== 'undefined' && Bun.write) {
@@ -424,7 +435,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         // Asset already exists - update it (idempotent)
                         const updatedAsset = await queries.updateAsset(database, existingAsset.id, {
                             filename: filename,
-                            storage_path: filePath,
+                            storage_path: storagePath,
                             mime_type: mimetype,
                             file_size: String(fileBuffer.length),
                             folder_path: folderPath,
@@ -440,7 +451,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const asset = await queries.createAsset(database, {
                         project_id: projectIdNum,
                         filename: filename,
-                        storage_path: filePath,
+                        storage_path: storagePath,
                         mime_type: mimetype,
                         file_size: String(fileBuffer.length),
                         component_id: componentId || null,
@@ -622,21 +633,19 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         };
                     }
 
-                    // Get numeric project ID (handles both UUID and numeric strings)
-                    const projectIdNum = await getNumericProjectId(projectId);
-                    if (projectIdNum === null) {
+                    // Resolve the project row (handles both UUID and numeric strings)
+                    const project = await resolveProject(projectId);
+                    if (!project) {
                         set.status = 404;
                         return { success: false, error: 'Project not found' };
                     }
+                    const projectIdNum = project.id;
 
-                    // Flat UUID-based storage: assets/{projectUuid}/{clientId}.{ext}
-                    const storagePath = getProjectAssetsDir(projectId);
-                    await fs.ensureDir(storagePath);
-
-                    // Use clientId as filename with original extension
+                    // Sharded storage: assets/<shard>/<projectUuid>/<clientId>.<ext>
                     const ext = sanitizeFileExtension(upload.filename);
-                    const flatFilename = `${clientId}${ext}`;
-                    const finalPath = safeJoin(storagePath, flatFilename);
+                    const storagePath = buildAssetStoragePath(project.uuid, `${clientId}${ext}`);
+                    const finalPath = resolveAssetStoragePath(storagePath);
+                    await fs.ensureDir(path.dirname(finalPath));
 
                     // Write combined file with parallel chunk reads
                     const writeStream = fs.createWriteStream(finalPath);
@@ -687,21 +696,25 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         // Update existing asset
                         asset = await queries.updateAsset(database, existingAsset.id, {
                             filename: upload.filename,
-                            storage_path: finalPath,
+                            storage_path: storagePath,
                             mime_type: mimetype as string,
                             file_size: String(stats?.size || 0),
                             component_id: componentId || null,
                         });
                         // Fallback to existing asset if update doesn't return the record
                         if (!asset) {
-                            asset = { ...existingAsset, storage_path: finalPath, file_size: String(stats?.size || 0) };
+                            asset = {
+                                ...existingAsset,
+                                storage_path: storagePath,
+                                file_size: String(stats?.size || 0),
+                            };
                         }
                     } else {
                         // Create new asset record
                         asset = await queries.createAsset(database, {
                             project_id: projectIdNum,
                             filename: upload.filename,
-                            storage_path: finalPath,
+                            storage_path: storagePath,
                             mime_type: mimetype as string,
                             file_size: String(stats?.size || 0),
                             component_id: componentId || null,
@@ -747,16 +760,16 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
             .get('/', async ({ params }) => {
                 const { projectId } = params;
 
-                // Get numeric project ID (handles both UUID and numeric strings)
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                // Resolve the project row (handles both UUID and numeric strings)
+                const project = await resolveProject(projectId);
+                if (!project) {
                     return {
                         success: true,
                         data: [],
                     };
                 }
 
-                const assets = await queries.findAllAssetsForProject(database, projectIdNum);
+                const assets = await queries.findAllAssetsForProject(database, project.id);
                 return {
                     success: true,
                     data: assets.map(serializeAsset),
@@ -767,23 +780,24 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
             .get('/by-client-id/:clientId', async ({ params, set }) => {
                 const { projectId, clientId } = params;
 
-                // Get numeric project ID (handles both UUID and numeric strings)
-                const projectIdNum = await getNumericProjectId(projectId);
+                // Resolve the project row (handles both UUID and numeric strings)
+                const project = await resolveProject(projectId);
 
-                const asset = await queries.findAssetByClientId(database, clientId, projectIdNum ?? undefined);
+                const asset = await queries.findAssetByClientId(database, clientId, project?.id);
                 if (!asset) {
                     set.status = 404;
                     return { success: false, error: 'Asset not found' };
                 }
 
                 // Check if file exists
-                if (!(await fileExists(asset.storage_path))) {
+                const absPath = resolveAssetFile(asset);
+                if (!absPath || !(await fileExists(absPath))) {
                     set.status = 404;
                     return { success: false, error: 'Asset file not found on disk' };
                 }
 
                 // Return file blob with metadata headers for collaborative sync
-                const fileBuffer = await readFile(asset.storage_path);
+                const fileBuffer = await readFile(absPath);
                 set.headers['content-type'] = asset.mime_type || 'application/octet-stream';
                 set.headers['content-disposition'] = buildContentDisposition(asset.filename);
                 // Add metadata headers for AssetWebSocketHandler prefetch
@@ -798,12 +812,13 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
             .get('/:assetId', async ({ params, set }) => {
                 const { projectId, assetId } = params;
 
-                // Get numeric project ID (handles both UUID and numeric strings)
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                // Resolve the project row (handles both UUID and numeric strings)
+                const project = await resolveProject(projectId);
+                if (!project) {
                     set.status = 404;
                     return { success: false, error: 'Project not found' };
                 }
+                const projectIdNum = project.id;
 
                 // IMPORTANT:
                 // AssetManager uses UUID-like client IDs in asset:// URLs and calls this endpoint.
@@ -830,13 +845,14 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 }
 
                 // Check if file exists
-                if (!(await fileExists(asset.storage_path))) {
+                const absPath = resolveAssetFile(asset);
+                if (!absPath || !(await fileExists(absPath))) {
                     set.status = 404;
                     return { success: false, error: 'Asset file not found' };
                 }
 
                 // Return file
-                const fileBuffer = await readFile(asset.storage_path);
+                const fileBuffer = await readFile(absPath);
                 set.headers['content-type'] = asset.mime_type || 'application/octet-stream';
                 set.headers['content-disposition'] = buildContentDisposition(asset.filename);
                 return fileBuffer;
@@ -853,8 +869,8 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 }
 
                 // Resolve the URL project so we can enforce asset ownership.
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                const project = await resolveProject(projectId);
+                if (!project) {
                     set.status = 404;
                     return { success: false, error: 'Project not found' };
                 }
@@ -862,7 +878,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 const asset = await queries.findAssetById(database, assetId);
                 // findAssetById is a global lookup; the asset must belong to the
                 // project named in the URL or this leaks other tenants' metadata.
-                if (!asset || asset.project_id !== projectIdNum) {
+                if (!asset || asset.project_id !== project.id) {
                     set.status = 404;
                     return { success: false, error: 'Asset not found' };
                 }
@@ -878,13 +894,13 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
             .delete('/by-client-id/:clientId', async ({ params, set }) => {
                 const { projectId, clientId } = params;
 
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                const project = await resolveProject(projectId);
+                if (!project) {
                     set.status = 404;
                     return { success: false, error: 'Project not found' };
                 }
 
-                const asset = await queries.findAssetByClientId(database, clientId, projectIdNum);
+                const asset = await queries.findAssetByClientId(database, clientId, project.id);
                 if (!asset) {
                     // Asset not on server - that's OK, just return success
                     // (asset may have been deleted locally but never uploaded)
@@ -892,7 +908,10 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 }
 
                 // Delete file from disk
-                await remove(asset.storage_path).catch(() => {});
+                const absPath = resolveAssetFile(asset);
+                if (absPath) {
+                    await remove(absPath).catch(() => {});
+                }
 
                 // Delete database record
                 await queries.deleteAsset(database, asset.id);
@@ -910,17 +929,20 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     return { success: true, deleted: 0 };
                 }
 
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                const project = await resolveProject(projectId);
+                if (!project) {
                     set.status = 404;
                     return { success: false, error: 'Project not found' };
                 }
 
-                const assets = await queries.findAssetsByClientIds(database, clientIds, projectIdNum);
+                const assets = await queries.findAssetsByClientIds(database, clientIds, project.id);
 
                 // Delete files and database records
                 for (const asset of assets) {
-                    await remove(asset.storage_path).catch(() => {});
+                    const absPath = resolveAssetFile(asset);
+                    if (absPath) {
+                        await remove(absPath).catch(() => {});
+                    }
                     await queries.deleteAsset(database, asset.id);
                 }
 
@@ -938,8 +960,8 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 }
 
                 // Resolve the URL project so we can enforce asset ownership.
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                const project = await resolveProject(projectId);
+                if (!project) {
                     set.status = 404;
                     return { success: false, error: 'Project not found' };
                 }
@@ -949,13 +971,16 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 // the URL project, any authenticated user could delete another
                 // tenant's asset (file + DB row) by numeric ID. Mirror the
                 // ownership guard used by GET '/:assetId'.
-                if (!asset || asset.project_id !== projectIdNum) {
+                if (!asset || asset.project_id !== project.id) {
                     set.status = 404;
                     return { success: false, error: 'Asset not found' };
                 }
 
                 // Delete file
-                await remove(asset.storage_path).catch(() => {});
+                const absPath = resolveAssetFile(asset);
+                if (absPath) {
+                    await remove(absPath).catch(() => {});
+                }
 
                 // Delete record
                 await queries.deleteAsset(database, assetId);
@@ -967,16 +992,16 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
             .get('/storage-usage', async ({ params }) => {
                 const { projectId } = params;
 
-                // Get numeric project ID (handles both UUID and numeric strings)
-                const projectIdNum = await getNumericProjectId(projectId);
-                if (projectIdNum === null) {
+                // Resolve the project row (handles both UUID and numeric strings)
+                const project = await resolveProject(projectId);
+                if (!project) {
                     return {
                         success: true,
                         data: { totalAssets: 0, totalSize: 0, totalSizeMB: '0.00' },
                     };
                 }
 
-                const assets = await queries.findAllAssetsForProject(database, projectIdNum);
+                const assets = await queries.findAllAssetsForProject(database, project.id);
                 const totalSize = assets.reduce((sum, a) => sum + parseInt(a.file_size || '0', 10), 0);
 
                 return {
@@ -999,12 +1024,13 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const { projectId } = params;
                     const data = body as AssetUploadRequest;
 
-                    // Get numeric project ID (handles both UUID and numeric strings)
-                    const projectIdNum = await getNumericProjectId(projectId);
-                    if (projectIdNum === null) {
+                    // Resolve the project row (handles both UUID and numeric strings)
+                    const project = await resolveProject(projectId);
+                    if (!project) {
                         set.status = 404;
                         return { success: false, error: 'Project not found' };
                     }
+                    const projectIdNum = project.id;
 
                     // Parse metadata from JSON string
                     let metadata: Array<{
@@ -1040,11 +1066,6 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         files = Array.isArray(data.files) ? data.files : [data.files];
                     }
 
-                    // Get base storage path using project UUID
-                    const baseStoragePath = getProjectAssetsDir(projectId);
-
-                    await fs.ensureDir(baseStoragePath);
-
                     // =====================================================
                     // PHASE 1: Convert all files to buffers in parallel
                     // =====================================================
@@ -1065,13 +1086,14 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                             fileBuffer = Buffer.from(file);
                         }
 
-                        // Flat UUID-based storage: assets/{projectUuid}/{clientId}.{ext}
+                        // Sharded storage: assets/<shard>/<projectUuid>/<clientId>.<ext>
                         // folderPath is only stored in database for UI/export, not on disk
 
                         // Use clientId as filename with original extension
                         const ext = sanitizeFileExtension(filename);
                         const flatFilename = `${fileMeta.clientId}${ext}`;
-                        const filePath = safeJoin(baseStoragePath, flatFilename);
+                        const storagePath = buildAssetStoragePath(project.uuid, flatFilename);
+                        const filePath = resolveAssetStoragePath(storagePath);
 
                         return {
                             clientId: fileMeta.clientId,
@@ -1080,6 +1102,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                             folderPath,
                             fileBuffer,
                             filePath,
+                            storagePath,
                             flatFilename,
                         };
                     });
@@ -1089,6 +1112,12 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     // =====================================================
                     // PHASE 2: Write all files to disk in parallel (Bun.write)
                     // =====================================================
+                    // Lazy directory creation: the project shard directory is
+                    // created only when there is something to write.
+                    const targetDirs = new Set(fileData.map(f => path.dirname(f.filePath)));
+                    for (const dir of targetDirs) {
+                        await fs.ensureDir(dir);
+                    }
                     const writeResults = await Promise.allSettled(
                         fileData.map(({ filePath, fileBuffer }) =>
                             typeof Bun !== 'undefined' && Bun.write
@@ -1156,7 +1185,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                             toUpdate.push({
                                 id: existing.id,
                                 data: {
-                                    storage_path: data.filePath,
+                                    storage_path: data.storagePath,
                                     file_size: String(data.fileBuffer.length),
                                     folder_path: data.folderPath,
                                 },
@@ -1170,7 +1199,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                             toCreate.push({
                                 project_id: projectIdNum,
                                 filename: data.filename,
-                                storage_path: data.filePath,
+                                storage_path: data.storagePath,
                                 mime_type: data.mimeType,
                                 file_size: String(data.fileBuffer.length),
                                 component_id: null,
@@ -1233,12 +1262,13 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                 try {
                     const { projectId } = params;
 
-                    // Get numeric project ID (handles both UUID and numeric strings)
-                    const projectIdNum = await getNumericProjectId(projectId);
-                    if (projectIdNum === null) {
+                    // Resolve the project row (handles both UUID and numeric strings)
+                    const project = await resolveProject(projectId);
+                    if (!project) {
                         set.status = 404;
                         return { success: false, error: 'Project not found' };
                     }
+                    const projectIdNum = project.id;
 
                     const clientId = request.headers.get('x-client-id') || uuidv4();
                     // clientId becomes the on-disk filename; reject traversal/separators.
@@ -1266,14 +1296,11 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                         }
                     }
 
-                    // Flat UUID-based storage: assets/{projectUuid}/{clientId}.{ext}
-                    const baseStoragePath = getProjectAssetsDir(projectId);
-                    await fs.ensureDir(baseStoragePath);
-
-                    // Use clientId as filename with original extension
+                    // Sharded storage: assets/<shard>/<projectUuid>/<clientId>.<ext>
                     const ext = sanitizeFileExtension(filename);
-                    const flatFilename = `${clientId}${ext}`;
-                    const filePath = safeJoin(baseStoragePath, flatFilename);
+                    const storagePath = buildAssetStoragePath(project.uuid, `${clientId}${ext}`);
+                    const filePath = resolveAssetStoragePath(storagePath);
+                    await fs.ensureDir(path.dirname(filePath));
 
                     // Stream body directly to disk
                     const body = request.body;
@@ -1311,7 +1338,7 @@ export function createAssetsRoutes(deps: AssetsDependencies = defaultDependencie
                     const asset = await queries.createAsset(database, {
                         project_id: projectIdNum,
                         filename,
-                        storage_path: filePath,
+                        storage_path: storagePath,
                         mime_type: contentType,
                         file_size: String(fileSize),
                         component_id: null,

--- a/src/routes/filemanager.spec.ts
+++ b/src/routes/filemanager.spec.ts
@@ -10,6 +10,10 @@ import * as assetQueries from '../db/queries/assets';
 import { findProjectByUuid, findAssetByClientId, updateAsset, checkProjectAccess } from '../db/queries';
 import { createFileManagerRoutes } from './filemanager';
 import { createFolderManagerService } from '../services/folder-manager';
+import {
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
@@ -101,14 +105,17 @@ describe('File Manager Routes', () => {
             title: 'Test Project',
         });
 
-        // Create folder manager with injected dependencies
+        // Create folder manager with injected dependencies. The storage
+        // resolvers are bound to tempDir so stored FILES_DIR-relative paths
+        // (and legacy absolute fixtures under tempDir) resolve there.
         const folderManager = createFolderManagerService({
             db,
             queries: assetQueries,
             fs,
             path,
             fflate,
-            getProjectAssetsDir: (uuid: string) => path.join(tempDir, 'assets', uuid),
+            resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure(tempDir, storagePath),
+            tryResolveAssetStoragePath: (storagePath: string) => tryResolveAssetStoragePathPure(tempDir, storagePath),
         });
 
         // Create routes with injected dependencies

--- a/src/routes/project.spec.ts
+++ b/src/routes/project.spec.ts
@@ -6,6 +6,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import {
+    getAssetShard,
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 
 import {
     createProjectRoutes,
@@ -103,7 +108,11 @@ function createMockFileHelper(): FileHelperDeps {
             await fs.appendFile(filePath, content);
         },
         getFilesDir: () => path.join(testDir, 'files'),
-        getProjectAssetsDir: (projectUuid: string) => path.join(testDir, 'assets', projectUuid),
+        // Asset storage resolvers bound to testDir: legacy absolute fixture
+        // paths under testDir/assets resolve to themselves, and new sharded
+        // relative paths resolve under testDir/assets/<shard>/<uuid>/.
+        resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure(testDir, storagePath),
+        tryResolveAssetStoragePath: (storagePath: string) => tryResolveAssetStoragePathPure(testDir, storagePath),
     };
 }
 
@@ -1680,6 +1689,53 @@ describe('Project Routes', () => {
             expect(newAssets![0].client_id).toBe(sourceClientId);
             expect(newAssets![0].filename).toBe('test-image.png');
             expect(newAssets![0].project_id).toBe(newProjectId);
+        });
+
+        it('should store duplicated assets with FILES_DIR-relative sharded paths (issue #2250)', async () => {
+            const sourceProject = createTestProject(910, 'uuid-910-sharded-dup', 1);
+
+            const sourceClientId = 'sharded-dup-client';
+            const sourceAssetDir = path.join(testDir, 'assets', String(sourceProject.id), sourceClientId);
+            await fs.ensureDir(sourceAssetDir);
+            const sourceFilePath = path.join(sourceAssetDir, 'picture.png');
+            await fs.writeFile(sourceFilePath, Buffer.from('shard-me'));
+
+            mockAssets.set(sourceProject.id, [
+                {
+                    id: 1,
+                    project_id: sourceProject.id,
+                    filename: 'picture.png',
+                    storage_path: sourceFilePath,
+                    mime_type: 'image/png',
+                    file_size: 8,
+                    client_id: sourceClientId,
+                    component_id: null,
+                    content_hash: 'h1',
+                },
+            ]);
+
+            const token = await createAuthToken(1);
+            const res = await app.handle(
+                new Request('http://localhost/api/projects/uuid/uuid-910-sharded-dup/duplicate', {
+                    method: 'POST',
+                    headers: { Cookie: `auth=${token}` },
+                }),
+            );
+
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            const newAssets = mockAssets.get(body.project.id);
+            expect(newAssets).toBeDefined();
+            expect(newAssets!.length).toBe(1);
+
+            const newUuid = body.project.uuid as string;
+            const storedPath = newAssets![0].storage_path as string;
+            expect(path.isAbsolute(storedPath)).toBe(false);
+            expect(storedPath).toBe(`assets/${getAssetShard(newUuid)}/${newUuid}/${sourceClientId}/picture.png`);
+
+            const resolved = resolveAssetStoragePathPure(testDir, storedPath);
+            expect(await fs.pathExists(resolved)).toBe(true);
+            expect((await fs.readFile(resolved)).toString()).toBe('shard-me');
         });
 
         it('should handle project with no assets during duplication', async () => {

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -25,8 +25,10 @@ import {
     readFileAsString as readFileAsStringDefault,
     appendFile as appendFileDefault,
     getFilesDir as getFilesDirDefault,
-    getProjectAssetsDir as getProjectAssetsDirDefault,
+    resolveAssetStoragePath as resolveAssetStoragePathDefault,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathDefault,
 } from '../services/file-helper';
+import { buildAssetStoragePath } from '../utils/asset-paths';
 
 // yjs-persistence functions no longer used here - endpoints moved to routes/yjs.ts
 
@@ -175,7 +177,8 @@ export interface FileHelperDeps {
     readFileAsString: typeof readFileAsStringDefault;
     appendFile: typeof appendFileDefault;
     getFilesDir: typeof getFilesDirDefault;
-    getProjectAssetsDir: typeof getProjectAssetsDirDefault;
+    resolveAssetStoragePath: typeof resolveAssetStoragePathDefault;
+    tryResolveAssetStoragePath: typeof tryResolveAssetStoragePathDefault;
 }
 
 /**
@@ -270,7 +273,8 @@ const defaultFileHelper: FileHelperDeps = {
     readFileAsString: readFileAsStringDefault,
     appendFile: appendFileDefault,
     getFilesDir: getFilesDirDefault,
-    getProjectAssetsDir: getProjectAssetsDirDefault,
+    resolveAssetStoragePath: resolveAssetStoragePathDefault,
+    tryResolveAssetStoragePath: tryResolveAssetStoragePathDefault,
 };
 
 const defaultQueries: QueriesDeps = {
@@ -779,7 +783,8 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
     const { getSession, updateSession, generateSessionId } = deps.sessionManager ?? defaultSessionManager;
 
     // File helper functions
-    const { getOdeSessionTempDir, getFilesDir, getProjectAssetsDir } = deps.fileHelper ?? defaultFileHelper;
+    const { getOdeSessionTempDir, getFilesDir, resolveAssetStoragePath, tryResolveAssetStoragePath } =
+        deps.fileHelper ?? defaultFileHelper;
 
     // Optional link-validation overrides (hermetic DNS/fetch for tests; empty in production)
     const linkValidation = deps.linkValidation ?? {};
@@ -1492,8 +1497,6 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                 const sourceAssets = await findAllAssetsForProject(db, project.id);
 
                 if (sourceAssets.length > 0) {
-                    const targetAssetsDir = getProjectAssetsDir(duplicateProject.uuid);
-
                     for (const asset of sourceAssets) {
                         if (!asset.client_id) continue;
 
@@ -1502,20 +1505,29 @@ export function createSymfonyCompatProjectRoutes(deps: ProjectDependencies = def
                         // alternate/legacy Yjs shapes or historical content fragments.
                         const duplicatedClientId = asset.client_id;
 
-                        // Copy physical file if it exists
+                        // Copy physical file if it exists. The stored path is
+                        // FILES_DIR-relative (legacy absolute values are handled
+                        // by the resolver); the copy is stored with a relative
+                        // sharded path under the new project's directory.
                         if (asset.storage_path) {
                             try {
-                                const sourceExists = await fs.pathExists(asset.storage_path);
-                                if (sourceExists) {
-                                    const targetFile = path.join(targetAssetsDir, duplicatedClientId, asset.filename);
+                                const sourcePath = tryResolveAssetStoragePath(asset.storage_path);
+                                const sourceExists = sourcePath ? await fs.pathExists(sourcePath) : false;
+                                if (sourcePath && sourceExists) {
+                                    const targetStoragePath = buildAssetStoragePath(
+                                        duplicateProject.uuid,
+                                        duplicatedClientId,
+                                        asset.filename,
+                                    );
+                                    const targetFile = resolveAssetStoragePath(targetStoragePath);
                                     await fs.ensureDir(path.dirname(targetFile));
-                                    await fs.copy(asset.storage_path, targetFile);
+                                    await fs.copy(sourcePath, targetFile);
 
                                     // Create new asset record with new client_id
                                     await createAsset(db, {
                                         project_id: duplicateProject.id,
                                         filename: asset.filename,
-                                        storage_path: targetFile,
+                                        storage_path: targetStoragePath,
                                         mime_type: asset.mime_type,
                                         file_size: asset.file_size,
                                         client_id: duplicatedClientId,

--- a/src/routes/upload-session.spec.ts
+++ b/src/routes/upload-session.spec.ts
@@ -6,6 +6,7 @@ import { Elysia } from 'elysia';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { createUploadSessionRoutes, type UploadSessionDependencies } from './upload-session';
+import { buildAssetStoragePath, getAssetShard } from '../utils/asset-paths';
 import {
     createUploadSessionManager,
     validateSession,
@@ -313,7 +314,7 @@ describe('Upload Session Routes - Integration', () => {
 
     it('should accept batch upload with valid session and single file', async () => {
         // Create assets directory
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -339,8 +340,50 @@ describe('Upload Session Routes - Integration', () => {
         expect(data.failed).toBe(0);
     });
 
+    it('should persist a FILES_DIR-relative sharded storage_path (issue #2250)', async () => {
+        const capturingQueries = {
+            createAssets: mock((_db: Kysely<Database>, assets: Array<{ client_id: string }>) =>
+                Promise.resolve(assets.map((a, i) => ({ id: i + 900, client_id: a.client_id }))),
+            ),
+            findAssetsByClientIds: mock(() => Promise.resolve([])),
+            bulkUpdateAssets: mock(() => Promise.resolve()),
+            findProjectByUuid: mock(() => Promise.resolve({ id: 42, uuid: projectUuid, user_id: 1 })),
+        };
+        const capturingApp = new Elysia().use(
+            createUploadSessionRoutes({
+                db: createMockDb(),
+                queries: capturingQueries as unknown as UploadSessionDependencies['queries'],
+            }),
+        );
+
+        const formData = new FormData();
+        formData.append(
+            'metadata',
+            JSON.stringify([{ clientId: 'sharded-asset-1', filename: 'photo.png', mimeType: 'image/png' }]),
+        );
+        formData.append('files', new Blob(['sharded bytes'], { type: 'image/png' }));
+
+        const response = await capturingApp.handle(
+            new Request(`http://localhost/api/upload-session/${sessionToken}/batch`, {
+                method: 'POST',
+                body: formData,
+            }),
+        );
+        expect(response.status).toBe(200);
+
+        const created = capturingQueries.createAssets.mock.calls[0][1] as unknown as Array<{
+            storage_path: string;
+        }>;
+        expect(created[0].storage_path).toBe(buildAssetStoragePath(projectUuid, 'sharded-asset-1.png'));
+        expect(path.isAbsolute(created[0].storage_path)).toBe(false);
+
+        // The physical file lives in the sharded directory, created lazily.
+        const physical = path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid, 'sharded-asset-1.png');
+        expect(await fs.pathExists(physical)).toBe(true);
+    });
+
     it('should accept batch upload with multiple files', async () => {
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -373,7 +416,7 @@ describe('Upload Session Routes - Integration', () => {
     });
 
     it('should accept batch upload without X-Upload-Session header', async () => {
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -396,7 +439,7 @@ describe('Upload Session Routes - Integration', () => {
     });
 
     it('should handle metadata as array instead of string', async () => {
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         // This tests the case where metadata is already parsed as array
         const formData = new FormData();
@@ -417,7 +460,7 @@ describe('Upload Session Routes - Integration', () => {
     });
 
     it('should handle file upload with missing metadata fields', async () => {
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         // Metadata with minimal fields
@@ -437,7 +480,7 @@ describe('Upload Session Routes - Integration', () => {
     });
 
     it('should handle file upload with folderPath', async () => {
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -517,7 +560,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -564,7 +607,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -606,7 +649,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -625,7 +668,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         expect(response.status).toBe(200);
 
         // Verify the file was created with correct extension
-        const files = await fs.readdir(path.join(TEST_DIR, 'assets', projectUuid));
+        const files = await fs.readdir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
         expect(files.some(f => f.endsWith('.jpg'))).toBe(true);
     });
 
@@ -645,7 +688,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -688,7 +731,7 @@ describe('Upload Session Routes - Edge Cases', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -714,7 +757,7 @@ describe('Upload Session Routes - Path Traversal Security (C1)', () => {
     let sessionToken: string;
     let mockQueries: ReturnType<typeof createMockQueries>;
     const projectUuid = 'traversal-security-project';
-    const assetsDir = path.join(TEST_DIR, 'assets', projectUuid);
+    const assetsDir = path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid);
 
     beforeEach(async () => {
         await fs.ensureDir(TEST_DIR);
@@ -870,7 +913,7 @@ describe('Upload Session Routes - Batch Size Limit (L1, memory DoS)', () => {
     let sessionToken: string;
     let mockQueries: ReturnType<typeof createMockQueries>;
     const projectUuid = 'batch-size-limit-project';
-    const assetsDir = path.join(TEST_DIR, 'assets', projectUuid);
+    const assetsDir = path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid);
 
     beforeEach(async () => {
         await fs.ensureDir(TEST_DIR);
@@ -1065,7 +1108,7 @@ describe('Upload Session Routes - Error Handling', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         // Create a large blob (we'll use multiple files that exceed MAX_BATCH_BYTES in total)
         // MAX_BATCH_BYTES is 100MB, so we create files that exceed this
@@ -1115,7 +1158,7 @@ describe('Upload Session Routes - Error Handling', () => {
 
         // Create an unwritable directory (by making it read-only or non-existent parent)
         // We'll use a path that will fail to write
-        const badPath = path.join(TEST_DIR, 'assets', projectUuid);
+        const badPath = path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid);
         await fs.ensureDir(badPath);
         // Create a file with the same name as what we'll try to write
         const blockingFilePath = path.join(badPath, 'blocking-asset');
@@ -1161,7 +1204,7 @@ describe('Upload Session Routes - Error Handling', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -1200,7 +1243,7 @@ describe('Upload Session Routes - Error Handling', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -1238,7 +1281,7 @@ describe('Upload Session Routes - Error Handling', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         formData.append(
@@ -1277,7 +1320,7 @@ describe('Upload Session Routes - Error Handling', () => {
         });
 
         app = new Elysia().use(routes);
-        await fs.ensureDir(path.join(TEST_DIR, 'assets', projectUuid));
+        await fs.ensureDir(path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid));
 
         const formData = new FormData();
         // Empty metadata array - will use defaults
@@ -1316,7 +1359,7 @@ describe('Upload Session Routes - Error Handling', () => {
         app = new Elysia().use(routes);
 
         // Create a path that will cause write to fail
-        const assetDir = path.join(TEST_DIR, 'assets', projectUuid);
+        const assetDir = path.join(TEST_DIR, 'assets', getAssetShard(projectUuid), projectUuid);
         await fs.ensureDir(assetDir);
         // Make the directory read-only to cause write failure
         await fs.chmod(assetDir, 0o444);

--- a/src/routes/upload-session.ts
+++ b/src/routes/upload-session.ts
@@ -12,14 +12,16 @@
  */
 import { Elysia } from 'elysia';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 import type { Kysely } from 'kysely';
 
 import { db } from '../db/client';
 import type { Database } from '../db/types';
 import { createAssets, findAssetsByClientIds, bulkUpdateAssets, findProjectByUuid } from '../db/queries';
 
-import { getProjectAssetsDir } from '../services/file-helper';
-import { isSafePathSegment, safeJoin, sanitizeFileExtension } from '../utils/safe-path';
+import { resolveAssetStoragePath } from '../services/file-helper';
+import { isSafePathSegment, sanitizeFileExtension } from '../utils/safe-path';
+import { buildAssetStoragePath } from '../utils/asset-paths';
 import {
     uploadSessionManager,
     validateSession,
@@ -186,9 +188,9 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         }
                     }
 
-                    // Get base storage path using project UUID
-                    const baseStoragePath = getProjectAssetsDir(session.projectId);
-                    await fs.ensureDir(baseStoragePath);
+                    // Storage paths are derived from the session's project UUID:
+                    // assets/<shard>/<projectUuid>/<clientId>.<ext> relative to
+                    // FILES_DIR, resolved to a physical path per file below.
 
                     // =====================================================
                     // PHASE 1: Convert files to buffers sequentially, aborting early
@@ -205,6 +207,7 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         folderPath: string;
                         fileBuffer: Buffer;
                         filePath: string;
+                        storagePath: string;
                         flatFilename: string;
                     };
                     const fileData: BufferedFile[] = [];
@@ -245,11 +248,13 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         }
 
                         // Use clientId as filename with original extension. clientId was validated as a
-                        // safe path segment above; safeJoin re-validates and asserts containment so a
-                        // crafted clientId or extension cannot escape the project assets directory.
+                        // safe path segment above; buildAssetStoragePath re-validates every segment and
+                        // resolveAssetStoragePath asserts containment, so a crafted clientId or extension
+                        // cannot escape the project assets directory.
                         const ext = sanitizeFileExtension(filename);
                         const flatFilename = `${fileMeta.clientId}${ext}`;
-                        const filePath = safeJoin(baseStoragePath, flatFilename);
+                        const storagePath = buildAssetStoragePath(session.projectId, flatFilename);
+                        const filePath = resolveAssetStoragePath(storagePath);
 
                         fileData.push({
                             clientId: fileMeta.clientId,
@@ -258,8 +263,15 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             folderPath,
                             fileBuffer,
                             filePath,
+                            storagePath,
                             flatFilename,
                         });
+                    }
+
+                    // Lazy directory creation: the sharded project directory is
+                    // created only when there is something to write.
+                    if (fileData.length > 0) {
+                        await fs.ensureDir(path.dirname(fileData[0].filePath));
                     }
 
                     // =====================================================
@@ -369,7 +381,7 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             toUpdate.push({
                                 id: existing.id,
                                 data: {
-                                    storage_path: data.filePath,
+                                    storage_path: data.storagePath,
                                     file_size: String(data.fileBuffer.length),
                                     folder_path: data.folderPath,
                                 },
@@ -383,7 +395,7 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                             toCreate.push({
                                 project_id: session.projectIdNum,
                                 filename: data.filename,
-                                storage_path: data.filePath,
+                                storage_path: data.storagePath,
                                 mime_type: data.mimeType,
                                 file_size: String(data.fileBuffer.length),
                                 component_id: null,

--- a/src/routes/upload-session.ts
+++ b/src/routes/upload-session.ts
@@ -19,7 +19,7 @@ import { db } from '../db/client';
 import type { Database } from '../db/types';
 import { createAssets, findAssetsByClientIds, bulkUpdateAssets, findProjectByUuid } from '../db/queries';
 
-import { resolveAssetStoragePath } from '../services/file-helper';
+import { resolveAssetStoragePath, tryResolveAssetStoragePath, remove } from '../services/file-helper';
 import { isSafePathSegment, sanitizeFileExtension } from '../utils/safe-path';
 import { buildAssetStoragePath } from '../utils/asset-paths';
 import {
@@ -378,6 +378,15 @@ export function createUploadSessionRoutes(deps: UploadSessionDependencies = defa
                         const existing = existingMap.get(data.clientId);
 
                         if (existing) {
+                            // A relocating update (row still pointing at a legacy
+                            // or conflict-parked location) must not leave the
+                            // superseded file behind as an untracked orphan.
+                            if (existing.storage_path && existing.storage_path !== data.storagePath) {
+                                const oldPath = tryResolveAssetStoragePath(existing.storage_path);
+                                if (oldPath && oldPath !== data.filePath) {
+                                    await remove(oldPath).catch(() => {});
+                                }
+                            }
                             toUpdate.push({
                                 id: existing.id,
                                 data: {

--- a/src/services/asset-storage-migration.spec.ts
+++ b/src/services/asset-storage-migration.spec.ts
@@ -366,6 +366,7 @@ describe('asset-storage-migration', () => {
 
     it('skips rows whose stored path cannot be interpreted, without touching the filesystem', async () => {
         const projectId = await seedProject();
+        await fs.ensureDir(path.join(filesDir, 'assets')); // storage is mounted
         await assetQueries.createAsset(db, {
             project_id: projectId,
             filename: 'weird.bin',
@@ -388,6 +389,7 @@ describe('asset-storage-migration', () => {
 
     it('rejects traversal attempts embedded in stored paths', async () => {
         const projectId = await seedProject();
+        await fs.ensureDir(path.join(filesDir, 'assets')); // storage is mounted
         await assetQueries.createAsset(db, {
             project_id: projectId,
             filename: 'evil.png',
@@ -489,6 +491,63 @@ describe('asset-storage-migration', () => {
         expect(second.orphanedFilesMoved).toBe(0);
         expect(second.skippedEntries).toBe(0);
         expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'once.png'))).toBe(true);
+    });
+
+    it('sweeps a two-digit legacy numeric directory (project ids 10-99) that is not a real bucket', async () => {
+        // Force a two-digit project id so the legacy directory name collides
+        // with the two-hex shard bucket namespace.
+        const projectId = await seedProject();
+        await db.updateTable('projects').set({ id: 42 }).where('id', '=', projectId).execute();
+
+        const orphan = path.join(filesDir, 'assets', '42', 'orphan.png');
+        await fs.ensureDir(path.dirname(orphan));
+        await fs.writeFile(orphan, 'numeric orphan');
+
+        const summary = await runMigration();
+
+        expect(summary.orphanedFilesMoved).toBe(1);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'orphan.png'))).toBe(true);
+        expect(await fs.pathExists(path.join(filesDir, 'assets', '42'))).toBe(false);
+    });
+
+    it('does not mistake a genuine two-digit shard bucket for a legacy numeric directory', async () => {
+        const projectId = await seedProject();
+        await db.updateTable('projects').set({ id: 42 }).where('id', '=', projectId).execute();
+
+        // A real bucket '42' containing a project directory that shards to '42'.
+        const bucketUuid = '42aabbcc-1234-4abc-8def-1234567890ab';
+        const inBucket = path.join(filesDir, 'assets', '42', bucketUuid, 'f.png');
+        await fs.ensureDir(path.dirname(inBucket));
+        await fs.writeFile(inBucket, 'sharded bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.orphanedFilesMoved).toBe(0);
+        expect(await fs.pathExists(inBucket)).toBe(true);
+    });
+
+    it('skips migration entirely when legacy rows exist but the assets root is missing (unmounted volume)', async () => {
+        const projectId = await seedProject();
+        const row = await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'unmounted.png',
+            storage_path: `/mnt/data/assets/${PROJECT_UUID}/unmounted.png`,
+            mime_type: 'image/png',
+            file_size: '4',
+            client_id: 'unmounted',
+            folder_path: '',
+        });
+        // No file is written: filesDir/assets does not exist at all.
+
+        const summary = await runMigration();
+
+        expect(summary.scannedRows).toBe(0);
+        expect(summary.rewrittenRows).toBe(0);
+        expect(summary.missingFiles).toBe(0);
+        expect(warnMessages.join('\n')).toContain('assets root');
+        // The row keeps its original pointer for the next (mounted) startup.
+        const after = await assetQueries.findAssetById(db, row.id);
+        expect(after!.storage_path).toBe(`/mnt/data/assets/${PROJECT_UUID}/unmounted.png`);
     });
 
     // =========================================================================

--- a/src/services/asset-storage-migration.spec.ts
+++ b/src/services/asset-storage-migration.spec.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
+import { now } from '../db/types';
 import { createTestDb, cleanTestDb, destroyTestDb, seedTestUser, seedTestProject } from '../../test/helpers/test-db';
 import * as assetQueries from '../db/queries/assets';
 import { getAssetShard, tryResolveAssetStoragePath } from '../utils/asset-paths';
@@ -548,6 +549,129 @@ describe('asset-storage-migration', () => {
         // The row keeps its original pointer for the next (mounted) startup.
         const after = await assetQueries.findAssetById(db, row.id);
         expect(after!.storage_path).toBe(`/mnt/data/assets/${PROJECT_UUID}/unmounted.png`);
+    });
+
+    // =========================================================================
+    // Progress logging
+    // =========================================================================
+
+    /**
+     * Bulk-insert legacy asset rows WITHOUT files on disk. The missing-file
+     * path is the cheapest way to drive row volume through phase 1: every row
+     * is scanned, counted as missing and rewritten, with no filesystem moves.
+     * Mirrors the column set used by assetQueries.createAsset (timestamps
+     * included) so the rows are valid for every dialect.
+     */
+    async function bulkInsertLegacyAssets(projectId: number, count: number): Promise<void> {
+        const timestamp = now();
+        const rows = Array.from({ length: count }, (_, i) => ({
+            project_id: projectId,
+            filename: `bulk-${i}.png`,
+            storage_path: path.join(filesDir, 'assets', PROJECT_UUID, `bulk-${i}.png`),
+            mime_type: 'image/png',
+            file_size: '0',
+            client_id: `bulk-client-${i}`,
+            folder_path: '',
+            created_at: timestamp,
+            updated_at: timestamp,
+        }));
+        const chunkSize = 500;
+        for (let offset = 0; offset < rows.length; offset += chunkSize) {
+            await db
+                .insertInto('assets')
+                .values(rows.slice(offset, offset + chunkSize))
+                .execute();
+        }
+    }
+
+    it('emits a progress line every 1,000 processed rows during a large migration', async () => {
+        const projectId = await seedProject();
+        // The assets root must exist or the missing-assets-root safety latch
+        // skips the whole run.
+        await fs.ensureDir(path.join(filesDir, 'assets'));
+        await bulkInsertLegacyAssets(projectId, 1500);
+
+        const summary = await runMigration();
+
+        const progressLines = logMessages.filter(message => message.includes('Migration progress'));
+        expect(progressLines).toEqual([
+            '[AssetStorage] Migration progress: 1,000/1,500 legacy row(s) processed, 500 pending.',
+        ]);
+        expect(summary.scannedRows).toBe(1500);
+        expect(summary.missingFiles).toBe(1500);
+        expect(logMessages.join('\n')).toContain('Migration summary');
+    });
+
+    it('emits a progress line with zero pending at an exact interval boundary', async () => {
+        const projectId = await seedProject();
+        await fs.ensureDir(path.join(filesDir, 'assets'));
+        await bulkInsertLegacyAssets(projectId, 1000);
+
+        await runMigration();
+
+        const progressLines = logMessages.filter(message => message.includes('Migration progress'));
+        expect(progressLines).toEqual([
+            '[AssetStorage] Migration progress: 1,000/1,000 legacy row(s) processed, 0 pending.',
+        ]);
+    });
+
+    it('runs a single legacy-row query on a converged startup (the total count is lazy)', async () => {
+        await seedProject();
+        await fs.ensureDir(path.join(filesDir, 'assets'));
+
+        let selectQueries = 0;
+        const countingDb = new Proxy(db, {
+            get(target, prop) {
+                if (prop === 'selectFrom') {
+                    return (...args: unknown[]) => {
+                        selectQueries++;
+                        return (target.selectFrom as (...a: unknown[]) => unknown).apply(target, args);
+                    };
+                }
+                const value = Reflect.get(target, prop, target);
+                return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+            },
+        }) as Kysely<Database>;
+
+        const summary = await runMigration({ db: countingDb });
+
+        expect(summary.scannedRows).toBe(0);
+        // Only the (empty) phase 1 batch query; the progress total COUNT must
+        // not run when there is no legacy work.
+        expect(selectQueries).toBe(1);
+    });
+
+    it('does not emit progress below the interval', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['small-1.png'], 'one', { client_id: 'small-1' });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['small-2.png'], 'two', { client_id: 'small-2' });
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(2);
+        expect(logMessages.filter(message => message.includes('Migration progress'))).toHaveLength(0);
+        expect(logMessages.join('\n')).toContain('Migration summary');
+    });
+
+    it('does not emit progress on a converged installation', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['conv-1.png'], 'one', { client_id: 'conv-1' });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['conv-2.png'], 'two', { client_id: 'conv-2' });
+        await runMigration();
+
+        // Second run over the converged installation.
+        logMessages.length = 0;
+        await runMigration();
+        expect(logMessages.filter(message => message.includes('Migration progress'))).toHaveLength(0);
+        expect(logMessages.join('\n')).toContain('up to date');
+
+        // A completely fresh installation (no rows, no assets root) is silent too.
+        await cleanTestDb(db);
+        const freshDir = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-migration-fresh-'));
+        logMessages.length = 0;
+        await runMigration({ getFilesDir: () => freshDir });
+        expect(logMessages.filter(message => message.includes('Migration progress'))).toHaveLength(0);
+        expect(logMessages.join('\n')).toContain('up to date');
     });
 
     // =========================================================================

--- a/src/services/asset-storage-migration.spec.ts
+++ b/src/services/asset-storage-migration.spec.ts
@@ -1,0 +1,517 @@
+/**
+ * Tests for the asset storage layout migration (issue #2250).
+ *
+ * Covers the one-time (but idempotent, restart-safe) startup migration from
+ * the legacy layout
+ *
+ *     FILES_DIR/assets/<projectUuid>/...        + absolute storage_path
+ *
+ * to the sharded layout
+ *
+ *     FILES_DIR/assets/<shard>/<projectUuid>/...  + FILES_DIR-relative storage_path
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import type { Kysely } from 'kysely';
+import type { Database } from '../db/types';
+import { createTestDb, cleanTestDb, destroyTestDb, seedTestUser, seedTestProject } from '../../test/helpers/test-db';
+import * as assetQueries from '../db/queries/assets';
+import { getAssetShard, tryResolveAssetStoragePath } from '../utils/asset-paths';
+import { migrateAssetStorage, type AssetStorageMigrationSummary } from './asset-storage-migration';
+
+describe('asset-storage-migration', () => {
+    let db: Kysely<Database>;
+    let filesDir: string;
+    let userId: number;
+    let logMessages: string[];
+    let warnMessages: string[];
+
+    const PROJECT_UUID = 'ab12cd34-1234-4abc-8def-1234567890ab';
+    const SHARD = getAssetShard(PROJECT_UUID); // 'ab'
+
+    beforeAll(async () => {
+        db = await createTestDb();
+    });
+
+    afterAll(async () => {
+        await destroyTestDb(db);
+    });
+
+    beforeEach(async () => {
+        await cleanTestDb(db);
+        userId = await seedTestUser(db);
+        filesDir = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-migration-test-'));
+        logMessages = [];
+        warnMessages = [];
+    });
+
+    async function runMigration(overrides: Record<string, unknown> = {}): Promise<AssetStorageMigrationSummary> {
+        return migrateAssetStorage({
+            db,
+            getFilesDir: () => filesDir,
+            log: (message: string) => logMessages.push(message),
+            warn: (message: string) => warnMessages.push(message),
+            ...overrides,
+        });
+    }
+
+    async function seedProject(uuid: string = PROJECT_UUID): Promise<number> {
+        return seedTestProject(db, userId, { uuid, title: `Project ${uuid}` });
+    }
+
+    async function writeLegacyFile(uuid: string, relSegments: string[], content: string): Promise<string> {
+        const abs = path.join(filesDir, 'assets', uuid, ...relSegments);
+        await fs.ensureDir(path.dirname(abs));
+        await fs.writeFile(abs, content);
+        return abs;
+    }
+
+    async function seedLegacyAsset(
+        projectId: number,
+        uuid: string,
+        relSegments: string[],
+        content: string,
+        overrides: Record<string, unknown> = {},
+    ) {
+        const abs = await writeLegacyFile(uuid, relSegments, content);
+        return assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: relSegments[relSegments.length - 1],
+            storage_path: abs,
+            mime_type: 'application/octet-stream',
+            file_size: String(content.length),
+            client_id: relSegments[0].replace(/\..*$/, ''),
+            folder_path: '',
+            ...overrides,
+        });
+    }
+
+    function shardedPath(uuid: string, ...relSegments: string[]): string {
+        return path.join(filesDir, 'assets', getAssetShard(uuid), uuid, ...relSegments);
+    }
+
+    // =========================================================================
+    // Normal migration
+    // =========================================================================
+
+    it('migrates a flat legacy asset: moves the file and rewrites the row to a relative path', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['client-1.png'], 'flat bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(1);
+        expect(summary.rewrittenRows).toBe(1);
+        expect(summary.errors).toBe(0);
+
+        // File moved to the sharded location; legacy location gone.
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'client-1.png'))).toBe(true);
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID, 'client-1.png'))).toBe(false);
+        expect((await fs.readFile(shardedPath(PROJECT_UUID, 'client-1.png'))).toString()).toBe('flat bytes');
+
+        // Row rewritten to the canonical relative representation.
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/client-1.png`);
+        expect(path.isAbsolute(row!.storage_path)).toBe(false);
+
+        // The rewritten row resolves through the shared resolver.
+        expect(tryResolveAssetStoragePath(filesDir, row!.storage_path)).toBe(shardedPath(PROJECT_UUID, 'client-1.png'));
+    });
+
+    it('migrates the nested ZIP-extraction layout (clientId/filename)', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['client-zip-1', 'index.html'], '<html></html>');
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(1);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'client-zip-1', 'index.html'))).toBe(true);
+
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/client-zip-1/index.html`);
+    });
+
+    it('empties and removes the legacy project directory after migration', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['client-1.png'], 'a');
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['client-2', 'page.html'], 'b');
+
+        await runMigration();
+
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID))).toBe(false);
+    });
+
+    it('migrates filenames containing spaces, parentheses and unicode', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(
+            projectId,
+            PROJECT_UUID,
+            ['client-x', 'imágen ñ (copy 2).png'],
+            'unicode bytes',
+        );
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(1);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/client-x/imágen ñ (copy 2).png`);
+        const resolved = tryResolveAssetStoragePath(filesDir, row!.storage_path);
+        expect(resolved).not.toBeNull();
+        expect((await fs.readFile(resolved!)).toString()).toBe('unicode bytes');
+    });
+
+    it('migrates multiple projects in one run', async () => {
+        const uuidB = 'ffe0d5aa-d8d2-4a7b-bf6d-c809321ccc2a';
+        const projectA = await seedProject();
+        const projectB = await seedProject(uuidB);
+        await seedLegacyAsset(projectA, PROJECT_UUID, ['a.png'], 'aa');
+        await seedLegacyAsset(projectB, uuidB, ['b.png'], 'bb', { client_id: 'b-client' });
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(2);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'a.png'))).toBe(true);
+        expect(await fs.pathExists(shardedPath(uuidB, 'b.png'))).toBe(true);
+    });
+
+    it('processes rows in bounded batches', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['batch-1.png'], '1', { client_id: 'c1' });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['batch-2.png'], '2', { client_id: 'c2' });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['batch-3.png'], '3', { client_id: 'c3' });
+
+        const summary = await runMigration({ batchSize: 1 });
+
+        expect(summary.movedFiles).toBe(3);
+        expect(summary.rewrittenRows).toBe(3);
+    });
+
+    it('migrates a numeric legacy directory (rows written via numeric project id URLs)', async () => {
+        const projectId = await seedProject();
+        // Legacy quirk: uploads addressed by numeric id created assets/<numericId>/.
+        const abs = path.join(filesDir, 'assets', String(projectId), 'client-n.png');
+        await fs.ensureDir(path.dirname(abs));
+        await fs.writeFile(abs, 'numeric dir bytes');
+        const asset = await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'client-n.png',
+            storage_path: abs,
+            mime_type: 'image/png',
+            file_size: '17',
+            client_id: 'client-n',
+            folder_path: '',
+        });
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(1);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/client-n.png`);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'client-n.png'))).toBe(true);
+    });
+
+    // =========================================================================
+    // Idempotency / resumability
+    // =========================================================================
+
+    it('is idempotent: a second run makes no changes', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['idem.png'], 'idem');
+
+        await runMigration();
+        const second = await runMigration();
+
+        expect(second.scannedRows).toBe(0);
+        expect(second.movedFiles).toBe(0);
+        expect(second.rewrittenRows).toBe(0);
+        expect(second.errors).toBe(0);
+    });
+
+    it('reconciles a row whose file was already moved (crash between move and rewrite)', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['half.png'], 'half');
+        // Simulate the interrupted state: file at destination, row still legacy.
+        const dest = shardedPath(PROJECT_UUID, 'half.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.move(path.join(filesDir, 'assets', PROJECT_UUID, 'half.png'), dest);
+
+        const summary = await runMigration();
+
+        expect(summary.alreadyMigrated).toBe(1);
+        expect(summary.rewrittenRows).toBe(1);
+        expect(summary.movedFiles).toBe(0);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/half.png`);
+    });
+
+    it('continues a partially migrated project (some rows migrated, some not)', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['done.png'], 'done', { client_id: 'done-c' });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['todo.png'], 'todo', { client_id: 'todo-c' });
+
+        // Fully migrate the first asset by hand (file + row).
+        const dest = shardedPath(PROJECT_UUID, 'done.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.move(path.join(filesDir, 'assets', PROJECT_UUID, 'done.png'), dest);
+        const doneRow = await assetQueries.findAssetByClientId(db, 'done-c', projectId);
+        await db
+            .updateTable('assets')
+            .set({ storage_path: `assets/${SHARD}/${PROJECT_UUID}/done.png` })
+            .where('id', '=', doneRow!.id)
+            .execute();
+
+        const summary = await runMigration();
+
+        expect(summary.scannedRows).toBe(1);
+        expect(summary.movedFiles).toBe(1);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'todo.png'))).toBe(true);
+    });
+
+    it('rewrites a row that already points at the sharded location with an absolute path', async () => {
+        const projectId = await seedProject();
+        const dest = shardedPath(PROJECT_UUID, 'abs-sharded.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'abs sharded');
+        const asset = await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'abs-sharded.png',
+            storage_path: dest,
+            mime_type: 'image/png',
+            file_size: '11',
+            client_id: 'abs-sharded',
+            folder_path: '',
+        });
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(0);
+        expect(summary.rewrittenRows).toBe(1);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/abs-sharded.png`);
+        expect(await fs.pathExists(dest)).toBe(true);
+    });
+
+    // =========================================================================
+    // Missing files and conflicts
+    // =========================================================================
+
+    it('logs missing source files and continues instead of aborting', async () => {
+        const projectId = await seedProject();
+        const missing = await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'ghost.png',
+            storage_path: path.join(filesDir, 'assets', PROJECT_UUID, 'ghost.png'),
+            mime_type: 'image/png',
+            file_size: '0',
+            client_id: 'ghost',
+            folder_path: '',
+        });
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['real.png'], 'real', { client_id: 'real-c' });
+
+        const summary = await runMigration();
+
+        expect(summary.missingFiles).toBe(1);
+        expect(summary.movedFiles).toBe(1);
+        expect(summary.errors).toBe(0);
+
+        // The missing row is still rewritten so the table converges.
+        const row = await assetQueries.findAssetById(db, missing.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/ghost.png`);
+        expect(warnMessages.join('\n')).toContain('ghost.png');
+    });
+
+    it('removes the legacy copy when source and destination are identical', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['same.png'], 'identical bytes');
+        const dest = shardedPath(PROJECT_UUID, 'same.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'identical bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.conflicts).toBe(0);
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID, 'same.png'))).toBe(false);
+        expect(await fs.pathExists(dest)).toBe(true);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/same.png`);
+    });
+
+    it('never overwrites when source and destination differ: keeps both and reports the conflict', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['conflict.png'], 'legacy content');
+        const dest = shardedPath(PROJECT_UUID, 'conflict.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'different content');
+
+        const summary = await runMigration();
+
+        expect(summary.conflicts).toBe(1);
+        // Both files survive untouched.
+        const legacyFile = path.join(filesDir, 'assets', PROJECT_UUID, 'conflict.png');
+        expect((await fs.readFile(legacyFile)).toString()).toBe('legacy content');
+        expect((await fs.readFile(dest)).toString()).toBe('different content');
+        // The row is rewritten to the portable relative form of the legacy
+        // location, so it keeps pointing at the file it pointed at before.
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/conflict.png`);
+        expect(tryResolveAssetStoragePath(filesDir, row!.storage_path)).toBe(legacyFile);
+        expect(warnMessages.join('\n')).toContain('conflict.png');
+    });
+
+    // =========================================================================
+    // Safety
+    // =========================================================================
+
+    it('skips rows whose stored path cannot be interpreted, without touching the filesystem', async () => {
+        const projectId = await seedProject();
+        await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'weird.bin',
+            storage_path: '/etc/passwd',
+            mime_type: 'application/octet-stream',
+            file_size: '0',
+            client_id: 'weird',
+            folder_path: '',
+        });
+
+        const summary = await runMigration();
+
+        expect(summary.skippedRows).toBe(1);
+        expect(summary.movedFiles).toBe(0);
+        expect(warnMessages.length).toBeGreaterThan(0);
+        // The row is left untouched for the operator to inspect.
+        const row = await assetQueries.findAssetByClientId(db, 'weird', projectId);
+        expect(row!.storage_path).toBe('/etc/passwd');
+    });
+
+    it('rejects traversal attempts embedded in stored paths', async () => {
+        const projectId = await seedProject();
+        await assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename: 'evil.png',
+            storage_path: `/mnt/data/assets/${PROJECT_UUID}/../../../etc/passwd`,
+            mime_type: 'image/png',
+            file_size: '0',
+            client_id: 'evil',
+            folder_path: '',
+        });
+
+        const summary = await runMigration();
+
+        expect(summary.skippedRows).toBe(1);
+        expect(summary.movedFiles).toBe(0);
+        const row = await assetQueries.findAssetByClientId(db, 'evil', projectId);
+        expect(row!.storage_path).toContain('..');
+    });
+
+    it('falls back to copy+verify+remove when rename fails with EXDEV', async () => {
+        const projectId = await seedProject();
+        const asset = await seedLegacyAsset(projectId, PROJECT_UUID, ['xdev.png'], 'cross-device bytes');
+
+        // Simulate a cross-device boundary: the first rename of the real file
+        // fails with EXDEV; the temp-file rename that finalizes the copy is
+        // allowed through.
+        let exdevThrown = false;
+        const fsWithExdev = {
+            ...fs,
+            rename: async (src: string, dest: string) => {
+                if (!exdevThrown && !src.includes('.migrate-tmp-')) {
+                    exdevThrown = true;
+                    const err = new Error('EXDEV: cross-device link not permitted') as NodeJS.ErrnoException;
+                    err.code = 'EXDEV';
+                    throw err;
+                }
+                return fs.rename(src, dest);
+            },
+        } as typeof fs;
+
+        const summary = await runMigration({ fs: fsWithExdev });
+
+        expect(exdevThrown).toBe(true);
+        expect(summary.movedFiles).toBe(1);
+        expect(summary.errors).toBe(0);
+        expect((await fs.readFile(shardedPath(PROJECT_UUID, 'xdev.png'))).toString()).toBe('cross-device bytes');
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID, 'xdev.png'))).toBe(false);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/xdev.png`);
+    });
+
+    // =========================================================================
+    // Orphan sweep (files on disk without database rows)
+    // =========================================================================
+
+    it('sweeps orphaned files from a legacy project directory into the sharded layout', async () => {
+        await seedProject();
+        await writeLegacyFile(PROJECT_UUID, ['orphan.css'], 'orphan bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.orphanedFilesMoved).toBe(1);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'orphan.css'))).toBe(true);
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID))).toBe(false);
+    });
+
+    it('removes an empty legacy project directory', async () => {
+        await seedProject();
+        await fs.ensureDir(path.join(filesDir, 'assets', PROJECT_UUID));
+
+        const summary = await runMigration();
+
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID))).toBe(false);
+        expect(summary.errors).toBe(0);
+    });
+
+    it('leaves unrecognized entries in the assets root untouched', async () => {
+        await seedProject();
+        const strayDir = path.join(filesDir, 'assets', 'not-a-project-dir');
+        await fs.ensureDir(strayDir);
+        await fs.writeFile(path.join(strayDir, 'stray.txt'), 'stray');
+        const strayFile = path.join(filesDir, 'assets', 'loose-file.txt');
+        await fs.writeFile(strayFile, 'loose');
+
+        const summary = await runMigration();
+
+        expect(summary.skippedEntries).toBe(2);
+        expect(await fs.pathExists(path.join(strayDir, 'stray.txt'))).toBe(true);
+        expect(await fs.pathExists(strayFile)).toBe(true);
+    });
+
+    it('does not descend into shard bucket directories during the sweep', async () => {
+        const projectId = await seedProject();
+        await seedLegacyAsset(projectId, PROJECT_UUID, ['once.png'], 'once');
+
+        await runMigration();
+        const second = await runMigration();
+
+        // The sharded content produced by the first run is not re-processed.
+        expect(second.orphanedFilesMoved).toBe(0);
+        expect(second.skippedEntries).toBe(0);
+        expect(await fs.pathExists(shardedPath(PROJECT_UUID, 'once.png'))).toBe(true);
+    });
+
+    // =========================================================================
+    // No-op behavior
+    // =========================================================================
+
+    it('does nothing on a fresh installation (no assets root, no rows)', async () => {
+        const summary = await runMigration();
+
+        expect(summary.scannedRows).toBe(0);
+        expect(summary.movedFiles).toBe(0);
+        expect(summary.errors).toBe(0);
+        // Lazy creation: the migration must not create the assets root.
+        expect(await fs.pathExists(path.join(filesDir, 'assets'))).toBe(false);
+    });
+
+    it('does nothing for a project with no assets', async () => {
+        await seedProject();
+
+        const summary = await runMigration();
+
+        expect(summary.scannedRows).toBe(0);
+        expect(summary.movedFiles).toBe(0);
+        expect(await fs.pathExists(path.join(filesDir, 'assets'))).toBe(false);
+    });
+});

--- a/src/services/asset-storage-migration.ts
+++ b/src/services/asset-storage-migration.ts
@@ -92,6 +92,13 @@ const DEFAULT_BATCH_SIZE = 500;
 const SHARD_BUCKET = /^[0-9a-f]{2}$/;
 
 /**
+ * Two-DIGIT names are ambiguous: they are valid shard buckets AND possible
+ * legacy numeric project-id directories (ids 10-99, from routes that used the
+ * raw numeric URL parameter as the directory name).
+ */
+const DECIMAL_BUCKET = /^\d{2}$/;
+
+/**
  * Move a file, preferring an atomic rename. On EXDEV (cross-device link, e.g.
  * bind mounts inside FILES_DIR) falls back to copy-to-temp + rename + verify +
  * remove, so the destination never holds a partially written file.
@@ -232,6 +239,26 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
         skippedEntries: 0,
         errors: 0,
     };
+
+    // Safety latch: if legacy rows exist but the assets root itself does not,
+    // the storage volume is almost certainly unmounted or FILES_DIR is
+    // mis-pointed. Rewriting rows in that state would discard their original
+    // pointers and 404 every asset — skip the whole run and retry next boot.
+    if (!(await fs.pathExists(assetsRoot))) {
+        const legacyRow = await db
+            .selectFrom('assets')
+            .select('assets.id')
+            .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+            .limit(1)
+            .executeTakeFirst();
+        if (legacyRow) {
+            warn(
+                `[AssetStorage] Legacy asset rows exist but the assets root '${assetsRoot}' does not exist; ` +
+                    `skipping migration this startup. Check that the storage volume is mounted and FILES_DIR is correct.`,
+            );
+            return summary;
+        }
+    }
 
     // =========================================================================
     // Phase 1: row-driven migration.
@@ -384,10 +411,31 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
             warn(`[AssetStorage] Could not read assets root ${assetsRoot}: ${err}`);
         }
 
+        // A directory is only skipped as a shard bucket when its contents look
+        // like sharded project directories: every entry is a directory whose
+        // name shards to this bucket. Legacy numeric project-id directories
+        // (flat asset files, or client-id subdirectories that shard elsewhere)
+        // fail this test and fall through to the sweep.
+        const looksLikeShardBucket = async (dir: string, bucketName: string): Promise<boolean> => {
+            try {
+                const entries = await fs.readdir(dir, { withFileTypes: true });
+                return entries.every(entry => entry.isDirectory() && getAssetShard(entry.name) === bucketName);
+            } catch {
+                return true; // unreadable: leave it alone
+            }
+        };
+
         for (const entry of rootEntries) {
             const entryName = entry.name;
             if (entry.isDirectory() && SHARD_BUCKET.test(entryName)) {
-                continue; // canonical shard bucket
+                if (
+                    !DECIMAL_BUCKET.test(entryName) ||
+                    (await looksLikeShardBucket(path.join(assetsRoot, entryName), entryName))
+                ) {
+                    continue; // canonical shard bucket
+                }
+                // Two-digit directory with non-bucket contents: treat it as a
+                // legacy numeric project-id directory below.
             }
             if (!entry.isDirectory()) {
                 summary.skippedEntries++;

--- a/src/services/asset-storage-migration.ts
+++ b/src/services/asset-storage-migration.ts
@@ -1,0 +1,513 @@
+/**
+ * Asset storage layout migration (issue #2250, ADR-2250-01).
+ *
+ * Converges existing installations from the legacy layout
+ *
+ *     FILES_DIR/assets/<projectUuid>/...        with absolute storage_path rows
+ *
+ * to the canonical sharded layout
+ *
+ *     FILES_DIR/assets/<shard>/<projectUuid>/... with FILES_DIR-relative rows
+ *
+ * Design constraints (see the ADR for the rationale):
+ *
+ * - This is deliberately NOT a Kysely schema migration. Filesystem moves and
+ *   database updates cannot share one transaction, so the migration is written
+ *   as an idempotent, resumable reconciliation that runs at every startup
+ *   (after schema migrations, before the server starts listening) and is a
+ *   fast no-op once everything has converged.
+ * - Per-row protocol: move the file first, then rewrite the row with an
+ *   optimistic `WHERE storage_path = <old>` guard. A crash between the two
+ *   steps leaves a state ("file at destination, row still legacy") that the
+ *   next run reconciles. The guard also makes concurrent execution by several
+ *   app instances safe: exactly one instance wins each row, the others
+ *   re-observe an already-converged state.
+ * - Never overwrite: when source and destination both exist with different
+ *   content, both files are kept, the conflict is reported, and the row is
+ *   rewritten to the portable relative form of its CURRENT (legacy) location.
+ * - Missing files are logged and the row is rewritten to the canonical target
+ *   so the table converges; reads treat the row exactly like before (404).
+ * - Rows whose stored value cannot be interpreted safely (no `assets/...`
+ *   suffix, traversal attempts) are left untouched and reported.
+ */
+import * as fsExtra from 'fs-extra';
+import * as pathModule from 'path';
+import * as cryptoModule from 'crypto';
+import type { Kysely } from 'kysely';
+import { db as defaultDb } from '../db/client';
+import type { Database } from '../db/types';
+import { now } from '../db/types';
+import { getFilesDir as defaultGetFilesDir } from './file-helper';
+import {
+    ASSETS_ROOT_DIR_NAME,
+    buildAssetStoragePath,
+    extractAssetsRelativeSegments,
+    getAssetShard,
+    isCanonicalAssetStoragePath,
+    tryResolveAssetStoragePath,
+} from '../utils/asset-paths';
+
+/**
+ * Result counters for one migration run. All counters are 0 on a fully
+ * converged installation.
+ */
+export interface AssetStorageMigrationSummary {
+    /** Legacy rows (storage_path not in the canonical relative form) examined. */
+    scannedRows: number;
+    /** Files physically moved to the sharded location. */
+    movedFiles: number;
+    /** Rows rewritten to a FILES_DIR-relative storage_path. */
+    rewrittenRows: number;
+    /** Rows whose file was already at the destination (crash recovery). */
+    alreadyMigrated: number;
+    /** Rows whose file exists at neither the legacy nor the sharded location. */
+    missingFiles: number;
+    /** Source/destination pairs with different content; both kept. */
+    conflicts: number;
+    /** Rows left untouched because their stored value is uninterpretable. */
+    skippedRows: number;
+    /** Files without database rows swept into the sharded layout. */
+    orphanedFilesMoved: number;
+    /** Unrecognized assets-root entries left in place. */
+    skippedEntries: number;
+    /** I/O or database errors; the affected items are retried on next startup. */
+    errors: number;
+}
+
+/**
+ * Injectable dependencies (DI pattern used across src/services).
+ */
+export interface AssetStorageMigrationDeps {
+    db?: Kysely<Database>;
+    fs?: typeof fsExtra;
+    getFilesDir?: () => string;
+    log?: (message: string) => void;
+    warn?: (message: string) => void;
+    /** Rows fetched per query; bounds memory on large installations. */
+    batchSize?: number;
+}
+
+const DEFAULT_BATCH_SIZE = 500;
+
+const SHARD_BUCKET = /^[0-9a-f]{2}$/;
+
+/**
+ * Move a file, preferring an atomic rename. On EXDEV (cross-device link, e.g.
+ * bind mounts inside FILES_DIR) falls back to copy-to-temp + rename + verify +
+ * remove, so the destination never holds a partially written file.
+ */
+async function moveFile(fs: typeof fsExtra, src: string, dest: string): Promise<void> {
+    try {
+        await fs.rename(src, dest);
+        return;
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EXDEV') {
+            throw err;
+        }
+    }
+    const tmp = `${dest}.migrate-tmp-${process.pid}-${cryptoModule.randomBytes(4).toString('hex')}`;
+    try {
+        await fs.copy(src, tmp);
+        const [srcStat, tmpStat] = await Promise.all([fs.stat(src), fs.stat(tmp)]);
+        if (srcStat.size !== tmpStat.size) {
+            throw new Error(`copy size mismatch moving ${src}`);
+        }
+        await fs.rename(tmp, dest);
+    } catch (err) {
+        await fs.remove(tmp).catch(() => {});
+        throw err;
+    }
+    await fs.remove(src);
+}
+
+/**
+ * Compare two files by size and SHA-256 content hash (streamed).
+ */
+async function filesAreIdentical(fs: typeof fsExtra, a: string, b: string): Promise<boolean> {
+    const [statA, statB] = await Promise.all([fs.stat(a), fs.stat(b)]);
+    if (statA.size !== statB.size) {
+        return false;
+    }
+    const hashFile = (filePath: string): Promise<string> =>
+        new Promise((resolve, reject) => {
+            const hash = cryptoModule.createHash('sha256');
+            const stream = fs.createReadStream(filePath);
+            stream.on('error', reject);
+            stream.on('data', chunk => hash.update(chunk));
+            stream.on('end', () => resolve(hash.digest('hex')));
+        });
+    const [hashA, hashB] = await Promise.all([hashFile(a), hashFile(b)]);
+    return hashA === hashB;
+}
+
+/**
+ * Rewrite one row's storage_path with an optimistic concurrency guard.
+ * Returns true when this call performed the update.
+ */
+async function rewriteRow(db: Kysely<Database>, id: number, oldPath: string, newPath: string): Promise<boolean> {
+    const result = await db
+        .updateTable('assets')
+        .set({ storage_path: newPath, updated_at: now() })
+        .where('id', '=', id)
+        .where('storage_path', '=', oldPath)
+        .execute();
+    return Number(result[0]?.numUpdatedRows ?? 0) > 0;
+}
+
+/**
+ * Remove a directory tree that contains no files (post-order). Leaves the
+ * tree untouched if any file remains anywhere inside it.
+ */
+async function removeDirIfEmpty(fs: typeof fsExtra, path: typeof pathModule, dir: string): Promise<boolean> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    let empty = true;
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            const removed = await removeDirIfEmpty(fs, path, path.join(dir, entry.name));
+            if (!removed) {
+                empty = false;
+            }
+        } else {
+            empty = false;
+        }
+    }
+    if (empty) {
+        await fs.rmdir(dir);
+    }
+    return empty;
+}
+
+/**
+ * Recursively list files under `dir` as relative segment arrays.
+ */
+async function listFilesRecursive(
+    fs: typeof fsExtra,
+    path: typeof pathModule,
+    dir: string,
+    prefix: string[] = [],
+): Promise<string[][]> {
+    const files: string[][] = [];
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            files.push(...(await listFilesRecursive(fs, path, path.join(dir, entry.name), [...prefix, entry.name])));
+        } else if (entry.isFile()) {
+            files.push([...prefix, entry.name]);
+        }
+    }
+    return files;
+}
+
+interface LegacyRow {
+    id: number;
+    storage_path: string;
+    project_uuid: string;
+}
+
+/**
+ * Run the asset storage layout migration. Idempotent, resumable, safe to run
+ * concurrently, and a fast no-op once the installation has converged.
+ */
+export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}): Promise<AssetStorageMigrationSummary> {
+    const db = deps.db ?? defaultDb;
+    const fs = deps.fs ?? fsExtra;
+    const path = pathModule;
+    const getFilesDir = deps.getFilesDir ?? defaultGetFilesDir;
+    const log = deps.log ?? ((message: string) => console.log(message));
+    const warn = deps.warn ?? ((message: string) => console.warn(message));
+    const batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    const filesDir = getFilesDir();
+    const assetsRoot = path.join(filesDir, ASSETS_ROOT_DIR_NAME);
+
+    const summary: AssetStorageMigrationSummary = {
+        scannedRows: 0,
+        movedFiles: 0,
+        rewrittenRows: 0,
+        alreadyMigrated: 0,
+        missingFiles: 0,
+        conflicts: 0,
+        skippedRows: 0,
+        orphanedFilesMoved: 0,
+        skippedEntries: 0,
+        errors: 0,
+    };
+
+    // =========================================================================
+    // Phase 1: row-driven migration.
+    // Every row whose storage_path is not FILES_DIR-relative is legacy.
+    // Cursor pagination (id > lastId) guarantees termination even for rows
+    // that are skipped without being rewritten.
+    // =========================================================================
+    let lastId = 0;
+    for (;;) {
+        const rows: LegacyRow[] = await db
+            .selectFrom('assets')
+            .innerJoin('projects', 'assets.project_id', 'projects.id')
+            .select(['assets.id as id', 'assets.storage_path as storage_path', 'projects.uuid as project_uuid'])
+            .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+            .where('assets.id', '>', lastId)
+            .orderBy('assets.id', 'asc')
+            .limit(batchSize)
+            .execute();
+
+        if (rows.length === 0) {
+            break;
+        }
+
+        for (const row of rows) {
+            lastId = row.id;
+            summary.scannedRows++;
+            try {
+                await migrateRow(row);
+            } catch (err) {
+                summary.errors++;
+                warn(`[AssetStorage] Failed to migrate asset ${row.id} (${row.storage_path}): ${err}`);
+            }
+        }
+    }
+
+    async function migrateRow(row: LegacyRow): Promise<void> {
+        const segments = extractAssetsRelativeSegments(row.storage_path);
+        if (!segments || segments.length < 2) {
+            // No safe `assets/...` suffix (arbitrary absolute path, traversal
+            // attempt, or a file directly under the assets root). Leave the row
+            // untouched for the operator to inspect.
+            summary.skippedRows++;
+            warn(`[AssetStorage] Leaving uninterpretable storage_path on asset ${row.id}: ${row.storage_path}`);
+            return;
+        }
+
+        const uuid = row.project_uuid;
+        const shard = getAssetShard(uuid);
+
+        // A row may already point (absolutely) at the sharded location, e.g.
+        // after a crash in an older run. Then the target IS the current
+        // location and only the row needs rewriting.
+        const alreadySharded = segments.length >= 3 && segments[0] === shard && segments[1] === uuid;
+        const relWithinProject = alreadySharded ? segments.slice(2) : segments.slice(1);
+        const targetStored = buildAssetStoragePath(uuid, ...relWithinProject);
+        if (!isCanonicalAssetStoragePath(targetStored)) {
+            summary.skippedRows++;
+            warn(`[AssetStorage] Could not derive a canonical path for asset ${row.id}: ${row.storage_path}`);
+            return;
+        }
+
+        const src = tryResolveAssetStoragePath(filesDir, row.storage_path);
+        const dest = tryResolveAssetStoragePath(filesDir, targetStored);
+        if (!src || !dest) {
+            summary.skippedRows++;
+            warn(`[AssetStorage] Could not resolve paths for asset ${row.id}: ${row.storage_path}`);
+            return;
+        }
+
+        if (src === dest) {
+            // Already at the sharded location; only the representation changes.
+            if (await rewriteRow(db, row.id, row.storage_path, targetStored)) {
+                summary.rewrittenRows++;
+            }
+            return;
+        }
+
+        const [srcExists, destExists] = await Promise.all([fs.pathExists(src), fs.pathExists(dest)]);
+
+        if (srcExists && !destExists) {
+            await fs.ensureDir(path.dirname(dest));
+            await moveFile(fs, src, dest);
+            summary.movedFiles++;
+            if (await rewriteRow(db, row.id, row.storage_path, targetStored)) {
+                summary.rewrittenRows++;
+            }
+            return;
+        }
+
+        if (!srcExists && destExists) {
+            // Crash recovery: the file was moved but the row was not rewritten.
+            summary.alreadyMigrated++;
+            if (await rewriteRow(db, row.id, row.storage_path, targetStored)) {
+                summary.rewrittenRows++;
+            }
+            return;
+        }
+
+        if (srcExists && destExists) {
+            if (await filesAreIdentical(fs, src, dest)) {
+                // Same content on both sides: keep the destination, drop the
+                // legacy copy, point the row at the canonical location.
+                await fs.remove(src);
+                summary.alreadyMigrated++;
+                if (await rewriteRow(db, row.id, row.storage_path, targetStored)) {
+                    summary.rewrittenRows++;
+                }
+                return;
+            }
+            // Different content: never overwrite. Keep BOTH files, report the
+            // conflict, and rewrite the row to the portable relative form of
+            // its current (legacy) location so it stays valid and portable.
+            summary.conflicts++;
+            const legacyStored = [ASSETS_ROOT_DIR_NAME, ...segments].join('/');
+            warn(
+                `[AssetStorage] Conflict for asset ${row.id}: '${legacyStored}' and '${targetStored}' differ. ` +
+                    `Keeping both; the database keeps pointing at the legacy location. Resolve manually.`,
+            );
+            if (isCanonicalAssetStoragePath(legacyStored)) {
+                if (await rewriteRow(db, row.id, row.storage_path, legacyStored)) {
+                    summary.rewrittenRows++;
+                }
+            }
+            return;
+        }
+
+        // Neither location has the file: record it and rewrite the row to the
+        // canonical target so the table converges. Reads behave exactly as
+        // before (missing file), matching the existing missing-asset policy.
+        summary.missingFiles++;
+        warn(`[AssetStorage] Asset file missing for asset ${row.id}: ${row.storage_path}`);
+        if (await rewriteRow(db, row.id, row.storage_path, targetStored)) {
+            summary.rewrittenRows++;
+        }
+    }
+
+    // =========================================================================
+    // Phase 2: filesystem sweep.
+    // Any assets-root entry that is not a two-hex shard bucket is a legacy
+    // leftover: orphan files (no DB row) are moved into the sharded layout,
+    // emptied directories are removed, unidentifiable entries are reported and
+    // left in place.
+    // =========================================================================
+    if (await fs.pathExists(assetsRoot)) {
+        let rootEntries: fsExtra.Dirent[] = [];
+        try {
+            rootEntries = await fs.readdir(assetsRoot, { withFileTypes: true });
+        } catch (err) {
+            summary.errors++;
+            warn(`[AssetStorage] Could not read assets root ${assetsRoot}: ${err}`);
+        }
+
+        for (const entry of rootEntries) {
+            const entryName = entry.name;
+            if (entry.isDirectory() && SHARD_BUCKET.test(entryName)) {
+                continue; // canonical shard bucket
+            }
+            if (!entry.isDirectory()) {
+                summary.skippedEntries++;
+                warn(`[AssetStorage] Leaving unexpected file in assets root: ${entryName}`);
+                continue;
+            }
+
+            // Identify the project this legacy directory belongs to: directory
+            // names are project UUIDs, or numeric project ids (legacy quirk).
+            let uuid: string | null = null;
+            const byUuid = await db
+                .selectFrom('projects')
+                .select('uuid')
+                .where('uuid', '=', entryName)
+                .executeTakeFirst();
+            if (byUuid) {
+                uuid = byUuid.uuid;
+            } else if (/^\d+$/.test(entryName)) {
+                const byId = await db
+                    .selectFrom('projects')
+                    .select('uuid')
+                    .where('id', '=', parseInt(entryName, 10))
+                    .executeTakeFirst();
+                uuid = byId?.uuid ?? null;
+            }
+
+            const legacyDir = path.join(assetsRoot, entryName);
+            if (!uuid) {
+                summary.skippedEntries++;
+                warn(`[AssetStorage] Leaving unrecognized assets directory in place: ${entryName}`);
+                continue;
+            }
+
+            try {
+                // Files still referenced by database rows (e.g. conflict rows
+                // rewritten to their legacy-relative location in phase 1) are
+                // live data, not orphans: never move them out from under a row.
+                const referencedPaths = new Set<string>();
+                const projectRow = await db
+                    .selectFrom('projects')
+                    .select('id')
+                    .where('uuid', '=', uuid)
+                    .executeTakeFirst();
+                if (projectRow) {
+                    const projectAssets = await db
+                        .selectFrom('assets')
+                        .select('storage_path')
+                        .where('project_id', '=', projectRow.id)
+                        .execute();
+                    for (const assetRow of projectAssets) {
+                        const resolved = assetRow.storage_path
+                            ? tryResolveAssetStoragePath(filesDir, assetRow.storage_path)
+                            : null;
+                        if (resolved && resolved.startsWith(legacyDir + path.sep)) {
+                            referencedPaths.add(resolved);
+                        }
+                    }
+                }
+
+                let referencedLeft = 0;
+                const files = await listFilesRecursive(fs, path, legacyDir);
+                for (const relSegments of files) {
+                    try {
+                        if (referencedPaths.has(path.join(legacyDir, ...relSegments))) {
+                            referencedLeft++;
+                            continue;
+                        }
+                        const targetStored = buildAssetStoragePath(uuid, ...relSegments);
+                        const dest = tryResolveAssetStoragePath(filesDir, targetStored);
+                        if (!dest) {
+                            summary.skippedEntries++;
+                            continue;
+                        }
+                        const src = path.join(legacyDir, ...relSegments);
+                        if (!(await fs.pathExists(dest))) {
+                            await fs.ensureDir(path.dirname(dest));
+                            await moveFile(fs, src, dest);
+                            summary.orphanedFilesMoved++;
+                        } else if (await filesAreIdentical(fs, src, dest)) {
+                            await fs.remove(src);
+                        } else {
+                            summary.conflicts++;
+                            warn(
+                                `[AssetStorage] Conflict sweeping '${src}': destination '${dest}' differs. ` +
+                                    `Keeping both. Resolve manually.`,
+                            );
+                        }
+                    } catch (err) {
+                        summary.errors++;
+                        warn(`[AssetStorage] Failed to sweep '${relSegments.join('/')}' in ${entryName}: ${err}`);
+                    }
+                }
+                if (referencedLeft > 0) {
+                    warn(
+                        `[AssetStorage] ${referencedLeft} file(s) under legacy directory '${entryName}' are still ` +
+                            `referenced by unresolved conflict rows and were left in place.`,
+                    );
+                } else {
+                    await removeDirIfEmpty(fs, path, legacyDir);
+                }
+            } catch (err) {
+                summary.errors++;
+                warn(`[AssetStorage] Failed to sweep legacy directory ${entryName}: ${err}`);
+            }
+        }
+    }
+
+    const didWork =
+        summary.scannedRows > 0 || summary.orphanedFilesMoved > 0 || summary.skippedEntries > 0 || summary.errors > 0;
+    if (didWork) {
+        log(
+            `[AssetStorage] Migration summary: ${summary.movedFiles} file(s) moved, ` +
+                `${summary.rewrittenRows} row(s) rewritten, ${summary.alreadyMigrated} already migrated, ` +
+                `${summary.missingFiles} missing, ${summary.conflicts} conflict(s), ` +
+                `${summary.orphanedFilesMoved} orphan(s) moved, ${summary.skippedRows} row(s) skipped, ` +
+                `${summary.skippedEntries} entr(ies) left in place, ${summary.errors} error(s).`,
+        );
+    } else {
+        log('[AssetStorage] Asset storage layout is up to date.');
+    }
+
+    return summary;
+}

--- a/src/services/asset-storage-migration.ts
+++ b/src/services/asset-storage-migration.ts
@@ -89,6 +89,9 @@ export interface AssetStorageMigrationDeps {
 
 const DEFAULT_BATCH_SIZE = 500;
 
+/** Rows processed between progress log lines during phase 1. */
+const PROGRESS_LOG_INTERVAL = 1000;
+
 const SHARD_BUCKET = /^[0-9a-f]{2}$/;
 
 /**
@@ -267,6 +270,7 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
     // that are skipped without being rewritten.
     // =========================================================================
     let lastId = 0;
+    let totalLegacyRows: number | null = null;
     for (;;) {
         const rows: LegacyRow[] = await db
             .selectFrom('assets')
@@ -282,6 +286,20 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
             break;
         }
 
+        // Count legacy rows once, only when there is actual work, so a
+        // converged startup issues zero extra queries. The count is a one-shot
+        // snapshot used only for progress logging; concurrent instances
+        // migrating rows in parallel make the pending figure approximate.
+        if (totalLegacyRows === null) {
+            const countRow = await db
+                .selectFrom('assets')
+                .innerJoin('projects', 'assets.project_id', 'projects.id')
+                .select(eb => eb.fn.countAll<number>().as('count'))
+                .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+                .executeTakeFirst();
+            totalLegacyRows = Number(countRow?.count ?? 0);
+        }
+
         for (const row of rows) {
             lastId = row.id;
             summary.scannedRows++;
@@ -290,6 +308,14 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
             } catch (err) {
                 summary.errors++;
                 warn(`[AssetStorage] Failed to migrate asset ${row.id} (${row.storage_path}): ${err}`);
+            }
+            if (summary.scannedRows % PROGRESS_LOG_INTERVAL === 0) {
+                const pending = Math.max(0, totalLegacyRows - summary.scannedRows);
+                log(
+                    `[AssetStorage] Migration progress: ${summary.scannedRows.toLocaleString('en-US')}/` +
+                        `${totalLegacyRows.toLocaleString('en-US')} legacy row(s) processed, ` +
+                        `${pending.toLocaleString('en-US')} pending.`,
+                );
             }
         }
     }

--- a/src/services/cleanup-scheduler.spec.ts
+++ b/src/services/cleanup-scheduler.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './cleanup-scheduler';
 import type { Kysely } from 'kysely';
 import type { Database, Project } from '../db/types';
+import { getAssetShard } from '../utils/asset-paths';
 
 describe('Cleanup Scheduler', () => {
     // Helper to create mock projects
@@ -185,6 +186,47 @@ describe('Cleanup Scheduler', () => {
 
             expect(result.success).toBe(true);
             expect(result.diskCleaned).toBe(1);
+            expect(fileHelper._removedPaths).toContain('/data/assets/uuid-1');
+        });
+
+        it('should clean up sharded asset directories', async () => {
+            const shard = getAssetShard('uuid-1');
+            const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
+            const existingPaths = new Set([`/data/assets/${shard}/uuid-1`]);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths });
+            const queries = createMockQueries({ unsavedProjects });
+
+            const deps: CleanupSchedulerDeps = {
+                db: {} as Kysely<Database>,
+                queries,
+                fileHelper,
+            };
+
+            const result = await runCleanup(deps, DEFAULT_CONFIG);
+
+            expect(result.success).toBe(true);
+            expect(result.diskCleaned).toBe(1);
+            expect(fileHelper._removedPaths).toContain(`/data/assets/${shard}/uuid-1`);
+        });
+
+        it('should clean up both sharded and legacy asset directories when both exist', async () => {
+            const shard = getAssetShard('uuid-1');
+            const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
+            const existingPaths = new Set([`/data/assets/${shard}/uuid-1`, '/data/assets/uuid-1']);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths });
+            const queries = createMockQueries({ unsavedProjects });
+
+            const deps: CleanupSchedulerDeps = {
+                db: {} as Kysely<Database>,
+                queries,
+                fileHelper,
+            };
+
+            const result = await runCleanup(deps, DEFAULT_CONFIG);
+
+            expect(result.success).toBe(true);
+            expect(result.diskCleaned).toBe(1);
+            expect(fileHelper._removedPaths).toContain(`/data/assets/${shard}/uuid-1`);
             expect(fileHelper._removedPaths).toContain('/data/assets/uuid-1');
         });
 

--- a/src/services/cleanup-scheduler.spec.ts
+++ b/src/services/cleanup-scheduler.spec.ts
@@ -230,6 +230,54 @@ describe('Cleanup Scheduler', () => {
             expect(fileHelper._removedPaths).toContain('/data/assets/uuid-1');
         });
 
+        it('should surface a legacy-directory removal error even when the sharded directory was removed', async () => {
+            const shard = getAssetShard('uuid-1');
+            const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
+            const existingPaths = new Set([`/data/assets/${shard}/uuid-1`, '/data/assets/uuid-1']);
+            const removeErrors = new Map([['/data/assets/uuid-1', new Error('EBUSY: locked')]]);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths, removeErrors });
+            const queries = createMockQueries({ unsavedProjects });
+
+            const deps: CleanupSchedulerDeps = {
+                db: {} as Kysely<Database>,
+                queries,
+                fileHelper,
+            };
+
+            const result = await runCleanup(deps, DEFAULT_CONFIG);
+
+            // The sharded dir was removed, but the failure must not be swallowed.
+            expect(result.diskCleaned).toBe(1);
+            expect(result.errors.length).toBe(1);
+            expect(result.errors[0]).toContain('EBUSY');
+            expect(result.success).toBe(false);
+        });
+
+        it('should report (not throw on) a project uuid that cannot form a safe directory path', async () => {
+            const unsavedProjects = [
+                createMockProject({ id: 1, uuid: '../evil' }),
+                createMockProject({ id: 2, uuid: 'uuid-2' }),
+            ];
+            const shard2 = getAssetShard('uuid-2');
+            const existingPaths = new Set([`/data/assets/${shard2}/uuid-2`]);
+            const fileHelper = createMockFileHelper({ filesDir: '/data', existingPaths });
+            const queries = createMockQueries({ unsavedProjects });
+
+            const deps: CleanupSchedulerDeps = {
+                db: {} as Kysely<Database>,
+                queries,
+                fileHelper,
+            };
+
+            const result = await runCleanup(deps, DEFAULT_CONFIG);
+
+            // Both projects are deleted from the DB; the bad uuid is reported
+            // as an asset-cleanup error and the second project is still cleaned.
+            expect(result.unsavedDeleted).toBe(2);
+            expect(result.diskCleaned).toBe(1);
+            expect(result.errors.length).toBe(1);
+        });
+
         it('should handle disk errors gracefully', async () => {
             const unsavedProjects = [createMockProject({ id: 1, uuid: 'uuid-1' })];
             const existingPaths = new Set(['/data/assets/uuid-1']);

--- a/src/services/cleanup-scheduler.ts
+++ b/src/services/cleanup-scheduler.ts
@@ -133,7 +133,15 @@ async function cleanupProjectAssets(
 ): Promise<{ cleaned: boolean; error?: string }> {
     // Remove both the sharded directory and the legacy unsharded directory,
     // so projects created before the sharding migration are fully cleaned up.
-    const candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    // Candidate computation can reject an unsafe project uuid; report that as
+    // a cleanup error instead of letting it abort the caller's loop.
+    let candidates: string[];
+    try {
+        candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { cleaned: false, error: `${projectUuid}: ${message}` };
+    }
     let cleaned = false;
     const errors: string[] = [];
 
@@ -203,7 +211,10 @@ export async function runCleanup(
                 const assetResult = await cleanupProjectAssets(project.uuid, deps.fileHelper);
                 if (assetResult.cleaned) {
                     result.diskCleaned++;
-                } else if (assetResult.error) {
+                }
+                // A partial failure (e.g. sharded dir removed, legacy dir
+                // locked) reports both cleaned=true AND an error.
+                if (assetResult.error) {
                     result.errors.push(assetResult.error);
                 }
             } catch (err) {
@@ -221,7 +232,10 @@ export async function runCleanup(
                 const assetResult = await cleanupProjectAssets(project.uuid, deps.fileHelper);
                 if (assetResult.cleaned) {
                     result.diskCleaned++;
-                } else if (assetResult.error) {
+                }
+                // A partial failure (e.g. sharded dir removed, legacy dir
+                // locked) reports both cleaned=true AND an error.
+                if (assetResult.error) {
                     result.errors.push(assetResult.error);
                 }
             } catch (err) {

--- a/src/services/cleanup-scheduler.ts
+++ b/src/services/cleanup-scheduler.ts
@@ -17,7 +17,7 @@ import {
 import { getFilesDir, remove, fileExists } from './file-helper';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
-import * as path from 'path';
+import { getProjectAssetsDirCandidates } from '../utils/asset-paths';
 
 /**
  * Configuration for the cleanup scheduler
@@ -131,19 +131,27 @@ async function cleanupProjectAssets(
     projectUuid: string,
     fileHelper: CleanupFileHelper,
 ): Promise<{ cleaned: boolean; error?: string }> {
-    const assetsDir = path.join(fileHelper.getFilesDir(), 'assets', projectUuid);
+    // Remove both the sharded directory and the legacy unsharded directory,
+    // so projects created before the sharding migration are fully cleaned up.
+    const candidates = getProjectAssetsDirCandidates(fileHelper.getFilesDir(), projectUuid);
+    let cleaned = false;
+    const errors: string[] = [];
 
-    try {
-        const exists = await fileHelper.fileExists(assetsDir);
-        if (!exists) {
-            return { cleaned: false };
+    for (const assetsDir of candidates) {
+        try {
+            const exists = await fileHelper.fileExists(assetsDir);
+            if (!exists) {
+                continue;
+            }
+            await fileHelper.remove(assetsDir);
+            cleaned = true;
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            errors.push(`${assetsDir}: ${message}`);
         }
-        await fileHelper.remove(assetsDir);
-        return { cleaned: true };
-    } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { cleaned: false, error: `${assetsDir}: ${message}` };
     }
+
+    return { cleaned, error: errors.length > 0 ? errors.join('; ') : undefined };
 }
 
 /**

--- a/src/services/file-helper.spec.ts
+++ b/src/services/file-helper.spec.ts
@@ -154,24 +154,95 @@ describe('File Helper Service', () => {
     });
 
     describe('getProjectAssetsDir', () => {
-        it('should return UUID-based path for project assets', () => {
+        it('should return a sharded UUID-based path for project assets', () => {
             const projectUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
             const result = fileHelper.getProjectAssetsDir(projectUuid);
-            expect(result).toContain('assets');
-            expect(result).toContain(projectUuid);
-            expect(result).toBe(path.join(testDir, 'assets', projectUuid));
+            expect(result).toBe(path.join(testDir, 'assets', 'a1', projectUuid));
         });
 
-        it('should handle different UUID formats', () => {
-            const uuid1 = 'simple-uuid-123';
-            const uuid2 = 'another-project-uuid';
+        it('should shard by the lowercased first two hex characters of the UUID', () => {
+            const projectUuid = 'FFE0D5AA-D8D2-4A7B-BF6D-C809321CCC2A';
+            const result = fileHelper.getProjectAssetsDir(projectUuid);
+            expect(result).toBe(path.join(testDir, 'assets', 'ff', projectUuid));
+        });
 
-            const result1 = fileHelper.getProjectAssetsDir(uuid1);
-            const result2 = fileHelper.getProjectAssetsDir(uuid2);
+        it('should place non-canonical identifiers in a deterministic hash bucket', () => {
+            const result1 = fileHelper.getProjectAssetsDir('simple-uuid-123');
+            const result2 = fileHelper.getProjectAssetsDir('simple-uuid-123');
+            expect(result1).toBe(result2);
+            const relative = path.relative(testDir, result1).split(path.sep);
+            expect(relative[0]).toBe('assets');
+            expect(relative[1]).toMatch(/^[0-9a-f]{2}$/);
+            expect(relative[2]).toBe('simple-uuid-123');
+        });
 
-            expect(result1).toContain(uuid1);
-            expect(result2).toContain(uuid2);
+        it('should give different projects different directories', () => {
+            const result1 = fileHelper.getProjectAssetsDir('simple-uuid-123');
+            const result2 = fileHelper.getProjectAssetsDir('another-project-uuid');
             expect(result1).not.toBe(result2);
+        });
+    });
+
+    describe('getProjectAssetsDirCandidates', () => {
+        it('should return the sharded directory and the legacy unsharded directory', () => {
+            const projectUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+            expect(fileHelper.getProjectAssetsDirCandidates(projectUuid)).toEqual([
+                path.join(testDir, 'assets', 'a1', projectUuid),
+                path.join(testDir, 'assets', projectUuid),
+            ]);
+        });
+    });
+
+    describe('resolveAssetStoragePath', () => {
+        const projectUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+        it('should resolve a canonical relative storage path under FILES_DIR', () => {
+            const stored = `assets/a1/${projectUuid}/client-1.png`;
+            expect(fileHelper.resolveAssetStoragePath(stored)).toBe(
+                path.join(testDir, 'assets', 'a1', projectUuid, 'client-1.png'),
+            );
+        });
+
+        it('should re-root legacy absolute storage paths under the current FILES_DIR', () => {
+            const legacy = `/old-deployment/data/assets/${projectUuid}/client-1.png`;
+            expect(fileHelper.resolveAssetStoragePath(legacy)).toBe(
+                path.join(testDir, 'assets', projectUuid, 'client-1.png'),
+            );
+        });
+
+        it('should keep the same stored path valid when FILES_DIR changes (portability)', () => {
+            const stored = `assets/a1/${projectUuid}/client-1.png`;
+            const helperA = createFileHelper({
+                getEnv: key => (key === 'FILES_DIR' ? '/mnt/data-a' : undefined),
+            });
+            const helperB = createFileHelper({
+                getEnv: key => (key === 'FILES_DIR' ? '/mnt/data-b' : undefined),
+            });
+            expect(helperA.resolveAssetStoragePath(stored)).toBe(
+                path.join('/mnt/data-a', 'assets', 'a1', projectUuid, 'client-1.png'),
+            );
+            expect(helperB.resolveAssetStoragePath(stored)).toBe(
+                path.join('/mnt/data-b', 'assets', 'a1', projectUuid, 'client-1.png'),
+            );
+        });
+
+        it('should throw for traversal attempts', () => {
+            expect(() => fileHelper.resolveAssetStoragePath('assets/../secrets.db')).toThrow();
+        });
+    });
+
+    describe('tryResolveAssetStoragePath', () => {
+        it('should return null for unresolvable stored values', () => {
+            expect(fileHelper.tryResolveAssetStoragePath('/somewhere/else/file.png')).toBeNull();
+            expect(fileHelper.tryResolveAssetStoragePath('assets/../evil')).toBeNull();
+        });
+
+        it('should resolve valid stored values', () => {
+            const projectUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+            const stored = `assets/a1/${projectUuid}/client-1.png`;
+            expect(fileHelper.tryResolveAssetStoragePath(stored)).toBe(
+                path.join(testDir, 'assets', 'a1', projectUuid, 'client-1.png'),
+            );
         });
     });
 

--- a/src/services/file-helper.spec.ts
+++ b/src/services/file-helper.spec.ts
@@ -181,6 +181,13 @@ describe('File Helper Service', () => {
             const result2 = fileHelper.getProjectAssetsDir('another-project-uuid');
             expect(result1).not.toBe(result2);
         });
+
+        it('should reject unsafe project identifiers instead of building a traversal path', () => {
+            expect(() => fileHelper.getProjectAssetsDir('../..')).toThrow();
+            expect(() => fileHelper.getProjectAssetsDir('a/b')).toThrow();
+            expect(() => fileHelper.getProjectAssetsDir('a\\b')).toThrow();
+            expect(() => fileHelper.getProjectAssetsDir('')).toThrow();
+        });
     });
 
     describe('getProjectAssetsDirCandidates', () => {

--- a/src/services/file-helper.ts
+++ b/src/services/file-helper.ts
@@ -20,6 +20,13 @@ export {
 } from '../utils/url.util';
 
 import { getSessionDateComponents, getOdeSessionPath } from '../utils/url.util';
+import {
+    ASSETS_ROOT_DIR_NAME,
+    getAssetShard,
+    getProjectAssetsDirCandidates as getProjectAssetsDirCandidatesPure,
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 
 // ============================================================================
 // Types and Interfaces
@@ -45,6 +52,9 @@ export interface FileHelper {
     getOdeSessionDistDir: (odeSessionId: string) => string;
     getOdeSessionTempDir: (odeSessionId: string) => string;
     getProjectAssetsDir: (projectUuid: string) => string;
+    getProjectAssetsDirCandidates: (projectUuid: string) => string[];
+    resolveAssetStoragePath: (storagePath: string) => string;
+    tryResolveAssetStoragePath: (storagePath: string) => string | null;
     getPublicDirectory: () => string;
     getLibsDir: () => string;
     getThemesDir: () => string;
@@ -139,8 +149,28 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
         return path.join(filesDir, 'dist', year, month, day, odeSessionId);
     };
 
+    // Sharded project asset directory: assets/<2-hex-shard>/<projectUuid>/.
+    // One 8-bit shard level, 256 lazy buckets — see ADR-2250-01.
     const getProjectAssetsDir = (projectUuid: string): string => {
-        return path.join(getFilesDir(), 'assets', projectUuid);
+        return path.join(getFilesDir(), ASSETS_ROOT_DIR_NAME, getAssetShard(projectUuid), projectUuid);
+    };
+
+    // Sharded + legacy unsharded directories, for deletion/cleanup paths that
+    // must also remove pre-sharding leftovers.
+    const getProjectAssetsDirCandidates = (projectUuid: string): string[] => {
+        return getProjectAssetsDirCandidatesPure(getFilesDir(), projectUuid);
+    };
+
+    // Resolve a stored assets.storage_path value (FILES_DIR-relative, or a
+    // legacy absolute value from before the relative-path migration) to an
+    // absolute path under the current FILES_DIR. Throws UnsafePathError.
+    const resolveAssetStoragePath = (storagePath: string): string => {
+        return resolveAssetStoragePathPure(getFilesDir(), storagePath);
+    };
+
+    // Non-throwing variant: unresolvable stored values behave like a missing file.
+    const tryResolveAssetStoragePath = (storagePath: string): string | null => {
+        return tryResolveAssetStoragePathPure(getFilesDir(), storagePath);
     };
 
     const getPublicDirectory = (): string => {
@@ -265,6 +295,9 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
         getOdeSessionDistDir,
         getOdeSessionTempDir,
         getProjectAssetsDir,
+        getProjectAssetsDirCandidates,
+        resolveAssetStoragePath,
+        tryResolveAssetStoragePath,
         getPublicDirectory,
         getLibsDir,
         getThemesDir,
@@ -300,6 +333,9 @@ export const getPreviewExportPath = defaultFileHelper.getPreviewExportPath;
 export const getOdeSessionDistDir = defaultFileHelper.getOdeSessionDistDir;
 export const getOdeSessionTempDir = defaultFileHelper.getOdeSessionTempDir;
 export const getProjectAssetsDir = defaultFileHelper.getProjectAssetsDir;
+export const getProjectAssetsDirCandidates = defaultFileHelper.getProjectAssetsDirCandidates;
+export const resolveAssetStoragePath = defaultFileHelper.resolveAssetStoragePath;
+export const tryResolveAssetStoragePath = defaultFileHelper.tryResolveAssetStoragePath;
 export const getPublicDirectory = defaultFileHelper.getPublicDirectory;
 export const getLibsDir = defaultFileHelper.getLibsDir;
 export const getThemesDir = defaultFileHelper.getThemesDir;

--- a/src/services/file-helper.ts
+++ b/src/services/file-helper.ts
@@ -24,9 +24,11 @@ import {
     ASSETS_ROOT_DIR_NAME,
     getAssetShard,
     getProjectAssetsDirCandidates as getProjectAssetsDirCandidatesPure,
+    isSafeAssetPathSegment,
     resolveAssetStoragePath as resolveAssetStoragePathPure,
     tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
 } from '../utils/asset-paths';
+import { UnsafePathError } from '../utils/safe-path';
 
 // ============================================================================
 // Types and Interfaces
@@ -150,8 +152,14 @@ export function createFileHelper(deps: FileHelperDeps = {}): FileHelper {
     };
 
     // Sharded project asset directory: assets/<2-hex-shard>/<projectUuid>/.
-    // One 8-bit shard level, 256 lazy buckets — see ADR-2250-01.
+    // One 8-bit shard level, 256 lazy buckets — see ADR-2250-01. The
+    // identifier is validated as a single path segment because projects.uuid
+    // is not format-validated at every creation site; a crafted value must
+    // never traverse out of the assets root.
     const getProjectAssetsDir = (projectUuid: string): string => {
+        if (!isSafeAssetPathSegment(projectUuid)) {
+            throw new UnsafePathError('Invalid project identifier for asset directory');
+        }
         return path.join(getFilesDir(), ASSETS_ROOT_DIR_NAME, getAssetShard(projectUuid), projectUuid);
     };
 

--- a/src/services/folder-manager.spec.ts
+++ b/src/services/folder-manager.spec.ts
@@ -8,6 +8,11 @@ import type { Kysely } from 'kysely';
 import type { Database } from '../db/types';
 import * as assetQueries from '../db/queries/assets';
 import { createFolderManagerService, type FolderManagerService } from './folder-manager';
+import {
+    getAssetShard,
+    resolveAssetStoragePath as resolveAssetStoragePathPure,
+    tryResolveAssetStoragePath as tryResolveAssetStoragePathPure,
+} from '../utils/asset-paths';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as fflate from 'fflate';
@@ -40,14 +45,16 @@ describe('Folder Manager Service', () => {
             title: 'Test Project',
         });
 
-        // Create service with injected dependencies
+        // Create service with injected dependencies. The storage resolvers are
+        // bound to tempDir so stored FILES_DIR-relative paths resolve there.
         service = createFolderManagerService({
             db,
             queries: assetQueries,
             fs,
             path,
             fflate,
-            getProjectAssetsDir: (uuid: string) => path.join(tempDir, 'assets', uuid),
+            resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure(tempDir, storagePath),
+            tryResolveAssetStoragePath: (storagePath: string) => tryResolveAssetStoragePathPure(tempDir, storagePath),
         });
 
         // Clean temp project directory
@@ -629,6 +636,16 @@ describe('Folder Manager Service', () => {
             expect(result.newAsset!.filename).toBe('test (copy).txt');
             expect(result.newAsset!.folder_path).toBe('docs');
             expect(result.newAsset!.client_id).not.toBe('original-id');
+
+            // The stored path is FILES_DIR-relative and sharded, and the copy
+            // physically exists at the resolved location.
+            const storedPath = result.newAsset!.storage_path;
+            expect(path.isAbsolute(storedPath)).toBe(false);
+            expect(storedPath.startsWith(`assets/${getAssetShard(testProjectUuid)}/${testProjectUuid}/`)).toBe(true);
+            expect(storedPath.endsWith('/test (copy).txt')).toBe(true);
+            const resolved = resolveAssetStoragePathPure(tempDir, storedPath);
+            expect(await fs.pathExists(resolved)).toBe(true);
+            expect(await fs.readFile(resolved, 'utf-8')).toBe('test content');
         });
 
         it('should increment copy number if copy exists', async () => {
@@ -705,6 +722,16 @@ describe('Folder Manager Service', () => {
             const indexAsset = await assetQueries.findAssetByPath(db, testProjectId, 'mywebsite', 'index.html');
             expect(indexAsset).toBeDefined();
             expect(indexAsset!.mime_type).toBe('text/html');
+
+            // Extracted assets are stored with FILES_DIR-relative sharded paths
+            // in the nested <clientId>/<filename> layout.
+            expect(path.isAbsolute(indexAsset!.storage_path)).toBe(false);
+            expect(
+                indexAsset!.storage_path.startsWith(`assets/${getAssetShard(testProjectUuid)}/${testProjectUuid}/`),
+            ).toBe(true);
+            expect(indexAsset!.storage_path.endsWith('/index.html')).toBe(true);
+            const resolvedIndex = resolveAssetStoragePathPure(tempDir, indexAsset!.storage_path);
+            expect(await fs.readFile(resolvedIndex, 'utf-8')).toBe('<html></html>');
 
             const cssAsset = await assetQueries.findAssetByPath(db, testProjectId, 'mywebsite/css', 'style.css');
             expect(cssAsset).toBeDefined();

--- a/src/services/folder-manager.spec.ts
+++ b/src/services/folder-manager.spec.ts
@@ -681,6 +681,47 @@ describe('Folder Manager Service', () => {
             expect(result.success).toBe(false);
             expect(result.error).toContain('not found');
         });
+
+        it('should distinguish a database failure from a copy failure and not leave an orphaned copy', async () => {
+            const sourceDir = path.join(tempDir, 'assets', testProjectUuid, 'db-fail');
+            await fs.ensureDir(sourceDir);
+            await fs.writeFile(path.join(sourceDir, 'doc.txt'), 'content');
+
+            const original = await assetQueries.createAsset(db, {
+                project_id: testProjectId,
+                filename: 'doc.txt',
+                storage_path: path.join(sourceDir, 'doc.txt'),
+                folder_path: 'docs',
+                client_id: 'db-fail-orig',
+            });
+
+            const failingService = createFolderManagerService({
+                db,
+                queries: {
+                    ...assetQueries,
+                    createAsset: async () => {
+                        throw new Error('SQLITE_BUSY: database is locked');
+                    },
+                },
+                fs,
+                path,
+                fflate,
+                resolveAssetStoragePath: (storagePath: string) => resolveAssetStoragePathPure(tempDir, storagePath),
+                tryResolveAssetStoragePath: (storagePath: string) =>
+                    tryResolveAssetStoragePathPure(tempDir, storagePath),
+            });
+
+            const result = await failingService.duplicateAsset(testProjectId, testProjectUuid, original.id);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('asset record');
+            expect(result.error).not.toContain('Failed to copy file');
+
+            // The physical copy must not linger as an untracked orphan.
+            const projectShardDir = path.join(tempDir, 'assets', getAssetShard(testProjectUuid), testProjectUuid);
+            const leftovers = (await fs.pathExists(projectShardDir)) ? await fs.readdir(projectShardDir) : [];
+            expect(leftovers.length).toBe(0);
+        });
     });
 
     // ============================================================================

--- a/src/services/folder-manager.ts
+++ b/src/services/folder-manager.ts
@@ -410,16 +410,23 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
         // absolute values from before the relative-path migration.
         const originalFilePath = original.storage_path ? tryResolveAssetStoragePath(original.storage_path) : null;
 
+        let newStoragePath: string;
+        let newFilePath: string;
         try {
             if (!originalFilePath) {
                 throw new Error('source storage path is not resolvable');
             }
-            const newStoragePath = buildAssetStoragePath(projectUuid, newClientId, newFilename);
-            const newFilePath = resolveAssetStoragePath(newStoragePath);
+            newStoragePath = buildAssetStoragePath(projectUuid, newClientId, newFilename);
+            newFilePath = resolveAssetStoragePath(newStoragePath);
             await fs.ensureDir(path.dirname(newFilePath));
             await fs.copy(originalFilePath, newFilePath);
+        } catch (err) {
+            return { success: false, error: `Failed to copy file: ${(err as Error).message}` };
+        }
 
-            // Create new asset record
+        // Create new asset record. A database failure is reported as such, and
+        // the already-copied file is removed so no untracked orphan remains.
+        try {
             const newAssetData: NewAsset = {
                 project_id: projectId,
                 filename: newFilename,
@@ -436,7 +443,8 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
 
             return { success: true, newAsset };
         } catch (err) {
-            return { success: false, error: `Failed to copy file: ${(err as Error).message}` };
+            await fs.remove(path.dirname(newFilePath)).catch(() => {});
+            return { success: false, error: `Failed to create asset record: ${(err as Error).message}` };
         }
     };
 

--- a/src/services/folder-manager.ts
+++ b/src/services/folder-manager.ts
@@ -12,7 +12,11 @@ import * as fflateModule from 'fflate';
 import * as fsExtra from 'fs-extra';
 import * as pathModule from 'path';
 import * as cryptoModule from 'crypto';
-import { getProjectAssetsDir as defaultGetProjectAssetsDir } from './file-helper';
+import {
+    resolveAssetStoragePath as defaultResolveAssetStoragePath,
+    tryResolveAssetStoragePath as defaultTryResolveAssetStoragePath,
+} from './file-helper';
+import { buildAssetStoragePath } from '../utils/asset-paths';
 
 // ============================================================================
 // Types and Interfaces
@@ -28,7 +32,8 @@ export interface FolderManagerDeps {
     fs?: typeof fsExtra;
     path?: typeof pathModule;
     crypto?: typeof cryptoModule;
-    getProjectAssetsDir?: (projectUuid: string) => string;
+    resolveAssetStoragePath?: (storagePath: string) => string;
+    tryResolveAssetStoragePath?: (storagePath: string) => string | null;
 }
 
 /**
@@ -152,7 +157,8 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
     const fs = deps.fs ?? fsExtra;
     const path = deps.path ?? pathModule;
     const crypto = deps.crypto ?? cryptoModule;
-    const getProjectAssetsDir = deps.getProjectAssetsDir ?? defaultGetProjectAssetsDir;
+    const resolveAssetStoragePath = deps.resolveAssetStoragePath ?? defaultResolveAssetStoragePath;
+    const tryResolveAssetStoragePath = deps.tryResolveAssetStoragePath ?? defaultTryResolveAssetStoragePath;
 
     // ========================================================================
     // Validation Functions
@@ -398,34 +404,40 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
         // Generate new UUID/client_id
         const newClientId = crypto.randomUUID();
 
-        // Copy the physical file
-        const projectAssetsDir = getProjectAssetsDir(projectUuid);
-        const originalFilePath = original.storage_path;
-        const newStoragePath = path.join(projectAssetsDir, newClientId, newFilename);
+        // Copy the physical file. The database stores the FILES_DIR-relative
+        // sharded path (nested layout: <clientId>/<filename>); the source path
+        // is resolved through the shared resolver, which also accepts legacy
+        // absolute values from before the relative-path migration.
+        const originalFilePath = original.storage_path ? tryResolveAssetStoragePath(original.storage_path) : null;
 
         try {
-            await fs.ensureDir(path.dirname(newStoragePath));
-            await fs.copy(originalFilePath, newStoragePath);
+            if (!originalFilePath) {
+                throw new Error('source storage path is not resolvable');
+            }
+            const newStoragePath = buildAssetStoragePath(projectUuid, newClientId, newFilename);
+            const newFilePath = resolveAssetStoragePath(newStoragePath);
+            await fs.ensureDir(path.dirname(newFilePath));
+            await fs.copy(originalFilePath, newFilePath);
+
+            // Create new asset record
+            const newAssetData: NewAsset = {
+                project_id: projectId,
+                filename: newFilename,
+                storage_path: newStoragePath,
+                mime_type: original.mime_type,
+                file_size: original.file_size,
+                client_id: newClientId,
+                component_id: null, // New asset is not attached to any component
+                content_hash: original.content_hash, // Same content
+                folder_path: original.folder_path, // Same folder
+            };
+
+            const newAsset = await queries.createAsset(db, newAssetData);
+
+            return { success: true, newAsset };
         } catch (err) {
             return { success: false, error: `Failed to copy file: ${(err as Error).message}` };
         }
-
-        // Create new asset record
-        const newAssetData: NewAsset = {
-            project_id: projectId,
-            filename: newFilename,
-            storage_path: newStoragePath,
-            mime_type: original.mime_type,
-            file_size: original.file_size,
-            client_id: newClientId,
-            component_id: null, // New asset is not attached to any component
-            content_hash: original.content_hash, // Same content
-            folder_path: original.folder_path, // Same folder
-        };
-
-        const newAsset = await queries.createAsset(db, newAssetData);
-
-        return { success: true, newAsset };
     };
 
     // ========================================================================
@@ -485,10 +497,15 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
             };
         }
 
-        // Read the ZIP file
+        // Read the ZIP file (the stored path is FILES_DIR-relative; legacy
+        // absolute values are handled by the resolver)
+        const zipFilePath = zipAsset.storage_path ? tryResolveAssetStoragePath(zipAsset.storage_path) : null;
         let zipData: Buffer;
         try {
-            zipData = await fs.readFile(zipAsset.storage_path);
+            if (!zipFilePath) {
+                throw new Error('unresolvable storage path');
+            }
+            zipData = await fs.readFile(zipFilePath);
         } catch {
             return {
                 success: false,
@@ -514,7 +531,6 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
             };
         }
 
-        const projectAssetsDir = getProjectAssetsDir(projectUuid);
         const createdAssets: Asset[] = [];
         const foundFolders = new Set<string>();
 
@@ -577,14 +593,22 @@ export function createFolderManagerService(deps: FolderManagerDeps = {}): Folder
                 continue;
             }
 
-            // Generate client ID and storage path
+            // Generate client ID and the FILES_DIR-relative storage path
+            // (nested layout: assets/<shard>/<projectUuid>/<clientId>/<filename>)
             const clientId = crypto.randomUUID();
-            const storagePath = path.join(projectAssetsDir, clientId, entryFilename);
+            let storagePath: string;
+            let physicalPath: string;
+            try {
+                storagePath = buildAssetStoragePath(projectUuid, clientId, entryFilename);
+                physicalPath = resolveAssetStoragePath(storagePath);
+            } catch {
+                continue; // Skip entries whose names cannot form a safe path
+            }
 
             // Write file to storage
             try {
-                await fs.ensureDir(path.dirname(storagePath));
-                await fs.writeFile(storagePath, Buffer.from(data));
+                await fs.ensureDir(path.dirname(physicalPath));
+                await fs.writeFile(physicalPath, Buffer.from(data));
             } catch {
                 continue; // Skip files that fail to write
             }

--- a/src/shared/export/providers/DatabaseAssetProvider.spec.ts
+++ b/src/shared/export/providers/DatabaseAssetProvider.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { DatabaseAssetProvider, type DatabaseAssetProviderQueries } from './DatabaseAssetProvider';
+import { tryResolveAssetStoragePath as tryResolveAssetStoragePathPure } from '../../../utils/asset-paths';
 import type { Kysely } from 'kysely';
 import type { Database, Asset } from '../../../db/types';
 import * as fs from 'fs-extra';
@@ -10,6 +11,11 @@ describe('DatabaseAssetProvider', () => {
     let tempDir: string;
     // Minimal mock database (actual queries are mocked)
     const mockDb = {} as Kysely<Database>;
+
+    // Pass-through resolver for tests that seed absolute storage_path values
+    // directly; resolution policy itself is covered by src/utils/asset-paths.spec.ts
+    // and the dedicated resolver tests below.
+    const identityResolve = (storedPath: string) => storedPath;
 
     // Mock database asset
     const createMockDbAsset = (overrides: Partial<Asset> = {}): Asset => ({
@@ -57,19 +63,19 @@ describe('DatabaseAssetProvider', () => {
 
     describe('constructor', () => {
         it('should create provider with database and project ID', () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             expect(provider).toBeDefined();
         });
 
         it('should create provider with optional session path', () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             expect(provider).toBeDefined();
         });
     });
 
     describe('getAsset', () => {
         it('should return null when asset not found in database or session', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             const result = await provider.getAsset('nonexistent-uuid/file.png');
             expect(result).toBeNull();
         });
@@ -89,7 +95,7 @@ describe('DatabaseAssetProvider', () => {
                     }),
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, identityResolve);
             const result = await provider.getAsset('db-asset-uuid/asset.png');
 
             expect(result).not.toBeNull();
@@ -98,19 +104,19 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should normalize path by removing leading slash', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('/asset-uuid-123/test-image.png');
             expect(result).not.toBeNull();
         });
 
         it('should normalize path by removing content/resources prefix', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('content/resources/asset-uuid-123/test-image.png');
             expect(result).not.toBeNull();
         });
 
         it('should find asset in session path assets directory', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('asset-uuid-123/test-image.png');
 
             expect(result).not.toBeNull();
@@ -120,7 +126,7 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should cache assets after first lookup', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
 
             // First lookup
             const result1 = await provider.getAsset('asset-uuid-123/test-image.png');
@@ -132,7 +138,7 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should find asset by client ID only (without filename)', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('asset-uuid-123');
 
             expect(result).not.toBeNull();
@@ -154,7 +160,7 @@ describe('DatabaseAssetProvider', () => {
                     }),
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries, identityResolve);
             const result = await provider.getAsset('asset-uuid-123/test-image.png');
 
             // Should get database content, not session content
@@ -164,7 +170,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('getAllAssets', () => {
         it('should return empty array when no assets found', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             const result = await provider.getAllAssets();
             expect(result).toEqual([]);
         });
@@ -184,7 +190,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, identityResolve);
             const result = await provider.getAllAssets();
 
             expect(result.length).toBe(1);
@@ -192,7 +198,7 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should collect assets from session path', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAllAssets();
 
             expect(result.length).toBeGreaterThan(0);
@@ -205,7 +211,7 @@ describe('DatabaseAssetProvider', () => {
             // Create empty asset directory
             await fs.ensureDir(path.join(tempDir, 'assets', 'empty-uuid'));
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAllAssets();
 
             // Should not include the empty directory
@@ -229,7 +235,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries, identityResolve);
             const result = await provider.getAllAssets();
 
             // Should have both DB asset and session asset
@@ -251,7 +257,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, identityResolve);
             const result = await provider.getAllAssets();
 
             expect(result.length).toBe(0);
@@ -260,7 +266,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('getProjectAssets', () => {
         it('should delegate to getAllAssets', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const allAssets = await provider.getAllAssets();
             const projectAssets = await provider.getProjectAssets();
 
@@ -270,13 +276,13 @@ describe('DatabaseAssetProvider', () => {
 
     describe('exists', () => {
         it('should return true when asset exists', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.exists('asset-uuid-123/test-image.png');
             expect(result).toBe(true);
         });
 
         it('should return false when asset does not exist', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.exists('nonexistent/file.png');
             expect(result).toBe(false);
         });
@@ -284,7 +290,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('getContent', () => {
         it('should return buffer content', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getContent('asset-uuid-123/test-image.png');
 
             expect(result).not.toBeNull();
@@ -293,7 +299,7 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should return null when asset not found', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getContent('nonexistent/file.png');
             expect(result).toBeNull();
         });
@@ -301,7 +307,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('getMimeType', () => {
         it('should return correct mime type for known extensions', () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
 
             expect(provider.getMimeType('image.png')).toBe('image/png');
             expect(provider.getMimeType('image.jpg')).toBe('image/jpeg');
@@ -315,20 +321,20 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should return default mime type for unknown extensions', () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             expect(provider.getMimeType('file.xyz')).toBe('application/octet-stream');
             expect(provider.getMimeType('file.unknown')).toBe('application/octet-stream');
         });
 
         it('should handle paths with directories', () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             expect(provider.getMimeType('some/path/to/image.png')).toBe('image/png');
         });
     });
 
     describe('clearCache', () => {
         it('should clear the asset cache', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
 
             // Populate cache
             await provider.getAsset('asset-uuid-123/test-image.png');
@@ -348,7 +354,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('forEachAsset', () => {
         it('should iterate over session assets sequentially', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const processed: string[] = [];
             const count = await provider.forEachAsset(async asset => {
                 processed.push(asset.id);
@@ -373,7 +379,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, identityResolve);
             const processed: string[] = [];
             const count = await provider.forEachAsset(async asset => {
                 processed.push(asset.id);
@@ -384,9 +390,76 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should return 0 for empty provider', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             const count = await provider.forEachAsset(async () => {});
             expect(count).toBe(0);
+        });
+    });
+
+    describe('storage path resolution (issue #2250)', () => {
+        // Real resolver semantics bound to tempDir as FILES_DIR.
+        const boundResolve = (storedPath: string) => tryResolveAssetStoragePathPure(tempDir, storedPath);
+
+        it('resolves FILES_DIR-relative sharded storage paths', async () => {
+            const stored = 'assets/ab/ab-project-uuid/rel-client-1.png';
+            const physical = path.join(tempDir, 'assets', 'ab', 'ab-project-uuid', 'rel-client-1.png');
+            await fs.ensureDir(path.dirname(physical));
+            await fs.writeFile(physical, Buffer.from('relative bytes'));
+
+            const mockQueries = createMockQueries({
+                findAllAssetsForProject: async () => [
+                    createMockDbAsset({
+                        client_id: 'rel-client-1',
+                        filename: 'rel-client-1.png',
+                        storage_path: stored,
+                    }),
+                ],
+            });
+
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, boundResolve);
+            const assets = await provider.getAllAssets();
+            expect(assets.length).toBe(1);
+            expect(assets[0].data.toString()).toBe('relative bytes');
+        });
+
+        it('resolves legacy absolute storage paths via the assets suffix', async () => {
+            const physical = path.join(tempDir, 'assets', 'legacy-project', 'legacy-client.png');
+            await fs.ensureDir(path.dirname(physical));
+            await fs.writeFile(physical, Buffer.from('legacy bytes'));
+
+            const mockQueries = createMockQueries({
+                findAssetByClientId: async () =>
+                    createMockDbAsset({
+                        client_id: 'legacy-client',
+                        filename: 'legacy-client.png',
+                        // Absolute path from a FILES_DIR that no longer exists.
+                        storage_path: '/decommissioned/data/assets/legacy-project/legacy-client.png',
+                    }),
+            });
+
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, boundResolve);
+            const asset = await provider.getAsset('legacy-client/legacy-client.png');
+            expect(asset).not.toBeNull();
+            expect(asset!.data.toString()).toBe('legacy bytes');
+        });
+
+        it('skips rows whose storage path cannot be resolved', async () => {
+            const mockQueries = createMockQueries({
+                findAllAssetsForProject: async () => [
+                    createMockDbAsset({
+                        client_id: 'bad-client',
+                        filename: 'bad.png',
+                        storage_path: '/somewhere/entirely/else/bad.png',
+                    }),
+                ],
+            });
+
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, boundResolve);
+            const assets = await provider.getAllAssets();
+            expect(assets.length).toBe(0);
+
+            const metadata = await provider.listAssetMetadata();
+            expect(metadata.length).toBe(0);
         });
     });
 
@@ -407,7 +480,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, mockQueries, identityResolve);
             const metadata = await provider.listAssetMetadata();
 
             expect(metadata.length).toBe(1);
@@ -418,7 +491,7 @@ describe('DatabaseAssetProvider', () => {
         });
 
         it('should return empty array for empty provider', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, undefined, createMockQueries(), identityResolve);
             const metadata = await provider.listAssetMetadata();
             expect(metadata).toEqual([]);
         });
@@ -426,7 +499,7 @@ describe('DatabaseAssetProvider', () => {
 
     describe('listAssetMetadata and forEachAsset consistency', () => {
         it('should return the same asset IDs from both methods with session path assets', async () => {
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
 
             const meta = await provider.listAssetMetadata();
             const idsFromMeta = new Set(meta.map(a => a.id));
@@ -454,7 +527,7 @@ describe('DatabaseAssetProvider', () => {
                 ],
             });
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries);
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, mockQueries, identityResolve);
 
             const meta = await provider.listAssetMetadata();
             const idsFromMeta = new Set(meta.map(a => a.id));
@@ -477,7 +550,7 @@ describe('DatabaseAssetProvider', () => {
             await fs.ensureDir(assetDir);
             await fs.writeFile(path.join(assetDir, 'my image.png'), Buffer.from('spaced data'));
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('space-uuid/my image.png');
 
             expect(result).not.toBeNull();
@@ -491,7 +564,7 @@ describe('DatabaseAssetProvider', () => {
             await fs.writeFile(path.join(assetDir, 'a-first.png'), Buffer.from('first'));
             await fs.writeFile(path.join(assetDir, 'b-second.png'), Buffer.from('second'));
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('multi-uuid');
 
             expect(result).not.toBeNull();
@@ -503,7 +576,7 @@ describe('DatabaseAssetProvider', () => {
             // Remove assets directory
             await fs.remove(path.join(tempDir, 'assets'));
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAllAssets();
 
             expect(result).toEqual([]);
@@ -515,7 +588,7 @@ describe('DatabaseAssetProvider', () => {
             await fs.ensureDir(resourcesDir);
             await fs.writeFile(path.join(resourcesDir, 'direct-file.png'), Buffer.from('direct content'));
 
-            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries());
+            const provider = new DatabaseAssetProvider(mockDb, 1, tempDir, createMockQueries(), identityResolve);
             const result = await provider.getAsset('direct-file.png');
 
             expect(result).not.toBeNull();

--- a/src/shared/export/providers/DatabaseAssetProvider.ts
+++ b/src/shared/export/providers/DatabaseAssetProvider.ts
@@ -25,6 +25,14 @@ import {
     findAssetByClientId as findAssetByClientIdDefault,
     findAllAssetsForProject as findAllAssetsForProjectDefault,
 } from '../../../db/queries/assets';
+import { tryResolveAssetStoragePath as tryResolveAssetStoragePathDefault } from '../../../services/file-helper';
+
+/**
+ * Resolves a stored `assets.storage_path` value to an absolute filesystem
+ * path, or null when it cannot be resolved. Injected for testing; defaults to
+ * the FILES_DIR-bound resolver from the file-helper service.
+ */
+export type StoragePathResolver = (storedPath: string) => string | null;
 
 /**
  * Query functions interface for dependency injection
@@ -52,24 +60,36 @@ export class DatabaseAssetProvider implements AssetProvider {
     private sessionPath?: string;
     private assetCache: Map<string, ExportAsset>;
     private queries: DatabaseAssetProviderQueries;
+    private resolveStoragePath: StoragePathResolver;
 
     /**
      * @param db - Kysely database instance
      * @param projectId - Project ID in the database
      * @param sessionPath - Optional session temp directory path for session-specific assets
      * @param queries - Optional query implementations for dependency injection (testing)
+     * @param resolveStoragePath - Optional storage path resolver override (testing)
      */
     constructor(
         db: Kysely<Database>,
         projectId: number,
         sessionPath?: string,
         queries?: Partial<DatabaseAssetProviderQueries>,
+        resolveStoragePath?: StoragePathResolver,
     ) {
         this.db = db;
         this.projectId = projectId;
         this.sessionPath = sessionPath;
         this.assetCache = new Map();
         this.queries = { ...defaultQueries, ...queries };
+        this.resolveStoragePath = resolveStoragePath ?? tryResolveAssetStoragePathDefault;
+    }
+
+    /**
+     * Resolve a row's stored storage_path to an absolute file path, or null
+     * when the row has no path or the value cannot be resolved safely.
+     */
+    private resolveAssetFile(dbAsset: Pick<Asset, 'storage_path'>): string | null {
+        return dbAsset.storage_path ? this.resolveStoragePath(dbAsset.storage_path) : null;
     }
 
     /**
@@ -94,10 +114,11 @@ export class DatabaseAssetProvider implements AssetProvider {
         // Try to find in database
         const dbAsset = await this.queries.findAssetByClientId(this.db, clientId, this.projectId);
 
-        if (dbAsset?.storage_path) {
-            // Read from storage_path
-            if (await fs.pathExists(dbAsset.storage_path)) {
-                const content = await fs.readFile(dbAsset.storage_path);
+        const storageFile = dbAsset ? this.resolveAssetFile(dbAsset) : null;
+        if (dbAsset && storageFile) {
+            // Read from the resolved storage path
+            if (await fs.pathExists(storageFile)) {
+                const content = await fs.readFile(storageFile);
                 const asset: ExportAsset = {
                     id: dbAsset.client_id || normalizedPath,
                     filename: dbAsset.filename,
@@ -196,9 +217,10 @@ export class DatabaseAssetProvider implements AssetProvider {
         const dbAssets = await this.queries.findAllAssetsForProject(this.db, this.projectId);
 
         for (const dbAsset of dbAssets) {
-            if (dbAsset.storage_path && (await fs.pathExists(dbAsset.storage_path))) {
+            const storageFile = this.resolveAssetFile(dbAsset);
+            if (storageFile && (await fs.pathExists(storageFile))) {
                 try {
-                    const content = await fs.readFile(dbAsset.storage_path);
+                    const content = await fs.readFile(storageFile);
                     const folderPath = dbAsset.folder_path || '';
                     // Build originalPath based on folderPath
                     const exportPath = folderPath ? `${folderPath}/${dbAsset.filename}` : dbAsset.filename;
@@ -289,9 +311,10 @@ export class DatabaseAssetProvider implements AssetProvider {
         // Database assets
         const dbAssets = await this.queries.findAllAssetsForProject(this.db, this.projectId);
         for (const dbAsset of dbAssets) {
-            if (dbAsset.storage_path && (await fs.pathExists(dbAsset.storage_path))) {
+            const storageFile = this.resolveAssetFile(dbAsset);
+            if (storageFile && (await fs.pathExists(storageFile))) {
                 try {
-                    const content = await fs.readFile(dbAsset.storage_path);
+                    const content = await fs.readFile(storageFile);
                     const folderPath = dbAsset.folder_path || '';
                     const exportPath = folderPath ? `${folderPath}/${dbAsset.filename}` : dbAsset.filename;
                     await callback({
@@ -355,7 +378,8 @@ export class DatabaseAssetProvider implements AssetProvider {
 
         const dbAssets = await this.queries.findAllAssetsForProject(this.db, this.projectId);
         for (const dbAsset of dbAssets) {
-            if (dbAsset.storage_path && (await fs.pathExists(dbAsset.storage_path))) {
+            const storageFile = this.resolveAssetFile(dbAsset);
+            if (storageFile && (await fs.pathExists(storageFile))) {
                 result.push({
                     id: dbAsset.client_id || String(dbAsset.id),
                     filename: dbAsset.filename,

--- a/src/utils/asset-paths.spec.ts
+++ b/src/utils/asset-paths.spec.ts
@@ -161,6 +161,21 @@ describe('asset-paths', () => {
             expect(extractAssetsRelativeSegments(`/mnt/data/assets/../etc/passwd`)).toBeNull();
             expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}/..`)).toBeNull();
         });
+
+        it('returns null for a single-segment suffix (would resolve to a directory)', () => {
+            // 'assets/ab' style values point at a whole bucket/project dir, not
+            // a file; deletes must never recursively remove those.
+            expect(extractAssetsRelativeSegments('/mnt/data/assets/ab')).toBeNull();
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}`)).toBeNull();
+        });
+
+        it('handles a file literally named assets by backtracking to an earlier component', () => {
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}/client-1/assets`)).toEqual([
+                uuid,
+                'client-1',
+                'assets',
+            ]);
+        });
     });
 
     describe('resolveAssetStoragePath', () => {
@@ -238,6 +253,17 @@ describe('asset-paths', () => {
             const candidates = getProjectAssetsDirCandidates(filesDir, 'ab');
             for (const candidate of candidates) {
                 expect(candidate).not.toBe(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab'));
+            }
+        });
+
+        it('applies the shard-bucket collision guard case-insensitively', () => {
+            // On case-insensitive filesystems (macOS/Windows desktop builds)
+            // 'AB' aliases the 'ab' bucket; the legacy candidate must be
+            // suppressed for uppercase two-hex identifiers too.
+            const candidates = getProjectAssetsDirCandidates(filesDir, 'AB');
+            expect(candidates.length).toBe(1);
+            for (const candidate of candidates) {
+                expect(candidate.toLowerCase()).not.toBe(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab'));
             }
         });
 

--- a/src/utils/asset-paths.spec.ts
+++ b/src/utils/asset-paths.spec.ts
@@ -1,0 +1,266 @@
+import * as nodePath from 'path';
+import {
+    ASSETS_ROOT_DIR_NAME,
+    buildAssetStoragePath,
+    extractAssetsRelativeSegments,
+    getAssetShard,
+    getProjectAssetsDirCandidates,
+    isCanonicalAssetStoragePath,
+    resolveAssetStoragePath,
+    tryResolveAssetStoragePath,
+} from './asset-paths';
+import { UnsafePathError } from './safe-path';
+
+describe('asset-paths', () => {
+    describe('getAssetShard', () => {
+        it('returns the first two hex characters of a canonical UUID', () => {
+            expect(getAssetShard('ab12cd34-1234-4abc-8def-1234567890ab')).toBe('ab');
+            expect(getAssetShard('00000000-0000-4000-8000-000000000000')).toBe('00');
+            expect(getAssetShard('ffe0d5aa-d8d2-4a7b-bf6d-c809321ccc2a')).toBe('ff');
+        });
+
+        it('lowercases the shard for uppercase canonical UUIDs', () => {
+            expect(getAssetShard('AB12CD34-1234-4ABC-8DEF-1234567890AB')).toBe('ab');
+        });
+
+        it('is deterministic for the same input', () => {
+            expect(getAssetShard('some-arbitrary-id')).toBe(getAssetShard('some-arbitrary-id'));
+        });
+
+        it('hashes non-canonical identifiers to a stable two-hex bucket (FNV-1a, low 8 bits)', () => {
+            // Golden values computed independently with FNV-1a 32-bit over UTF-8 bytes.
+            expect(getAssetShard('123')).toBe('1b');
+            expect(getAssetShard('20250116143027ABCDEF')).toBe('d0');
+            expect(getAssetShard('not-a-uuid')).toBe('e0');
+            expect(getAssetShard('456')).toBe('3c');
+        });
+
+        it('always returns a valid two-character lowercase hex bucket', () => {
+            for (const id of ['a', 'zz', 'project x', '../../evil', '9'.repeat(64)]) {
+                expect(getAssetShard(id)).toMatch(/^[0-9a-f]{2}$/);
+            }
+        });
+
+        it('throws UnsafePathError for empty or non-string input', () => {
+            expect(() => getAssetShard('')).toThrow(UnsafePathError);
+            expect(() => getAssetShard(undefined as unknown as string)).toThrow(UnsafePathError);
+        });
+    });
+
+    describe('buildAssetStoragePath', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+
+        it('builds a POSIX path under assets/<shard>/<uuid>/ for a flat asset', () => {
+            expect(buildAssetStoragePath(uuid, 'client-id-1.png')).toBe(`assets/ab/${uuid}/client-id-1.png`);
+        });
+
+        it('builds a nested path for extracted/duplicated assets', () => {
+            expect(buildAssetStoragePath(uuid, 'client-id-1', 'index.html')).toBe(
+                `assets/ab/${uuid}/client-id-1/index.html`,
+            );
+        });
+
+        it('accepts filenames with spaces, parentheses and unicode', () => {
+            expect(buildAssetStoragePath(uuid, 'client-id-1', 'photo (copy 2).png')).toBe(
+                `assets/ab/${uuid}/client-id-1/photo (copy 2).png`,
+            );
+            expect(buildAssetStoragePath(uuid, 'client-id-1', 'imágen ñ.png')).toBe(
+                `assets/ab/${uuid}/client-id-1/imágen ñ.png`,
+            );
+        });
+
+        it('uses POSIX separators regardless of platform', () => {
+            const stored = buildAssetStoragePath(uuid, 'a', 'b.txt');
+            expect(stored).not.toContain('\\');
+            expect(stored.split('/')).toEqual(['assets', 'ab', uuid, 'a', 'b.txt']);
+        });
+
+        it('requires at least one segment below the project directory', () => {
+            expect(() => buildAssetStoragePath(uuid)).toThrow(UnsafePathError);
+        });
+
+        it('rejects traversal and separator-bearing segments', () => {
+            expect(() => buildAssetStoragePath(uuid, '..')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath(uuid, '.')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath(uuid, 'a/b.txt')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath(uuid, 'a\\b.txt')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath(uuid, '')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath(uuid, 'nul\0byte.png')).toThrow(UnsafePathError);
+        });
+
+        it('rejects an unsafe project identifier', () => {
+            expect(() => buildAssetStoragePath('../evil', 'f.png')).toThrow(UnsafePathError);
+            expect(() => buildAssetStoragePath('', 'f.png')).toThrow(UnsafePathError);
+        });
+    });
+
+    describe('isCanonicalAssetStoragePath', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+
+        it('accepts new-format sharded paths', () => {
+            expect(isCanonicalAssetStoragePath(`assets/ab/${uuid}/client.png`)).toBe(true);
+            expect(isCanonicalAssetStoragePath(`assets/ab/${uuid}/client/file name (1).html`)).toBe(true);
+        });
+
+        it('accepts unsharded assets-relative paths (conflict fallback form)', () => {
+            expect(isCanonicalAssetStoragePath(`assets/${uuid}/client.png`)).toBe(true);
+        });
+
+        it('rejects absolute paths', () => {
+            expect(isCanonicalAssetStoragePath(`/mnt/data/assets/${uuid}/client.png`)).toBe(false);
+            expect(isCanonicalAssetStoragePath(`C:\\data\\assets\\${uuid}\\client.png`)).toBe(false);
+        });
+
+        it('rejects traversal, backslashes, empty segments and non-assets prefixes', () => {
+            expect(isCanonicalAssetStoragePath(`assets/../etc/passwd`)).toBe(false);
+            expect(isCanonicalAssetStoragePath(`assets\\ab\\${uuid}\\f.png`)).toBe(false);
+            expect(isCanonicalAssetStoragePath(`assets//${uuid}/f.png`)).toBe(false);
+            expect(isCanonicalAssetStoragePath(`themes/site/foo`)).toBe(false);
+            expect(isCanonicalAssetStoragePath('assets')).toBe(false);
+            expect(isCanonicalAssetStoragePath('assets/')).toBe(false);
+            expect(isCanonicalAssetStoragePath('')).toBe(false);
+            expect(isCanonicalAssetStoragePath(null)).toBe(false);
+            expect(isCanonicalAssetStoragePath(42)).toBe(false);
+        });
+    });
+
+    describe('extractAssetsRelativeSegments', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+
+        it('extracts the assets-relative segments from a legacy absolute POSIX path', () => {
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}/client.png`)).toEqual([uuid, 'client.png']);
+        });
+
+        it('extracts from a legacy absolute Windows path', () => {
+            expect(extractAssetsRelativeSegments(`C:\\app\\data\\assets\\${uuid}\\client.png`)).toEqual([
+                uuid,
+                'client.png',
+            ]);
+        });
+
+        it('extracts nested ZIP-extraction layouts', () => {
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}/client-1/index.html`)).toEqual([
+                uuid,
+                'client-1',
+                'index.html',
+            ]);
+        });
+
+        it('uses the last assets component when several are present', () => {
+            expect(extractAssetsRelativeSegments(`/srv/assets/data/assets/${uuid}/f.png`)).toEqual([uuid, 'f.png']);
+        });
+
+        it('returns null when there is no assets component', () => {
+            expect(extractAssetsRelativeSegments('/mnt/data/tmp/2026/01/01/x/f.png')).toBeNull();
+            expect(extractAssetsRelativeSegments('/mnt/assets-data/foo/f.png')).toBeNull();
+        });
+
+        it('returns null when the suffix is empty or unsafe', () => {
+            expect(extractAssetsRelativeSegments('/mnt/data/assets')).toBeNull();
+            expect(extractAssetsRelativeSegments('/mnt/data/assets/')).toBeNull();
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/../etc/passwd`)).toBeNull();
+            expect(extractAssetsRelativeSegments(`/mnt/data/assets/${uuid}/..`)).toBeNull();
+        });
+    });
+
+    describe('resolveAssetStoragePath', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+        const filesDir = nodePath.join(nodePath.sep, 'srv', 'exelearning-data');
+
+        it('resolves a canonical relative path under FILES_DIR', () => {
+            const resolved = resolveAssetStoragePath(filesDir, `assets/ab/${uuid}/client.png`);
+            expect(resolved).toBe(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab', uuid, 'client.png'));
+        });
+
+        it('resolves the same stored path under a different FILES_DIR (portability)', () => {
+            const stored = `assets/ab/${uuid}/client.png`;
+            const otherFilesDir = nodePath.join(nodePath.sep, 'mnt', 'restored');
+            expect(resolveAssetStoragePath(filesDir, stored)).toStartWith(filesDir + nodePath.sep);
+            expect(resolveAssetStoragePath(otherFilesDir, stored)).toStartWith(otherFilesDir + nodePath.sep);
+        });
+
+        it('re-roots a legacy absolute path under the current FILES_DIR', () => {
+            const legacy = `/old-mount/data/assets/${uuid}/client.png`;
+            expect(resolveAssetStoragePath(filesDir, legacy)).toBe(
+                nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, uuid, 'client.png'),
+            );
+        });
+
+        it('re-roots a legacy Windows absolute path under the current FILES_DIR', () => {
+            const legacy = `C:\\app\\data\\assets\\${uuid}\\client.png`;
+            expect(resolveAssetStoragePath(filesDir, legacy)).toBe(
+                nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, uuid, 'client.png'),
+            );
+        });
+
+        it('throws UnsafePathError for traversal attempts', () => {
+            expect(() => resolveAssetStoragePath(filesDir, 'assets/../secrets.db')).toThrow(UnsafePathError);
+            expect(() => resolveAssetStoragePath(filesDir, `/x/assets/../../etc/passwd`)).toThrow(UnsafePathError);
+        });
+
+        it('throws UnsafePathError for values that cannot be interpreted at all', () => {
+            expect(() => resolveAssetStoragePath(filesDir, '/mnt/elsewhere/file.png')).toThrow(UnsafePathError);
+            expect(() => resolveAssetStoragePath(filesDir, 'relative/but/not/assets.png')).toThrow(UnsafePathError);
+            expect(() => resolveAssetStoragePath(filesDir, '')).toThrow(UnsafePathError);
+        });
+
+        it('never resolves outside FILES_DIR/assets', () => {
+            const attempts = ['assets/ab/../../outside.png', `/mnt/data/assets/${uuid}/\0.png`, 'assets/./client.png'];
+            for (const attempt of attempts) {
+                let resolved: string | null = null;
+                try {
+                    resolved = resolveAssetStoragePath(filesDir, attempt);
+                } catch (err) {
+                    expect(err).toBeInstanceOf(UnsafePathError);
+                }
+                if (resolved !== null) {
+                    const assetsRoot = nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME);
+                    expect(resolved.startsWith(assetsRoot + nodePath.sep)).toBe(true);
+                }
+            }
+        });
+    });
+
+    describe('getProjectAssetsDirCandidates', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+        const filesDir = nodePath.join(nodePath.sep, 'srv', 'exelearning-data');
+
+        it('returns the sharded directory first, then the legacy unsharded directory', () => {
+            expect(getProjectAssetsDirCandidates(filesDir, uuid)).toEqual([
+                nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab', uuid),
+                nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, uuid),
+            ]);
+        });
+
+        it('never returns a legacy candidate that collides with a shard bucket directory', () => {
+            // A hypothetical two-hex project identifier must not cause the
+            // legacy candidate to point at a shard bucket (mass deletion).
+            const candidates = getProjectAssetsDirCandidates(filesDir, 'ab');
+            for (const candidate of candidates) {
+                expect(candidate).not.toBe(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab'));
+            }
+        });
+
+        it('throws UnsafePathError for unsafe project identifiers', () => {
+            expect(() => getProjectAssetsDirCandidates(filesDir, '../evil')).toThrow(UnsafePathError);
+            expect(() => getProjectAssetsDirCandidates(filesDir, '')).toThrow(UnsafePathError);
+        });
+    });
+
+    describe('tryResolveAssetStoragePath', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+        const filesDir = nodePath.join(nodePath.sep, 'srv', 'exelearning-data');
+
+        it('returns the resolved path for valid input', () => {
+            expect(tryResolveAssetStoragePath(filesDir, `assets/ab/${uuid}/f.png`)).toBe(
+                nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, 'ab', uuid, 'f.png'),
+            );
+        });
+
+        it('returns null instead of throwing for invalid input', () => {
+            expect(tryResolveAssetStoragePath(filesDir, '/mnt/elsewhere/file.png')).toBeNull();
+            expect(tryResolveAssetStoragePath(filesDir, 'assets/../evil')).toBeNull();
+            expect(tryResolveAssetStoragePath(filesDir, '')).toBeNull();
+        });
+    });
+});

--- a/src/utils/asset-paths.ts
+++ b/src/utils/asset-paths.ts
@@ -25,7 +25,7 @@ export const ASSETS_ROOT_DIR_NAME = 'assets';
 /** Canonical UUID shape (8-4-4-4-12 hex groups, any version, any case). */
 const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const SHARD_HEX = /^[0-9a-f]{2}$/;
+const SHARD_HEX_ANY_CASE = /^[0-9a-fA-F]{2}$/;
 
 /**
  * Validates one stored-path segment. Deliberately more permissive than
@@ -33,7 +33,7 @@ const SHARD_HEX = /^[0-9a-f]{2}$/;
  * spaces, parentheses and non-ASCII characters. Only structural hazards are
  * rejected: separators, traversal tokens, control characters and emptiness.
  */
-function isSafeStoredSegment(segment: unknown): segment is string {
+export function isSafeAssetPathSegment(segment: unknown): segment is string {
     if (typeof segment !== 'string' || segment.length === 0 || segment.length > 255) {
         return false;
     }
@@ -88,14 +88,14 @@ export function getAssetShard(projectId: string): string {
  * FILES_DIR. At least one segment below the project directory is required.
  */
 export function buildAssetStoragePath(projectUuid: string, ...segments: string[]): string {
-    if (!isSafeStoredSegment(projectUuid)) {
+    if (!isSafeAssetPathSegment(projectUuid)) {
         throw new UnsafePathError('Invalid project identifier in asset storage path');
     }
     if (segments.length === 0) {
         throw new UnsafePathError('Asset storage path requires at least one segment');
     }
     for (const segment of segments) {
-        if (!isSafeStoredSegment(segment)) {
+        if (!isSafeAssetPathSegment(segment)) {
             throw new UnsafePathError('Invalid segment in asset storage path');
         }
     }
@@ -118,16 +118,19 @@ export function isCanonicalAssetStoragePath(value: unknown): value is string {
     if (segments.length < 3 || segments[0] !== ASSETS_ROOT_DIR_NAME) {
         return false;
     }
-    return segments.slice(1).every(isSafeStoredSegment);
+    return segments.slice(1).every(isSafeAssetPathSegment);
 }
 
 /**
  * Extracts the assets-relative segments from a legacy stored value (an
  * absolute host path written by versions before the relative-path migration,
- * with either POSIX or Windows separators). Returns the segments after the
- * LAST `assets` path component, or null when the value contains no `assets`
- * component or the suffix is unsafe. The absolute prefix is deliberately
- * ignored: it refers to whatever FILES_DIR was when the row was written.
+ * with either POSIX or Windows separators). Uses the LAST `assets` path
+ * component that yields a valid suffix — backtracking to earlier components
+ * covers files literally named `assets` — and requires at least two suffix
+ * segments (a project directory plus a filename), so a value can never
+ * resolve to a whole bucket or project directory. Returns null when no safe
+ * interpretation exists. The absolute prefix is deliberately ignored: it
+ * refers to whatever FILES_DIR was when the row was written.
  */
 export function extractAssetsRelativeSegments(storedPath: string): string[] | null {
     if (typeof storedPath !== 'string' || storedPath.length === 0) {
@@ -138,15 +141,18 @@ export function extractAssetsRelativeSegments(storedPath: string): string[] | nu
     if (segments.length > 0 && segments[segments.length - 1] === '') {
         segments.pop();
     }
-    const assetsIndex = segments.lastIndexOf(ASSETS_ROOT_DIR_NAME);
-    if (assetsIndex === -1) {
-        return null;
+    let assetsIndex = segments.lastIndexOf(ASSETS_ROOT_DIR_NAME);
+    while (assetsIndex !== -1) {
+        const suffix = segments.slice(assetsIndex + 1);
+        if (suffix.length >= 2 && suffix.every(isSafeAssetPathSegment)) {
+            return suffix;
+        }
+        if (assetsIndex === 0) {
+            break;
+        }
+        assetsIndex = segments.lastIndexOf(ASSETS_ROOT_DIR_NAME, assetsIndex - 1);
     }
-    const suffix = segments.slice(assetsIndex + 1);
-    if (suffix.length === 0 || !suffix.every(isSafeStoredSegment)) {
-        return null;
-    }
-    return suffix;
+    return null;
 }
 
 /**
@@ -196,14 +202,16 @@ export function tryResolveAssetStoragePath(filesDir: string, storedPath: string)
  * created before the sharding migration are fully cleaned up.
  */
 export function getProjectAssetsDirCandidates(filesDir: string, projectUuid: string): string[] {
-    if (!isSafeStoredSegment(projectUuid)) {
+    if (!isSafeAssetPathSegment(projectUuid)) {
         throw new UnsafePathError('Invalid project identifier for asset directory');
     }
     const shard = getAssetShard(projectUuid);
     const candidates = [nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, shard, projectUuid)];
-    if (!SHARD_HEX.test(projectUuid)) {
+    if (!SHARD_HEX_ANY_CASE.test(projectUuid)) {
         // Defensive: a two-hex "uuid" would make the legacy candidate collide
-        // with a shard bucket directory; never offer that for deletion.
+        // with a shard bucket directory; never offer that for deletion. The
+        // check is case-insensitive because case-insensitive filesystems
+        // (macOS/Windows desktop builds) alias 'AB' to the 'ab' bucket.
         candidates.push(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, projectUuid));
     }
     return candidates;

--- a/src/utils/asset-paths.ts
+++ b/src/utils/asset-paths.ts
@@ -1,0 +1,210 @@
+/**
+ * Asset storage path utilities — single source of truth for the physical
+ * layout of project assets and for the portable database representation of
+ * `assets.storage_path`.
+ *
+ * Layout (one 8-bit shard level, 256 lazy buckets — see ADR-2250-01):
+ *
+ *     FILES_DIR/assets/<shard>/<projectUuid>/<file...>
+ *
+ * Database representation: POSIX-style paths relative to FILES_DIR, always
+ * starting with the `assets/` component, e.g.
+ *
+ *     assets/ab/ab12cd34-.../client-id.png
+ *
+ * Everything here is pure (no filesystem, no environment access) so the shard
+ * and path grammar can be tested exhaustively. Resolution against the real
+ * FILES_DIR is wrapped by `src/services/file-helper.ts`.
+ */
+import * as nodePath from 'path';
+import { isWithinBase, UnsafePathError } from './safe-path';
+
+/** Name of the assets root directory under FILES_DIR. */
+export const ASSETS_ROOT_DIR_NAME = 'assets';
+
+/** Canonical UUID shape (8-4-4-4-12 hex groups, any version, any case). */
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const SHARD_HEX = /^[0-9a-f]{2}$/;
+
+/**
+ * Validates one stored-path segment. Deliberately more permissive than
+ * `isSafePathSegment` because historical asset filenames legitimately contain
+ * spaces, parentheses and non-ASCII characters. Only structural hazards are
+ * rejected: separators, traversal tokens, control characters and emptiness.
+ */
+function isSafeStoredSegment(segment: unknown): segment is string {
+    if (typeof segment !== 'string' || segment.length === 0 || segment.length > 255) {
+        return false;
+    }
+    if (segment === '.' || segment === '..') {
+        return false;
+    }
+    if (segment.includes('/') || segment.includes('\\')) {
+        return false;
+    }
+    for (let i = 0; i < segment.length; i++) {
+        const code = segment.charCodeAt(i);
+        if (code <= 0x1f || code === 0x7f) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** FNV-1a 32-bit hash over the UTF-8 bytes of `value`. */
+function fnv1a32(value: string): number {
+    let hash = 0x811c9dc5;
+    const bytes = new TextEncoder().encode(value);
+    for (const byte of bytes) {
+        hash ^= byte;
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash;
+}
+
+/**
+ * Returns the two-character lowercase hex shard bucket for a project
+ * identifier. Canonical UUIDs (the normal case — project UUIDs are generated
+ * with `crypto.randomUUID()` / `uuid.v4()`) use their first two hex
+ * characters, so the bucket is readable straight off the UUID and uniformly
+ * distributed. Any other identifier (`projects.uuid` is not format-validated
+ * at every creation site) falls back to a deterministic 8-bit FNV-1a hash so
+ * the mapping is total and stable.
+ */
+export function getAssetShard(projectId: string): string {
+    if (typeof projectId !== 'string' || projectId.length === 0) {
+        throw new UnsafePathError('Invalid project identifier for asset shard');
+    }
+    if (CANONICAL_UUID.test(projectId)) {
+        return projectId.slice(0, 2).toLowerCase();
+    }
+    return (fnv1a32(projectId) & 0xff).toString(16).padStart(2, '0');
+}
+
+/**
+ * Builds the canonical stored (database) path for an asset file:
+ * `assets/<shard>/<projectUuid>/<segments...>`, POSIX separators, relative to
+ * FILES_DIR. At least one segment below the project directory is required.
+ */
+export function buildAssetStoragePath(projectUuid: string, ...segments: string[]): string {
+    if (!isSafeStoredSegment(projectUuid)) {
+        throw new UnsafePathError('Invalid project identifier in asset storage path');
+    }
+    if (segments.length === 0) {
+        throw new UnsafePathError('Asset storage path requires at least one segment');
+    }
+    for (const segment of segments) {
+        if (!isSafeStoredSegment(segment)) {
+            throw new UnsafePathError('Invalid segment in asset storage path');
+        }
+    }
+    return [ASSETS_ROOT_DIR_NAME, getAssetShard(projectUuid), projectUuid, ...segments].join('/');
+}
+
+/**
+ * Returns true if `value` is a well-formed stored asset path: a relative
+ * POSIX path starting with `assets/`, containing at least a project directory
+ * and a filename, with only safe segments. Both the sharded form
+ * (`assets/<shard>/<uuid>/...`) and the unsharded assets-relative form
+ * (`assets/<uuid>/...`, used as a conservative fallback for migration
+ * conflicts) are accepted — resolution does not depend on shard depth.
+ */
+export function isCanonicalAssetStoragePath(value: unknown): value is string {
+    if (typeof value !== 'string' || value.includes('\\')) {
+        return false;
+    }
+    const segments = value.split('/');
+    if (segments.length < 3 || segments[0] !== ASSETS_ROOT_DIR_NAME) {
+        return false;
+    }
+    return segments.slice(1).every(isSafeStoredSegment);
+}
+
+/**
+ * Extracts the assets-relative segments from a legacy stored value (an
+ * absolute host path written by versions before the relative-path migration,
+ * with either POSIX or Windows separators). Returns the segments after the
+ * LAST `assets` path component, or null when the value contains no `assets`
+ * component or the suffix is unsafe. The absolute prefix is deliberately
+ * ignored: it refers to whatever FILES_DIR was when the row was written.
+ */
+export function extractAssetsRelativeSegments(storedPath: string): string[] | null {
+    if (typeof storedPath !== 'string' || storedPath.length === 0) {
+        return null;
+    }
+    const segments = storedPath.split(/[\\/]/);
+    // A trailing separator produces one empty trailing segment; drop it.
+    if (segments.length > 0 && segments[segments.length - 1] === '') {
+        segments.pop();
+    }
+    const assetsIndex = segments.lastIndexOf(ASSETS_ROOT_DIR_NAME);
+    if (assetsIndex === -1) {
+        return null;
+    }
+    const suffix = segments.slice(assetsIndex + 1);
+    if (suffix.length === 0 || !suffix.every(isSafeStoredSegment)) {
+        return null;
+    }
+    return suffix;
+}
+
+/**
+ * Resolves a stored `assets.storage_path` value to an absolute filesystem
+ * path under `filesDir`. Canonical relative values resolve directly; legacy
+ * absolute values are re-rooted under the current FILES_DIR via their
+ * `assets/...` suffix (transitional read fallback — see ADR-2250-01). Throws
+ * {@link UnsafePathError} when the value cannot be interpreted safely or the
+ * result would escape `FILES_DIR/assets`.
+ */
+export function resolveAssetStoragePath(filesDir: string, storedPath: string): string {
+    let segments: string[];
+    if (isCanonicalAssetStoragePath(storedPath)) {
+        segments = storedPath.split('/').slice(1);
+    } else {
+        const extracted = extractAssetsRelativeSegments(storedPath);
+        if (!extracted) {
+            throw new UnsafePathError('Stored asset path cannot be resolved under FILES_DIR/assets');
+        }
+        segments = extracted;
+    }
+    const assetsRoot = nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME);
+    const resolved = nodePath.join(assetsRoot, ...segments);
+    if (resolved === nodePath.resolve(assetsRoot) || !isWithinBase(assetsRoot, resolved)) {
+        throw new UnsafePathError('Resolved asset path escapes FILES_DIR/assets');
+    }
+    return resolved;
+}
+
+/**
+ * Non-throwing variant of {@link resolveAssetStoragePath}: returns null for
+ * values that cannot be resolved. Intended for read paths where an
+ * unresolvable stored value should behave like a missing file.
+ */
+export function tryResolveAssetStoragePath(filesDir: string, storedPath: string): string | null {
+    try {
+        return resolveAssetStoragePath(filesDir, storedPath);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Returns the physical project asset directory candidates for `projectUuid`
+ * under `filesDir`: the canonical sharded directory first, then the legacy
+ * unsharded directory. Deletion/cleanup paths must remove both so projects
+ * created before the sharding migration are fully cleaned up.
+ */
+export function getProjectAssetsDirCandidates(filesDir: string, projectUuid: string): string[] {
+    if (!isSafeStoredSegment(projectUuid)) {
+        throw new UnsafePathError('Invalid project identifier for asset directory');
+    }
+    const shard = getAssetShard(projectUuid);
+    const candidates = [nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, shard, projectUuid)];
+    if (!SHARD_HEX.test(projectUuid)) {
+        // Defensive: a two-hex "uuid" would make the legacy candidate collide
+        // with a shard bucket directory; never offer that for deletion.
+        candidates.push(nodePath.join(filesDir, ASSETS_ROOT_DIR_NAME, projectUuid));
+    }
+    return candidates;
+}

--- a/src/websocket/asset-coordinator.spec.ts
+++ b/src/websocket/asset-coordinator.spec.ts
@@ -1584,6 +1584,37 @@ describe('Asset Coordinator Service (DI)', () => {
             manifest: [],
         };
 
+        it('should create the upload session with the canonical projects.uuid, not the raw client value', async () => {
+            // Simulates a case-insensitive DB collation: the lookup for the
+            // client-supplied identifier returns a row whose canonical uuid
+            // differs. Storage paths derive from the session's projectId, so it
+            // must be the canonical value (issue #2250).
+            let createArgs: any;
+            const usm = {
+                createSession: async (args: any) => {
+                    createArgs = args;
+                    return { sessionToken: 'tok-canon', expiresAt: Date.now() + 60_000 };
+                },
+                validateSession: async () => ({ sessionId: 'sess-c', projectId: 'canonical-uuid', userId: 3 }),
+                onProgress: () => {},
+                onBatchComplete: () => {},
+            };
+            const c = buildCoordinator(usm, { id: 7, uuid: 'canonical-uuid', user_id: 3 });
+            const socket = createMockSocket();
+            c.registerClient('session-project', 'client-1', socket);
+
+            await c.handleMessage('session-project', 'client-1', {
+                type: 'upload-session-create',
+                data: validData,
+            });
+
+            expect(createArgs).toBeDefined();
+            expect(createArgs.projectId).toBe('canonical-uuid');
+            expect(createArgs.projectIdNum).toBe(7);
+
+            c.cleanupProject('session-project');
+        });
+
         it('should register progress + batch callbacks and forward their events to the client', async () => {
             let progressCb: ((p: any) => void) | undefined;
             let batchCb: ((r: any) => void) | undefined;

--- a/src/websocket/asset-coordinator.ts
+++ b/src/websocket/asset-coordinator.ts
@@ -979,9 +979,14 @@ export function createAssetCoordinator(deps: AssetCoordinatorDeps = {}): AssetCo
             // The userId is used for session validation but the actual auth is via the session token
             const userId = project.user_id || 0;
 
-            // Create session (async due to jose JWT library)
+            // Create session (async due to jose JWT library). The session's
+            // projectId is the CANONICAL projects.uuid from the database, not
+            // the raw client-supplied value: storage paths are derived from it
+            // (upload-session.ts), and a case-variant identifier (possible with
+            // case-insensitive DB collations) would otherwise mint a second
+            // on-disk directory that cleanup would never remove.
             const { sessionToken, expiresAt } = await uploadSessionManager.createSession({
-                projectId: projectUuid,
+                projectId: project.uuid,
                 projectIdNum: project.id,
                 userId,
                 clientId,


### PR DESCRIPTION
## Summary

Project asset storage moves from a flat, absolute-path model to a sharded, portable one:

- **Layout:** `FILES_DIR/assets/<projectUuid>/…` → `FILES_DIR/assets/<2-hex-shard>/<projectUuid>/…` (one shard level, 256 lazily created buckets).
- **Database:** `assets.storage_path` now stores POSIX-style paths **relative to `FILES_DIR`** (`assets/ab/<uuid>/<clientId>.png`) instead of absolute host paths.
- **Migration:** existing installations converge automatically at startup via an idempotent, resumable, never-overwriting reconciliation.
- All path construction/resolution is centralized in `src/utils/asset-paths.ts` + `src/services/file-helper.ts`; documented in [ADR-2250-01](doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md) and the [change design/admin guide](doc/architecture/changes/2250-asset-storage-sharding/design.md).

## Problem

Issue #2250 raises two distinct concerns, and this PR deliberately treats them differently:

1. **Absolute `storage_path` — a concrete architectural defect.** Every asset row was pinned to one specific `FILES_DIR` mount (`/mnt/data/assets/…`), so moving, remounting or restoring the data directory invalidated every row. Themes and templates already store FILES_DIR-relative paths; assets were the outlier. This is fixed outright.
2. **Flat `assets/` root — a preventive concern, not a demonstrated bug.** ext4 with `dir_index` resolves known-name lookups through an htree index, and nothing in the codebase enumerates the assets root at runtime (all `readdir`s are per-project — verified in #2250, consistent with #1842). We shard **now** because it is cheap now: fixing (1) decouples the database from the physical layout, and retrofitting a layout change after years of data accumulation would be far more expensive.

## Decision

```
FILES_DIR/assets/<shard>/<projectUuid>/<clientId>.<ext>
FILES_DIR/assets/<shard>/<projectUuid>/<clientId>/<filename>   (ZIP extraction / duplication)
```

`<shard>` = lowercased first two hex characters of the canonical project UUID (v4, uniformly distributed — the bucket is readable straight off the UUID). Because `projects.uuid` is not format-validated at every creation site (`createProjectWithUuid` accepts client-supplied ids verbatim), non-canonical identifiers fall back to a deterministic 8-bit FNV-1a hash, so the mapping is total and stable. **One shard level, 256 possible buckets, created lazily** — never pre-created.

## Why one level

Average bucket-namespace occupancy (lazy creation — unused buckets never exist on disk):

| Projects | 1 level (256) | 2 levels (65,536) | 3 levels (16,777,216) |
|---:|---:|---:|---:|
| 20,000 | ≈ 78 | ≈ 0.31 | ≈ 0.0012 |
| 200,000 | ≈ 781 | ≈ 3.05 | ≈ 0.0119 |
| 1,000,000 | ≈ 3,906 | ≈ 15.26 | ≈ 0.0596 |
| 10,000,000 | ≈ 39,063 | ≈ 152.59 | ≈ 0.5960 |

One level already caps per-bucket counts very effectively at any plausible eXeLearning scale, with minimal depth and minimal intermediate directories. Two levels (the issue's original proposal) would leave buckets ~15 entries deep at one **million** projects — the extra level does nearly nothing except add depth; three levels is pure overhead. There is no measured evidence that 65k or 16M buckets are needed, and the now-portable `storage_path` makes a future re-shard cheap if measurements ever justify it. Precedent: **Git itself uses exactly one two-hex-character level** for loose objects ("splayed over 256 subdirectories using the first two characters of the sha1 object name" — [gitrepository-layout](https://git-scm.com/docs/gitrepository-layout), [gitformat-loose](https://git-scm.com/docs/gitformat-loose)); the issue's description of two levels as "the scheme used by Git" was not accurate. We do not claim one level is universally optimal — it is the proportional choice for the expected scale and current evidence (full rationale and rejected options in the ADR).

## Migration

Runs automatically inside `bootstrap()` on **every** startup (after schema migrations, before `app.listen()`); it is a fast no-op once converged: one legacy-row query plus one readdir of the assets root, plus bounded content checks for existing two-decimal shard buckets (`00`–`99`), which are ambiguous with legacy numeric project-id directories. Re-checking every boot is deliberate (it lets restored legacy data converge automatically). During a large migration a progress line (`[AssetStorage] Migration progress: 1,000/3,250 legacy row(s) processed, 2,250 pending.`) is printed every 1,000 processed rows. Deliberately **not** a Kysely migration: filesystem moves and row updates cannot share a transaction, so this is a startup reconciliation instead (`src/services/asset-storage-migration.ts`).

- **Files:** `assets/<uuid>/…` → `assets/<shard>/<uuid>/…` via rename (same filesystem: metadata-only); `EXDEV` falls back to copy-to-temp + rename + size-verify + remove, so the destination never holds a partial file. Handles the flat layout, the nested ZIP-extraction layout, and the legacy numeric-directory quirk (`assets/<numericId>/`, from routes that accepted numeric project ids).
- **Rows:** legacy absolute values are rewritten to the canonical relative form, derived from the row's own `assets/…` suffix (the stale absolute prefix is ignored).
- **Orphans:** files on disk without rows are swept into the sharded layout; emptied legacy directories are removed; unrecognized entries are reported and left alone.
- **Temporary legacy-read compatibility exists**: the shared resolver re-roots legacy absolute values under the *current* `FILES_DIR` via their `assets/…` suffix, so unmigrated/conflict rows keep working (and become FILES_DIR-portable even before migration). All new writes emit **only** the new format — there is no dual-write, and removal of the fallback is tracked as ADR follow-up. Permanent dual-layout support and a hard cut-over were both evaluated and rejected (ADR, "Migration / compatibility strategy").

## Safety

- **Idempotent & resumable:** per-row protocol is *move file, then rewrite row* under an optimistic `WHERE id = ? AND storage_path = <old>` guard; a crash between the two steps leaves a state the next boot reconciles. Individual file errors are counted and logged, never abort the run, and are retried on the next startup.
- **Restart/interruption states handled explicitly:** source-only → move; destination-only → rewrite row (crash recovery); both identical (size + SHA-256) → drop legacy copy; **both different → never overwrite**: keep both files, log the conflict, park the row on its legacy location in portable relative form, re-report on every boot until an operator resolves it; neither → log missing, converge the row (reads keep returning 404 exactly as before); uninterpretable values (no `assets/…` suffix, traversal) → left untouched and reported, and the migration never dereferences arbitrary absolute paths from the database.
- **Concurrent multi-instance startup** (Redis HA): the optimistic guards and existence checks make the race benign — one instance wins each row.
- **Path security:** every stored-value → physical-path conversion goes through one resolver that rejects `..`, separators in segments, control characters, and anything escaping `FILES_DIR/assets` (separator-aware containment via the existing `isWithinBase`).
- **Cleanup paths** (cleanup scheduler, admin user deletion, `projects-cleanup` CLI) remove both the sharded and the legacy directory during the transition.

## Tests

All executed locally on this branch (macOS, Bun 1.3.14):

- `make fix` / `make lint` — clean (exit 0; the two Biome warnings also appear on a clean checkout of `main`).
- `make test-unit` — **8,104 pass, 0 fail** (backend, 232 files); per-file 90% coverage gate **passed**, including every new/modified file.
- `make test-frontend` — 14,120 pass, **1 fail**: `focusedEditMode.test.js › removes all focus-mode state` — a known pre-existing flake that fails on clean `main` in full runs and passes in isolation (re-verified both here: passes 20/20 in isolation, and `git diff origin/main -- public/` is empty — this PR touches no frontend files).
- `make test-integration` — **727 pass, 0 fail**.
- `make test-e2e` — **528 passed, 6 skipped, 0 failed** (16.9 m, full Playwright suite: file manager incl. special-characters, upload, import/export, project clone/duplicate, save flows) — run twice: once on the base implementation and once again on the final branch including the review-hardening commit. `make test-e2e-static` was not run: this change touches only server-side storage code — no `public/`, embedding or static-build files are modified, and the static app runs without a server.
- New/updated suites: `src/utils/asset-paths.spec.ts` (shard determinism, golden FNV values, grammar, traversal rejection, directory-level-value rejection), `src/services/asset-storage-migration.spec.ts` (26 tests: every migration state, idempotency, batching, EXDEV fallback, orphan sweep incl. two-digit numeric-dir/bucket disambiguation, unmounted-volume latch, conflicts, unicode filenames, traversal safety), `src/services/file-helper.spec.ts` (**FILES_DIR portability regression test**: the same stored path resolves under two different `FILES_DIR` values without rewriting the row), plus updated specs for upload/download/delete/duplicate/ZIP-extract/sync/stream/export-provider/cleanup/coordinator flows asserting relative sharded writes, the legacy-read fallback, and partial-failure reporting.
- An adversarial multi-agent review pass was run on the branch before opening this PR; the confirmed findings (unmounted-volume rewrite hazard, numeric-directory sweep gap for project ids 10–99, unvalidated project identifiers reaching `getProjectAssetsDir`, directory-level legacy values, swallowed partial cleanup errors, superseded-file orphans on relocating re-uploads, missing legacy-dir fallback in server-side exports, non-canonical UUID in upload sessions, case-blind bucket-collision guard) are fixed in the final commit, each with a regression test.

## Benchmarking

This change is **preventive**; it is not justified by a current runtime failure, and no benchmark was required to adopt it. A reproducible benchmark ships anyway: `scripts/benchmark-asset-storage.ts` compares 0/1/2/3 levels (creation, known-path `stat`, root/bucket `readdir`, full recursive traversal) at configurable scale with seeded, reproducible datasets; `--json` captures environment metadata. It is not part of CI (its spec checks harness correctness only — no timing thresholds).

One real run was executed while developing (20,000 projects × 2 assets, **macOS 25.4.0 / APFS / Apple M5 / Bun 1.3.14 — not the production ext4 target**): 5,000 known-path stats: 184 ms flat vs ≈ 57 ms at every sharded depth; root readdir 8.2 ms/20,000 entries flat vs 0.2 ms/256; full traversal 1.21 s flat, **1.04 s at one level, 1.64 s at two, 2.25 s at three** — deeper trees make the full walk *slower*, consistent with sharding redistributing entries rather than removing work. These numbers must not be extrapolated to ext4 or network storage; the ADR recommends running the benchmark on local ext4 SSD/NVMe, on the actual production backend, and on NFS/SAN if used.

## Operational considerations

- Persistent `FILES_DIR` data must live outside the container writable layer. Docker named volumes and bind mounts can both expose host/external storage, named volumes are not inherently a performance problem (they bypass the storage-driver union-filesystem overhead — [Docker storage docs](https://docs.docker.com/engine/storage/)), and volumes can themselves be NFS-backed. NFS/SAN/network storage behaves differently from local ext4 and should be measured on the actual deployment.
- ext4 is **not** unsuitable for large installations: with `dir_index` lookups are htree-indexed, `dir_nlink` lifts the old ~65k subdirectory limit, and `large_dir` raises directory size/htree height further ([ext4(5)](https://man7.org/linux/man-pages/man5/ext4.5.html)). Very large deployments should choose ext4/XFS/Btrfs/OpenZFS/NFS/SAN-backed storage from operational requirements and measured workloads, not from folklore.
- Full-tree operations (backup, `du`, `find`, `tar`, `rsync` list generation) still scale with total object count — sharding bounds directory sizes; it does not shrink the tree.
- Upgrade/downtime/verification/rollback details for administrators: [change design doc](doc/architecture/changes/2250-asset-storage-sharding/design.md) ("Administrator guide"). Short version: back up DB + `FILES_DIR` first; first boot renames existing files before listening (seconds to a few minutes locally, longer on network storage); success is `[AssetStorage] Asset storage layout is up to date.` on the next boot; rollback = restore the pre-upgrade backup.

## ADR

[ADR-2250-01 — Shard project asset storage using a single 8-bit bucket level](doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md) (Accepted). Change document: [`doc/architecture/changes/2250-asset-storage-sharding/design.md`](doc/architecture/changes/2250-asset-storage-sharding/design.md). `make architecture-check` passes.

## References

- Linux kernel ext4: [directories](https://docs.kernel.org/filesystems/ext4/directory.html), [inodes](https://docs.kernel.org/filesystems/ext4/inodes.html); [ext4(5)](https://man7.org/linux/man-pages/man5/ext4.5.html)
- Git: [gitformat-loose](https://git-scm.com/docs/gitformat-loose), [gitrepository-layout](https://git-scm.com/docs/gitrepository-layout)
- Docker: [storage](https://docs.docker.com/engine/storage/), [volumes](https://docs.docker.com/engine/storage/volumes/), [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/)
- Btrfs: [kernel docs](https://docs.kernel.org/filesystems/btrfs.html)

## Historical context

PR #788 intentionally introduced the UUID-per-project directories and lazy creation this PR builds on — this is an evolution of that design, not a correction of a mistake. Issue #1842 confirms application-level filesystem enumeration is scoped to individual project directories, never the assets root.

Out of scope (as requested in the issue): the hardcoded `data/chunks` upload root is unrelated to sharding and is left for a separate issue.

## Issue

Closes #2250

