### PR TITLE
feat(cli): assets:conflicts — list and resolve asset storage conflicts (keep-old / keep-new)

### DIFF
--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -275,7 +275,7 @@ We will:
 - A transitional legacy-read fallback exists in the resolver until installations
   converge; it must eventually be removed (see "Follow-up work").
 - Startup performs a cheap, bounded check per boot even on converged installations: one
-  indexed-free `NOT LIKE 'assets/%'` query, one readdir of the assets root, and a
+  indexed-free `NOT LIKE 'assets/__/%'` query, one readdir of the assets root, and a
   content check (`readdir`) of each existing two-decimal shard bucket (`00`-`99`) to
   distinguish it from a legacy numeric project-id directory.
 

--- a/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
+++ b/doc/architecture/adr/ADR-2250-01-shard-project-asset-storage.md
@@ -340,7 +340,8 @@ We will:
   the migration's per-boot summary tells operators when their installation is clean).
 - Provide a CLI subcommand that lists parked migration conflicts and resolves them
   with an explicit keep-old / keep-new choice
-  (<https://github.com/exelearning/exelearning/issues/2287>).
+  (<https://github.com/exelearning/exelearning/issues/2287>, implemented as
+  `assets:conflicts` — see the change document for #2287).
 - Consider validating client-supplied project identifiers at creation time so the
   FNV-1a fallback becomes purely defensive.
 

--- a/doc/architecture/changes/2250-asset-storage-sharding/design.md
+++ b/doc/architecture/changes/2250-asset-storage-sharding/design.md
@@ -133,8 +133,8 @@ each boot). Unrecognized entries are reported and left alone.
 - **Verifying success**: after the upgrade boot, the log shows the summary; on the next
   boot it shows `Asset storage layout is up to date.` and
   `SELECT COUNT(*) FROM assets WHERE storage_path NOT LIKE 'assets/%'` returns 0.
-  Remaining warnings identify conflict files to resolve manually (a reconciliation
-  CLI is tracked in issue #2287).
+  Remaining warnings identify conflict files; list and resolve them with
+  `bun cli assets:conflicts` (issue #2287).
 - **Rollback**: restore the pre-upgrade backup (database + `FILES_DIR`) and redeploy the
   previous release. Rolling back only the binary after migration is not supported —
   old releases cannot read relative paths.

--- a/doc/architecture/changes/2287-asset-conflict-cli/design.md
+++ b/doc/architecture/changes/2287-asset-conflict-cli/design.md
@@ -1,0 +1,133 @@
+---
+tracking_issue: 2287
+title: "CLI resolution of asset storage conflicts"
+status: accepted
+date: 2026-08-16
+authors:
+  - "@erseco"
+reviewers:
+  - "@ignaciogros"
+implementation_prs: []
+related_adrs:
+  - "ADR-2250-01"
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-fable-5"
+---
+
+# CLI resolution of asset storage conflicts — design
+
+## Current state
+
+The startup migration introduced by #2250 (ADR-2250-01) applies a strict
+never-overwrite rule: when a row's legacy file (`assets/<uuid>/…`) and its
+canonical sharded destination (`assets/<shard>/<uuid>/…`) both exist with
+different content (size + SHA-256), both files are kept and the row is parked
+on its legacy location in portable relative form. Parked rows never converge:
+the same warning is re-emitted on every boot, the phase 2 sweep leaves the
+referenced legacy directory in place, and the only resolution is SSH-ing in and
+comparing files by hand. The migration is correct to refuse the decision — but
+the decision has no supported tool.
+
+## Goals
+
+- List every unresolved conflict with enough information to decide from the
+  terminal: both absolute paths, file sizes, modification times.
+- Resolve one conflict at a time with an **explicit operator choice**
+  (`--keep-old` / `--keep-new`); never delete or overwrite either copy without
+  that choice.
+- Let the installation converge after resolution without further steps.
+- Keep every operation crash-safe under the same reconciliation model as the
+  startup migration.
+
+## Non-goals
+
+- **Phase 2 sweep conflicts** (orphan files without a database row whose
+  sharded destination differs) are out of scope: with no row there is no
+  stable identity to resolve by, and no convergence is blocked — the files are
+  simply both kept. They remain reported by the per-boot warning.
+- Bulk resolution (`--all`). Conflicts are expected to be rare; forcing one
+  explicit choice per asset is the point of the tool.
+- Any change to the migration's never-overwrite semantics.
+
+## Design
+
+### Detection (shared grammar, shared meaning)
+
+A row is an unresolved conflict when all of the following hold:
+
+1. `deriveShardedAssetStoragePath(projectUuid, storage_path)` — a new pure
+   helper in `src/utils/asset-paths.ts` mirroring the migration's per-row
+   derivation — yields a canonical target different from the stored value;
+2. both the stored location and the target resolve safely under
+   `FILES_DIR/assets` (`tryResolveAssetStoragePath`);
+3. both files exist; and
+4. their content differs, decided by the **same** `filesAreIdentical`
+   (size + streamed SHA-256) the migration uses.
+
+`listAssetStorageConflicts` (`src/services/asset-conflicts.ts`) scans all
+asset rows in cursor-paged batches; rows already in canonical form are skipped
+with a pure string comparison, so they cost no filesystem I/O. This is an
+explicit admin command — a full table scan is acceptable and keeps the
+detection free of extra bookkeeping state.
+
+### Resolution
+
+`resolveAssetStorageConflict(assetId, choice, {dryRun})` re-classifies the row
+at resolution time (the listing may be stale) and then:
+
+- `keep-new`: remove the legacy copy → rewrite the row to the canonical value.
+- `keep-old`: remove the canonical copy → `moveFile` (rename, EXDEV-safe copy
+  fallback) the legacy copy into its place → rewrite the row.
+- Copies that turn out identical are converged with the exact rule the startup
+  migration applies automatically (remove legacy copy, rewrite row) — that
+  path is decision-free, so it does not require the choice to be meaningful.
+
+Operation order is deliberate: a crash at any intermediate point leaves a
+state (`file only at destination`, `row still legacy`, …) that the next
+startup migration reconciles on its own. Row rewrites reuse the migration's
+`rewriteRow` with its optimistic `WHERE storage_path = <old>` guard, so a
+concurrently starting instance can never be raced into a lost update; a failed
+guard aborts with a clear message instead of resolving blindly.
+
+The emptied legacy directory is intentionally **not** removed by the CLI —
+the phase 2 sweep already owns that cleanup and runs on the next boot.
+
+### CLI surface
+
+`bun cli assets:conflicts` (`src/cli/commands/assets-conflicts.ts`):
+
+- `list` (default): human-readable listing, or `--json` for scripting (printed
+  raw, without the `SUCCESS` prefix, via a new optional `raw` field in the CLI
+  command contract).
+- `resolve <asset-id> --keep-old|--keep-new [--dry-run]`: refuses to act
+  unless exactly one of the two choice flags is present.
+
+### Startup warning
+
+The per-boot conflict warnings (row conflicts and sweep conflicts) now print
+both **absolute paths and file sizes**, and the row-conflict warning points at
+`bun cli assets:conflicts`, so the operator can decide straight from the logs.
+
+## Security and privacy
+
+All path resolution stays inside the hardened resolver
+(`tryResolveAssetStoragePath`); uninterpretable stored values are never
+touched and resolution refuses them explicitly. No copy is ever deleted
+without an explicit operator flag.
+
+## Testing strategy
+
+- `src/services/asset-conflicts.spec.ts`: real test database + temp
+  `FILES_DIR` (same harness as the migration spec) covering listing (parked
+  and absolute rows, free-destination/identical/uninterpretable non-conflicts,
+  batching), both resolutions, dry-run, identical-copy convergence, unknown
+  id, non-conflict rows, concurrent-guard failure, and an end-to-end
+  "resolve then run the startup migration" convergence check.
+- `src/cli/commands/assets-conflicts.spec.ts`: command contract (subcommands,
+  flag validation, JSON output, delegation, exit codes) with injected service
+  dependencies.
+- `src/utils/asset-paths.spec.ts`: the derivation helper.
+- `src/services/asset-storage-migration.spec.ts`: the enriched warnings.

--- a/doc/architecture/changes/2287-asset-conflict-cli/design.md
+++ b/doc/architecture/changes/2287-asset-conflict-cli/design.md
@@ -7,7 +7,7 @@ authors:
   - "@erseco"
 reviewers:
   - "@ignaciogros"
-implementation_prs: []
+implementation_prs: [2290]
 related_adrs:
   - "ADR-2250-01"
 supersedes: []

--- a/doc/architecture/changes/2287-asset-conflict-cli/design.md
+++ b/doc/architecture/changes/2287-asset-conflict-cli/design.md
@@ -87,7 +87,11 @@ at resolution time (the listing may be stale) and then:
 
 Operation order is deliberate: a crash at any intermediate point leaves a
 state (`file only at destination`, `row still legacy`, …) that the next
-startup migration reconciles on its own. Row rewrites reuse the migration's
+startup migration reconciles on its own. For that to hold, the migration's
+phase 1 filter selects every non-canonical row (`NOT LIKE 'assets/__/%'`),
+so parked conflict rows (`assets/<uuid>/...`) are re-examined at every
+startup — an interrupted resolution self-heals, and an unresolved conflict is
+re-reported without rewriting the row. Row rewrites reuse the migration's
 `rewriteRow` with its optimistic `WHERE storage_path = <old>` guard, so a
 concurrently starting instance can never be raced into a lost update; a failed
 guard aborts with a clear message instead of resolving blindly.

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -393,3 +393,12 @@ eXeLearning stores intermediate/temporary files (exports, conversions, etc.) und
 - `bun cli tmp-cleanup [--max-age=SECONDS]`
 - Example cron (daily at 03:00, keeping 24h):
   - `0 3 * * * cd /opt/exelearning && bun cli tmp-cleanup --max-age=86400`
+
+### Asset storage conflicts
+
+When the startup migration to the sharded asset layout (see ADR-2250-01) finds a legacy file **and** a different file already present at the canonical location, it keeps both copies and logs a warning on every boot — it never overwrites data on its own. Such rows stay in the legacy layout until an operator picks a winner:
+
+- `bun cli assets:conflicts` — list unresolved conflicts with both absolute paths, sizes and modification times (`--json` for scripting).
+- `bun cli assets:conflicts resolve <asset-id> --keep-old|--keep-new [--dry-run]` — resolve one conflict: `--keep-old` keeps the legacy copy (moving it into the canonical location), `--keep-new` keeps the canonical copy. Nothing is deleted without one of these explicit flags.
+
+After resolution the database row points at the canonical sharded location and the next startup tidies the emptied legacy directory.

--- a/src/cli/commands/assets-conflicts.spec.ts
+++ b/src/cli/commands/assets-conflicts.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the Assets Conflicts Command (issue #2287)
+ */
+import { describe, it, expect } from 'bun:test';
+import { execute, printHelp, runCli, type AssetsConflictsDependencies } from './assets-conflicts';
+import type { AssetStorageConflict, ResolveConflictResult } from '../../services/asset-conflicts';
+
+describe('Assets Conflicts Command', () => {
+    const sampleConflict: AssetStorageConflict = {
+        assetId: 123,
+        projectUuid: 'ab12cd34-1234-4abc-8def-1234567890ab',
+        filename: 'photo.png',
+        storedPath: 'assets/ab12cd34-1234-4abc-8def-1234567890ab/photo.png',
+        canonicalStoredPath: 'assets/ab/ab12cd34-1234-4abc-8def-1234567890ab/photo.png',
+        legacyPath: '/data/assets/ab12cd34-1234-4abc-8def-1234567890ab/photo.png',
+        canonicalPath: '/data/assets/ab/ab12cd34-1234-4abc-8def-1234567890ab/photo.png',
+        legacySize: 14,
+        canonicalSize: 17,
+        legacyMtime: '2026-08-01T10:00:00.000Z',
+        canonicalMtime: '2026-08-02T11:00:00.000Z',
+    };
+
+    function createDeps(options: { conflicts?: AssetStorageConflict[]; resolveResult?: ResolveConflictResult } = {}) {
+        const { conflicts = [], resolveResult = { success: true, resolved: true, message: 'resolved' } } = options;
+        const resolveCalls: Array<{ assetId: number; choice: string; dryRun: boolean }> = [];
+        const deps: AssetsConflictsDependencies = {
+            listConflicts: async () => conflicts,
+            resolveConflict: async (assetId, choice, resolveOptions = {}) => {
+                resolveCalls.push({ assetId, choice, dryRun: resolveOptions.dryRun === true });
+                return resolveResult;
+            },
+        };
+        return { deps, resolveCalls };
+    }
+
+    describe('list', () => {
+        it('reports when there are no conflicts', async () => {
+            const { deps } = createDeps();
+
+            const result = await execute([], {}, deps);
+
+            expect(result.success).toBe(true);
+            expect(result.message).toContain('No unresolved asset storage conflicts');
+        });
+
+        it('lists conflicts with both absolute paths, sizes, mtimes and a resolve hint', async () => {
+            const { deps } = createDeps({ conflicts: [sampleConflict] });
+
+            const result = await execute(['list'], {}, deps);
+
+            expect(result.success).toBe(true);
+            expect(result.message).toContain('Asset 123');
+            expect(result.message).toContain(sampleConflict.projectUuid);
+            expect(result.message).toContain(sampleConflict.legacyPath);
+            expect(result.message).toContain(sampleConflict.canonicalPath);
+            expect(result.message).toContain('14 bytes');
+            expect(result.message).toContain('17 bytes');
+            expect(result.message).toContain('2026-08-01T10:00:00.000Z');
+            expect(result.message).toContain('resolve <asset-id> --keep-old | --keep-new');
+        });
+
+        it('outputs machine-parseable JSON with --json', async () => {
+            const { deps } = createDeps({ conflicts: [sampleConflict] });
+
+            const result = await execute(['list'], { json: true }, deps);
+
+            expect(result.success).toBe(true);
+            expect(result.raw).toBe(true);
+            const parsed = JSON.parse(result.message);
+            expect(parsed).toHaveLength(1);
+            expect(parsed[0].assetId).toBe(123);
+        });
+    });
+
+    describe('resolve', () => {
+        it('requires a positive integer asset id', async () => {
+            const { deps, resolveCalls } = createDeps();
+
+            for (const positional of [['resolve'], ['resolve', 'abc'], ['resolve', '-3'], ['resolve', '1.5']]) {
+                const result = await execute(positional, { 'keep-new': true }, deps);
+                expect(result.success).toBe(false);
+                expect(result.message).toContain('Usage:');
+            }
+            expect(resolveCalls).toHaveLength(0);
+        });
+
+        it('requires exactly one of --keep-old / --keep-new', async () => {
+            const { deps, resolveCalls } = createDeps();
+
+            const neither = await execute(['resolve', '123'], {}, deps);
+            expect(neither.success).toBe(false);
+            expect(neither.message).toContain('exactly one');
+
+            const both = await execute(['resolve', '123'], { 'keep-old': true, 'keep-new': true }, deps);
+            expect(both.success).toBe(false);
+            expect(both.message).toContain('exactly one');
+
+            expect(resolveCalls).toHaveLength(0);
+        });
+
+        it('delegates keep-new resolution to the service', async () => {
+            const { deps, resolveCalls } = createDeps();
+
+            const result = await execute(['resolve', '123'], { 'keep-new': true }, deps);
+
+            expect(result.success).toBe(true);
+            expect(resolveCalls).toEqual([{ assetId: 123, choice: 'keep-new', dryRun: false }]);
+        });
+
+        it('delegates keep-old with --dry-run to the service', async () => {
+            const { deps, resolveCalls } = createDeps();
+
+            await execute(['resolve', '42'], { 'keep-old': true, 'dry-run': true }, deps);
+
+            expect(resolveCalls).toEqual([{ assetId: 42, choice: 'keep-old', dryRun: true }]);
+        });
+
+        it('propagates a failed resolution', async () => {
+            const { deps } = createDeps({
+                resolveResult: { success: false, resolved: false, message: 'changed concurrently' },
+            });
+
+            const result = await execute(['resolve', '123'], { 'keep-new': true }, deps);
+
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('concurrently');
+        });
+    });
+
+    it('rejects unknown subcommands', async () => {
+        const { deps } = createDeps();
+
+        const result = await execute(['frobnicate'], {}, deps);
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('frobnicate');
+    });
+
+    describe('runCli', () => {
+        it('exits 0 and prints help with --help', async () => {
+            let exitCode: number | undefined;
+
+            await runCli(['bun', 'cli', 'assets:conflicts', '--help'], createDeps().deps, code => {
+                exitCode = code;
+            });
+
+            expect(exitCode).toBe(0);
+        });
+
+        it('exits 0 on a successful list', async () => {
+            let exitCode: number | undefined;
+
+            await runCli(['bun', 'cli', 'assets:conflicts'], createDeps().deps, code => {
+                exitCode = code;
+            });
+
+            expect(exitCode).toBe(0);
+        });
+
+        it('exits 0 printing raw JSON with --json', async () => {
+            let exitCode: number | undefined;
+            const { deps } = createDeps({ conflicts: [sampleConflict] });
+
+            await runCli(['bun', 'cli', 'assets:conflicts', 'list', '--json'], deps, code => {
+                exitCode = code;
+            });
+
+            expect(exitCode).toBe(0);
+        });
+
+        it('exits 0 on a dry-run resolve', async () => {
+            let exitCode: number | undefined;
+            const { deps } = createDeps({
+                resolveResult: { success: true, resolved: false, message: '[dry-run] would resolve' },
+            });
+
+            await runCli(
+                ['bun', 'cli', 'assets:conflicts', 'resolve', '123', '--keep-new', '--dry-run'],
+                deps,
+                code => {
+                    exitCode = code;
+                },
+            );
+
+            expect(exitCode).toBe(0);
+        });
+
+        it('exits non-zero on failure', async () => {
+            let exitCode: number | undefined;
+
+            await runCli(['bun', 'cli', 'assets:conflicts', 'resolve'], createDeps().deps, code => {
+                exitCode = code;
+            });
+
+            expect(exitCode).not.toBe(0);
+        });
+
+        it('exits non-zero when the service throws', async () => {
+            let exitCode: number | undefined;
+            const deps: AssetsConflictsDependencies = {
+                listConflicts: async () => {
+                    throw new Error('disk on fire');
+                },
+                resolveConflict: async () => ({ success: true, resolved: true, message: 'unused' }),
+            };
+
+            await runCli(['bun', 'cli', 'assets:conflicts'], deps, code => {
+                exitCode = code;
+            });
+
+            expect(exitCode).not.toBe(0);
+        });
+    });
+
+    it('printHelp does not throw', () => {
+        expect(() => printHelp()).not.toThrow();
+    });
+});

--- a/src/cli/commands/assets-conflicts.ts
+++ b/src/cli/commands/assets-conflicts.ts
@@ -1,0 +1,167 @@
+/**
+ * Assets Conflicts Command (issue #2287)
+ * Lists asset storage conflicts parked by the startup migration and resolves
+ * them with an explicit keep-old / keep-new operator choice.
+ *
+ * Usage: bun cli assets:conflicts [list|resolve <asset-id>] [options]
+ * Options:
+ *   --keep-old   Resolve keeping the legacy copy (moved to the canonical location)
+ *   --keep-new   Resolve keeping the canonical (sharded) copy
+ *   --dry-run    Show what resolve would do without changing anything
+ *   --json       Output the conflict list as JSON
+ */
+import { parseArgs, getBoolean, hasHelp } from '../utils/args';
+import { success, error, warning, colors, EXIT_CODES } from '../utils/output';
+import {
+    listAssetStorageConflicts,
+    resolveAssetStorageConflict,
+    type AssetStorageConflict,
+} from '../../services/asset-conflicts';
+
+export interface AssetsConflictsDependencies {
+    listConflicts: typeof listAssetStorageConflicts;
+    resolveConflict: typeof resolveAssetStorageConflict;
+}
+
+const defaultDependencies: AssetsConflictsDependencies = {
+    listConflicts: listAssetStorageConflicts,
+    resolveConflict: resolveAssetStorageConflict,
+};
+
+function formatConflict(conflict: AssetStorageConflict): string {
+    return [
+        `Asset ${conflict.assetId} — project ${conflict.projectUuid} — ${conflict.filename}`,
+        `  legacy   : ${conflict.legacyPath} (${conflict.legacySize} bytes, modified ${conflict.legacyMtime})`,
+        `  canonical: ${conflict.canonicalPath} (${conflict.canonicalSize} bytes, modified ${conflict.canonicalMtime})`,
+    ].join('\n');
+}
+
+export async function execute(
+    positional: string[],
+    flags: Record<string, string | boolean | string[]>,
+    deps: AssetsConflictsDependencies = defaultDependencies,
+): Promise<{ success: boolean; message: string; raw?: boolean }> {
+    const subcommand = positional[0] ?? 'list';
+
+    if (subcommand === 'list') {
+        const conflicts = await deps.listConflicts();
+        if (getBoolean(flags, 'json', false)) {
+            // raw: printed without the SUCCESS prefix so the output stays
+            // machine-parseable (e.g. piped into jq).
+            return { success: true, message: JSON.stringify(conflicts, null, 2), raw: true };
+        }
+        if (conflicts.length === 0) {
+            return { success: true, message: 'No unresolved asset storage conflicts.' };
+        }
+        return {
+            success: true,
+            message:
+                `${conflicts.length} unresolved asset storage conflict(s):\n\n` +
+                `${conflicts.map(formatConflict).join('\n\n')}\n\n` +
+                `Resolve with: bun cli assets:conflicts resolve <asset-id> --keep-old | --keep-new`,
+        };
+    }
+
+    if (subcommand === 'resolve') {
+        const idRaw = positional[1];
+        const assetId = Number(idRaw);
+        if (!idRaw || !Number.isInteger(assetId) || assetId <= 0) {
+            return {
+                success: false,
+                message: 'Usage: bun cli assets:conflicts resolve <asset-id> --keep-old | --keep-new',
+            };
+        }
+        const keepOld = getBoolean(flags, 'keep-old', false);
+        const keepNew = getBoolean(flags, 'keep-new', false);
+        if (keepOld === keepNew) {
+            return {
+                success: false,
+                message:
+                    'Choose exactly one of --keep-old (legacy copy wins) or --keep-new (canonical copy wins). ' +
+                    'Nothing is deleted without this explicit choice.',
+            };
+        }
+        const result = await deps.resolveConflict(assetId, keepOld ? 'keep-old' : 'keep-new', {
+            dryRun: getBoolean(flags, 'dry-run', false),
+        });
+        return { success: result.success, message: result.message };
+    }
+
+    return {
+        success: false,
+        message: `Unknown subcommand '${subcommand}'. Use 'list' or 'resolve <asset-id>'.`,
+    };
+}
+
+export function printHelp(): void {
+    console.log(`
+${colors.bold('assets:conflicts')} - List and resolve asset storage conflicts
+
+${colors.cyan('Usage:')}
+  bun cli assets:conflicts [list] [--json]
+  bun cli assets:conflicts resolve <asset-id> --keep-old|--keep-new [--dry-run]
+
+${colors.cyan('Options:')}
+  --keep-old   Keep the legacy copy: it is moved to the canonical sharded location
+  --keep-new   Keep the canonical (sharded) copy: the legacy copy is removed
+  --dry-run    Show what resolve would do without changing anything
+  --json       Output the conflict list as JSON
+  -h, --help   Show this help message
+
+${colors.cyan('Behavior:')}
+  - A conflict is a database row whose legacy file and canonical sharded
+    destination both exist with different content. The startup migration
+    keeps both copies and re-reports the conflict on every boot (never
+    overwrites); this command is the explicit way to pick a winner.
+  - Nothing is deleted or overwritten without --keep-old or --keep-new.
+  - After resolution the row points at the canonical location and the next
+    startup migration tidies the emptied legacy directory.
+
+${colors.cyan('Examples:')}
+  bun cli assets:conflicts
+  bun cli assets:conflicts list --json
+  bun cli assets:conflicts resolve 123 --keep-new --dry-run
+  bun cli assets:conflicts resolve 123 --keep-old
+`);
+}
+
+/**
+ * CLI entry point handler - extracted for testability
+ */
+export async function runCli(
+    argv: string[],
+    deps: AssetsConflictsDependencies = defaultDependencies,
+    exitFn: (code: number) => void = code => process.exit(code),
+): Promise<void> {
+    const { positional, flags } = parseArgs(argv);
+
+    if (hasHelp(flags)) {
+        printHelp();
+        exitFn(EXIT_CODES.SUCCESS);
+        return;
+    }
+
+    try {
+        const result = await execute(positional, flags, deps);
+        if (result.success) {
+            if (result.raw) {
+                console.log(result.message);
+            } else if (getBoolean(flags, 'dry-run', false)) {
+                warning(result.message);
+            } else {
+                success(result.message);
+            }
+        } else {
+            error(result.message);
+        }
+        exitFn(result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.FAILURE);
+    } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+        exitFn(EXIT_CODES.FAILURE);
+    }
+}
+
+// Allow running directly
+if (import.meta.main) {
+    runCli(process.argv);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import * as elpExport from './commands/elp-export';
 import * as checkQuota from './commands/check-quota';
 import * as projectsPurge from './commands/projects-purge';
 import * as projectsCleanup from './commands/projects-cleanup';
+import * as assetsConflicts from './commands/assets-conflicts';
 import * as updateLicenses from './commands/update-licenses';
 import * as maintenance from './commands/maintenance';
 
@@ -31,7 +32,7 @@ interface CommandModule {
     execute: (
         positional: string[],
         flags: Record<string, string | boolean | string[]>,
-    ) => Promise<{ success: boolean; message?: string; token?: string }>;
+    ) => Promise<{ success: boolean; message?: string; token?: string; raw?: boolean }>;
     printHelp: () => void;
 }
 
@@ -50,6 +51,7 @@ const COMMANDS: Record<string, CommandModule> = {
     'check-quota': checkQuota,
     'projects:purge': projectsPurge,
     'projects:cleanup': projectsCleanup,
+    'assets:conflicts': assetsConflicts,
     'update-licenses': updateLicenses,
     maintenance: maintenance,
 };
@@ -200,6 +202,7 @@ ${colors.cyan('Maintenance:')}
   translations:format [--locale=en]           Add CDATA where needed and normalise indentation
   projects:purge --yes                        Delete all projects and assets
   projects:cleanup [--unsaved-age=24]        Clean unsaved/guest projects
+  assets:conflicts [list|resolve <id>]       List/resolve asset storage conflicts
   update-licenses [--dry-run]                Update license info in public/libs/README.md
 
 ${colors.cyan('ELPX Processing:')}
@@ -294,6 +297,9 @@ async function main(): Promise<void> {
             // Special handling for jwt:generate - output token only
             if (command === 'jwt:generate' && result.token) {
                 console.log(result.token);
+            } else if (result.message && result.raw) {
+                // Machine-parseable output (e.g. --json): no SUCCESS prefix.
+                console.log(result.message);
             } else if (result.message) {
                 success(result.message);
             }

--- a/src/services/asset-conflicts.spec.ts
+++ b/src/services/asset-conflicts.spec.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for the asset storage conflict service (issue #2287).
+ *
+ * A conflict is a row whose storage_path is not the canonical sharded form
+ * AND whose current file and canonical destination both exist with different
+ * content. The service lists such rows and resolves them only with an
+ * explicit keep-old / keep-new operator choice.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import type { Kysely } from 'kysely';
+import type { Database } from '../db/types';
+import { createTestDb, cleanTestDb, destroyTestDb, seedTestUser, seedTestProject } from '../../test/helpers/test-db';
+import * as assetQueries from '../db/queries/assets';
+import { getAssetShard } from '../utils/asset-paths';
+import { migrateAssetStorage } from './asset-storage-migration';
+import { listAssetStorageConflicts, resolveAssetStorageConflict } from './asset-conflicts';
+
+describe('asset-conflicts', () => {
+    let db: Kysely<Database>;
+    let filesDir: string;
+    let userId: number;
+
+    const PROJECT_UUID = 'ab12cd34-1234-4abc-8def-1234567890ab';
+    const SHARD = getAssetShard(PROJECT_UUID); // 'ab'
+
+    beforeAll(async () => {
+        db = await createTestDb();
+    });
+
+    afterAll(async () => {
+        await destroyTestDb(db);
+    });
+
+    beforeEach(async () => {
+        await cleanTestDb(db);
+        userId = await seedTestUser(db);
+        filesDir = await fs.mkdtemp(path.join(os.tmpdir(), 'asset-conflicts-test-'));
+    });
+
+    function deps(overrides: Record<string, unknown> = {}) {
+        return { db, getFilesDir: () => filesDir, ...overrides };
+    }
+
+    function legacyPath(uuid: string, ...relSegments: string[]): string {
+        return path.join(filesDir, 'assets', uuid, ...relSegments);
+    }
+
+    function shardedPath(uuid: string, ...relSegments: string[]): string {
+        return path.join(filesDir, 'assets', getAssetShard(uuid), uuid, ...relSegments);
+    }
+
+    async function seedProject(uuid: string = PROJECT_UUID): Promise<number> {
+        return seedTestProject(db, userId, { uuid, title: `Project ${uuid}` });
+    }
+
+    async function seedAssetRow(projectId: number, storedPath: string, filename: string, clientId: string) {
+        return assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename,
+            storage_path: storedPath,
+            mime_type: 'application/octet-stream',
+            file_size: '0',
+            client_id: clientId,
+            folder_path: '',
+        });
+    }
+
+    /**
+     * Seeds the canonical parked-conflict state produced by the startup
+     * migration: a row pointing (relative form) at the legacy location, the
+     * legacy file, and a DIFFERENT file at the sharded destination.
+     */
+    async function seedParkedConflict(
+        filename = 'conflict.png',
+        legacyContent = 'legacy content',
+        canonicalContent = 'different content',
+        clientId = 'conflict-c',
+    ) {
+        const projectId = await seedProject();
+        const src = legacyPath(PROJECT_UUID, filename);
+        await fs.ensureDir(path.dirname(src));
+        await fs.writeFile(src, legacyContent);
+        const dest = shardedPath(PROJECT_UUID, filename);
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, canonicalContent);
+        const asset = await seedAssetRow(projectId, `assets/${PROJECT_UUID}/${filename}`, filename, clientId);
+        return { projectId, asset, src, dest };
+    }
+
+    // =========================================================================
+    // Listing
+    // =========================================================================
+
+    it('returns no conflicts on a fresh installation', async () => {
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('returns no conflicts when every row is canonical', async () => {
+        const projectId = await seedProject();
+        const dest = shardedPath(PROJECT_UUID, 'ok.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'ok bytes');
+        await seedAssetRow(projectId, `assets/${SHARD}/${PROJECT_UUID}/ok.png`, 'ok.png', 'ok-c');
+
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('lists a parked conflict with both absolute paths, sizes and mtimes', async () => {
+        const { asset, src, dest } = await seedParkedConflict();
+
+        const conflicts = await listAssetStorageConflicts(deps());
+
+        expect(conflicts).toHaveLength(1);
+        const conflict = conflicts[0];
+        expect(conflict.assetId).toBe(asset.id);
+        expect(conflict.projectUuid).toBe(PROJECT_UUID);
+        expect(conflict.filename).toBe('conflict.png');
+        expect(conflict.storedPath).toBe(`assets/${PROJECT_UUID}/conflict.png`);
+        expect(conflict.canonicalStoredPath).toBe(`assets/${SHARD}/${PROJECT_UUID}/conflict.png`);
+        expect(conflict.legacyPath).toBe(src);
+        expect(conflict.canonicalPath).toBe(dest);
+        expect(conflict.legacySize).toBe('legacy content'.length);
+        expect(conflict.canonicalSize).toBe('different content'.length);
+        expect(Date.parse(conflict.legacyMtime)).not.toBeNaN();
+        expect(Date.parse(conflict.canonicalMtime)).not.toBeNaN();
+    });
+
+    it('lists a conflict for a legacy absolute row as well', async () => {
+        const projectId = await seedProject();
+        const src = legacyPath(PROJECT_UUID, 'abs.png');
+        await fs.ensureDir(path.dirname(src));
+        await fs.writeFile(src, 'old bytes');
+        const dest = shardedPath(PROJECT_UUID, 'abs.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'newer bytes!');
+        await seedAssetRow(projectId, src, 'abs.png', 'abs-c');
+
+        const conflicts = await listAssetStorageConflicts(deps());
+
+        expect(conflicts).toHaveLength(1);
+        expect(conflicts[0].legacyPath).toBe(src);
+        expect(conflicts[0].canonicalPath).toBe(dest);
+    });
+
+    it('does not list rows whose destination is free (normal migration territory)', async () => {
+        const projectId = await seedProject();
+        const src = legacyPath(PROJECT_UUID, 'pending.png');
+        await fs.ensureDir(path.dirname(src));
+        await fs.writeFile(src, 'pending bytes');
+        await seedAssetRow(projectId, `assets/${PROJECT_UUID}/pending.png`, 'pending.png', 'pending-c');
+
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('does not list rows whose two copies are identical', async () => {
+        const { src, dest } = await seedParkedConflict('same.png', 'same bytes', 'same bytes', 'same-c');
+        expect(await fs.pathExists(src)).toBe(true);
+        expect(await fs.pathExists(dest)).toBe(true);
+
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('does not list an absolute row that already points at the sharded location', async () => {
+        const projectId = await seedProject();
+        const dest = shardedPath(PROJECT_UUID, 'abs-sharded.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'abs sharded bytes');
+        await seedAssetRow(projectId, dest, 'abs-sharded.png', 'abs-sharded-c');
+
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('does not list uninterpretable rows', async () => {
+        const projectId = await seedProject();
+        await seedAssetRow(projectId, '/etc/passwd', 'passwd', 'weird-c');
+
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('paginates candidates in bounded batches', async () => {
+        const projectId = await seedProject();
+        for (const name of ['a.png', 'b.png', 'c.png']) {
+            const src = legacyPath(PROJECT_UUID, name);
+            await fs.ensureDir(path.dirname(src));
+            await fs.writeFile(src, `legacy ${name}`);
+            const dest = shardedPath(PROJECT_UUID, name);
+            await fs.ensureDir(path.dirname(dest));
+            await fs.writeFile(dest, `canonical ${name}!`);
+            await seedAssetRow(projectId, `assets/${PROJECT_UUID}/${name}`, name, `c-${name}`);
+        }
+
+        const conflicts = await listAssetStorageConflicts(deps({ batchSize: 1 }));
+
+        expect(conflicts).toHaveLength(3);
+    });
+
+    // =========================================================================
+    // Resolution
+    // =========================================================================
+
+    it('keep-new removes the legacy copy and rewrites the row to the canonical location', async () => {
+        const { asset, src, dest } = await seedParkedConflict();
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps());
+
+        expect(result.success).toBe(true);
+        expect(result.resolved).toBe(true);
+        expect(await fs.pathExists(src)).toBe(false);
+        expect((await fs.readFile(dest)).toString()).toBe('different content');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/conflict.png`);
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('keep-old moves the legacy copy over the canonical location and rewrites the row', async () => {
+        const { asset, src, dest } = await seedParkedConflict();
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-old', {}, deps());
+
+        expect(result.success).toBe(true);
+        expect(result.resolved).toBe(true);
+        expect(await fs.pathExists(src)).toBe(false);
+        expect((await fs.readFile(dest)).toString()).toBe('legacy content');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/conflict.png`);
+        expect(await listAssetStorageConflicts(deps())).toEqual([]);
+    });
+
+    it('lets the installation converge after resolution (startup migration removes the legacy dir)', async () => {
+        const { asset } = await seedParkedConflict();
+
+        await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps());
+        const summary = await migrateAssetStorage(deps({ log: () => {}, warn: () => {} }));
+
+        expect(summary.conflicts).toBe(0);
+        expect(summary.errors).toBe(0);
+        expect(await fs.pathExists(path.join(filesDir, 'assets', PROJECT_UUID))).toBe(false);
+    });
+
+    it('dry-run reports the actions without touching files or rows', async () => {
+        const { asset, src, dest } = await seedParkedConflict();
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', { dryRun: true }, deps());
+
+        expect(result.success).toBe(true);
+        expect(result.resolved).toBe(false);
+        expect(result.message).toContain(src);
+        expect(result.message).toContain(dest);
+        expect((await fs.readFile(src)).toString()).toBe('legacy content');
+        expect((await fs.readFile(dest)).toString()).toBe('different content');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/conflict.png`);
+    });
+
+    it('converges identical copies safely (same rule as the startup migration)', async () => {
+        const { asset, src, dest } = await seedParkedConflict('same.png', 'equal', 'equal', 'same-c');
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps());
+
+        expect(result.success).toBe(true);
+        expect(result.resolved).toBe(true);
+        expect(result.message).toContain('identical');
+        expect(await fs.pathExists(src)).toBe(false);
+        expect((await fs.readFile(dest)).toString()).toBe('equal');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/same.png`);
+    });
+
+    it('dry-run on identical copies reports the convergence without touching anything', async () => {
+        const { asset, src, dest } = await seedParkedConflict('same.png', 'equal', 'equal', 'same-c');
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-old', { dryRun: true }, deps());
+
+        expect(result.success).toBe(true);
+        expect(result.resolved).toBe(false);
+        expect(result.message).toContain('identical');
+        expect(await fs.pathExists(src)).toBe(true);
+        expect(await fs.pathExists(dest)).toBe(true);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/same.png`);
+    });
+
+    it('refuses to resolve a row whose destination is free (startup migration territory)', async () => {
+        const projectId = await seedProject();
+        const src = legacyPath(PROJECT_UUID, 'pending.png');
+        await fs.ensureDir(path.dirname(src));
+        await fs.writeFile(src, 'pending bytes');
+        const asset = await seedAssetRow(projectId, `assets/${PROJECT_UUID}/pending.png`, 'pending.png', 'pending-c');
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps());
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('startup migration');
+        expect((await fs.readFile(src)).toString()).toBe('pending bytes');
+    });
+
+    it('fails clearly for an unknown asset id', async () => {
+        const result = await resolveAssetStorageConflict(99999, 'keep-new', {}, deps());
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('99999');
+    });
+
+    it('fails clearly when the row is not an unresolved conflict', async () => {
+        const projectId = await seedProject();
+        const dest = shardedPath(PROJECT_UUID, 'ok.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'ok');
+        const asset = await seedAssetRow(projectId, `assets/${SHARD}/${PROJECT_UUID}/ok.png`, 'ok.png', 'ok-c');
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-old', {}, deps());
+
+        expect(result.success).toBe(false);
+        expect(result.resolved).toBe(false);
+        expect(await fs.pathExists(dest)).toBe(true);
+    });
+
+    it('fails clearly for an uninterpretable row without touching anything', async () => {
+        const projectId = await seedProject();
+        const asset = await seedAssetRow(projectId, '/etc/passwd', 'passwd', 'weird-c');
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps());
+
+        expect(result.success).toBe(false);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe('/etc/passwd');
+    });
+
+    it('reports a concurrent row change instead of resolving blindly', async () => {
+        const { asset, src, dest } = await seedParkedConflict();
+
+        // Stub updateTable so the optimistic guard reports zero updated rows,
+        // as if another instance had rewritten the row concurrently.
+        const guardFailingDb = new Proxy(db, {
+            get(target, prop) {
+                if (prop === 'updateTable') {
+                    const chain = {
+                        set: () => chain,
+                        where: () => chain,
+                        execute: async () => [{ numUpdatedRows: BigInt(0) }],
+                    };
+                    return () => chain;
+                }
+                const value = Reflect.get(target, prop, target);
+                return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+            },
+        }) as Kysely<Database>;
+
+        const result = await resolveAssetStorageConflict(asset.id, 'keep-new', {}, deps({ db: guardFailingDb }));
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('concurrently');
+        // keep-new removes the legacy file before rewriting; the canonical
+        // copy must never be touched by a failed guard.
+        expect(await fs.pathExists(src)).toBe(false);
+        expect((await fs.readFile(dest)).toString()).toBe('different content');
+    });
+});

--- a/src/services/asset-conflicts.ts
+++ b/src/services/asset-conflicts.ts
@@ -1,0 +1,293 @@
+/**
+ * Asset storage conflict service (issue #2287, ADR-2250-01).
+ *
+ * The startup migration (asset-storage-migration.ts) never overwrites: when a
+ * row's legacy file and its canonical sharded destination both exist with
+ * different content, both files are kept and the row is parked on its legacy
+ * location. Those rows never converge on their own — resolving them requires
+ * an explicit operator choice, which this service provides:
+ *
+ * - `listAssetStorageConflicts` finds every parked or legacy row whose two
+ *   copies currently differ, with both absolute paths, sizes and mtimes.
+ * - `resolveAssetStorageConflict` applies an explicit `keep-old` / `keep-new`
+ *   choice to ONE asset. Nothing is ever deleted or overwritten without that
+ *   choice; identical copies are converged with the same rule the startup
+ *   migration applies automatically.
+ *
+ * Both operations reuse the migration's building blocks (`filesAreIdentical`,
+ * `moveFile`, `rewriteRow`) so "conflict" and "move" mean exactly the same
+ * thing at startup and in the CLI, and every step stays crash-safe: any
+ * interruption leaves a state the next startup migration reconciles.
+ */
+import * as fsExtra from 'fs-extra';
+import * as pathModule from 'path';
+import type { Kysely } from 'kysely';
+import { db as defaultDb } from '../db/client';
+import type { Database } from '../db/types';
+import { getFilesDir as defaultGetFilesDir } from './file-helper';
+import { filesAreIdentical, moveFile, rewriteRow } from './asset-storage-migration';
+import { deriveShardedAssetStoragePath, tryResolveAssetStoragePath } from '../utils/asset-paths';
+
+const DEFAULT_BATCH_SIZE = 500;
+
+/** One unresolved storage conflict, ready to display to an operator. */
+export interface AssetStorageConflict {
+    assetId: number;
+    projectUuid: string;
+    filename: string;
+    /** Current database value (parked relative or legacy absolute form). */
+    storedPath: string;
+    /** Canonical sharded value the row converges to after resolution. */
+    canonicalStoredPath: string;
+    /** Absolute path of the copy the database currently points at. */
+    legacyPath: string;
+    /** Absolute path of the copy at the canonical sharded location. */
+    canonicalPath: string;
+    legacySize: number;
+    canonicalSize: number;
+    legacyMtime: string;
+    canonicalMtime: string;
+}
+
+export type ConflictResolutionChoice = 'keep-old' | 'keep-new';
+
+export interface ResolveConflictResult {
+    success: boolean;
+    /** True when files/rows were actually changed (false for dry-run). */
+    resolved: boolean;
+    message: string;
+}
+
+/**
+ * Injectable dependencies (DI pattern used across src/services).
+ */
+export interface AssetConflictsDeps {
+    db?: Kysely<Database>;
+    fs?: typeof fsExtra;
+    getFilesDir?: () => string;
+    /** Rows fetched per query; bounds memory on large installations. */
+    batchSize?: number;
+}
+
+interface CandidateRow {
+    id: number;
+    storage_path: string;
+    filename: string;
+    project_uuid: string;
+}
+
+type RowClassification =
+    | { state: 'converged' | 'uninterpretable' | 'incomplete' }
+    | { state: 'identical' | 'conflict'; src: string; dest: string; target: string };
+
+/**
+ * Classifies one row against the filesystem. Converged rows are recognized
+ * with a pure string comparison, so they cost no I/O.
+ */
+async function classifyRow(fs: typeof fsExtra, filesDir: string, row: CandidateRow): Promise<RowClassification> {
+    const target = deriveShardedAssetStoragePath(row.project_uuid, row.storage_path);
+    if (!target) {
+        return { state: 'uninterpretable' };
+    }
+    if (target === row.storage_path) {
+        return { state: 'converged' };
+    }
+    const src = tryResolveAssetStoragePath(filesDir, row.storage_path);
+    const dest = tryResolveAssetStoragePath(filesDir, target);
+    if (!src || !dest) {
+        return { state: 'uninterpretable' };
+    }
+    if (src === dest) {
+        // Same physical file under a non-canonical representation; the
+        // startup migration rewrites these rows without any file operation.
+        return { state: 'converged' };
+    }
+    const [srcExists, destExists] = await Promise.all([fs.pathExists(src), fs.pathExists(dest)]);
+    if (!srcExists || !destExists) {
+        // Nothing to decide: the startup migration handles free destinations
+        // and missing files on its own.
+        return { state: 'incomplete' };
+    }
+    if (await filesAreIdentical(fs, src, dest)) {
+        return { state: 'identical', src, dest, target };
+    }
+    return { state: 'conflict', src, dest, target };
+}
+
+function candidateQuery(db: Kysely<Database>) {
+    return db
+        .selectFrom('assets')
+        .innerJoin('projects', 'assets.project_id', 'projects.id')
+        .select([
+            'assets.id as id',
+            'assets.storage_path as storage_path',
+            'assets.filename as filename',
+            'projects.uuid as project_uuid',
+        ]);
+}
+
+/**
+ * Lists every unresolved storage conflict. Scans all asset rows in bounded
+ * batches; rows already in canonical form are skipped with a string
+ * comparison, so only non-canonical rows cost filesystem checks.
+ */
+export async function listAssetStorageConflicts(deps: AssetConflictsDeps = {}): Promise<AssetStorageConflict[]> {
+    const db = deps.db ?? defaultDb;
+    const fs = deps.fs ?? fsExtra;
+    const getFilesDir = deps.getFilesDir ?? defaultGetFilesDir;
+    const batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE;
+    const filesDir = getFilesDir();
+
+    const conflicts: AssetStorageConflict[] = [];
+    let lastId = 0;
+    for (;;) {
+        const rows: CandidateRow[] = await candidateQuery(db)
+            .where('assets.id', '>', lastId)
+            .orderBy('assets.id', 'asc')
+            .limit(batchSize)
+            .execute();
+        if (rows.length === 0) {
+            break;
+        }
+        for (const row of rows) {
+            lastId = row.id;
+            const classified = await classifyRow(fs, filesDir, row);
+            if (classified.state !== 'conflict') {
+                continue;
+            }
+            const [srcStat, destStat] = await Promise.all([fs.stat(classified.src), fs.stat(classified.dest)]);
+            conflicts.push({
+                assetId: row.id,
+                projectUuid: row.project_uuid,
+                filename: row.filename,
+                storedPath: row.storage_path,
+                canonicalStoredPath: classified.target,
+                legacyPath: classified.src,
+                canonicalPath: classified.dest,
+                legacySize: srcStat.size,
+                canonicalSize: destStat.size,
+                legacyMtime: srcStat.mtime.toISOString(),
+                canonicalMtime: destStat.mtime.toISOString(),
+            });
+        }
+    }
+    return conflicts;
+}
+
+/**
+ * Resolves ONE conflict with an explicit operator choice.
+ *
+ * - `keep-new`: the canonical copy wins — the legacy copy is removed, then
+ *   the row is rewritten to the canonical location.
+ * - `keep-old`: the legacy copy wins — the canonical copy is removed, the
+ *   legacy file is moved into its place, then the row is rewritten.
+ *
+ * Operation order is chosen so a crash at any point leaves a state the next
+ * startup migration converges on its own. Row rewrites keep the migration's
+ * optimistic `WHERE storage_path = <old>` guard, so a concurrently starting
+ * instance can never be raced into losing an update.
+ */
+export async function resolveAssetStorageConflict(
+    assetId: number,
+    choice: ConflictResolutionChoice,
+    options: { dryRun?: boolean } = {},
+    deps: AssetConflictsDeps = {},
+): Promise<ResolveConflictResult> {
+    const db = deps.db ?? defaultDb;
+    const fs = deps.fs ?? fsExtra;
+    const getFilesDir = deps.getFilesDir ?? defaultGetFilesDir;
+    const filesDir = getFilesDir();
+    const dryRun = options.dryRun === true;
+
+    const row: CandidateRow | undefined = await candidateQuery(db).where('assets.id', '=', assetId).executeTakeFirst();
+    if (!row) {
+        return { success: false, resolved: false, message: `Asset ${assetId} does not exist.` };
+    }
+
+    const classified = await classifyRow(fs, filesDir, row);
+    if (classified.state === 'converged') {
+        return {
+            success: false,
+            resolved: false,
+            message: `Asset ${assetId} is already at its canonical location; nothing to resolve.`,
+        };
+    }
+    if (classified.state === 'uninterpretable') {
+        return {
+            success: false,
+            resolved: false,
+            message:
+                `Asset ${assetId} has an uninterpretable storage_path (${row.storage_path}); ` +
+                `it is not a storage conflict. Inspect the row manually.`,
+        };
+    }
+    if (classified.state === 'incomplete') {
+        return {
+            success: false,
+            resolved: false,
+            message:
+                `Asset ${assetId} is not an unresolved conflict (one of the two locations has no file); ` +
+                `the startup migration will converge it automatically.`,
+        };
+    }
+
+    const { src, dest, target } = classified;
+
+    if (classified.state === 'identical') {
+        // Both copies have the same content: converging is decision-free and
+        // matches what the startup migration does on every boot.
+        if (dryRun) {
+            return {
+                success: true,
+                resolved: false,
+                message: `[dry-run] Copies are identical; would remove '${src}' and point the row at '${dest}'.`,
+            };
+        }
+        await fs.remove(src);
+        if (!(await rewriteRow(db, row.id, row.storage_path, target))) {
+            return concurrentChange(assetId);
+        }
+        return {
+            success: true,
+            resolved: true,
+            message: `Copies were identical; removed '${src}' and pointed asset ${assetId} at '${dest}'.`,
+        };
+    }
+
+    if (dryRun) {
+        const plan =
+            choice === 'keep-new'
+                ? `remove legacy '${src}' and keep canonical '${dest}'`
+                : `remove canonical '${dest}' and move legacy '${src}' into its place`;
+        return { success: true, resolved: false, message: `[dry-run] Would ${plan}, then rewrite the row.` };
+    }
+
+    if (choice === 'keep-new') {
+        await fs.remove(src);
+    } else {
+        await fs.remove(dest);
+        await fs.ensureDir(pathModule.dirname(dest));
+        await moveFile(fs, src, dest);
+    }
+    if (!(await rewriteRow(db, row.id, row.storage_path, target))) {
+        return concurrentChange(assetId);
+    }
+    const kept = choice === 'keep-new' ? 'canonical' : 'legacy';
+    return {
+        success: true,
+        resolved: true,
+        message:
+            `Kept the ${kept} copy for asset ${assetId}; the row now points at '${dest}'. ` +
+            `The next startup migration tidies any emptied legacy directory.`,
+    };
+}
+
+function concurrentChange(assetId: number): ResolveConflictResult {
+    return {
+        success: false,
+        resolved: false,
+        message:
+            `The database row for asset ${assetId} changed concurrently (another instance may be ` +
+            `migrating); re-run 'assets:conflicts list' and try again.`,
+    };
+}

--- a/src/services/asset-storage-migration.spec.ts
+++ b/src/services/asset-storage-migration.spec.ts
@@ -387,6 +387,101 @@ describe('asset-storage-migration', () => {
         expect(sweepWarn).toContain(dest);
         expect(sweepWarn).toContain(`(${'orphan bytes'.length} bytes)`);
         expect(sweepWarn).toContain(`(${'existing different bytes'.length} bytes)`);
+        // Sweep conflicts have no database row, so the assets:conflicts CLI
+        // cannot resolve them; the warning must say WHY it is manual instead
+        // of looking inconsistent with the phase 1 conflict warning.
+        expect(sweepWarn).toContain('No database row references this file');
+    });
+
+    // =========================================================================
+    // Parked conflict rows (assets/<uuid>/... written by the conflict branch)
+    // =========================================================================
+
+    async function seedParkedRow(projectId: number, filename: string) {
+        return assetQueries.createAsset(db, {
+            project_id: projectId,
+            filename,
+            storage_path: `assets/${PROJECT_UUID}/${filename}`,
+            mime_type: 'application/octet-stream',
+            file_size: '0',
+            client_id: filename.replace(/\..*$/, ''),
+            folder_path: '',
+        });
+    }
+
+    it('converges a parked row whose legacy copy is gone (interrupted keep-new resolution)', async () => {
+        const projectId = await seedProject();
+        const asset = await seedParkedRow(projectId, 'parked-new.png');
+        // Crash state after `assets:conflicts resolve --keep-new`: the legacy
+        // copy was removed but the row was not rewritten yet.
+        const dest = shardedPath(PROJECT_UUID, 'parked-new.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'kept canonical bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.alreadyMigrated).toBe(1);
+        expect(summary.rewrittenRows).toBe(1);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/parked-new.png`);
+    });
+
+    it('completes an interrupted keep-old resolution: parked row with a free destination', async () => {
+        const projectId = await seedProject();
+        const asset = await seedParkedRow(projectId, 'parked-old.png');
+        // Crash state after `assets:conflicts resolve --keep-old` removed the
+        // canonical copy but before the legacy copy was moved into its place.
+        await writeLegacyFile(PROJECT_UUID, ['parked-old.png'], 'kept legacy bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.movedFiles).toBe(1);
+        expect(summary.rewrittenRows).toBe(1);
+        const dest = shardedPath(PROJECT_UUID, 'parked-old.png');
+        expect((await fs.readFile(dest)).toString()).toBe('kept legacy bytes');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${SHARD}/${PROJECT_UUID}/parked-old.png`);
+    });
+
+    it('re-reports an unresolved parked conflict on every run without rewriting the row', async () => {
+        const projectId = await seedProject();
+        const asset = await seedParkedRow(projectId, 'parked-live.png');
+        await writeLegacyFile(PROJECT_UUID, ['parked-live.png'], 'legacy content');
+        const dest = shardedPath(PROJECT_UUID, 'parked-live.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'different content');
+        const before = await assetQueries.findAssetById(db, asset.id);
+
+        const summary = await runMigration();
+
+        expect(summary.conflicts).toBe(1);
+        // No churn: the row already holds the parked value, so it must not be
+        // rewritten (updated_at untouched) just to re-report the conflict.
+        expect(summary.rewrittenRows).toBe(0);
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/parked-live.png`);
+        expect(row!.updated_at).toEqual(before!.updated_at);
+        // Both copies survive and the operator is pointed at the CLI.
+        expect((await fs.readFile(path.join(filesDir, 'assets', PROJECT_UUID, 'parked-live.png'))).toString()).toBe(
+            'legacy content',
+        );
+        expect((await fs.readFile(dest)).toString()).toBe('different content');
+        expect(warnMessages.find(message => message.includes('Conflict for asset'))).toContain('assets:conflicts');
+    });
+
+    it('skips migration when parked rows exist but the assets root is missing (unmounted volume)', async () => {
+        const projectId = await seedProject();
+        const asset = await seedParkedRow(projectId, 'parked-unmounted.png');
+        // No file is written: filesDir/assets does not exist at all. Without
+        // the safety latch the row would be "missing" on both sides and get
+        // rewritten to the sharded target, losing its parked pointer.
+        const summary = await runMigration();
+
+        expect(summary.scannedRows).toBe(0);
+        expect(summary.rewrittenRows).toBe(0);
+        expect(warnMessages.join('\n')).toContain('assets root');
+        const row = await assetQueries.findAssetById(db, asset.id);
+        expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/parked-unmounted.png`);
     });
 
     // =========================================================================

--- a/src/services/asset-storage-migration.spec.ts
+++ b/src/services/asset-storage-migration.spec.ts
@@ -358,7 +358,35 @@ describe('asset-storage-migration', () => {
         const row = await assetQueries.findAssetById(db, asset.id);
         expect(row!.storage_path).toBe(`assets/${PROJECT_UUID}/conflict.png`);
         expect(tryResolveAssetStoragePath(filesDir, row!.storage_path)).toBe(legacyFile);
-        expect(warnMessages.join('\n')).toContain('conflict.png');
+        // The warning must carry both absolute paths and both sizes so the
+        // operator can decide without hunting for the files (issue #2287).
+        const conflictWarn = warnMessages.find(message => message.includes('Conflict for asset'));
+        expect(conflictWarn).toContain(legacyFile);
+        expect(conflictWarn).toContain(dest);
+        expect(conflictWarn).toContain(`(${'legacy content'.length} bytes)`);
+        expect(conflictWarn).toContain(`(${'different content'.length} bytes)`);
+        expect(conflictWarn).toContain('assets:conflicts');
+    });
+
+    it('reports sweep conflicts with both absolute paths and sizes, keeping both files', async () => {
+        await seedProject();
+        // Orphan file (no database row) in the legacy directory, with a
+        // DIFFERENT file already at the sharded destination.
+        const orphanSrc = await writeLegacyFile(PROJECT_UUID, ['sweep-conflict.png'], 'orphan bytes');
+        const dest = shardedPath(PROJECT_UUID, 'sweep-conflict.png');
+        await fs.ensureDir(path.dirname(dest));
+        await fs.writeFile(dest, 'existing different bytes');
+
+        const summary = await runMigration();
+
+        expect(summary.conflicts).toBe(1);
+        expect((await fs.readFile(orphanSrc)).toString()).toBe('orphan bytes');
+        expect((await fs.readFile(dest)).toString()).toBe('existing different bytes');
+        const sweepWarn = warnMessages.find(message => message.includes('Conflict sweeping'));
+        expect(sweepWarn).toContain(orphanSrc);
+        expect(sweepWarn).toContain(dest);
+        expect(sweepWarn).toContain(`(${'orphan bytes'.length} bytes)`);
+        expect(sweepWarn).toContain(`(${'existing different bytes'.length} bytes)`);
     });
 
     // =========================================================================

--- a/src/services/asset-storage-migration.ts
+++ b/src/services/asset-storage-migration.ts
@@ -105,8 +105,11 @@ const DECIMAL_BUCKET = /^\d{2}$/;
  * Move a file, preferring an atomic rename. On EXDEV (cross-device link, e.g.
  * bind mounts inside FILES_DIR) falls back to copy-to-temp + rename + verify +
  * remove, so the destination never holds a partially written file.
+ *
+ * Exported for reuse by the conflict-resolution service (issue #2287) — the
+ * migration and the CLI must move files with identical semantics.
  */
-async function moveFile(fs: typeof fsExtra, src: string, dest: string): Promise<void> {
+export async function moveFile(fs: typeof fsExtra, src: string, dest: string): Promise<void> {
     try {
         await fs.rename(src, dest);
         return;
@@ -132,8 +135,11 @@ async function moveFile(fs: typeof fsExtra, src: string, dest: string): Promise<
 
 /**
  * Compare two files by size and SHA-256 content hash (streamed).
+ *
+ * Exported for reuse by the conflict-resolution service (issue #2287) so
+ * "conflict" means the same thing at startup and in the CLI.
  */
-async function filesAreIdentical(fs: typeof fsExtra, a: string, b: string): Promise<boolean> {
+export async function filesAreIdentical(fs: typeof fsExtra, a: string, b: string): Promise<boolean> {
     const [statA, statB] = await Promise.all([fs.stat(a), fs.stat(b)]);
     if (statA.size !== statB.size) {
         return false;
@@ -153,8 +159,12 @@ async function filesAreIdentical(fs: typeof fsExtra, a: string, b: string): Prom
 /**
  * Rewrite one row's storage_path with an optimistic concurrency guard.
  * Returns true when this call performed the update.
+ *
+ * Exported for reuse by the conflict-resolution service (issue #2287); the
+ * guard is what makes CLI resolution safe against a concurrently starting
+ * instance re-running the migration.
  */
-async function rewriteRow(db: Kysely<Database>, id: number, oldPath: string, newPath: string): Promise<boolean> {
+export async function rewriteRow(db: Kysely<Database>, id: number, oldPath: string, newPath: string): Promise<boolean> {
     const result = await db
         .updateTable('assets')
         .set({ storage_path: newPath, updated_at: now() })
@@ -395,13 +405,17 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
                 return;
             }
             // Different content: never overwrite. Keep BOTH files, report the
-            // conflict, and rewrite the row to the portable relative form of
-            // its current (legacy) location so it stays valid and portable.
+            // conflict with both absolute paths and sizes so the operator can
+            // decide without hunting for the files, and rewrite the row to the
+            // portable relative form of its current (legacy) location so it
+            // stays valid and portable.
             summary.conflicts++;
             const legacyStored = [ASSETS_ROOT_DIR_NAME, ...segments].join('/');
+            const [srcStat, destStat] = await Promise.all([fs.stat(src), fs.stat(dest)]);
             warn(
-                `[AssetStorage] Conflict for asset ${row.id}: '${legacyStored}' and '${targetStored}' differ. ` +
-                    `Keeping both; the database keeps pointing at the legacy location. Resolve manually.`,
+                `[AssetStorage] Conflict for asset ${row.id}: legacy '${src}' (${srcStat.size} bytes) and ` +
+                    `sharded '${dest}' (${destStat.size} bytes) differ. Keeping both; the database keeps ` +
+                    `pointing at the legacy location. Resolve with 'bun cli assets:conflicts'.`,
             );
             if (isCanonicalAssetStoragePath(legacyStored)) {
                 if (await rewriteRow(db, row.id, row.storage_path, legacyStored)) {
@@ -544,9 +558,10 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
                             await fs.remove(src);
                         } else {
                             summary.conflicts++;
+                            const [srcStat, destStat] = await Promise.all([fs.stat(src), fs.stat(dest)]);
                             warn(
-                                `[AssetStorage] Conflict sweeping '${src}': destination '${dest}' differs. ` +
-                                    `Keeping both. Resolve manually.`,
+                                `[AssetStorage] Conflict sweeping '${src}' (${srcStat.size} bytes): destination ` +
+                                    `'${dest}' (${destStat.size} bytes) differs. Keeping both. Resolve manually.`,
                             );
                         }
                     } catch (err) {

--- a/src/services/asset-storage-migration.ts
+++ b/src/services/asset-storage-migration.ts
@@ -22,6 +22,11 @@
  *   next run reconciles. The guard also makes concurrent execution by several
  *   app instances safe: exactly one instance wins each row, the others
  *   re-observe an already-converged state.
+ * - Phase 1 re-examines every non-canonical row, including conflict rows
+ *   parked on `assets/<uuid>/...` by a previous run. That is what makes an
+ *   interrupted `assets:conflicts resolve` (issue #2287) self-heal at the
+ *   next startup: whichever copy the interruption left behind is either
+ *   moved or adopted, and the row converges.
  * - Never overwrite: when source and destination both exist with different
  *   content, both files are kept, the conflict is reported, and the row is
  *   rewritten to the portable relative form of its CURRENT (legacy) location.
@@ -93,6 +98,14 @@ const DEFAULT_BATCH_SIZE = 500;
 const PROGRESS_LOG_INTERVAL = 1000;
 
 const SHARD_BUCKET = /^[0-9a-f]{2}$/;
+
+/**
+ * LIKE pattern matching rows already in the canonical sharded form
+ * (`assets/<two-char shard>/...`). Phase 1 selects everything else: legacy
+ * absolute paths AND parked conflict rows (`assets/<uuid>/...`), so states
+ * left by an interrupted CLI resolution are reconciled at the next startup.
+ */
+const CANONICAL_ROW_LIKE = `${ASSETS_ROOT_DIR_NAME}/__/%`;
 
 /**
  * Two-DIGIT names are ambiguous: they are valid shard buckets AND possible
@@ -261,7 +274,7 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
         const legacyRow = await db
             .selectFrom('assets')
             .select('assets.id')
-            .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+            .where('assets.storage_path', 'not like', CANONICAL_ROW_LIKE)
             .limit(1)
             .executeTakeFirst();
         if (legacyRow) {
@@ -275,7 +288,8 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
 
     // =========================================================================
     // Phase 1: row-driven migration.
-    // Every row whose storage_path is not FILES_DIR-relative is legacy.
+    // Every row whose storage_path is not in the canonical sharded form is
+    // (re)examined — legacy absolute paths and parked conflict rows alike.
     // Cursor pagination (id > lastId) guarantees termination even for rows
     // that are skipped without being rewritten.
     // =========================================================================
@@ -286,7 +300,7 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
             .selectFrom('assets')
             .innerJoin('projects', 'assets.project_id', 'projects.id')
             .select(['assets.id as id', 'assets.storage_path as storage_path', 'projects.uuid as project_uuid'])
-            .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+            .where('assets.storage_path', 'not like', CANONICAL_ROW_LIKE)
             .where('assets.id', '>', lastId)
             .orderBy('assets.id', 'asc')
             .limit(batchSize)
@@ -305,7 +319,7 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
                 .selectFrom('assets')
                 .innerJoin('projects', 'assets.project_id', 'projects.id')
                 .select(eb => eb.fn.countAll<number>().as('count'))
-                .where('assets.storage_path', 'not like', `${ASSETS_ROOT_DIR_NAME}/%`)
+                .where('assets.storage_path', 'not like', CANONICAL_ROW_LIKE)
                 .executeTakeFirst();
             totalLegacyRows = Number(countRow?.count ?? 0);
         }
@@ -417,7 +431,10 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
                     `sharded '${dest}' (${destStat.size} bytes) differ. Keeping both; the database keeps ` +
                     `pointing at the legacy location. Resolve with 'bun cli assets:conflicts'.`,
             );
-            if (isCanonicalAssetStoragePath(legacyStored)) {
+            // Already-parked rows re-enter this branch on every startup while
+            // the conflict stays unresolved; only rewrite when the stored
+            // value actually changes, so re-reporting causes no row churn.
+            if (isCanonicalAssetStoragePath(legacyStored) && legacyStored !== row.storage_path) {
                 if (await rewriteRow(db, row.id, row.storage_path, legacyStored)) {
                     summary.rewrittenRows++;
                 }
@@ -561,7 +578,9 @@ export async function migrateAssetStorage(deps: AssetStorageMigrationDeps = {}):
                             const [srcStat, destStat] = await Promise.all([fs.stat(src), fs.stat(dest)]);
                             warn(
                                 `[AssetStorage] Conflict sweeping '${src}' (${srcStat.size} bytes): destination ` +
-                                    `'${dest}' (${destStat.size} bytes) differs. Keeping both. Resolve manually.`,
+                                    `'${dest}' (${destStat.size} bytes) differs. Keeping both. No database row ` +
+                                    `references this file, so 'bun cli assets:conflicts' cannot resolve it; ` +
+                                    `compare the copies and remove one manually.`,
                             );
                         }
                     } catch (err) {

--- a/src/utils/asset-paths.spec.ts
+++ b/src/utils/asset-paths.spec.ts
@@ -2,6 +2,7 @@ import * as nodePath from 'path';
 import {
     ASSETS_ROOT_DIR_NAME,
     buildAssetStoragePath,
+    deriveShardedAssetStoragePath,
     extractAssetsRelativeSegments,
     getAssetShard,
     getProjectAssetsDirCandidates,
@@ -287,6 +288,41 @@ describe('asset-paths', () => {
             expect(tryResolveAssetStoragePath(filesDir, '/mnt/elsewhere/file.png')).toBeNull();
             expect(tryResolveAssetStoragePath(filesDir, 'assets/../evil')).toBeNull();
             expect(tryResolveAssetStoragePath(filesDir, '')).toBeNull();
+        });
+    });
+
+    describe('deriveShardedAssetStoragePath', () => {
+        const uuid = 'ab12cd34-1234-4abc-8def-1234567890ab';
+
+        it('maps an already-sharded canonical value to itself', () => {
+            expect(deriveShardedAssetStoragePath(uuid, `assets/ab/${uuid}/f.png`)).toBe(`assets/ab/${uuid}/f.png`);
+            expect(deriveShardedAssetStoragePath(uuid, `assets/ab/${uuid}/client/inner.html`)).toBe(
+                `assets/ab/${uuid}/client/inner.html`,
+            );
+        });
+
+        it('maps a parked conflict value (assets/<uuid>/...) to its sharded target', () => {
+            expect(deriveShardedAssetStoragePath(uuid, `assets/${uuid}/f.png`)).toBe(`assets/ab/${uuid}/f.png`);
+        });
+
+        it('maps a legacy absolute value to its sharded target via the assets suffix', () => {
+            expect(deriveShardedAssetStoragePath(uuid, `/mnt/data/assets/${uuid}/f.png`)).toBe(
+                `assets/ab/${uuid}/f.png`,
+            );
+            expect(deriveShardedAssetStoragePath(uuid, `C:\\data\\assets\\${uuid}\\f.png`)).toBe(
+                `assets/ab/${uuid}/f.png`,
+            );
+        });
+
+        it('re-parents a legacy numeric-directory value under the project uuid', () => {
+            expect(deriveShardedAssetStoragePath(uuid, 'assets/42/f.png')).toBe(`assets/ab/${uuid}/f.png`);
+        });
+
+        it('returns null for uninterpretable or unsafe values', () => {
+            expect(deriveShardedAssetStoragePath(uuid, '/etc/passwd')).toBeNull();
+            expect(deriveShardedAssetStoragePath(uuid, `assets/${uuid}/../../evil`)).toBeNull();
+            expect(deriveShardedAssetStoragePath(uuid, '')).toBeNull();
+            expect(deriveShardedAssetStoragePath('', `assets/${uuid}/f.png`)).toBeNull();
         });
     });
 });

--- a/src/utils/asset-paths.ts
+++ b/src/utils/asset-paths.ts
@@ -196,6 +196,34 @@ export function tryResolveAssetStoragePath(filesDir: string, storedPath: string)
 }
 
 /**
+ * Derives the canonical sharded stored path (`assets/<shard>/<uuid>/...`) for
+ * any interpretable stored value: canonical values map to themselves, parked
+ * conflict values (`assets/<uuid>/...`) and legacy absolute values map to
+ * their sharded target. Returns null when the value has no safe
+ * interpretation. Pure companion to the startup migration's per-row
+ * derivation, used by the conflict-resolution service (issue #2287).
+ */
+export function deriveShardedAssetStoragePath(projectUuid: string, storedPath: string): string | null {
+    const segments = extractAssetsRelativeSegments(storedPath);
+    if (!segments || segments.length < 2) {
+        return null;
+    }
+    let shard: string;
+    try {
+        shard = getAssetShard(projectUuid);
+    } catch {
+        return null;
+    }
+    const alreadySharded = segments.length >= 3 && segments[0] === shard && segments[1] === projectUuid;
+    const relWithinProject = alreadySharded ? segments.slice(2) : segments.slice(1);
+    try {
+        return buildAssetStoragePath(projectUuid, ...relWithinProject);
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Returns the physical project asset directory candidates for `projectUuid`
  * under `filesDir`: the canonical sharded directory first, then the legacy
  * unsharded directory. Deletion/cleanup paths must remove both so projects


### PR DESCRIPTION
Implements #2287, the conflict-resolution follow-up from the review of #2266.

> [!IMPORTANT]
> **Stacked on #2266** (base branch is `2250-asset-storage-does-not-scale`). Do **not** merge before #2266 lands in `main`; GitHub retargets this PR automatically afterwards. Issue #2287 is marked *blocked by* #2250 accordingly.

## What

- `bun cli assets:conflicts` lists the conflicts parked by the startup migration (ADR-2250-01 never-overwrite rule): asset id, project, and **both absolute paths with file sizes and mtimes**. `--json` prints raw machine-parseable output.
- `bun cli assets:conflicts resolve <asset-id> --keep-old|--keep-new [--dry-run]` resolves **one** conflict with an explicit operator choice — nothing is ever deleted or overwritten without one of the two flags. `--keep-old` moves the legacy copy into the canonical sharded location; `--keep-new` keeps the canonical copy. Copies that turn out identical converge with the migration's own decision-free rule.
- Crash-safe by construction: operation order plus the migration's optimistic `WHERE storage_path = <old>` guard mean any interruption (or a concurrently starting instance) leaves a state the next startup migration reconciles; the emptied legacy directory is tidied by the next boot's sweep.
- No duplicated semantics: the service reuses the migration's `filesAreIdentical` / `moveFile` / `rewriteRow` (now exported), plus a new pure `deriveShardedAssetStoragePath` in the shared path grammar (`src/utils/asset-paths.ts`).
- The per-boot conflict warnings now print both absolute paths and sizes and point at the CLI (the other half of issue #2287).

## How to test

Unit level (real filesystem + real test DB):

```bash
bun test src/services/asset-conflicts.spec.ts src/cli/commands/assets-conflicts.spec.ts
```

Manually, on a dev install (fabricate a conflict, then resolve it):

```bash
# 1. Upload any image to a project, note the asset row:
#    UUID=<project uuid>  FILE=<stored filename>  ID=<asset id>  FILES=./data
# 2. Park the row on a diverging legacy copy:
mkdir -p "$FILES/assets/$UUID"
echo "legacy version" > "$FILES/assets/$UUID/$FILE"
sqlite3 "$FILES/exelearning.db" \
  "UPDATE assets SET storage_path='assets/$UUID/$FILE' WHERE id=$ID;"
# 3. Restart the app: the boot log reports the conflict with both paths and sizes.
# 4. Inspect and resolve:
bun cli assets:conflicts
bun cli assets:conflicts list --json
bun cli assets:conflicts resolve $ID --keep-new --dry-run
bun cli assets:conflicts resolve $ID --keep-new
# 5. Restart again: no conflict warning; the legacy directory is gone.
```

## Docs

- New change document `doc/architecture/changes/2287-asset-conflict-cli/design.md` (scope, resolution semantics, why phase-2 orphan conflicts stay out).
- `doc/deployment.md`: new "Asset storage conflicts" maintenance section.
- Cross-references updated in ADR-2250-01 and the #2250 admin guide.

## Validation

`make fix`, `make architecture-check`, `make test-unit` (8,344 pass; all files ≥ 90 % coverage — new service 98.8 %, new command 99 %), `make test-integration` (727 pass), `make test-e2e` (530 passed, 6 skipped, 0 failed). No translations touched; no schema changes.
