### PR TITLE
fix(form): use configured pass rate for score

### DIFF
--- a/public/files/perm/idevices/base/form/export/form.js
+++ b/public/files/perm/idevices/base/form/export/form.js
@@ -765,7 +765,7 @@ var $form = {
         if (data.addBtnAnswers & showAnswers.length) showAnswers.show();
         data.gameOver = true;
         $form.checkAllQuestions(data);
-        $form.showScore(50, data);
+        $form.showScore(data.passRate, data);
         if ($('body').hasClass('exe-scorm') && data.isScorm > 0) {
             $form.sendScore(data);
         }


### PR DESCRIPTION
## Summary

Use the configured `passRate` when calculating the Form iDevice score instead of the hardcoded `50%` threshold.

## Changes

- Removed the hardcoded `50` value from the score calculation.
- Passed `data.passRate` to `showScore()`.

## Validation

- Ran `git diff --check`
- Ran `node --check public/files/perm/idevices/base/form/export/form.js`

Fixes #2317