### PR TITLE
i18n(gl): fix translation for slide idevice in messages.gl.xlf

### DIFF
--- a/translations/messages.gl.xlf
+++ b/translations/messages.gl.xlf
@@ -8487,7 +8487,7 @@
       </trans-unit>
       <trans-unit id="SFRf.in" resname="Slide">
         <source>Slide</source>
-        <target>Arrastrar</target>
+        <target>Diapositiva</target>
       </trans-unit>
       <trans-unit id="Q8bU.kF" resname="Swap">
         <source>Swap</source>


### PR DESCRIPTION
## Description
Fixes the translation string for **slide iDevice** in the `messages.gl.xlf` file.

> **Note:** This PR only modifies this specific string (`slide -> Diapositiva`). **The rest of the translation strings in the file have not been reviewed.**

## Related Issue
Closes #2251

## Changes
- Updated Galician translation string for `slide iDevice` in `messages.gl.xlf`.