### PR TITLE
fix(markdown): render single-dollar LaTeX formulas in the Markdown iDevice

### DIFF
--- a/public/app/common/app_common.js
+++ b/public/app/common/app_common.js
@@ -67,21 +67,26 @@ export default class Common {
    * stashed before Showdown runs so that markdown processing does not eat
    * underscores, asterisks or backslashes inside formulas. They are restored
    * verbatim afterwards so MathJax can pick them up at render time.
+   * Single-dollar inline math ($...$) is normalized to \(...\) because the
+   * MathJax configuration shipped with eXeLearning does not enable the $
+   * inline delimiter (#1990).
    */
   markdownToHTML(content) {
     var src = String(content == null ? '' : content);
     var store = [];
+    var stash = function (match) {
+      store.push(match);
+      return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
+    };
     [
       /\\\[[\s\S]*?\\\]/g,
       /\$\$[\s\S]*?\$\$/g,
       /\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}/g,
       /\\\([\s\S]*?\\\)/g,
     ].forEach(function (re) {
-      src = src.replace(re, function (match) {
-        store.push(match);
-        return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
-      });
+      src = src.replace(re, stash);
     });
+    src = this.normalizeDollarMath(src, stash);
 
     var converter = new showdown.Converter({
       noHeaderId: true,
@@ -95,6 +100,60 @@ export default class Common {
     return html.replace(/EXELATEXBEGIN(\d+)EXELATEXEND/g, function (_, i) {
       return store[Number(i)] !== undefined ? store[Number(i)] : _;
     });
+  }
+
+  /**
+   * Convert single-dollar inline math ($...$) into \(...\) and stash it.
+   *
+   * Chatbot-generated Markdown commonly delimits inline formulas with single
+   * dollars, but the MathJax configuration used by eXeLearning only enables
+   * \(...\) for inline math, and Showdown would mangle underscores inside the
+   * formula before MathJax could see it (#1990). Pandoc-style rules keep
+   * plain dollar amounts out of math mode: the opening $ must be followed by
+   * a non-space character, the closing $ must be preceded by a non-space
+   * character and must not be followed by a digit, neither may be escaped,
+   * and the pair must sit on a single line. Fenced code blocks and inline
+   * code spans are left untouched.
+   *
+   * @param {string} src markdown source (LaTeX already stashed)
+   * @param {function(string): string} stashFn stores a formula, returns its placeholder
+   * @returns {string}
+   */
+  normalizeDollarMath(src, stashFn) {
+    var fenceRe = /^\s{0,3}(?:`{3,}|~{3,})/;
+    var codeSpanRe = /(`+)[\s\S]*?\1/g;
+    // A formula is either a single character or first/last characters with a
+    // lazy body; the last character may not be a backslash, so an escaped \$
+    // before the closing delimiter rejects the pair instead of producing a
+    // formula that ends in a stray backslash (a MathJax TeX error).
+    var dollarRe = /(^|[^\\$])\$([^\s$\\]|[^\s$][^$\n]*?[^\s$\\])\$(?!\d|\$)/g;
+    var convert = function (text) {
+      return text.replace(dollarRe, function (match, prefix, formula) {
+        return prefix + stashFn('\\(' + formula + '\\)');
+      });
+    };
+    var inFence = false;
+    return String(src)
+      .split('\n')
+      .map(function (line) {
+        if (fenceRe.test(line)) {
+          inFence = !inFence;
+          return line;
+        }
+        if (inFence || line.indexOf('$') === -1) {
+          return line;
+        }
+        var out = '';
+        var last = 0;
+        var m;
+        codeSpanRe.lastIndex = 0;
+        while ((m = codeSpanRe.exec(line)) !== null) {
+          out += convert(line.slice(last, m.index)) + m[0];
+          last = m.index + m[0].length;
+        }
+        return out + convert(line.slice(last));
+      })
+      .join('\n');
   }
 
   /**

--- a/public/app/common/app_common.test.js
+++ b/public/app/common/app_common.test.js
@@ -286,6 +286,91 @@ describe('Common', () => {
       );
       expect(result).toContain('\\begin{align}a_1 &= b_1 \\\\ c &= d\\end{align}');
     });
+
+    describe('single-dollar inline math (#1990)', () => {
+      it('converts $...$ into \\(...\\) so MathJax can render it', () => {
+        const result = common.markdownToHTML('The formula $a^2 + b^2 = c^2$ is famous');
+        expect(result).toContain('\\(a^2 + b^2 = c^2\\)');
+        expect(result).not.toContain('$a^2');
+      });
+
+      it('protects formula underscores from markdown emphasis', () => {
+        window.showdown.Converter = vi.fn().mockImplementation(function () {
+          this.makeHtml = vi.fn(
+            (content) => `<p>${content.replace(/_([^_]+)_/g, '<em>$1</em>')}</p>`
+          );
+        });
+        const result = common.markdownToHTML('Indexed: $a_1 + b_2$ end');
+        expect(result).toContain('\\(a_1 + b_2\\)');
+        expect(result).not.toContain('<em>');
+      });
+
+      it('converts several formulas on the same line', () => {
+        const result = common.markdownToHTML('$x_1$ and $y_2$');
+        expect(result).toContain('\\(x_1\\)');
+        expect(result).toContain('\\(y_2\\)');
+      });
+
+      it('leaves currency amounts untouched', () => {
+        const result = common.markdownToHTML('It costs $10 and $20 in total');
+        expect(result).toContain('$10 and $20');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('leaves price ranges untouched', () => {
+        const result = common.markdownToHTML('Discounts from $5-$10 apply');
+        expect(result).toContain('$5-$10');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('ignores escaped dollar signs', () => {
+        const result = common.markdownToHTML('Escaped \\$x\\$ stays');
+        expect(result).toContain('\\$x\\$');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('rejects a pair whose closing dollar is escaped', () => {
+        const result = common.markdownToHTML('Mixed $a\\$b$ tail');
+        expect(result).toContain('$a\\$b$');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('keeps TeX \\$ escapes inside a candidate formula literal', () => {
+        const result = common.markdownToHTML('Price $\\text{a \\$ b}$ here');
+        expect(result).toContain('$\\text{a \\$ b}$');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('still converts formulas that start with a backslash', () => {
+        const result = common.markdownToHTML('Greek $\\alpha$ letter');
+        expect(result).toContain('\\(\\alpha\\)');
+      });
+
+      it('does not touch dollars inside inline code spans', () => {
+        const result = common.markdownToHTML('Use `$HOME$` here');
+        expect(result).toContain('`$HOME$`');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('does not touch dollars inside fenced code blocks', () => {
+        const result = common.markdownToHTML('```\necho $a$ $b$\n```\nAfter $x$ end');
+        expect(result).toContain('echo $a$ $b$');
+        expect(result).toContain('\\(x\\)');
+      });
+
+      it('does not pair dollars across lines', () => {
+        const result = common.markdownToHTML('Costs $5.\nWorth $10 more');
+        expect(result).toContain('$5.');
+        expect(result).toContain('$10');
+        expect(result).not.toContain('\\(');
+      });
+
+      it('keeps $$...$$ display math as-is', () => {
+        const result = common.markdownToHTML('Display $$a_1 + b_2$$ and inline $c_3$');
+        expect(result).toContain('$$a_1 + b_2$$');
+        expect(result).toContain('\\(c_3\\)');
+      });
+    });
   });
 
   describe('initTooltips', () => {

--- a/public/files/perm/idevices/base/markdown-text/edition/markdown-text.js
+++ b/public/files/perm/idevices/base/markdown-text/edition/markdown-text.js
@@ -322,6 +322,10 @@ var $exeDevice = {
 
     stashLatex: function (text) {
         const store = [];
+        const stash = function (match) {
+            store.push(match);
+            return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
+        };
         let src = String(text == null ? '' : text);
         [
             /\\\[[\s\S]*?\\\]/g,
@@ -329,12 +333,65 @@ var $exeDevice = {
             /\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}/g,
             /\\\([\s\S]*?\\\)/g,
         ].forEach(function (re) {
-            src = src.replace(re, function (match) {
-                store.push(match);
-                return 'EXELATEXBEGIN' + (store.length - 1) + 'EXELATEXEND';
-            });
+            src = src.replace(re, stash);
         });
+        src = this.normalizeDollarMath(src, stash);
         return { text: src, store: store };
+    },
+
+    /**
+     * Convert single-dollar inline math ($...$) into \(...\) and stash it.
+     *
+     * Mirror of eXe.app.common.markdownToHTML (app_common.js) for the
+     * standalone Showdown fallback: the MathJax configuration used by
+     * eXeLearning only enables \(...\) for inline math, and Showdown would
+     * mangle underscores inside the formula before MathJax could see it
+     * (#1990). Pandoc-style rules keep plain dollar amounts out of math
+     * mode: the opening $ must be followed by a non-space character, the
+     * closing $ must be preceded by a non-space character and must not be
+     * followed by a digit, neither may be escaped, and the pair must sit on
+     * a single line. Fenced code blocks and inline code spans are left
+     * untouched.
+     *
+     * @param {string} src markdown source (LaTeX already stashed)
+     * @param {function(string): string} stashFn stores a formula, returns its placeholder
+     * @returns {string}
+     */
+    normalizeDollarMath: function (src, stashFn) {
+        const fenceRe = /^\s{0,3}(?:`{3,}|~{3,})/;
+        const codeSpanRe = /(`+)[\s\S]*?\1/g;
+        // A formula is either a single character or first/last characters with
+        // a lazy body; the last character may not be a backslash, so an escaped
+        // \$ before the closing delimiter rejects the pair instead of producing
+        // a formula that ends in a stray backslash (a MathJax TeX error).
+        const dollarRe = /(^|[^\\$])\$([^\s$\\]|[^\s$][^$\n]*?[^\s$\\])\$(?!\d|\$)/g;
+        const convert = function (text) {
+            return text.replace(dollarRe, function (match, prefix, formula) {
+                return prefix + stashFn('\\(' + formula + '\\)');
+            });
+        };
+        let inFence = false;
+        return String(src)
+            .split('\n')
+            .map(function (line) {
+                if (fenceRe.test(line)) {
+                    inFence = !inFence;
+                    return line;
+                }
+                if (inFence || line.indexOf('$') === -1) {
+                    return line;
+                }
+                let out = '';
+                let last = 0;
+                let m;
+                codeSpanRe.lastIndex = 0;
+                while ((m = codeSpanRe.exec(line)) !== null) {
+                    out += convert(line.slice(last, m.index)) + m[0];
+                    last = m.index + m[0].length;
+                }
+                return out + convert(line.slice(last));
+            })
+            .join('\n');
     },
 
     restoreLatex: function (html, store) {

--- a/public/files/perm/idevices/base/markdown-text/edition/markdown-text.test.js
+++ b/public/files/perm/idevices/base/markdown-text/edition/markdown-text.test.js
@@ -566,6 +566,73 @@ describe('markdown-text iDevice', () => {
     });
   });
 
+  describe('single-dollar inline math fallback (#1990)', () => {
+    beforeEach(() => {
+      delete eXe.app.common;
+      global.showdown = {
+        Converter: class {
+          setOption() {}
+          makeHtml(text) {
+            // Pretend Showdown mangles underscores into <em>
+            return `<p>${text.replace(/_([^_]+)_/g, '<em>$1</em>')}</p>`;
+          }
+        },
+      };
+    });
+
+    afterEach(() => {
+      delete global.showdown;
+    });
+
+    it('converts $...$ into \\(...\\) and protects it from Showdown', () => {
+      const result = $exeDevice.computeMarkdownHtml('Indexed: $a_1 + b_2$ end');
+
+      expect(result).toContain('\\(a_1 + b_2\\)');
+      expect(result).not.toContain('<em>');
+    });
+
+    it('leaves currency amounts untouched', () => {
+      const result = $exeDevice.computeMarkdownHtml('It costs $10 and $20 in total');
+
+      expect(result).toContain('$10 and $20');
+      expect(result).not.toContain('\\(');
+    });
+
+    it('does not touch dollars inside inline code spans', () => {
+      const result = $exeDevice.computeMarkdownHtml('Use `$HOME$` here');
+
+      expect(result).toContain('`$HOME$`');
+      expect(result).not.toContain('\\(');
+    });
+
+    it('does not touch dollars inside fenced code blocks', () => {
+      const result = $exeDevice.computeMarkdownHtml('```\necho $a$ $b$\n```\nAfter $x$ end');
+
+      expect(result).toContain('echo $a$ $b$');
+      expect(result).toContain('\\(x\\)');
+    });
+
+    it('stashLatex stores the normalized formula', () => {
+      const stash = $exeDevice.stashLatex('Formula $a_1$ end');
+
+      expect(stash.store).toContain('\\(a_1\\)');
+      expect(stash.text).not.toContain('$a_1$');
+    });
+
+    it('rejects a pair whose closing dollar is escaped', () => {
+      const result = $exeDevice.computeMarkdownHtml('Mixed $a\\$b$ tail');
+
+      expect(result).toContain('$a\\$b$');
+      expect(result).not.toContain('\\(');
+    });
+
+    it('still converts formulas that start with a backslash', () => {
+      const result = $exeDevice.computeMarkdownHtml('Greek $\\alpha$ letter');
+
+      expect(result).toContain('\\(\\alpha\\)');
+    });
+  });
+
   describe('createMarkdownEditorHTML', () => {
     it('creates container with correct id', () => {
       const html = $exeDevice.createMarkdownEditorHTML('myId', 'My Title');

--- a/test/e2e/playwright/specs/idevices/markdown-text.spec.ts
+++ b/test/e2e/playwright/specs/idevices/markdown-text.spec.ts
@@ -105,6 +105,45 @@ test.describe('Markdown Text iDevice', () => {
         await expect(previewPane).toContainText('subtitle');
     });
 
+    test('renders single-dollar LaTeX via MathJax and keeps currency literal (#1990)', async ({
+        authenticatedPage,
+        createProject,
+    }) => {
+        const page = authenticatedPage;
+        const projectUuid = await createProject(page, 'Markdown Dollar Math');
+        await gotoWorkarea(page, projectUuid);
+        await waitForAppReady(page);
+
+        const ideviceId = await addMarkdownIdevice(page);
+        await editIdevice(page, ideviceId);
+
+        await setEditorValue(
+            page,
+            ideviceId,
+            '#markdownTextarea',
+            'The formula $a^2 + b^2 = c^2$ is famous. It costs $5 and $10 total.',
+        );
+
+        await saveIdevice(page, ideviceId);
+
+        // The workarea rendered view typesets the normalized \(...\) formula.
+        const article = page.locator(`.idevice_node[id="${ideviceId}"]`);
+        await expect(article.locator('mjx-container, .exe-math-rendered').first()).toBeVisible({ timeout: 15000 });
+        // Plain dollar amounts must stay literal text (no math false positive).
+        await expect(article).toContainText('costs $5 and $10 total');
+
+        await saveProject(page);
+        await openPreviewPanel(page);
+        await waitForPreviewContent(page);
+
+        const iframe = getPreviewFrame(page);
+        const previewNode = iframe.locator('.idevice_node.markdown-text').first();
+        await expect(previewNode.locator('mjx-container, svg[data-mml-node], .exe-math-rendered').first()).toBeVisible({
+            timeout: 15000,
+        });
+        await expect(previewNode).toContainText('costs $5 and $10 total');
+    });
+
     test('feedback section renders in preview and escapes attribute values', async ({
         authenticatedPage,
         createProject,


### PR DESCRIPTION
## Summary
- `$...$` inline math in the Markdown Text iDevice was never rendered: the MathJax configuration only enables `\(...\)` inline delimiters (so a lone `$` never triggers loading or typesetting), and Showdown mangled formula underscores first (`$a_1 + b_2$` became `$a<em>1 + b</em>2$`).
- Normalize `$...$` to `\(...\)` during markdown-to-HTML conversion — in the shared `eXe.app.common.markdownToHTML` helper and in the iDevice's standalone Showdown fallback — so `hasLatex` detection, the LaTeX pre-renderer, workarea, preview and exports all work unchanged. The global MathJax configuration is untouched, avoiding `$` false positives in existing non-markdown content.
- Pandoc-style rules keep plain dollar amounts literal (`It costs $5 and $10` is not math); escaped dollars never pair (a formula cannot end in a backslash, so `\$` before a closing delimiter rejects the pair); fenced code blocks and inline code spans are skipped; `$$...$$` display math keeps working as before.

Known heuristic limit (shared with Pandoc and markdown-it-texmath): a line carrying both a leading and a trailing dollar amount, e.g. `Cuesta $5 y vale 10$`, satisfies the pairing rules and is treated as math.

## How to test
```bash
npx vitest run public/app/common/app_common.test.js public/files/perm/idevices/base/markdown-text/edition/markdown-text.test.js
make bundle
bun x playwright test --project=chromium test/e2e/playwright/specs/idevices/markdown-text.spec.ts
```
Manually: add a Markdown Text iDevice, write `The formula $a^2 + b^2 = c^2$ costs $5 and $10`, save — the formula renders via MathJax in the workarea and preview while the prices stay literal.

## Screenshots
Workarea rendered view after the fix — the formula typeset by MathJax, the prices literal:

![Markdown iDevice rendering an inline LaTeX formula while dollar prices stay literal](https://github.com/user-attachments/assets/81561916-3bb9-4ca2-b3dd-5004e6faab0f)

Closes #1990
