### PR TITLE
Improve the presentation and accessibility of the effects

### DIFF
--- a/doc/development/styles.md
+++ b/doc/development/styles.md
@@ -209,6 +209,53 @@ h2 { color: red !important; }
 
 ---
 
+## Effects (FX)
+
+The Accordion, Tabs, Pagination, Carousel and Timeline effects are styled by
+`exe_effects.css`, which ships with eXeLearning. Every effect is wrapped in
+`<div class="exe-fx exe-...">`.
+
+Their controls (tab labels, page numbers, carousel arrows, accordion titles and the
+timeline markers) are links, but **not links inside a block of text**. `exe_effects.css`
+therefore keeps them free of underlines and gives them a focus ring of its own, so a
+keyboard user always sees where the focus is, whatever style is applied.
+
+The ring is drawn with `outline`, outside the control, over the page background. To
+recolour it, set one custom property rather than restyling every control:
+
+```css
+.exe-content {
+    --exe-fx-focus-color: #054d4d; /* default: #1a1a1a */
+}
+```
+
+Keep at least a 3:1 contrast ratio between that colour and the page background. Paint
+the controls themselves with `background` or `box-shadow` — the ring never uses
+`box-shadow`, so both keep working together.
+
+To recolour the controls, target `.exe-content .fx-tabs a` and
+`.exe-content .fx-pagination a`: the carousel pagination carries the `fx-pagination`
+class too, so it needs no rule of its own.
+
+Careful with the current page, which is a **filled chip**: `exe_effects.css` gives it a
+dark background *and* white text, and a rule that recolours every pagination link is more
+specific than that pair, so it repaints the text and leaves it on the dark chip. Either
+exclude it or restyle the whole chip:
+
+```css
+/* Leave the chip alone... */
+.exe-content .fx-pagination li:not(.fx-current) a {
+    color: #b14900;
+}
+/* ...or give it both halves of the pair */
+.exe-content .fx-pagination .fx-current a {
+    background: #145cb1;
+    color: #ffffff;
+}
+```
+
+---
+
 ## CSS Classes by Export Type
 
 Each export type adds a CSS class to the `<body>` element:

--- a/public/app/common/exe_effects/exe_effects.css
+++ b/public/app/common/exe_effects/exe_effects.css
@@ -9,24 +9,24 @@
 .exe-content .exe-accordion h2{border-radius:3px;margin:0;font-size:1em}
 .js .exe-accordion h2{padding:0;border:0;display:block;background:none;border-radius:3px}
 html .js .fx-accordion-title{text-decoration:none}
-.exe-content .fx-accordion-title.active,.exe-content .fx-accordion-title:hover,.exe-content .fx-accordion-title:focus{/*background:#4c4c4c;*/filter:alpha(opacity=90);opacity:.9;text-decoration:none}
+.exe-content .fx-accordion-title.active,.exe-content .fx-accordion-title:hover,.exe-content .fx-accordion-title:focus{/*background:#4c4c4c;*/filter:alpha(opacity=90);opacity:.9}
 .fx-accordion-section:last-child .fx-accordion-title{border-bottom:none}
 .fx-accordion-content{padding:0 15px;display:none; margin-top: 10px;}
 /* Tabs */
 .exe-tabs{margin:2em auto;width:90%}
 .js .exe-tabs{width:96%}
-.exe-tabs .fx-tabs{margin:0;padding:0;list-style:none;overflow:auto}
+.exe-tabs .fx-tabs{margin:0;padding:0;list-style:none}
+.exe-tabs .fx-tabs:after{content:".";display:block;clear:both;visibility:hidden;line-height:0;height:0}
 .exe-tabs h2{margin-top:2em}
 .js .exe-tabs h2{margin-top:.5em}
 * html .exe-tabs .fx-tabs{width:100%} /* IE6 */
 .exe-tabs .fx-tabs li{display:inline}
-.exe-tabs .fx-tabs a{display:block;padding:10px 15px;outline:none;float:left;text-decoration:none}
-.exe-tabs .fx-tabs a:hover,.exe-tabs .fx-tabs a:focus{text-decoration:underline}
+.exe-tabs .fx-tabs a{display:block;padding:10px 15px;float:left;text-decoration:none}
 .fx-tabs .fx-current a{background:#efefef;border-top-left-radius:5px;border-top-right-radius:5px}
 .exe-tabs .fx-tab-content{display:none;background:#efefef;padding:15px;border-radius:5px}
 .exe-tabs .fx-default-panel{border-top-left-radius:0}
 .exe-tabs .fx-tab-content.fx-current{display:block}
-/* Pagination */
+/* Pagination (shared with the carousel: its list carries both classes) */
 .exe-paginated{margin:2em auto;width:90%}
 .js .exe-paginated{width:96%}
 .exe-paginated .fx-pagination{margin:0 0 11px 0;padding:0;list-style:none;text-align:center}
@@ -34,26 +34,21 @@ html .js .fx-accordion-title{text-decoration:none}
 .js .exe-paginated h2{margin-top:1em}
 .fx-pagination li{display:inline;padding:0;margin:0 3px}
 .fx-pagination .fx-prev{margin-right:6px}
-.fx-pagination a{outline:none;display:inline-block;padding:3px 11px;cursor:pointer;border-radius:5px;background:#efefef;text-decoration:none}
-.fx-pagination a:hover,.fx-pagination a:focus{color:inherit;text-decoration:underline}
+.fx-pagination a{display:inline-block;padding:3px 11px;cursor:pointer;border-radius:5px;background:#efefef;text-decoration:none}
+.fx-pagination a:hover,.fx-pagination a:focus{color:inherit}
 .fx-prev-next a{font-family:Arial,Verdana,Helvetica,sans-serif}
 .fx-pagination .fx-disabled{filter:alpha(opacity=30);opacity:.3}
-.fx-pagination .fx-disabled,.fx-pagination .fx-disabled a,.fx-pagination .fx-disabled a:hover{cursor:text;text-decoration:none}
+.fx-pagination .fx-disabled,.fx-pagination .fx-disabled a,.fx-pagination .fx-disabled a:hover{cursor:text}
 .fx-pagination .fx-current a{background:#333;color:#fff}
 .fx-page-content{display:none;background:#efefef;padding:1px 15px .5em 15px;border-radius:5px}
 .fx-page-content.fx-current{display:block}
 /* Carousel */
 .exe-carousel{margin:2em auto;width:90%;position:relative}
 .js .exe-carousel{width:96%}
-.fx-carousel-pagination{margin:11px 0 0 0;padding:0;list-style:none;text-align:center;overflow:auto}
+.fx-carousel-pagination{margin:11px 0 0 0;padding:0;list-style:none;text-align:center}
+.fx-carousel-pagination:after{content:".";display:block;clear:both;visibility:hidden;line-height:0;height:0}
 .exe-content .exe-carousel h2{margin-top:2em}
 .js .exe-carousel h2{margin-top:1em}
-.fx-carousel-pagination li{display:inline;padding:0;margin:0 3px}
-.fx-carousel-pagination a{outline:none;display:inline-block;padding:3px 11px;border-radius:5px;background:#efefef;text-decoration:none}
-.fx-carousel-pagination a:hover,.fx-carousel-pagination a:focus{text-decoration:underline}
-.fx-carousel-pagination .fx-disabled{filter:alpha(opacity=30);opacity:.3}
-.fx-carousel-pagination .fx-disabled,.fx-carousel-pagination .fx-disabled a,.fx-carousel-pagination .fx-disabled a:hover{cursor:text;text-decoration:none}
-.fx-carousel-pagination .fx-current a{background:#333;color:#fff}
 .fx-pagination .fx-current a:hover,
 .fx-pagination .fx-current a:focus {color:#fff}
 .fx-carousel-content{display:none;background:#efefef;padding:1px 15px .5em 15px;border-radius:5px;margin:0 65px}
@@ -61,8 +56,7 @@ html .js .fx-accordion-title{text-decoration:none}
 .fx-carousel-pagination li{font-size:.85em}
 .fx-carousel-pagination .fx-carousel-prev-next{position:absolute;top:15px;left:0;*left:-10px} /* IE6, IE7 */
 .fx-carousel-pagination .fx-carousel-prev-next a{width:50px;height:50px;padding:0;line-height:50px;font-size:25px;font-family:Arial,Verdana,Helvetica,sans-serif;border-radius:25px;text-align:left;text-indent:10px}
-.fx-carousel-pagination .fx-carousel-prev-next a:hover{text-decoration:none;color:inherit}
-.fx-carousel-pagination .fx-carousel-prev-next a:focus{text-decoration:none}
+.fx-carousel-pagination .fx-carousel-prev-next a:hover{color:inherit}
 .fx-carousel-pagination .fx-carousel-next{left:auto;right:0}
 .fx-carousel-pagination .fx-carousel-next a{text-indent:14px}
 @media all and (max-width: 700px){
@@ -83,7 +77,7 @@ div.fx-timeline-minor{clear:left;float:left;margin:0 12px 0 0;padding:4px 4px 4p
 .fx-timeline-minor h3{clear:left;font-size:1.25em;list-style-type:none;line-height:1.2em;margin:5px 0 12px;padding:0 0 0 24px;white-space:nowrap}
 .fx-timeline-major h3:before{content:"‒";margin:0 9px 0 -25px}
 .fx-timeline-minor h3 a{color:#333;cursor:pointer;text-decoration:none}
-.fx-timeline-major h2 a:hover,.fx-timeline-major h2 a:focus,.fx-timeline-minor h3 a:hover,.fx-timeline-minor h3 a:focus{text-decoration:underline}
+.fx-timeline-minor h3 a:hover,.fx-timeline-minor h3 a:focus{text-decoration:underline}
 .fx-timeline-minor h3 a.closed{font-size:1em}
 .fx-timeline-event{padding-left:19px;width:100%}
 .fx-timeline-event p{line-height:1.5em;margin:6px 0 10px}
@@ -93,6 +87,35 @@ html[xmlns] .fx-timeline-container,html[xmlns] .fx-timeline-event{display:block}
 * html .fx-timeline-container,* html .fx-timeline-event{height:1%;overflow:visible}
 .fx-static-timeline-container p{margin-left:6px}
 .fx-ie-dash{float:left;line-height:3.2em;font-weight:bolder} /* IE<8 */
+
+/* Controls: links, but not inside a block of text, so no underline (WCAG 1.4.1) */
+.exe-fx .fx-tabs a,
+.exe-fx .fx-tabs a:hover,
+.exe-fx .fx-tabs a:focus,
+.exe-fx .fx-pagination a,
+.exe-fx .fx-pagination a:hover,
+.exe-fx .fx-pagination a:focus,
+.exe-fx .fx-accordion-title,
+.exe-fx .fx-accordion-title:hover,
+.exe-fx .fx-accordion-title:focus,
+.exe-fx .fx-timeline-expand,
+.exe-fx .fx-timeline-expand:hover,
+.exe-fx .fx-timeline-expand:focus,
+.exe-fx .fx-timeline-major h2 a,
+.exe-fx .fx-timeline-major h2 a:hover,
+.exe-fx .fx-timeline-major h2 a:focus{text-decoration:none}
+.exe-fx .fx-timeline-major h2 a:hover,
+.exe-fx .fx-timeline-major h2 a:focus{filter:alpha(opacity=80);opacity:.8}
+
+/* Focus indicator (WCAG 2.4.7); a style can retint it with --exe-fx-focus-color */
+.exe-fx .fx-tabs a:focus-visible,
+.exe-fx .fx-pagination a:focus-visible,
+.exe-fx .fx-accordion-title:focus-visible,
+.exe-fx .fx-timeline-expand:focus-visible,
+.exe-fx .fx-timeline-major h2 a:focus-visible,
+.exe-fx .fx-timeline-minor h3 a:focus-visible{outline:2px solid var(--exe-fx-focus-color,#1a1a1a);outline-offset:2px}
+/* The accordion clips its children: let the ring out */
+.js .exe-accordion:has(.fx-accordion-title:focus-visible){overflow:visible}
 
 /* Print version */
 @media print{

--- a/public/app/common/exe_effects/exe_effects.css.test.js
+++ b/public/app/common/exe_effects/exe_effects.css.test.js
@@ -1,0 +1,183 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const themesDir = join(here, '..', '..', '..', 'files', 'perm', 'themes', 'base');
+
+const css = readFileSync(join(here, 'exe_effects.css'), 'utf8');
+
+/**
+ * Splits a stylesheet into `{ selectors, declarations }` rules.
+ *
+ * Rules nested in an at-rule are returned too (the at-rule prelude is dropped),
+ * which is all these tests need: they only ever look at selectors and at the
+ * declarations that belong to them.
+ *
+ * @param {string} source Stylesheet text.
+ * @returns {{selectors: string[], declarations: string}[]} The rules it contains.
+ */
+function parseRules(source) {
+  const rules = [];
+  const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+  let match = rulePattern.exec(withoutComments);
+  while (match !== null) {
+    const selectors = match[1]
+      .split(',')
+      .map((selector) => selector.trim().replace(/\s+/g, ' '))
+      .filter((selector) => selector.length > 0 && !selector.startsWith('@'));
+    if (selectors.length > 0) {
+      rules.push({ selectors: selectors, declarations: match[2].replace(/\s+/g, ' ').trim() });
+    }
+    match = rulePattern.exec(withoutComments);
+  }
+  return rules;
+}
+
+const rules = parseRules(css);
+
+/**
+ * @param {string} selector Selector to look for, exactly as authored.
+ * @returns {{selectors: string[], declarations: string}[]} Rules that list it.
+ */
+function rulesFor(selector) {
+  return rules.filter((rule) => rule.selectors.includes(selector));
+}
+
+// Interactive controls of every effect. They are links, but not links inside a
+// block of text, so they carry no underline and need a focus ring of their own.
+const CONTROLS = [
+  '.exe-fx .fx-tabs a',
+  '.exe-fx .fx-pagination a',
+  '.exe-fx .fx-accordion-title',
+  '.exe-fx .fx-timeline-expand',
+  '.exe-fx .fx-timeline-major h2 a',
+];
+
+const FOCUS_RINGS = CONTROLS.concat(['.exe-fx .fx-timeline-minor h3 a']).map(
+  (selector) => `${selector}:focus-visible`
+);
+
+// Any selector naming a part of an effect, whatever the effect.
+const FX_PART = /\.(fx-|exe-accordion|exe-tabs|exe-paginated|exe-carousel|exe-timeline)/;
+
+describe('exe_effects.css', () => {
+  it('parses into rules', () => {
+    expect(rules.length).toBeGreaterThan(50);
+  });
+
+  it('never suppresses the outline of an effect control', () => {
+    const suppressed = rules.filter(
+      (rule) =>
+        rule.selectors.some((selector) => FX_PART.test(selector)) &&
+        /outline\s*:\s*(none|0)\b/.test(rule.declarations)
+    );
+    expect(suppressed.map((rule) => rule.selectors.join(', '))).toEqual([]);
+  });
+
+  it.each(FOCUS_RINGS)('draws a focus ring on %s', (selector) => {
+    const declarations = rulesFor(selector).map((rule) => rule.declarations);
+    expect(declarations.length).toBeGreaterThan(0);
+    expect(declarations.join(' ')).toMatch(/outline\s*:\s*2px solid/);
+  });
+
+  it('lets a style retint the ring, and never paints it with box-shadow', () => {
+    const focusRules = rules.filter((rule) =>
+      rule.selectors.some((selector) => selector.endsWith(':focus-visible'))
+    );
+    expect(focusRules.length).toBeGreaterThan(0);
+    for (const rule of focusRules) {
+      expect(rule.declarations).toMatch(/outline:2px solid var\(--exe-fx-focus-color,#[0-9a-f]{3,6}\)/);
+      // Styles paint these controls with box-shadow: the ring must not take it over.
+      expect(rule.declarations).not.toContain('box-shadow');
+    }
+  });
+
+  it.each(['.exe-tabs .fx-tabs', '.fx-carousel-pagination'])('does not clip the ring of %s', (selector) => {
+    for (const rule of rulesFor(selector)) {
+      expect(rule.declarations).not.toContain('overflow:');
+    }
+    expect(rulesFor(selector + ':after')[0].declarations).toContain('clear:both');
+  });
+
+  it('lets the ring out of the accordion, which clips its children', () => {
+    const [rule] = rulesFor('.js .exe-accordion:has(.fx-accordion-title:focus-visible)');
+    expect(rule.declarations).toBe('overflow:visible');
+    expect(rulesFor('.js .exe-accordion')[0].declarations).toContain('overflow:hidden');
+  });
+
+  it.each(CONTROLS)('leaves %s free of underlines in every state', (selector) => {
+    const states = [selector, `${selector}:hover`, `${selector}:focus`];
+    for (const state of states) {
+      const declarations = rulesFor(state).map((rule) => rule.declarations);
+      expect(declarations.join(' ')).toContain('text-decoration:none');
+    }
+  });
+
+  it('never underlines an effect control', () => {
+    const underlined = rules.filter(
+      (rule) =>
+        rule.selectors.some((selector) => CONTROLS.some((control) => selector.startsWith(control))) &&
+        /text-decoration\s*:\s*underline/.test(rule.declarations)
+    );
+    expect(underlined.map((rule) => rule.selectors.join(', '))).toEqual([]);
+  });
+
+  it('keeps the underline on the timeline event headings, which are plain text links', () => {
+    const [rule] = rulesFor('.fx-timeline-minor h3 a:hover');
+    expect(rule.declarations).toContain('text-decoration:underline');
+  });
+
+  it('styles the carousel pagination through .fx-pagination, which its list also carries', () => {
+    const duplicated = rules.filter((rule) =>
+      rule.selectors.some(
+        (selector) => selector === '.fx-carousel-pagination a' || selector === '.fx-carousel-pagination li'
+      )
+    );
+    expect(duplicated.map((rule) => rule.declarations)).toEqual(['font-size:.85em']);
+  });
+});
+
+describe('bundled styles', () => {
+  const styles = readdirSync(themesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  it('finds the bundled styles', () => {
+    expect(styles).toContain('base');
+    expect(styles).toContain('universal');
+  });
+
+  it.each(styles)('%s does not suppress the focus ring of the effects', (style) => {
+    const styleRules = parseRules(readFileSync(join(themesDir, style, 'style.css'), 'utf8'));
+    const suppressed = styleRules.filter(
+      (rule) =>
+        rule.selectors.some((selector) => FX_PART.test(selector)) &&
+        /outline\s*:\s*(none|0)\b/.test(rule.declarations)
+    );
+    expect(suppressed.map((rule) => rule.selectors.join(', '))).toEqual([]);
+  });
+
+  it.each(styles)('%s keeps the current page chip readable', (style) => {
+    const styleRules = parseRules(readFileSync(join(themesDir, style, 'style.css'), 'utf8'));
+    // exe_effects.css pairs a dark background with white text on the current chip. A rule
+    // recolouring every pagination link outranks that pair, so it would repaint the text
+    // but not the background and leave it unreadable on the dark chip.
+    const repaintsEveryLink = styleRules.some(
+      (rule) =>
+        rule.selectors.some((selector) => /\.fx-(pagination|carousel-pagination) a$/.test(selector)) &&
+        /(^|;)color:/.test(rule.declarations)
+    );
+    const restylesTheChip = styleRules.some((rule) =>
+      rule.selectors.some((selector) => /\.fx-current a$/.test(selector))
+    );
+    expect(repaintsEveryLink && !restylesTheChip).toBe(false);
+  });
+
+  it.each(['base', 'universal'])('%s recolours the ring through --exe-fx-focus-color', (style) => {
+    const source = readFileSync(join(themesDir, style, 'style.css'), 'utf8');
+    expect(source).toMatch(/--exe-fx-focus-color:\s*#[0-9a-f]{3,6};/i);
+  });
+});

--- a/public/files/perm/themes/base/base/style.css
+++ b/public/files/perm/themes/base/base/style.css
@@ -29,7 +29,9 @@ body.exe-web-site {
     color: #973f00;
 }
 
-.exe-content .fx-tabs a {
+/* The current page is a filled chip, so it keeps the colour of the effects */
+.exe-content .fx-tabs a,
+.exe-content .fx-pagination li:not(.fx-current) a {
     color: #b14900;
 }
 
@@ -687,6 +689,10 @@ label[for="teacher-mode-toggler"] {
 }
 
 /* Focus */
+.exe-content {
+    --exe-fx-focus-color: #054d4d;
+}
+
 .exe-content a:focus-visible,
 #siteNav a:focus-visible,
 #packageLicense a:focus-visible,

--- a/public/files/perm/themes/base/universal/style.css
+++ b/public/files/perm/themes/base/universal/style.css
@@ -96,17 +96,18 @@ body#tinymce {
     --bs-focus-ring-color: #0d70c7;
 }
 
-/* Effects: the effects stylesheet removes the outline on these controls */
+/* Effects (the carousel pagination also carries the .fx-pagination class) */
 .exe-content .fx-tabs a,
-.exe-content .fx-pagination a,
-.exe-content .fx-carousel-pagination a {
+.exe-content .fx-pagination a {
     color: #145cb1;
 }
-.exe-content .fx-tabs a:focus-visible,
-.exe-content .fx-pagination a:focus-visible,
-.exe-content .fx-carousel-pagination a:focus-visible {
-    outline: 2px solid #0d70c7;
-    outline-offset: 2px;
+/* The current page is a filled chip: it needs the pair, not just the colour */
+.exe-content .fx-pagination .fx-current a {
+    background: #145cb1;
+    color: #ffffff;
+}
+.exe-content {
+    --exe-fx-focus-color: #0d70c7;
 }
 
 /* General icons (Material Symbols) */


### PR DESCRIPTION
CSS only: no markup changes, `exe_effects.js` is untouched. The controls of the Accordion, Tabs, Pagination, Carousel and Timeline are still links, but they are not links inside a block of text, so `exe_effects.css` stops underlining them on hover and focus. In exchange it now draws a focus ring on every one of them: `outline: none` is gone, and `.fx-tabs` / `.fx-carousel-pagination` no longer clip the ring with `overflow: auto`, so a keyboard user can always see where the focus is.

A style recolours the ring with one custom property, `--exe-fx-focus-color`; `base` and `universal` set it to keep the color they already used. A style that sets nothing keeps working exactly as before and simply inherits the default `#1a1a1a` ring. A style painting its controls with `background` or `box-shadow` is never overridden.

Two contrast failures found while auditing the seven styles are fixed too.